### PR TITLE
Autologin to eventyay-talk when attendee is logged into eventyay-tickets

### DIFF
--- a/src/pretix/helpers/jwt_generate.py
+++ b/src/pretix/helpers/jwt_generate.py
@@ -24,3 +24,23 @@ def generate_sso_token(user):
         jwt_token = jwt.encode(jwt_payload, settings.SECRET_KEY, algorithm='HS256')
         return jwt_token
     return None
+
+
+def generate_customer_sso_token(customer):
+    """
+    Generate a JWT token for the user.
+    @param customer: User obj
+    @return: jwt token
+    """
+    if customer:
+        jwt_payload = {
+            'email': customer.email,
+            'name': customer.name,
+            'is_active': customer.is_active,
+            'locale': customer.locale,
+            'exp': datetime.utcnow() + timedelta(hours=1),  # Token expiration
+            'iat': datetime.utcnow(),
+        }
+        jwt_token = jwt.encode(jwt_payload, settings.SECRET_KEY, algorithm='HS256')
+        return jwt_token
+    return None

--- a/src/pretix/presale/views/open_id_connect.py
+++ b/src/pretix/presale/views/open_id_connect.py
@@ -27,6 +27,7 @@ from pretix.multidomain.middlewares import CsrfViewMiddleware
 from pretix.multidomain.urlreverse import build_absolute_uri
 from pretix.presale.forms.customer_forms import AuthenticationForm
 from pretix.presale.utils import customer_login, get_customer_auth_time
+from pretix.presale.views.customer_view.authentication_view import set_cookie_after_logged_in
 
 RESPONSE_TYPES_SUPPORTED = ("code", "id_token token", "id_token", "code id_token", "code id_token token", "code token")
 
@@ -206,6 +207,8 @@ class AuthorizeView(View):
         response = redirect(redirect_uri)
         response['Cache-Control'] = 'no-store'
         response['Pragma'] = 'no-cache'
+
+        set_cookie_after_logged_in(self.request, response)
 
         return response
 


### PR DESCRIPTION
This PR related to issue #203 
Autologin to eventyay-talk when attendee is logged into eventyay-tickets
When attendee login in ticket shop, will generate a token and to cookie, whenever attendee visit talk component, talk component will consider that cookie for auto login.

<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

Enable autologin to eventyay-talk for attendees logged into eventyay-tickets by setting a JWT token as a cookie upon successful login. Introduce a utility function to generate customer-specific JWT tokens.

New Features:
- Implement autologin functionality for eventyay-talk when an attendee is logged into eventyay-tickets by setting a JWT token as a cookie.

Enhancements:
- Add a utility function to generate a JWT token for customers, including user details and token expiration.

<!-- Generated by sourcery-ai[bot]: end summary -->