### PR TITLE
Removed MariaDB/MySQL Support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,6 @@ FROM python:3.8
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \
             build-essential \
-            default-libmysqlclient-dev \
             gettext \
             git \
             libffi-dev \
@@ -51,7 +50,6 @@ RUN pip3 install -U \
     pip3 install \
         -r requirements.txt \
         -r requirements/memcached.txt \
-        -r requirements/mysql.txt \
         gunicorn django-extensions ipython && \
     rm -rf ~/.cache/pip
 

--- a/doc/admin/config.rst
+++ b/doc/admin/config.rst
@@ -135,7 +135,7 @@ Database settings
 Example::
 
     [database]
-    backend=mysql
+    backend=postgresql
     name=pretix
     user=pretix
     password=abcd
@@ -143,12 +143,8 @@ Example::
     port=3306
 
 ``backend``
-    One of ``mysql``, ``sqlite3``, ``oracle`` and ``postgresql``.
+    One of ``sqlite3``, ``oracle`` and ``postgresql``.
     Default: ``sqlite3``.
-
-    If you use MySQL, be sure to create your database using
-    ``CREATE DATABASE <dbname> CHARACTER SET utf8;``. Otherwise, Unicode
-    support will not properly work.
 
 ``name``
     The database's name. Default: ``db.sqlite3``.
@@ -156,9 +152,6 @@ Example::
 ``user``, ``password``, ``host``, ``port``
     Connection details for the database connection. Empty by default.
 
-``galera``
-    Indicates if the database backend is a MySQL/MariaDB Galera cluster and
-    turns on some optimizations/special case handlers. Default: ``False``
 
 .. _`config-replica`:
 

--- a/src/pretix/settings.py
+++ b/src/pretix/settings.py
@@ -71,17 +71,12 @@ PRETIX_AUTH_BACKENDS = config.get('pretix', 'auth_backends', fallback='pretix.ba
 db_backend = config.get('database', 'backend', fallback='sqlite3')
 if db_backend == 'postgresql_psycopg2':
     db_backend = 'postgresql'
-DATABASE_IS_GALERA = config.getboolean('database', 'galera', fallback=False)
-if DATABASE_IS_GALERA and 'mysql' in db_backend:
-    db_options = {
-        'init_command': 'SET SESSION wsrep_sync_wait = 1;'
-    }
-else:
-    db_options = {}
+if db_backend == 'mysql':
+    print("MySQL/MariaDB is not supported")
+    sys.exit(1)
 
-if 'mysql' in db_backend:
-    db_options['charset'] = 'utf8mb4'
-JSON_FIELD_AVAILABLE = db_backend in ('mysql', 'postgresql')
+JSON_FIELD_AVAILABLE = db_backend == 'postgresql'
+db_options = {}
 
 db_tls_config = build_db_tls_config(config, db_backend)
 if (db_tls_config is not None):
@@ -98,10 +93,7 @@ DATABASES = {
         'PORT': config.get('database', 'port', fallback=''),
         'CONN_MAX_AGE': 0 if db_backend == 'sqlite3' else 120,
         'OPTIONS': db_options,
-        'TEST': {
-            'CHARSET': 'utf8mb4',
-            'COLLATION': 'utf8mb4_unicode_ci',
-        } if 'mysql' in db_backend else {}
+        'TEST': {}
     }
 }
 DATABASE_REPLICA = 'default'
@@ -116,10 +108,7 @@ if config.has_section('replica'):
         'PORT': config.get('replica', 'port', fallback=DATABASES['default']['PORT']),
         'CONN_MAX_AGE': 0 if db_backend == 'sqlite3' else 120,
         'OPTIONS': db_options,
-        'TEST': {
-            'CHARSET': 'utf8mb4',
-            'COLLATION': 'utf8mb4_unicode_ci',
-        } if 'mysql' in db_backend else {}
+        'TEST': {}
     }
     DATABASE_ROUTERS = ['pretix.helpers.database.ReplicaRouter']
 

--- a/src/requirements/mysql.txt
+++ b/src/requirements/mysql.txt
@@ -1,2 +1,0 @@
-mysqlclient
-

--- a/src/setup.py
+++ b/src/setup.py
@@ -203,7 +203,6 @@ setup(
             'freezegun',
         ],
         'memcached': ['pylibmc'],
-        'mysql': ['mysqlclient'],
     },
 
     packages=find_packages(exclude=['tests', 'tests.*']),

--- a/src/tests/travis_mysql.cfg
+++ b/src/tests/travis_mysql.cfg
@@ -1,5 +1,5 @@
 [database]
-backend=mysql
+backend=sqlite3
 name=pretix
 user=root
 password=


### PR DESCRIPTION
This PR fixes #29

Removed `mysql/mariadb` from `dockerfile` and `requirements`.
Added a condition to exit with code 1 if we try to start with `mysql` in config

PS: Their is one more PR which tries to solve the same issue but it misses some changes and is quite old without any activity, so I created this PR.