### PR TITLE
Rename Wikimania Katowice to a variable for {event}

### DIFF
--- a/src/pretix/locale/ar/LC_MESSAGES/django.po
+++ b/src/pretix/locale/ar/LC_MESSAGES/django.po
@@ -24407,3 +24407,9 @@ msgstr "طلباتي"
 
 msgid "Logout"
 msgstr "تسجيل الخروج"
+
+msgid "Want to create a %(event_name)s account?"
+msgstr "هل تريد إنشاء حساب %(event_name)s؟"
+
+msgid "Already have a %(event_name)s account?"
+msgstr "هل لديك حساب %(event_name)s بالفعل؟"

--- a/src/pretix/locale/ca/LC_MESSAGES/django.po
+++ b/src/pretix/locale/ca/LC_MESSAGES/django.po
@@ -23294,3 +23294,9 @@ msgstr "Les meves comandes"
 
 msgid "Logout"
 msgstr "Tancar sessió"
+
+msgid "Want to create a %(event_name)s account?"
+msgstr "Voleu crear un compte de %(event_name)s?"
+
+msgid "Already have a %(event_name)s account?"
+msgstr "Ja teniu un compte de %(event_name)s?"

--- a/src/pretix/locale/cs/LC_MESSAGES/django.po
+++ b/src/pretix/locale/cs/LC_MESSAGES/django.po
@@ -21176,3 +21176,9 @@ msgstr "Moje objednávky"
 
 msgid "Logout"
 msgstr "Odhlásit se"
+
+msgid "Want to create a %(event_name)s account?"
+msgstr "Voleu crear un compte de %(event_name)s?"
+
+msgid "Already have a %(event_name)s account?"
+msgstr "Ja teniu un compte de %(event_name)s?"

--- a/src/pretix/locale/da/LC_MESSAGES/django.po
+++ b/src/pretix/locale/da/LC_MESSAGES/django.po
@@ -24708,3 +24708,9 @@ msgstr "Mine ordrer"
 
 msgid "Logout"
 msgstr "Log ud"
+
+msgid "Want to create a %(event_name)s account?"
+msgstr "Vil du oprette en %(event_name)s konto?"
+
+msgid "Already have a %(event_name)s account?"
+msgstr "Har du allerede en %(event_name)s konto?"

--- a/src/pretix/locale/de/LC_MESSAGES/django.po
+++ b/src/pretix/locale/de/LC_MESSAGES/django.po
@@ -25661,3 +25661,9 @@ msgstr "Nehmen Sie an der Online-Veranstaltung teil"
 
 msgid "My Orders"
 msgstr "Meine Bestellungen"
+
+msgid "Want to create a %(event_name)s account?"
+msgstr "Möchten Sie ein %(event_name)s Konto erstellen?"
+
+msgid "Already have a %(event_name)s account?"
+msgstr "Haben Sie bereits ein %(event_name)s Konto?"

--- a/src/pretix/locale/de_Informal/LC_MESSAGES/django.po
+++ b/src/pretix/locale/de_Informal/LC_MESSAGES/django.po
@@ -25607,3 +25607,9 @@ msgstr "Nehmen Sie an der Online-Veranstaltung teil"
 
 msgid "My Orders"
 msgstr "Meine Bestellungen"
+
+msgid "Want to create a %(event_name)s account?"
+msgstr "Möchtest du ein %(event_name)s Konto erstellen?"
+
+msgid "Already have a %(event_name)s account?"
+msgstr "Hast du bereits ein %(event_name)s Konto?"

--- a/src/pretix/locale/django.pot
+++ b/src/pretix/locale/django.pot
@@ -21057,3 +21057,9 @@ msgstr ""
 
 msgid "Logout"
 msgstr ""
+
+msgid "Want to create a %(event_name)s account?"
+msgstr ""
+
+msgid "Already have a %(event_name)s account?"
+msgstr ""

--- a/src/pretix/locale/el/LC_MESSAGES/django.po
+++ b/src/pretix/locale/el/LC_MESSAGES/django.po
@@ -25764,3 +25764,9 @@ msgstr "Οι παραγγελίες μου"
 
 msgid "Logout"
 msgstr "Αποσύνδεση"
