### PR TITLE
Remove stripe from auto deployment

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -89,7 +89,6 @@ dependencies = [
         'sepaxml==2.6.*',
         'geoip2==4.*',
         'paypalhttp==1.*',
-        'eventyay-stripe @ git+https://your_token@github.com/fossasia/eventyay-tickets-stripe.git@master',
         'sendgrid==6.11.*',
         'importlib_metadata==8.*',
         'qrcode==7.4.*',

--- a/src/set_github_token.py
+++ b/src/set_github_token.py
@@ -9,15 +9,6 @@ github_token = os.getenv('GITHUB_TOKEN')
 pyproject = toml.load('/pretix/pyproject.toml')
 
 # If github_token is None, remove the eventyay-stripe dependency
-if not github_token:
-    pyproject['project']['dependencies'] = [dep for dep in pyproject['project']['dependencies'] if not dep.startswith('eventyay-stripe')]
-else:
-    # Iterate over the dependencies
-    for i, dep in enumerate(pyproject['project']['dependencies']):
-        if dep.startswith('eventyay-stripe'):
-            # Update the stripe dependency with the stripe_key
-            pyproject['project']['dependencies'][i] = f'eventyay-stripe @ git+https://{github_token}@github.com/fossasia/eventyay-tickets-stripe.git@master'
-            break
 
 # Write the updated pyproject.toml back to file
 with open('/pretix/pyproject.toml', 'w') as f:


### PR DESCRIPTION
## Summary by Sourcery

Enhancements:
- Remove conditional logic for handling 'eventyay-stripe' dependency based on the presence of a GitHub token.