### PR TITLE
Remove video url form in event setting

### DIFF
--- a/src/pretix/api/serializers/event.py
+++ b/src/pretix/api/serializers/event.py
@@ -725,7 +725,6 @@ class EventSettingsSerializer(SettingsSerializer):
         'schedule_link',
         'session_link',
         'speaker_link',
-        'video_link'
     ]
 
     def __init__(self, *args, **kwargs):

--- a/src/pretix/base/configurations/default_setting.py
+++ b/src/pretix/base/configurations/default_setting.py
@@ -2390,16 +2390,6 @@ Your {organizer} team"""))
             help_text=_("This should point to your speakers."),
         ),
     },
-    'video_link': {
-        'default': None,
-        'type': str,
-        'form_class': forms.URLField,
-        'serializer_class': serializers.URLField,
-        'form_kwargs': dict(
-            label=_("Video URL"),
-            help_text=_("This should point to your Video Live URL."),
-        ),
-    },
     'seating_choice': {
         'default': 'True',
         'form_class': forms.BooleanField,

--- a/src/pretix/control/forms/event.py
+++ b/src/pretix/control/forms/event.py
@@ -497,7 +497,6 @@ class EventSettingsForm(SettingsForm):
         'schedule_link',
         'session_link',
         'speaker_link',
-        'video_link'
     ]
 
     def clean(self):
@@ -1341,11 +1340,6 @@ class QuickSetupForm(I18nForm):
     speaker_link = forms.URLField(
         label=_("Speaker URL"),
         help_text=_("This should point to your speakers."),
-        required=False,
-    )
-    video_link = forms.URLField(
-        label=_("Video URL"),
-        help_text=_("This should point to your Video URL."),
         required=False,
     )
     contact_mail = forms.EmailField(

--- a/src/pretix/control/templates/pretixcontrol/event/settings.html
+++ b/src/pretix/control/templates/pretixcontrol/event/settings.html
@@ -35,7 +35,6 @@
                 {% bootstrap_field sform.schedule_link layout="control" %}
                 {% bootstrap_field sform.session_link layout="control" %}
                 {% bootstrap_field sform.speaker_link layout="control" %}
-                {% bootstrap_field sform.video_link layout="control" %}
 
                 {% if meta_forms %}
                     <div class="form-group metadata-group">


### PR DESCRIPTION
This PR is about remove video url form in event settings, using video plugin instead.

<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

Remove the video URL form field from event settings across various components, including configurations, forms, serializers, and templates, in favor of using a video plugin.

Enhancements:
- Remove the video URL form field from event settings, opting to use a video plugin instead.

<!-- Generated by sourcery-ai[bot]: end summary -->