+
+msgid "Want to create a %(event_name)s account?"
+msgstr "Θέλετε να δημιουργήσετε έναν λογαριασμό %(event_name)s;"
+
+msgid "Already have a %(event_name)s account?"
+msgstr "Έχετε ήδη λογαριασμό %(event_name)s;"

--- a/src/pretix/locale/es/LC_MESSAGES/django.po
+++ b/src/pretix/locale/es/LC_MESSAGES/django.po
@@ -25975,3 +25975,9 @@ msgstr "Mis pedidos"
 
 msgid "Logout"
 msgstr "Cerrar sesión"
+
+msgid "Want to create a %(event_name)s account?"
+msgstr "¿Quieres crear una cuenta de %(event_name)s?"
+
+msgid "Already have a %(event_name)s account?"
+msgstr "¿Ya tienes una cuenta de %(event_name)s?"

--- a/src/pretix/locale/fi/LC_MESSAGES/django.po
+++ b/src/pretix/locale/fi/LC_MESSAGES/django.po
@@ -21336,3 +21336,9 @@ msgstr "Tilaukseni"
 
 msgid "Logout"
 msgstr "Kirjaudu ulos"
+
+msgid "Want to create a %(event_name)s account?"
+msgstr "Haluatko luoda %(event_name)s-tilin?"
+
+msgid "Already have a %(event_name)s account?"
+msgstr "Onko sinulla jo %(event_name)s-tili?"

--- a/src/pretix/locale/fr/LC_MESSAGES/django.po
+++ b/src/pretix/locale/fr/LC_MESSAGES/django.po
@@ -26662,3 +26662,9 @@ msgstr "Mes commandes"
 
 msgid "Logout"
 msgstr "Se déconnecter"
+
+msgid "Want to create a %(event_name)s account?"
+msgstr "Voulez-vous créer un compte %(event_name)s?"
+
+msgid "Already have a %(event_name)s account?"
+msgstr "Avez-vous déjà un compte %(event_name)s?"

--- a/src/pretix/locale/hu/LC_MESSAGES/django.po
+++ b/src/pretix/locale/hu/LC_MESSAGES/django.po
@@ -21255,3 +21255,9 @@ msgstr "Rendeléseim"
 
 msgid "Logout"
 msgstr "Kijelentkezés"
+
+msgid "Want to create a %(event_name)s account?"
+msgstr "Szeretnél létrehozni egy %(event_name)s fiókot?"
+
+msgid "Already have a %(event_name)s account?"
+msgstr "Már van %(event_name)s fiókod?"

--- a/src/pretix/locale/it/LC_MESSAGES/django.po
+++ b/src/pretix/locale/it/LC_MESSAGES/django.po
@@ -22083,3 +22083,9 @@ msgstr "I miei ordini"
 
 msgid "Logout"
 msgstr "Disconnettersi"
+
+msgid "Want to create a %(event_name)s account?"
+msgstr "Vuoi creare un account %(event_name)s?"
+
+msgid "Already have a %(event_name)s account?"
+msgstr "Hai già un account %(event_name)s?"

--- a/src/pretix/locale/lv/LC_MESSAGES/django.po
+++ b/src/pretix/locale/lv/LC_MESSAGES/django.po
@@ -22587,3 +22587,9 @@ msgstr "Mani pasūtījumi"
 
 msgid "Logout"
 msgstr "Izrakstīties"
+
+msgid "Want to create a %(event_name)s account?"
+msgstr "Vai vēlaties izveidot %(event_name)s kontu?"
+
+msgid "Already have a %(event_name)s account?"
+msgstr "Vai jums jau ir %(event_name)s konts?"

--- a/src/pretix/locale/nb_NO/LC_MESSAGES/django.po
+++ b/src/pretix/locale/nb_NO/LC_MESSAGES/django.po
@@ -21056,3 +21056,9 @@ msgstr ""
 
 msgid "Logout"
 msgstr ""
+
+msgid "Want to create a %(event_name)s account?"
+msgstr ""
+
+msgid "Already have a %(event_name)s account?"
+msgstr ""

--- a/src/pretix/locale/nl/LC_MESSAGES/django.po
+++ b/src/pretix/locale/nl/LC_MESSAGES/django.po
@@ -24825,3 +24825,9 @@ msgstr "Mijn bestellingen"
 
 msgid "Logout"
 msgstr "Uitloggen"
