### PR TITLE
Revoked devices to be removed from device list

### DIFF
--- a/src/pretix/control/templates/pretixcontrol/organizers/devices.html
+++ b/src/pretix/control/templates/pretixcontrol/organizers/devices.html
@@ -42,6 +42,7 @@
                 </thead>
                 <tbody>
                 {% for d in devices %}
+                {% if not d.revoked %}
                     <tr {% if d.revoked %}class="text-muted"{% endif %}>
                         <td>
                             {{ d.device_id }}
@@ -103,6 +104,7 @@
                                     class="btn btn-default btn-sm"><i class="fa fa-edit"></i></a>
                         </td>
                     </tr>
+                {% endif %}
                 {% endfor %}
                 </tbody>
             </table>


### PR DESCRIPTION
This PR solves issue #242 , revoked devices will be removed from the list with a prompt.

**Before Revoking**
<img width="1470" alt="image" src="https://github.com/user-attachments/assets/b258b3fe-11d0-4fb7-8cb4-326426c89620">

**After Revoking**
<img width="1470" alt="image" src="https://github.com/user-attachments/assets/656c7f4c-21b0-4118-b94e-d576f1cd81a1">

<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

This pull request enhances the device management feature by ensuring that revoked devices are removed from the device list, improving the clarity and accuracy of the displayed information.

- **Enhancements**:
    - Revoked devices are now removed from the device list with a prompt.

<!-- Generated by sourcery-ai[bot]: end summary -->