### PR TITLE
Remove jsonfallback: not needed and breaking

### DIFF
--- a/src/requirements/production.txt
+++ b/src/requirements/production.txt
@@ -41,7 +41,6 @@ jsonschema
 openpyxl==3.0.*
 django-oauth-toolkit==1.2.*
 oauthlib==3.1.*
-django-jsonfallback>=2.1.2
 psycopg2-binary==2.8.6
 tqdm==4.*
 # Stripe

--- a/src/setup.py
+++ b/src/setup.py
@@ -158,7 +158,6 @@ setup(
         'chardet<3.1.0,>=3.0.2',
         'mt-940==3.2',
         'django-i18nfield==1.9.*,>=1.9.1',
-        'django-jsonfallback>=2.1.2',
         'psycopg2-binary==2.8.6',
         'tqdm==4.*',
         'vobject==0.9.*',


### PR DESCRIPTION
As pointed out in https://github.com/fossasia/eventyay-tickets/pull/98#issuecomment-2123539094, the `django-mysql` being used doesn't have the `connection_is_mariadb` function and even though there were efforts to remove that it seems dependencies were not adjusted accordingly. It seems like `django-jsonfallback` is actually not compatible with the version we use of `django-mysql` due to the `connection_is_mariadb` dependency, even at its latest version.

However it seems like [#diff-39276994c50b9f2771c0cffec4886e775edcf1c739f13fca75c4c406340119b7](https://github.com/fossasia/eventyay-tickets/commit/c308e868eb360d5d70879462e4b8295264bb587c#diff-39276994c50b9f2771c0cffec4886e775edcf1c739f13fca75c4c406340119b7) introduced a replacement for `[django-jsonfallback](https://github.com/raphaelm/django-jsonfallback/tree/master)` functions but missed removing the dependency. Doing it here.

Note that this is untested and only fixing `django-jsonfallback` there might be other inconsistent dependencies.