### PR TITLE
Add Exhibitors Plugin as part of the deployment

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -97,6 +97,7 @@ dependencies = [
         'pretix-venueless @ git+https://github.com/fossasia/eventyay-ticket-video.git@master',
         'django-sso==3.0.2',
         'PyJWT~=2.8.0',
+        'exhibitors @ git+https://github.com/fossasia/eventyay-tickets-exhibitors.git@master',
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
Note that only merge this PR after Exhibitors plugin (https://github.com/fossasia/eventyay-tickets-exhibitors) is ready

This PR related to issue #352 Add Exhibitors Plugin as part of the deployment