### PR TITLE
Workflow to build specific PRs for autodeployment

### DIFF
--- a/.github/workflows/docker-pr-deploy.yml
+++ b/.github/workflows/docker-pr-deploy.yml
@@ -24,5 +24,5 @@ jobs:
         with:
           context: .
           push: true
-          tags: pr-deployment
+          tags: deployment
           labels: eventyay/eventyay-tickets

--- a/.github/workflows/docker-pr-deploy.yml
+++ b/.github/workflows/docker-pr-deploy.yml
@@ -1,0 +1,28 @@
+name: Docker-pr-deploy
+on:
+  workflow_dispatch:
+
+jobs:
+  push_to_registry:
+    name: Push Docker image to Docker hub
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out the repo
+        uses: actions/checkout@v4
+        with:
+          repository: inputs.repository
+          ref: inputs.ref
+      
+      - name: Log in to Docker Hub
+        uses: docker/login-action@f054a8b539a109f9f41c372932f1ae047eff08c9
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+      
+      - name: Build and push Docker image
+        uses: docker/build-push-action@ad44023a93711e3deb337508980b4b5e9bcdc5dc
+        with:
+          context: .
+          push: true
+          tags: pr-deployment
+          labels: eventyay/eventyay-tickets


### PR DESCRIPTION
Adding a workflow that helps build PRs from any repo and reference declared on the input and pushes them to `eventyay/eventyay-tickets` with the tag `pr-deployment` so we can auto deploy them in the test server that has been recently created and check the result before merging.