### PR TITLE
Fix join online video button after remove customer feature

### DIFF
--- a/src/pretix/api/urls.py
+++ b/src/pretix/api/urls.py
@@ -98,4 +98,5 @@ urlpatterns = [
     url(r"^upload$", upload.UploadView.as_view(), name="upload"),
     url(r"^me$", user.MeView.as_view(), name="user.me"),
     url(r"^version$", version.VersionView.as_view(), name="version"),
+    url(r"(?P<organizer>[^/]+)/(?P<event>[^/]+)/ticket-check", event.CustomerOrderCheckView.as_view()),
 ]

--- a/src/pretix/api/urls.py
+++ b/src/pretix/api/urls.py
@@ -98,5 +98,6 @@ urlpatterns = [
     url(r"^upload$", upload.UploadView.as_view(), name="upload"),
     url(r"^me$", user.MeView.as_view(), name="user.me"),
     url(r"^version$", version.VersionView.as_view(), name="version"),
-    url(r"(?P<organizer>[^/]+)/(?P<event>[^/]+)/ticket-check", event.CustomerOrderCheckView.as_view()),
+    url(r"(?P<organizer>[^/]+)/(?P<event>[^/]+)/ticket-check", event.CustomerOrderCheckView.as_view(),
+        name="event.ticket-check"),
 ]

--- a/src/pretix/api/views/event.py
+++ b/src/pretix/api/views/event.py
@@ -1,12 +1,14 @@
 import django_filters
 from django.db import transaction
 from django.db.models import ProtectedError, Q
+from django.http import JsonResponse
 from django.utils.timezone import now
 from django_filters.rest_framework import DjangoFilterBackend, FilterSet
 from django_scopes import scopes_disabled
 from rest_framework import filters, serializers, views, viewsets
 from rest_framework.exceptions import PermissionDenied
 from rest_framework.response import Response
+from rest_framework.views import APIView
 
 from pretix.api.auth.permission import EventCRUDPermission
 from pretix.api.serializers.event import (
@@ -15,7 +17,7 @@ from pretix.api.serializers.event import (
 )
 from pretix.api.views import ConditionalListView
 from pretix.base.models import (
-    CartPosition, Device, Event, TaxRule, TeamAPIToken,
+    CartPosition, Device, Event, Order, Organizer, TaxRule, TeamAPIToken, User,
 )
 from pretix.base.models.event import SubEvent
 from pretix.base.settings import SETTINGS_AFFECTING_CSS
@@ -402,3 +404,40 @@ class EventSettingsView(views.APIView):
                 'request': request
             })
         return Response(s.data)
+
+
+class CustomerOrderCheckView(APIView):
+
+    authentication_classes = ()
+    permission_classes = ()
+
+    @scopes_disabled()
+    def post(self, request, *args, **kwargs):
+        if (not kwargs.get("event")
+                or not kwargs.get("organizer")):
+            return Response(status=400, data={"error": "Missing parameters."})
+
+        try:
+            organizer = Organizer.objects.get(slug=kwargs["organizer"])
+            event = Event.objects.get(slug=kwargs["event"], organizer=organizer)
+            user = User.objects.get(email__iexact=request.data.get("user_email"))
+
+        except Organizer.DoesNotExist:
+            return JsonResponse(status=404, data={"error": "Organizer not found."})
+        except Event.DoesNotExist:
+            return JsonResponse(status=404, data={"error": "Event not found."})
+        except User.DoesNotExist:
+            return JsonResponse(status=404, data={"error": "Customer not found."})
+
+        # Get all orders of customer which belong to this event
+        order_list = (Order.objects.filter(Q(event=event)
+                                           & (Q(email__iexact=user.email))).select_related('event').order_by('-datetime'))
+
+        if not order_list:
+            return JsonResponse(status=404, data={"error": "Customer has no orders for this event."})
+
+        for order in order_list:
+            if order.status == 'p':
+                return JsonResponse(status=200, data={"message": "Customer has paid orders."})
+
+        return JsonResponse(status=400, data={"message": "Customer did not paid orders."})

