### PR TITLE
Removed Python 3.6, 3.7 from GitHub Action script

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -18,17 +18,13 @@ jobs:
     name: Tests
     strategy:
       matrix:
-        python-version: [3.6, 3.7, 3.8]
+        python-version: [3.8]
         database: [sqlite, postgres, mysql]
         exclude:
           - database: mysql
-            python-version: 3.7
+            python-version: 3.8
           - database: sqlite
-            python-version: 3.7
-          - database: mysql
-            python-version: 3.6
-          - database: sqlite
-            python-version: 3.6
+            python-version: 3.8
     steps:
       - uses: actions/checkout@v2
       - uses: getong/mariadb-action@v1.1


### PR DESCRIPTION
Fixed: None

Removed Python 3.6, 3.7 from GitHub Action script.