### PR TITLE
Unified QR response

### DIFF
--- a/src/pretix/base/pdf.py
+++ b/src/pretix/base/pdf.py
@@ -6,6 +6,7 @@ import os
 import subprocess
 import tempfile
 import uuid
+import json
 from collections import OrderedDict
 from functools import partial
 from io import BytesIO
@@ -552,11 +553,11 @@ class Renderer:
 
     def _draw_barcodearea(self, canvas: Canvas, op: OrderPosition, o: dict):
         content = o.get('content', 'secret')
-        if content == 'secret':
-            content = op.secret
-        elif content == 'pseudonymization_id':
-            content = op.pseudonymization_id
-
+        content_dict = {
+                'ticket': op.secret,
+                'lead': op.pseudonymization_id
+        }
+        content = json.dumps(content_dict)
         level = 'H'
         if len(content) > 32:
             level = 'M'

--- a/src/pretix/base/pdf.py
+++ b/src/pretix/base/pdf.py
@@ -554,6 +554,7 @@ class Renderer:
     def _draw_barcodearea(self, canvas: Canvas, op: OrderPosition, o: dict):
         content = o.get('content', 'secret')
         content_dict = {
+                'event': str(op.event),
                 'ticket': op.secret,
                 'lead': op.pseudonymization_id
         }


### PR DESCRIPTION
This PR tries to Solve Issue #191 (Integrate Check-in and Lead Scanning into a Single QR Code)

Since both the codes are generated on a order they are now embedded into a single QR in the following json format

```json
{
  "ticket": "5uhbd49wms2fakafn5nzq7pcqpbjun2v",
  "lead": "PZD97WTMFJ"
}
```

<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

Unify the QR code generation by embedding both the ticket and lead information into a single JSON object, allowing for integrated check-in and lead scanning functionality.

New Features:
- Integrate check-in and lead scanning into a single QR code by embedding both codes into a unified JSON format.

<!-- Generated by sourcery-ai[bot]: end summary -->