### PR TITLE
Fix unit test

### DIFF
--- a/src/tests/base/test_orders.py
+++ b/src/tests/base/test_orders.py
@@ -373,7 +373,7 @@ class PaymentReminderTests(TestCase):
                 code='FOO', event=self.event, email='dummy@dummy.test',
                 status=Order.STATUS_PENDING, locale='en',
                 datetime=now() - timedelta(hours=4),
-                expires=now() - timedelta(hours=4) + timedelta(days=10),
+                expires=now().replace(hour=5, minute=0, second=0) + timedelta(days=10),
                 total=Decimal('46.00'),
             )
             self.ticket = Item.objects.create(event=self.event, name='Early-bird ticket',


### PR DESCRIPTION
Fix test_sent_days failed when run at 0 - 4 a.m

## Summary by Sourcery

Bug Fixes:
- Fix the unit test 'test_sent_days' to ensure it does not fail when run between 0 - 4 a.m by adjusting the expiration time to a consistent hour.