+
+msgid "Want to create a %(event_name)s account?"
+msgstr "Wil je een %(event_name)s account aanmaken?"
+
+msgid "Already have a %(event_name)s account?"
+msgstr "Heb je al een %(event_name)s account?"

--- a/src/pretix/locale/nl_BE/LC_MESSAGES/django.po
+++ b/src/pretix/locale/nl_BE/LC_MESSAGES/django.po
@@ -21056,3 +21056,9 @@ msgstr ""
 
 msgid "Logout"
 msgstr ""
+
+msgid "Want to create a %(event_name)s account?"
+msgstr ""
+
+msgid "Already have a %(event_name)s account?"
+msgstr ""

--- a/src/pretix/locale/nl_Informal/LC_MESSAGES/django.po
+++ b/src/pretix/locale/nl_Informal/LC_MESSAGES/django.po
@@ -24696,3 +24696,9 @@ msgstr "Mijn bestellingen"
 
 msgid "Logout"
 msgstr "Afmelden"
+
+msgid "Want to create a %(event_name)s account?"
+msgstr "Wil je een %(event_name)s account aanmaken?"
+
+msgid "Already have a %(event_name)s account?"
+msgstr "Heb je al een %(event_name)s account?"

--- a/src/pretix/locale/pl/LC_MESSAGES/django.po
+++ b/src/pretix/locale/pl/LC_MESSAGES/django.po
@@ -22086,3 +22086,9 @@ msgstr "Moje zamówienia"
 
 msgid "Logout"
 msgstr "Wyloguj się"
+
+msgid "Want to create a %(event_name)s account?"
+msgstr "Chcesz utworzyć konto %(event_name)s?"
+
+msgid "Already have a %(event_name)s account?"
+msgstr "Masz już konto %(event_name)s?"

--- a/src/pretix/locale/pl_Informal/LC_MESSAGES/django.po
+++ b/src/pretix/locale/pl_Informal/LC_MESSAGES/django.po
@@ -21058,3 +21058,9 @@ msgstr "Moje zamówienia"
 
 msgid "Logout"
 msgstr "Wyloguj się"
+
+msgid "Want to create a %(event_name)s account?"
+msgstr "Chcesz utworzyć konto %(event_name)s?"
+
+msgid "Already have a %(event_name)s account?"
+msgstr "Masz już konto %(event_name)s?"

--- a/src/pretix/locale/pt/LC_MESSAGES/django.po
+++ b/src/pretix/locale/pt/LC_MESSAGES/django.po
@@ -28,7 +28,8 @@ msgstr ""
 msgid "pretixSCAN"
 msgstr ""
 
-#: pretix/api/auth/devicesecurity.py:52msgid "pretixSCAN (kiosk mode, online only)"
+#: pretix/api/auth/devicesecurity.py:52
+msgid "pretixSCAN (kiosk mode, online only)"
 msgstr ""
 
 #: pretix/api/auth/devicesecurity.py:80

--- a/src/pretix/locale/pt/LC_MESSAGES/django.po
+++ b/src/pretix/locale/pt/LC_MESSAGES/django.po
@@ -28,8 +28,7 @@ msgstr ""
 msgid "pretixSCAN"
 msgstr ""
 
-#: pretix/api/auth/devicesecurity.py:52
-msgid "pretixSCAN (kiosk mode, online only)"
+#: pretix/api/auth/devicesecurity.py:52msgid "pretixSCAN (kiosk mode, online only)"
 msgstr ""
 
 #: pretix/api/auth/devicesecurity.py:80
@@ -21057,3 +21056,9 @@ msgstr ""
 
 msgid "Logout"
 msgstr ""
+
+msgid "Want to create a %(event_name)s account?"
+msgstr "Quer criar uma conta %(event_name)s?"
+
+msgid "Already have a %(event_name)s account?"
+msgstr "Já tem uma conta %(event_name)s?"

--- a/src/pretix/locale/pt_BR/LC_MESSAGES/django.po
+++ b/src/pretix/locale/pt_BR/LC_MESSAGES/django.po
@@ -22880,3 +22880,9 @@ msgstr "Meus pedidos"
 
 msgid "Logout"
 msgstr "Sair"
