### PR TITLE
Allows tab IDs to be set in the HTML code

### DIFF
--- a/src/pretix/control/templates/pretixcontrol/item/index.html
+++ b/src/pretix/control/templates/pretixcontrol/item/index.html
@@ -116,7 +116,7 @@
                         {% bootstrap_field form.generate_tickets layout="control" %}
                         {% bootstrap_field form.checkin_attention layout="control" %}
                     </fieldset>
-                    <fieldset>
+                    <fieldset id="tab-item-additional-settings">
                         <legend>{% trans "Additional settings" %}</legend>
                         {% bootstrap_field form.issue_giftcard layout="control" %}
                         {% bootstrap_field form.show_quota_left layout="control" %}

--- a/src/pretix/control/templates/pretixcontrol/organizers/edit.html
+++ b/src/pretix/control/templates/pretixcontrol/organizers/edit.html
@@ -151,7 +151,7 @@
                         {% bootstrap_field sform.name_scheme layout="control" %}
                         {% bootstrap_field sform.name_scheme_titles layout="control" %}
                     </fieldset>
-                    <fieldset>
+                    <fieldset id="tab-organizer-privacy">
                         <legend>{% trans "Privacy" %}</legend>
                         {% bootstrap_field sform.privacy_policy layout="control" %}
                     </fieldset>

--- a/src/pretix/static/pretixcontrol/js/ui/tabs.js
+++ b/src/pretix/static/pretixcontrol/js/ui/tabs.js
@@ -12,7 +12,8 @@ $(function () {
         var validity_error = false;
         $form.find("fieldset").each(function () {
             var $fieldset = $(this);
-            var tid = "tab-" + j + "-" + i;
+            var tid = $fieldset.attr("id");
+            if (!tid) tid = "tab-" + j + "-" + i;
             var $tabli = $("<li>").appendTo($tabs);
             var $tablink = $("<a>").attr("role", "tab")
                 .attr("data-toggle", "tab")


### PR DESCRIPTION
> Fixes [#153  Fix tab links](https://github.com/fossasia/eventyay-video/issues/153)
> 
> #### Short description of what this resolves:
> Set tab IDs in HTML code, making them persistent if new tab is added by plugins.
> 
> #### Changes proposed in this pull request:
> * Set tab IDs for additional setting tab and privacy policy tab
> 
> #### Checklist
> * [x]  I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia).
> * [x]  My branch is up-to-date with the Upstream `development` branch.
> * [ ]  The acceptance, integration, unit tests and linter pass locally with my changes
> * [ ]  I have added tests that prove my fix is effective or that my feature works
> * [ ]  I have added necessary documentation (if appropriate)