--- a/src/pretix/presale/views/event.py
+++ b/src/pretix/presale/views/event.py
@@ -1,10 +1,7 @@
 import calendar
 import datetime as dt
-import hashlib
 import importlib.util
 import logging
-import random
-import string
 import sys
 from collections import defaultdict
 from datetime import date, datetime, timedelta
@@ -47,8 +44,8 @@ from pretix.presale.views.organizer import (
     EventListMixin, add_subevents_for_days, days_for_template,
     filter_qs_by_attr, weeks_for_template,
 )
-from ...eventyay_common.utils import encode_email
 
+from ...eventyay_common.utils import encode_email
 from ...helpers.formats.en.formats import WEEK_FORMAT
 from . import (
     CartMixin, EventViewMixin, allow_frame_if_namespaced, get_cart,

--- a/src/pretix/presale/views/event.py
+++ b/src/pretix/presale/views/event.py
@@ -466,7 +466,9 @@ class EventIndex(EventViewMixin, EventListMixin, CartMixin, TemplateView):
         context['event_name'] = event_name
 
         context['is_video_plugin_enabled'] = False
-        if pretix_venueless is not None:
+        if (pretix_venueless is not None
+                and pretix_venueless.apps is not None
+                and pretix_venueless.apps.PluginApp is not None):
             if pretix_venueless.apps.PluginApp.name in self.request.event.get_plugins():
                 context['is_video_plugin_enabled'] = True
 

--- a/src/pretix/presale/views/event.py
+++ b/src/pretix/presale/views/event.py
@@ -466,11 +466,10 @@ class EventIndex(EventViewMixin, EventListMixin, CartMixin, TemplateView):
         context['event_name'] = event_name
 
         context['is_video_plugin_enabled'] = False
-        if (pretix_venueless is not None
-                and pretix_venueless.apps is not None
-                and pretix_venueless.apps.PluginApp is not None):
-            if pretix_venueless.apps.PluginApp.name in self.request.event.get_plugins():
-                context['is_video_plugin_enabled'] = True
+
+        if getattr(getattr(getattr(pretix_venueless, 'apps', None), 'PluginApp', None), 'name',
+                   None) in self.request.event.get_plugins():
+            context['is_video_plugin_enabled'] = True
 
         context['guest_checkout_allowed'] = not self.request.event.settings.require_registered_account_for_tickets
 

--- a/src/pretix/presale/views/event.py
+++ b/src/pretix/presale/views/event.py
@@ -47,6 +47,7 @@ from pretix.presale.views.organizer import (
     EventListMixin, add_subevents_for_days, days_for_template,
     filter_qs_by_attr, weeks_for_template,
 )
+from ...eventyay_common.utils import encode_email
 
 from ...helpers.formats.en.formats import WEEK_FORMAT
 from . import (
@@ -768,20 +769,3 @@ class JoinOnlineVideoView(EventViewMixin, View):
         )
         baseurl = self.request.event.settings.venueless_url
         return '{}/#token={}'.format(baseurl, token).replace("//#", "/#")
-
-
-def encode_email(email):
-    """
-    Encode email to a short hash and get first 7 characters
-    @param email: User's email
-    @return: encoded string
-    """
-    hash_object = hashlib.sha256(email.encode())
-    hash_hex = hash_object.hexdigest()
-    short_hash = hash_hex[:7]
-    characters = string.ascii_letters + string.digits
-    random_suffix = "".join(
-        random.choice(characters) for _ in range(7 - len(short_hash))
-    )
-    final_result = short_hash + random_suffix
-    return final_result.upper()


### PR DESCRIPTION
This PR to rework join online video button feature in ticket shop.
As before, the token to join online video using customer's id for identifier in video, but since customer feature is removed, we will using User's email or Order's email as User identifier in video.

## Summary by Sourcery

Rework the 'join online video' button feature by replacing the customer identifier with the user's email or order's email. Introduce a new API view to check customer orders for an event and refactor the video plugin check for better code clarity.

Bug Fixes:
- Fix the 'join online video' button functionality by using the user's email or order's email as the identifier instead of the removed customer feature.

Enhancements:
- Refactor the video plugin check to improve code readability and reliability.