+
+msgid "Want to create a %(event_name)s account?"
+msgstr "Quer criar uma conta %(event_name)s?"
+
+msgid "Already have a %(event_name)s account?"
+msgstr "Já tem uma conta %(event_name)s?"

--- a/src/pretix/locale/pt_PT/LC_MESSAGES/django.po
+++ b/src/pretix/locale/pt_PT/LC_MESSAGES/django.po
@@ -24097,3 +24097,9 @@ msgstr "Minhas encomendas"
 
 msgid "Logout"
 msgstr "Encerrar sessão"
+
+msgid "Want to create a %(event_name)s account?"
+msgstr "Quer criar uma conta %(event_name)s?"
+
+msgid "Already have a %(event_name)s account?"
+msgstr "Já tem uma conta %(event_name)s?"

--- a/src/pretix/locale/ro/LC_MESSAGES/django.po
+++ b/src/pretix/locale/ro/LC_MESSAGES/django.po
@@ -21060,3 +21060,9 @@ msgstr ""
 
 msgid "Logout"
 msgstr ""
+
+msgid "Want to create a %(event_name)s account?"
+msgstr "Doriți să creați un cont %(event_name)s?"
+
+msgid "Already have a %(event_name)s account?"
+msgstr "Aveți deja un cont %(event_name)s?"

--- a/src/pretix/locale/ru/LC_MESSAGES/django.po
+++ b/src/pretix/locale/ru/LC_MESSAGES/django.po
@@ -22674,3 +22674,9 @@ msgstr "Мои заказы"
 
 msgid "Logout"
 msgstr "Выйти"
+
+msgid "Want to create a %(event_name)s account?"
+msgstr "Хотите создать аккаунт %(event_name)s?"
+
+msgid "Already have a %(event_name)s account?"
+msgstr "У вас уже есть аккаунт %(event_name)s?"

--- a/src/pretix/locale/sl/LC_MESSAGES/django.po
+++ b/src/pretix/locale/sl/LC_MESSAGES/django.po
@@ -21934,3 +21934,9 @@ msgstr "Moja naročila"
 
 msgid "Logout"
 msgstr "Odjava"
+
+msgid "Want to create a %(event_name)s account?"
+msgstr "ඔබට %(event_name)s ගිණුමක් සාදන්න අවශ්‍යද?"
+
+msgid "Already have a %(event_name)s account?"
+msgstr "ඔබට දැනටමත් %(event_name)s ගිණුමක් තිබේද?"

--- a/src/pretix/locale/sv/LC_MESSAGES/django.po
+++ b/src/pretix/locale/sv/LC_MESSAGES/django.po
@@ -22076,3 +22076,9 @@ msgstr "Mina beställningar"
 
 msgid "Logout"
 msgstr "Logga ut"
+
+msgid "Want to create a %(event_name)s account?"
+msgstr "Želite ustvariti račun %(event_name)s?"
+
+msgid "Already have a %(event_name)s account?"
+msgstr "Ali že imate račun %(event_name)s?"

--- a/src/pretix/locale/tr/LC_MESSAGES/django.po
+++ b/src/pretix/locale/tr/LC_MESSAGES/django.po
@@ -25935,3 +25935,9 @@ msgstr "Siparişlerim"
 
 msgid "Logout"
 msgstr "Çıkış Yap"
+
+msgid "Want to create a %(event_name)s account?"
+msgstr "%(event_name)s hesabı oluşturmak ister misiniz?"
+
+msgid "Already have a %(event_name)s account?"
+msgstr "Zaten bir %(event_name)s hesabınız var mı?"

--- a/src/pretix/locale/ua/LC_MESSAGES/django.po
+++ b/src/pretix/locale/ua/LC_MESSAGES/django.po
@@ -20831,3 +20831,9 @@ msgstr ""
 
 msgid "Join online event"
 msgstr ""
+
+msgid "Want to create a %(event_name)s account?"
+msgstr "Бажаєте створити обліковий запис %(event_name)s?"
+
+msgid "Already have a %(event_name)s account?"
+msgstr "Вже маєте обліковий запис %(event_name)s?"

--- a/src/pretix/locale/zh_Hans/LC_MESSAGES/django.po
+++ b/src/pretix/locale/zh_Hans/LC_MESSAGES/django.po
@@ -24233,3 +24233,9 @@ msgstr "我的订单"
 
 msgid "Logout"
 msgstr "退出登录"
