### PR TITLE
Fix issue None name in header

### DIFF
--- a/src/pretix/control/templates/pretixcontrol/base.html
+++ b/src/pretix/control/templates/pretixcontrol/base.html
@@ -8,7 +8,7 @@
 <html{% if rtl %} dir="rtl" class="rtl"{% endif %}>
 	<head>
 		<title>{% block title %}{% endblock %}{% if url_name != "index" %} :: {% endif %}
-            {{ settings.INSTANCE_NAME }}</title>
+            {{ django_settings.INSTANCE_NAME }}</title>
 		{% compress css %}
     		<link rel="stylesheet" type="text/x-scss" href="{% static "pretixcontrol/scss/main.scss" %}" />
             <link rel="stylesheet" type="text/x-scss" href="{% static "lightbox/css/lightbox.scss" %}" />
@@ -122,7 +122,7 @@
                     {% endif %}
                     <a class="navbar-brand" href="{% url "control:index" %}">
                         <img src="{% static "pretixbase/img/eventyay-icon.svg" %}" />
-                        {{ settings.INSTANCE_NAME }}
+                        {{ django_settings.INSTANCE_NAME }}
                     </a>
                 </div>
                 <ul class="nav navbar-nav navbar-top-links navbar-left flip hidden-xs">


### PR DESCRIPTION
<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

Fix the incorrect reference to the instance name in the HTML template to ensure the correct name is displayed in the header and navbar.

Bug Fixes:
- Correct the reference to the instance name in the HTML template by replacing 'settings.INSTANCE_NAME' with 'django_settings.INSTANCE_NAME'.

<!-- Generated by sourcery-ai[bot]: end summary -->