### PR TITLE
Add space between notification and header

### DIFF
--- a/src/pretix/static/pretixbase/scss/_theme.scss
+++ b/src/pretix/static/pretixbase/scss/_theme.scss
@@ -118,6 +118,7 @@
 .alert-success, .alert-danger, .alert-info, .alert-warning, .alert-legal {
   position: relative;
   padding-left: 65px;
+  margin-top: 10px;
 
   &::before {
     color: white;


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/ffa602cc-67a0-42c5-bab7-a7ba1e864787)

<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

Add margin-top to notification alerts to create space between the notification and the header, improving visual spacing.

Enhancements:
- Add margin-top to notification alerts to create space between the notification and the header.

<!-- Generated by sourcery-ai[bot]: end summary -->