### PR TITLE
Fix error missing hijack-tags in common page

### DIFF
--- a/src/pretix/base/middleware.py
+++ b/src/pretix/base/middleware.py
@@ -243,7 +243,8 @@ class SecurityMiddleware(MiddlewareMixin):
             'form-action': ["{dynamic}", "https:"] + (['http:'] if settings.SITE_URL.startswith('http://') else []),
         }
         if settings.LOG_CSP:
-            h['report-uri'] = ["/csp_report/"]
+            base_path = settings.BASE_PATH
+            h['report-uri'] = [f"{base_path}/csp_report/"]
         if 'Content-Security-Policy' in resp:
             _merge_csp(h, _parse_csp(resp['Content-Security-Policy']))
         if settings.CSP_ADDITIONAL_HEADER:

--- a/src/pretix/eventyay_common/templates/eventyay_common/base.html
+++ b/src/pretix/eventyay_common/templates/eventyay_common/base.html
@@ -1,7 +1,6 @@
 {% load compress %}
 {% load static %}
 {% load i18n %}
-{% load hijack_tags %}
 {% load statici18n %}
 {% load eventsignal %}
 {% load eventurl %}
@@ -192,7 +191,7 @@
                     </ul>
                 </div>
             {% endif %}
-            {% if request|is_hijacked %}
+            {% if request.user.is_hijacked %}
                 <div class="impersonate-warning">
                     <span class="fa fa-user-secret"></span>
                     {% blocktrans with user=request.user%}You are currently working on behalf of {{ user }}.{% endblocktrans %}


### PR DESCRIPTION
Remove hijack-tags which not existed and add base path for csp_report

<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

Fix the missing hijack-tags in the common page template and enhance the CSP report URI configuration by including the base path.

Bug Fixes:
- Fix missing hijack-tags in the common page template by removing the non-existent tag.

Enhancements:
- Add base path to the CSP report URI in the middleware to ensure correct report-uri configuration.

<!-- Generated by sourcery-ai[bot]: end summary -->