### PR TITLE
Implement script to create customer account for customer placed order before

### DIFF
--- a/src/pretix/base/management/commands/create_customer_account.py
+++ b/src/pretix/base/management/commands/create_customer_account.py
@@ -8,7 +8,7 @@ from pretix.base.models import Organizer, Event, Order, Customer
 
 
 class Command(BaseCommand):
-    help = 'Create SocialApp entries for Eventyay-ticket Provider'
+    help = 'Create customer account for all orders with email address.'
 
     def add_arguments(self, parser):
         parser.add_argument('--organizer-slug', type=str, help='Organizer Slug')

--- a/src/pretix/base/management/commands/create_customer_account.py
+++ b/src/pretix/base/management/commands/create_customer_account.py
@@ -1,0 +1,61 @@
+import sys
+
+from django.core.management.base import BaseCommand
+from django_scopes import scopes_disabled
+
+from pretix.base.forms.questions import NamePartsFormField
+from pretix.base.i18n import get_language_without_region
+from pretix.base.models import Organizer, Event, Order, Customer
+from pretix.base.settings import PERSON_NAME_SCHEMES
+
+
+class Command(BaseCommand):
+    help = 'Create SocialApp entries for Eventyay-ticket Provider'
+
+    def add_arguments(self, parser):
+        parser.add_argument('--organizer-slug', type=str, help='Organizer Slug')
+        parser.add_argument('--event-slug', type=str, help='Event Slug')
+
+    def handle(self, *args, **options):
+        organizer_slug = options.get('organizer-slug') or input('Enter Organizer Slug: ')
+        event_slug = options.get('event-slug') or input('Enter Event Slug: ')
+
+        try:
+            with scopes_disabled():
+                organizer = Organizer.objects.get(slug=organizer_slug)
+                event = Event.objects.get(slug=event_slug, organizer=organizer)
+        except Organizer.DoesNotExist:
+            self.stderr.write(self.style.ERROR('Organizer not found.'))
+            sys.exit(1)
+        except Event.DoesNotExist:
+            self.stderr.write(self.style.ERROR('Event not found.'))
+            sys.exit(1)
+
+        if not organizer.settings.customer_accounts or not organizer.settings.customer_accounts_native:
+            self.stderr.write(self.style.ERROR('Organizer not enable customer account yet.'))
+            sys.exit(1)
+
+        with scopes_disabled():
+            orders = Order.objects.filter(event=event)
+            # Get all orders email and check if they have a customer account or not
+            for order in orders:
+                if order.email:
+                    customer = Customer.objects.filter(email=order.email).first()
+                    if not customer:
+                        name_parts_data = {
+                            "_scheme": "full",
+                            "full_name":order.email.split("@")[0]
+                        }
+                        customer = organizer.customers.create(
+                            email=order.email,
+                            name_parts=name_parts_data,
+                            is_active=True,
+                            is_verified=False,
+                            locale=get_language_without_region(),
+                        )
+                        customer.set_unusable_password()
+                        customer.save()
+                    # Update order with customer
+                    if order.customer is None:
+                        order.customer = customer
+                        order.save()

--- a/src/pretix/base/management/commands/create_customer_account.py
+++ b/src/pretix/base/management/commands/create_customer_account.py
@@ -3,10 +3,8 @@ import sys
 from django.core.management.base import BaseCommand
 from django_scopes import scopes_disabled
 
-from pretix.base.forms.questions import NamePartsFormField
 from pretix.base.i18n import get_language_without_region
 from pretix.base.models import Organizer, Event, Order, Customer
-from pretix.base.settings import PERSON_NAME_SCHEMES
 
 
 class Command(BaseCommand):


### PR DESCRIPTION
This PR is partly of this issue https://github.com/fossasia/eventyay-talk/issues/166

Implement a script to create customer account for customer who placed order before.
By execute this script create_customer_account: python manage.py create_customer_account
then input organizer and event short name.
1. It will scan all the order of event.
2. detect order with email not have customer account
3. create customer account and link to that order
4. for order already have account, link that customer account to order as well

<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

Add a script to create customer accounts for orders that do not have an associated customer account. The script scans all orders for a specified event and links existing customer accounts or creates new ones if necessary.

New Features:
- Introduce a management command to create customer accounts for orders without associated customer accounts.

<!-- Generated by sourcery-ai[bot]: end summary -->