+
+msgid "Want to create a %(event_name)s account?"
+msgstr "想创建一个%(event_name)s账户吗?"
+
+msgid "Already have a %(event_name)s account?"
+msgstr "已经有一个%(event_name)s账户了吗?"

--- a/src/pretix/presale/templates/pretixpresale/fragment_modals.html
+++ b/src/pretix/presale/templates/pretixpresale/fragment_modals.html
@@ -64,17 +64,17 @@
                     </a>
                 </p>
                 <p class="text">
-                    {% trans "Want to create a " %}
-                    {{ event_name }}
-                    {% trans "account?" %}
+                    {% blocktrans with event_name=event_name %}
+                        Want to create a {{ event_name }} account?
+                    {% endblocktrans %}
                     <a class="btn btn-link" href='{% eventurl request.organizer "presale:organizer.customer.register" %}'>
                         {% trans "Sign up here" %}
                     </a>
                 </p>
                 <p class="text">
-                    {% trans "Already have a " %}
-                    {{ event_name }}
-                    {% trans "account?" %}
+                    {% blocktrans with event_name=event_name %}
+                        Already have a {{ event_name }} account?
+                    {% endblocktrans %}
                     <a class="btn btn-link" href='{% eventurl request.organizer "presale:organizer.customer.login" %}'>
                         {% trans "Login here" %}
                     </a>

--- a/src/pretix/presale/templates/pretixpresale/fragment_modals.html
+++ b/src/pretix/presale/templates/pretixpresale/fragment_modals.html
@@ -64,13 +64,17 @@
                     </a>
                 </p>
                 <p class="text">
-                    {% trans "Want to create a Wikimania Katowice account?" %}
+                    {% trans "Want to create a " %}
+                    {{ event_name }}
+                    {% trans "account?" %}
                     <a class="btn btn-link" href='{% eventurl request.organizer "presale:organizer.customer.register" %}'>
                         {% trans "Sign up here" %}
                     </a>
                 </p>
                 <p class="text">
-                    {% trans "Already have a Wikimania Katowice account?" %}
+                    {% trans "Already have a " %}
+                    {{ event_name }}
+                    {% trans "account?" %}
                     <a class="btn btn-link" href='{% eventurl request.organizer "presale:organizer.customer.login" %}'>
                         {% trans "Login here" %}
                     </a>

--- a/src/pretix/presale/views/event.py
+++ b/src/pretix/presale/views/event.py
@@ -434,6 +434,16 @@ class EventIndex(EventViewMixin, EventListMixin, CartMixin, TemplateView):
         else:
             context['cart_redirect'] = self.request.path
 
+        # Get event_name in language code
+        event_name = self.request.event.name.data.get(self.request.LANGUAGE_CODE)
+        if event_name is None:
+            # If event_name is not available in the language code, get event name in english
+            event_name = self.request.event.name.data.get('en')
+        if event_name is None and len(self.request.event.name.data) > 0:
+            # If event_name is not available in english, get the first available event name
+            event_name = next(iter(self.request.event.name.data.values()))
+        context['event_name'] = event_name
+
         return context
 
     def _subevent_list_context(self):


### PR DESCRIPTION
> Fixes [#302 ](https://github.com/fossasia/eventyay-tickets/issues/302)
> 
> #### Short description of what this resolves:
> Get event name variable instead of hardcode event name.
> 
> #### Changes proposed in this pull request:
> * Get event name base on current language and set in message
> 
> #### Checklist
> * [x]  I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia).
> * [x]  My branch is up-to-date with the Upstream `development` branch.
> * [ ]  The acceptance, integration, unit tests and linter pass locally with my changes
> * [ ]  I have added tests that prove my fix is effective or that my feature works
> * [ ]  I have added necessary documentation (if appropriate)

<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

Refactor the code to dynamically retrieve the event name based on the current language setting, replacing the hardcoded 'Wikimania Katowice' with a variable. This ensures that the event name is displayed correctly in the user's preferred language.

Enhancements:
- Replace hardcoded event name 'Wikimania Katowice' with a dynamic variable that retrieves the event name based on the current language setting.

<!-- Generated by sourcery-ai[bot]: end summary -->