### PR TITLE
Set base path using force_script_name

### DIFF
--- a/src/pretix/presale/templates/pretixpresale/index.html
+++ b/src/pretix/presale/templates/pretixpresale/index.html
@@ -16,7 +16,8 @@
             {% endblocktrans %}
         </p>
         <p>
-            {% blocktrans trimmed with a_attr="href='/control/'" %}
+            {% url 'control:index' as index_url %}
+            {% blocktrans trimmed with a_attr="href="|add:index_url %}
                 If you're looking to configure this installation, please <a {{ a_attr }}>head over here</a>.
             {% endblocktrans %}
         </p>

--- a/src/pretix/settings.py
+++ b/src/pretix/settings.py
@@ -113,9 +113,9 @@ if config.has_section('replica'):
     }
     DATABASE_ROUTERS = ['pretix.helpers.database.ReplicaRouter']
 
-STATIC_URL = config.get('urls', 'static', fallback='/static/')
+STATIC_URL = config.get('urls', 'static', fallback='/tickets/static/')
 
-MEDIA_URL = config.get('urls', 'media', fallback='/media/')
+MEDIA_URL = config.get('urls', 'media', fallback='/tickets/media/')
 
 INSTANCE_NAME = config.get('pretix', 'instance_name', fallback='eventyay')
 PRETIX_REGISTRATION = config.getboolean('pretix', 'registration', fallback=True)
@@ -779,3 +779,5 @@ if config.has_option('geoip', 'path'):
     HAS_GEOIP = True
     GEOIP_PATH = config.get('geoip', 'path')
     GEOIP_COUNTRY = config.get('geoip', 'filename_country', fallback='GeoLite2-Country.mmdb')
+
+FORCE_SCRIPT_NAME = '/tickets'

--- a/src/pretix/settings.py
+++ b/src/pretix/settings.py
@@ -113,9 +113,13 @@ if config.has_section('replica'):
     }
     DATABASE_ROUTERS = ['pretix.helpers.database.ReplicaRouter']
 
-STATIC_URL = config.get('urls', 'static', fallback='/tickets/static/')
+BASE_PATH = config.get('pretix', 'base_path', fallback='')
 
-MEDIA_URL = config.get('urls', 'media', fallback='/tickets/media/')
+FORCE_SCRIPT_NAME = BASE_PATH
+
+STATIC_URL = config.get('urls', 'static', fallback=BASE_PATH + '/static/')
+
+MEDIA_URL = config.get('urls', 'media', fallback=BASE_PATH + 'media/')
 
 INSTANCE_NAME = config.get('pretix', 'instance_name', fallback='eventyay')
 PRETIX_REGISTRATION = config.getboolean('pretix', 'registration', fallback=True)
@@ -779,5 +783,3 @@ if config.has_option('geoip', 'path'):
     HAS_GEOIP = True
     GEOIP_PATH = config.get('geoip', 'path')
     GEOIP_COUNTRY = config.get('geoip', 'filename_country', fallback='GeoLite2-Country.mmdb')
-
-FORCE_SCRIPT_NAME = '/tickets'

--- a/src/pretix/settings.py
+++ b/src/pretix/settings.py
@@ -119,7 +119,7 @@ FORCE_SCRIPT_NAME = BASE_PATH
 
 STATIC_URL = config.get('urls', 'static', fallback=BASE_PATH + '/static/')
 
-MEDIA_URL = config.get('urls', 'media', fallback=BASE_PATH + 'media/')
+MEDIA_URL = config.get('urls', 'media', fallback=BASE_PATH + '/media/')
 
 INSTANCE_NAME = config.get('pretix', 'instance_name', fallback='eventyay')
 PRETIX_REGISTRATION = config.getboolean('pretix', 'registration', fallback=True)


### PR DESCRIPTION
<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

Set the base path for static and media URLs to '/tickets' by updating STATIC_URL and MEDIA_URL, and introduce FORCE_SCRIPT_NAME to '/tickets' in the settings.

Enhancements:
- Update STATIC_URL and MEDIA_URL to include '/tickets' as the base path.

<!-- Generated by sourcery-ai[bot]: end summary -->