### PR TITLE
Display colors only get applied if round edges and fonts are choose

### DIFF
--- a/src/pretix/presale/style.py
+++ b/src/pretix/presale/style.py
@@ -63,7 +63,7 @@ def compile_scss(object, file="main.scss", fonts=True):
         sassrules.append('$border-radius-small: 0;')
 
     font = object.settings.get('primary_font')
-    if font != 'Open Sans' and fonts:
+    if font != 'Open Sans' and fonts and font:
         sassrules.append(get_font_stylesheet(font))
         sassrules.append(
             '$font-family-sans-serif: "{}", "Open Sans", "OpenSans", "Helvetica Neue", Helvetica, Arial, sans-serif '


### PR DESCRIPTION
Related to issue #338 
Fix issue color not applied when font empty by add a condition to check if font is empty

<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

Fix the application of display colors by ensuring that the font setting is not empty before applying styles.

Bug Fixes:
- Fix the issue where display colors were not applied when the font setting was empty by adding a condition to check if the font is specified.

<!-- Generated by sourcery-ai[bot]: end summary -->