### PR TITLE
Add orientation and height fields to Badgelayouts API response

### DIFF
--- a/doc/plugins/badges.rst
+++ b/doc/plugins/badges.rst
@@ -77,7 +77,7 @@ Endpoints
 
    .. sourcecode:: http
 
-      GET /api/v1/organizers/bigevents/events/democon/layoutsbadge/1/ HTTP/1.1
+      GET /api/v1/organizers/bigevents/events/democon/badgelayouts/1/ HTTP/1.1
       Host: pretix.eu
       Accept: application/json, text/javascript
 

--- a/src/pretix/plugins/badges/api.py
+++ b/src/pretix/plugins/badges/api.py
@@ -21,10 +21,11 @@ class NestedItemAssignmentSerializer(I18nAwareModelSerializer):
 class BadgeLayoutSerializer(I18nAwareModelSerializer):
     layout = CompatibleJSONField()
     item_assignments = NestedItemAssignmentSerializer(many=True)
+    size = CompatibleJSONField()
 
     class Meta:
         model = BadgeLayout
-        fields = ('id', 'name', 'default', 'layout', 'background', 'item_assignments')
+        fields = ('id', 'name', 'default', 'layout', 'size', 'background', 'item_assignments')
 
 
 class BadgeLayoutViewSet(viewsets.ReadOnlyModelViewSet):

--- a/src/pretix/plugins/badges/migrations/0002_initial.py
+++ b/src/pretix/plugins/badges/migrations/0002_initial.py
@@ -16,6 +16,11 @@ class Migration(migrations.Migration):
     operations = [
         migrations.AddField(
             model_name='badgelayout',
+            name='size',
+            field=models.TextField(default='[{"width": 148, "height": 105, "orientation": "portrait"}]'),
+        ),
+        migrations.AddField(
+            model_name='badgelayout',
             name='event',
             field=models.ForeignKey(on_delete=django.db.models.deletion.CASCADE, related_name='badge_layouts', to='pretixbase.event'),
         ),

--- a/src/pretix/plugins/badges/models.py
+++ b/src/pretix/plugins/badges/models.py
@@ -36,6 +36,12 @@ class BadgeLayout(LoggedModel):
                 '"fontfamily":"Open Sans","bold":true,"italic":false,"width":"121.83","content":"attendee_name",'
                 '"text":"Max Mustermann","align":"center"}]'
     )
+
+    size = models.TextField(
+            default='[{"width": 148, "height": 105, "orientation": "portrait"}]'
+    )
+    
+
     background = models.FileField(null=True, blank=True, upload_to=bg_name, max_length=255)
 
     class Meta:


### PR DESCRIPTION
This PR aims to solve Issue #188 , this PR also fixes a small error with the Badgelayouts API Documentation

- [x]  Added Default values in a filed called Size

```  json     
 "size": [
                {
                    "width": 148,
                    "height": 105,
                    "orientation": "portrait"
                }
            ],
```

- [ ] Dynamic updation  of height, width and orientation based of background