### PR TITLE
Update join_online_event placeholder

### DIFF
--- a/src/pretix/multidomain/urlreverse.py
+++ b/src/pretix/multidomain/urlreverse.py
@@ -174,7 +174,7 @@ def generate_token_url(event, order, position):
     else:
         # else user position Id to generate token
         video_url = generate_token(event, None, position)
-    return '<a href="{}" class="button">Join online event</a>'.format(video_url)
+    return video_url
 
 
 def generate_token(event, customer_code, position):


### PR DESCRIPTION
Instead of return 'Join online event' button which not able to translate to other languages, return url and then can be set to button with input languages.

<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

Return the URL for joining an online event instead of an HTML button, allowing for language-specific button text to be set externally.

<!-- Generated by sourcery-ai[bot]: end summary -->