### PR TITLE
Not show Join online event if plugin is disable

### DIFF
--- a/src/pretix/presale/templates/pretixpresale/event/index.html
+++ b/src/pretix/presale/templates/pretixpresale/event/index.html
@@ -62,7 +62,7 @@
                         <i class="fa fa-ticket"></i> {% trans "Tickets" %}
                     </a>
                 </div>
-                {% if request.event.settings.video_link %}
+                {% if is_video_plugin_enabled %}
                     <div class="video-link">
                         <a join-event-link class="header-nav btn btn-outline-success join-event"
                             href='{% eventurl request.event "presale:event.onlinevideo.join" %}'>

--- a/src/pretix/presale/views/event.py
+++ b/src/pretix/presale/views/event.py
@@ -50,7 +50,14 @@ from . import (
     iframe_entry_view_wrapper,
 )
 
-from pretix_venueless.apps import PluginApp
+import importlib.util
+
+package_name = 'pretix_venueless'
+
+if importlib.util.find_spec(package_name) is not None:
+    pretix_venueless = import_module(package_name)
+else:
+    pretix_venueless = None
 
 SessionStore = import_module(settings.SESSION_ENGINE).SessionStore
 
@@ -446,10 +453,10 @@ class EventIndex(EventViewMixin, EventListMixin, CartMixin, TemplateView):
             event_name = next(iter(self.request.event.name.data.values()))
         context['event_name'] = event_name
 
-        if PluginApp.name in self.request.event.get_plugins():
-            context['is_video_plugin_enabled'] = True
-        else:
-            context['is_video_plugin_enabled'] = False
+        context['is_video_plugin_enabled'] = False
+        if pretix_venueless is not None:
+            if pretix_venueless.apps.PluginApp.name in self.request.event.get_plugins():
+                context['is_video_plugin_enabled'] = True
 
         return context
 

--- a/src/pretix/presale/views/event.py
+++ b/src/pretix/presale/views/event.py
@@ -50,6 +50,8 @@ from . import (
     iframe_entry_view_wrapper,
 )
 
+from pretix_venueless.apps import PluginApp
+
 SessionStore = import_module(settings.SESSION_ENGINE).SessionStore
 
 logger = logging.getLogger(__name__)
@@ -443,6 +445,11 @@ class EventIndex(EventViewMixin, EventListMixin, CartMixin, TemplateView):
             # If event_name is not available in english, get the first available event name
             event_name = next(iter(self.request.event.name.data.values()))
         context['event_name'] = event_name
+
+        if PluginApp.name in self.request.event.get_plugins():
+            context['is_video_plugin_enabled'] = True
+        else:
+            context['is_video_plugin_enabled'] = False
 
         return context
 


### PR DESCRIPTION
This fix is about to check if video plugin not installed then not showing 'Join Online Event' in ticket shop

<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

Prevent the 'Join Online Event' button from appearing in the ticket shop when the video plugin is disabled by checking the plugin's installation status.

Bug Fixes:
- Ensure 'Join Online Event' button is not displayed in the ticket shop if the video plugin is not installed.

<!-- Generated by sourcery-ai[bot]: end summary -->