### PR TITLE
Update psycopg2 to version 2.9.9

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -65,7 +65,7 @@ dependencies = [
         'chardet==5.1.*',
         'mt-940==4.30.*',
         'django-i18nfield==1.9.*,>=1.9.4',
-        'psycopg2-binary',
+        'psycopg2-binary==2.9.9',
         'tqdm==4.*',
         'vobject==0.9.*',
         'pycountry',


### PR DESCRIPTION
Relate this issue #91 
Currently eventyay-ticket not specify psycopg2 version, so it take latest version which is 2.9.9
However, it's generally a good practice to specify the version of the packages using to ensure the consistency and reproducibility of your project's environment.
