### PR TITLE
Add option for scroll-over color for menu items

### DIFF
--- a/src/pretix/api/serializers/event.py
+++ b/src/pretix/api/serializers/event.py
@@ -717,6 +717,7 @@ class EventSettingsSerializer(SettingsSerializer):
         'theme_color_danger',
         'theme_color_background',
         'theme_round_borders',
+        'hover_button_color',
         'primary_font',
         'logo_image',
         'logo_image_large',

--- a/src/pretix/api/serializers/organizer.py
+++ b/src/pretix/api/serializers/organizer.py
@@ -275,6 +275,7 @@ class OrganizerSettingsSerializer(SettingsSerializer):
         'theme_color_success',
         'theme_color_danger',
         'theme_color_background',
+        'hover_button_color',
         'theme_round_borders',
         'primary_font',
         'organizer_logo_image',

--- a/src/pretix/base/configurations/default_setting.py
+++ b/src/pretix/base/configurations/default_setting.py
@@ -1929,6 +1929,26 @@ Your {organizer} team"""))
             widget=forms.TextInput(attrs={'class': 'colorpickerfield no-contrast'})
         ),
     },
+    'hover_button_color': {
+        'default': '#2185d0',
+        'type': str,
+        'form_class': forms.CharField,
+        'serializer_class': serializers.CharField,
+        'serializer_kwargs': dict(
+            validators=[
+                RegexValidator(regex='^#[0-9a-fA-F]{6}$',
+                               message=_('Please enter the hexadecimal code of a color, e.g. #990000.')),
+            ],
+        ),
+        'form_kwargs': dict(
+            label=_("Scroll-over color"),
+            validators=[
+                RegexValidator(regex='^#[0-9a-fA-F]{6}$',
+                               message=_('Please enter the hexadecimal code of a color, e.g. #990000.')),
+            ],
+            widget=forms.TextInput(attrs={'class': 'colorpickerfield no-contrast'})
+        ),
+    },
     'theme_round_borders': {
         'default': 'True',
         'type': bool,
@@ -2427,7 +2447,7 @@ Your {organizer} team"""))
 
 CSS_SETTINGS = {
     'primary_color', 'theme_color_success', 'theme_color_danger', 'primary_font',
-    'theme_color_background', 'theme_round_borders'
+    'theme_color_background', 'theme_round_borders', 'hover_button_color'
 }
 
 TITLE_GROUP = OrderedDict([

--- a/src/pretix/control/forms/event.py
+++ b/src/pretix/control/forms/event.py
@@ -489,6 +489,7 @@ class EventSettingsForm(SettingsForm):
         'theme_color_danger',
         'theme_color_background',
         'theme_round_borders',
+        'hover_button_color',
         'primary_font',
         'logo_image',
         'logo_image_large',

--- a/src/pretix/control/forms/organizer_forms/organizer_settings_form.py
+++ b/src/pretix/control/forms/organizer_forms/organizer_settings_form.py
@@ -44,6 +44,7 @@ class OrganizerSettingsForm(SettingsForm):
         'theme_color_success',
         'theme_color_danger',
         'theme_color_background',
+        'hover_button_color',
         'theme_round_borders',
         'primary_font',
         'privacy_policy'

--- a/src/pretix/control/templates/pretixcontrol/event/settings.html
+++ b/src/pretix/control/templates/pretixcontrol/event/settings.html
@@ -212,6 +212,7 @@
                     {% bootstrap_field sform.theme_color_success layout="control" %}
                     {% bootstrap_field sform.theme_color_danger layout="control" %}
                     {% bootstrap_field sform.theme_color_background layout="control" %}
+                    {% bootstrap_field sform.hover_button_color layout="control" %}
                     {% bootstrap_field sform.theme_round_borders layout="control" %}
                     {% bootstrap_field sform.primary_font layout="control" %}
                 {% endpropagated %}

--- a/src/pretix/control/templates/pretixcontrol/organizers/edit.html
+++ b/src/pretix/control/templates/pretixcontrol/organizers/edit.html
@@ -135,6 +135,7 @@
                         {% bootstrap_field sform.theme_color_success layout="control" %}
                         {% bootstrap_field sform.theme_color_danger layout="control" %}
                         {% bootstrap_field sform.theme_color_background layout="control" %}
+                        {% bootstrap_field sform.hover_button_color layout="control" %}
                         {% bootstrap_field sform.theme_round_borders layout="control" %}
                         {% bootstrap_field sform.primary_font layout="control" %}
                         {% bootstrap_field sform.favicon layout="control" %}

--- a/src/pretix/presale/style.py
+++ b/src/pretix/presale/style.py
@@ -57,6 +57,8 @@ def compile_scss(object, file="main.scss", fonts=True):
         sassrules.append('$brand-danger: {};'.format(object.settings.get('theme_color_danger')))
     if object.settings.get('theme_color_background'):
         sassrules.append('$body-bg: {};'.format(object.settings.get('theme_color_background')))
+    if object.settings.get('hover_button_color'):
+       sassrules.append('$hover-button-color: {};'.format(object.settings.get('hover_button_color')))
     if not object.settings.get('theme_round_borders'):
         sassrules.append('$border-radius-base: 0;')
         sassrules.append('$border-radius-large: 0;')
@@ -82,6 +84,7 @@ def compile_scss(object, file="main.scss", fonts=True):
             sassrules.append(resp)
 
     sasssrc = "\n".join(sassrules)
+
     srcchecksum = hashlib.sha1(sasssrc.encode('utf-8')).hexdigest()
 
     cp = cache.get_or_set('sass_compile_prefix', now().isoformat())

--- a/src/pretix/presale/templates/pretixpresale/base.html
+++ b/src/pretix/presale/templates/pretixpresale/base.html
@@ -16,7 +16,6 @@
             <link rel="stylesheet" type="text/x-scss" href="{% static "pretixpresale/scss/main.scss" %}"/>
         {% endcompress %}
     {% endif %}
-    <link rel="stylesheet" type="text/css" href="{% static "pretixpresale/scss/custom.css" %}"/>
 
     {% include "pretixpresale/fragment_js.html" %}
     <meta name="referrer" content="origin">

--- a/src/pretix/static/pretixbase/scss/_variables.scss
+++ b/src/pretix/static/pretixbase/scss/_variables.scss
@@ -24,6 +24,8 @@ $brand-warning: #ffb419 !default;
 $brand-danger:  #db2828  !default;
 
 $btn-default-border: #CCCCCC;
+$hover-button-color:  #2185d0 !default;
+
 
 $border-radius-base:        3px !default;
 $border-radius-large:       4px !default;

--- a/src/pretix/static/pretixpresale/scss/custom.scss
+++ b/src/pretix/static/pretixpresale/scss/custom.scss
@@ -42,7 +42,7 @@
         }
         a:hover {
             color: #fff;
-            color: darken($btn-primary-bg, 10%) !important;
+            background-color: $hover-button-color !important;
         }
         .popover-content {
             .options {

--- a/src/pretix/static/pretixpresale/scss/main.scss
+++ b/src/pretix/static/pretixpresale/scss/main.scss
@@ -16,6 +16,7 @@ $body-bg: #f5f5f5 !default;
 @import "_forms.scss";
 @import "_calendar.scss";
 @import "_checkout.scss";
+@import "custom.scss";
 @import "../../pretixbase/scss/webfont.scss";
 
 /* See https://github.com/pretix/pretix/pull/761 */


### PR DESCRIPTION
This PR fix issue #339 Add option for scroll-over color for menu items

![image](https://github.com/user-attachments/assets/cd19f949-ad95-4b07-abbd-da663e239bc2)


![image](https://github.com/user-attachments/assets/fc335771-e51f-4421-b2ff-c50c0b9cd713)

<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

Add a new configuration option 'hover_button_color' to customize the scroll-over color for menu items, and update relevant SCSS and HTML templates to apply this new setting.

New Features:
- Introduce a new configuration option 'hover_button_color' to allow customization of the scroll-over color for menu items.

Enhancements:
- Update the SCSS and HTML templates to utilize the new 'hover_button_color' setting for styling menu items.

<!-- Generated by sourcery-ai[bot]: end summary -->