### PR TITLE
Add a down arrow next to user name to show dropdown options and ensure it works on all pages

### DIFF
--- a/src/pretix/control/templates/pretixcontrol/base.html
+++ b/src/pretix/control/templates/pretixcontrol/base.html
@@ -60,6 +60,7 @@
             <script type="text/javascript" src="{% static "lightbox/js/lightbox.min.js" %}"></script>
             <script type="text/javascript" src="{% static "are-you-sure/jquery.are-you-sure.js" %}"></script>
             <script type="text/javascript" src="{% static "pretixcontrol/js/ui/popover.js" %}"></script>
+            <script type="text/javascript" src="{% static "utils/js/utils.js" %}"></script>
 		{% endcompress %}
         {{ html_head|safe }}
 

--- a/src/pretix/presale/templates/pretixpresale/base.html
+++ b/src/pretix/presale/templates/pretixpresale/base.html
@@ -46,6 +46,7 @@
     <meta name="theme-color" content="{{ settings.primary_color|default:"#2185d0" }}">
     {% compress js %}
         <script type="text/javascript" src="{% static "pretixpresale/js/ui/popover.js" %}"></script>
+        <script type="text/javascript" src="{% static "utils/js/utils.js" %}"></script>
     {% endcompress %}
 </head>
 <body class="nojs" data-locale="{{ request.LANGUAGE_CODE }}" data-now="{% now "U.u" %}" data-datetimeformat="{{ js_datetime_format }}" data-timeformat="{{ js_time_format }}" data-dateformat="{{ js_date_format }}" data-datetimelocale="{{ js_locale }}" data-currency="{{ request.event.currency }}">

--- a/src/pretix/static/pretixcontrol/js/ui/popover.js
+++ b/src/pretix/static/pretixcontrol/js/ui/popover.js
@@ -37,14 +37,7 @@ $(function () {
     }
     $('[data-toggle="popover-profile"]').popover(options).click(function (evt) {
         evt.stopPropagation();
-        const isVisible = $(this).data('bs.popover').tip().hasClass('in');
-        $('[data-toggle="popover"]').popover('hide');
-
-        if (isVisible) {
-            $(this).popover('hide');
-        } else {
-            $(this).popover('show');
-        }
+        togglePopover(this);
     })
 })
 

--- a/src/pretix/static/pretixcontrol/js/ui/popover.js
+++ b/src/pretix/static/pretixcontrol/js/ui/popover.js
@@ -35,11 +35,16 @@ $(function () {
         trigger: 'manual'
 
     }
-    $('[data-toggle="popover-profile"]').popover(options).click(function(evt) {
+    $('[data-toggle="popover-profile"]').popover(options).click(function (evt) {
         evt.stopPropagation();
-        $(this).popover('show');
+        const isVisible = $(this).data('bs.popover').tip().hasClass('in');
         $('[data-toggle="popover"]').popover('hide');
 
+        if (isVisible) {
+            $(this).popover('hide');
+        } else {
+            $(this).popover('show');
+        }
     })
 })
 

--- a/src/pretix/static/pretixpresale/js/ui/popover.js
+++ b/src/pretix/static/pretixpresale/js/ui/popover.js
@@ -72,10 +72,16 @@ $(function () {
         trigger: 'manual'
 
     }
-    $('[data-toggle="popover-profile"]').popover(options).click(function(evt) {
+    $('[data-toggle="popover-profile"]').popover(options).click(function (evt) {
         evt.stopPropagation();
-        $(this).popover('show');
+        const isVisible = $(this).data('bs.popover').tip().hasClass('in');
         $('[data-toggle="popover"]').popover('hide');
+
+        if (isVisible) {
+            $(this).popover('hide');
+        } else {
+            $(this).popover('show');
+        }
 
         // Ensure Organizer Area is hidden initially
         $('.organizer-area').hide();

--- a/src/pretix/static/pretixpresale/js/ui/popover.js
+++ b/src/pretix/static/pretixpresale/js/ui/popover.js
@@ -74,14 +74,7 @@ $(function () {
     }
     $('[data-toggle="popover-profile"]').popover(options).click(function (evt) {
         evt.stopPropagation();
-        const isVisible = $(this).data('bs.popover').tip().hasClass('in');
-        $('[data-toggle="popover"]').popover('hide');
-
-        if (isVisible) {
-            $(this).popover('hide');
-        } else {
-            $(this).popover('show');
-        }
+        togglePopover(this);
 
         // Ensure Organizer Area is hidden initially
         $('.organizer-area').hide();

--- a/src/pretix/static/utils/js/utils.js
+++ b/src/pretix/static/utils/js/utils.js
@@ -1,0 +1,11 @@
+function togglePopover(element) {
+    const popover = $(element).data('bs.popover');
+    const isVisible = popover.tip().hasClass('in');
+    $('[data-toggle="popover"]').popover('hide');
+
+    if (isVisible) {
+        $(element).popover('hide');
+    } else {
+        $(element).popover('show');
+    }
+}


### PR DESCRIPTION
This PR resolves #378
- Fix the popover toggle functionality to ensure it correctly shows and hides the dropdown options when the user name is clicked.
- On the first click of the username, the popover will show. On the second click, the popover will hide.

## Summary by Sourcery

Bug Fixes:
- Fix the popover toggle functionality to correctly show and hide dropdown options when the user name is clicked.