### PR TITLE
Show event title if logo not present

### DIFF
--- a/src/pretix/presale/templates/pretixpresale/event/index.html
+++ b/src/pretix/presale/templates/pretixpresale/event/index.html
@@ -207,6 +207,14 @@
                 {% endif %}
             </h2>
         {% endif %}
+        {% if not event_logo %}
+            <h2 class="content-header">
+                {{ event.name }}
+                {% if request.event.settings.show_dates_on_frontpage %}
+                    <small>{{ event.get_date_range_display }}</small>
+                {% endif %}
+            </h2>
+        {% endif %}
         {% if frontpage_text and not cart_namespace %}
             <div>
                 {{ frontpage_text|rich_text }}


### PR DESCRIPTION
This PR resolve issue #337 

Add condition to check if logo not present, then show event name

Testing capture:

![image](https://github.com/user-attachments/assets/38619e84-1bc4-433c-b3bb-29e0e0e5b197)

<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

Add a feature to display the event name as a header if the event logo is not available on the event page.

New Features:
- Display the event name as a header when the event logo is not present on the event page.

<!-- Generated by sourcery-ai[bot]: end summary -->