### PR TITLE
Add TLS/mTLS options in database and cache settings for PostgreSQL and Redis

### DIFF
--- a/src/pretix/settings.py
+++ b/src/pretix/settings.py
@@ -83,6 +83,30 @@ if 'mysql' in db_backend:
     db_options['charset'] = 'utf8mb4'
 JSON_FIELD_AVAILABLE = db_backend in ('mysql', 'postgresql')
 
+postgresql_sslmode = config.get('database', 'sslmode', fallback='disable')
+USE_DATABASE_TLS = postgresql_sslmode != 'disable'
+USE_DATABASE_MTLS = USE_DATABASE_TLS and config.has_option('database', 'sslcert')
+
+if USE_DATABASE_TLS or USE_DATABASE_MTLS:
+    tls_config = {}
+    if not USE_DATABASE_MTLS:
+        if 'postgresql' in db_backend:
+            tls_config = {
+                'sslmode': config.get('database', 'sslmode'),
+                'sslrootcert': config.get('database', 'sslrootcert'),
+            }
+    else:
+        if 'postgresql' in db_backend:
+            tls_config = {
+                'sslmode': config.get('database', 'sslmode'),
+                'sslrootcert': config.get('database', 'sslrootcert'),
+                'sslcert': config.get('database', 'sslcert'),
+                'sslkey': config.get('database', 'sslkey'),
+            }
+
+    db_options.update(tls_config)
+
+
 DATABASES = {
     'default': {
         'ENGINE': 'django.db.backends.' + db_backend,
@@ -208,23 +232,61 @@ if HAS_MEMCACHED:
     }
 
 HAS_REDIS = config.has_option('redis', 'location')
+USE_REDIS_SENTINEL = config.has_option('redis', 'sentinels')
+redis_ssl_cert_reqs = config.get('redis', 'ssl_cert_reqs', fallback='none')
+USE_REDIS_TLS = redis_ssl_cert_reqs != 'none'
+USE_REDIS_MTLS = USE_REDIS_TLS and config.has_option('redis', 'ssl_certfile')
+HAS_REDIS_PASSWORD = config.has_option('redis', 'password')
+
 if HAS_REDIS:
+    OPTIONS = {
+        "CLIENT_CLASS": "django_redis.client.DefaultClient",
+        "REDIS_CLIENT_KWARGS": {"health_check_interval": 30}
+    }
+    if USE_REDIS_SENTINEL:
+        DJANGO_REDIS_CONNECTION_FACTORY = "django_redis.pool.SentinelConnectionFactory"
+        OPTIONS["CLIENT_CLASS"] = "django_redis.client.SentinelClient"
+        OPTIONS["CONNECTION_POOL_CLASS"] = "redis.sentinel.SentinelConnectionPool"
+        # See https://github.com/jazzband/django-redis/issues/540
+        OPTIONS["SENTINEL_KWARGS"] = {"socket_timeout": 1}
+        OPTIONS["SENTINELS"] = [tuple(sentinel) for sentinel in loads(config.get('redis', 'sentinels'))]
+
+    if USE_REDIS_TLS or USE_REDIS_MTLS:
+        tls_config = {}
+        if not USE_REDIS_MTLS:
+            tls_config = {
+                'ssl_cert_reqs': config.get('redis', 'ssl_cert_reqs'),
+                'ssl_ca_certs': config.get('redis', 'ssl_ca_certs'),
+            }
+        else:
+            tls_config = {
+                'ssl_cert_reqs': config.get('redis', 'ssl_cert_reqs'),
+                'ssl_ca_certs': config.get('redis', 'ssl_ca_certs'),
+                'ssl_keyfile': config.get('redis', 'ssl_keyfile'),
+                'ssl_certfile': config.get('redis', 'ssl_certfile'),
+            }
+
+        if USE_REDIS_SENTINEL is False:
+            # The CONNECTION_POOL_KWARGS option is necessary for self-signed certs. For further details, please check
+            # https://github.com/jazzband/django-redis/issues/554#issuecomment-949498321
+            OPTIONS["CONNECTION_POOL_KWARGS"] = tls_config
+            OPTIONS["REDIS_CLIENT_KWARGS"].update(tls_config)
+        else:
+            OPTIONS["SENTINEL_KWARGS"].update(tls_config)
+
+    if HAS_REDIS_PASSWORD:
+          OPTIONS["PASSWORD"] = config.get('redis', 'password')
+    
     CACHES['redis'] = {
         "BACKEND": "django_redis.cache.RedisCache",
         "LOCATION": config.get('redis', 'location'),
-        "OPTIONS": {
-            "CLIENT_CLASS": "django_redis.client.DefaultClient",
-            "REDIS_CLIENT_KWARGS": {"health_check_interval": 30}
-        }
+        "OPTIONS": OPTIONS
     }
     CACHES['redis_sessions'] = {
         "BACKEND": "django_redis.cache.RedisCache",
         "LOCATION": config.get('redis', 'location'),
         "TIMEOUT": 3600 * 24 * 30,
-        "OPTIONS": {
-            "CLIENT_CLASS": "django_redis.client.DefaultClient",
-            "REDIS_CLIENT_KWARGS": {"health_check_interval": 30}
-        }
+        "OPTIONS": OPTIONS
     }
     if not HAS_MEMCACHED:
         CACHES['default'] = CACHES['redis']


### PR DESCRIPTION
This PR fixes: #28 

**Current behavior:-**
With the current settings we can use PostgreSQL as database and Redis as cache, we only have to specify it in the configurations.
- For PostgreSQL we can set the `database: backend:` config to `postgresql` 
- For Redis we can give the server location in `redis: location:` config

By giving these configs our application will start running with postgresql and redis as DB and cache respectively.

However, the current `settings.py` does not specify any TLS/mTLS options for DB and cache.

**New Behavior:-**
So to support TLS connections with the database and cache I have added new options only for postgresql database and redis caches.

The new keys added are:-
- for postresql
  - database: sslmode
  - database: sslrootcert
  - database: sslcert
  - database: sslkey
- for redis
  - redis: ssl_cert_reqs
  - redis: ssl_ca_certs
  - redis: ssl_keyfile
  - redis: ssl_certfile
  
These values should be set in the configurations before running the server if we need to run in TLS/mTLS mode.

I have tested the code manually by running postgresql locally on a different port.