### PR TITLE
Enhance User Interface in Organizer Area

### DIFF
--- a/src/pretix/control/navigation.py
+++ b/src/pretix/control/navigation.py
@@ -307,7 +307,7 @@ def get_global_navigation(request):
             'icon': 'shopping-cart',
         },
         {
-            'label': _('Events'),
+            'label': _('My events'),
             'url': reverse('control:events'),
             'active': 'events' in url.url_name,
             'icon': 'calendar',
@@ -325,7 +325,7 @@ def get_global_navigation(request):
             'icon': 'search',
         },
         {
-            'label': _('User settings'),
+            'label': _('Account'),
             'url': reverse('control:user.settings'),
             'active': False,
             'icon': 'user',
@@ -372,7 +372,7 @@ def get_organizer_navigation(request):
         return []
     nav = [
         {
-            'label': _('Events'),
+            'label': _('My events'),
             'url': reverse('control:organizer', kwargs={
                 'organizer': request.organizer.slug
             }),

--- a/src/pretix/control/templates/pretixcontrol/base.html
+++ b/src/pretix/control/templates/pretixcontrol/base.html
@@ -224,7 +224,7 @@
                         <div class="dropdown context-selector">
                             {% block nav_top_header %}
                                 {% if request.event %}
-                                    <a href="#" class="dropdown-toggle" data-toggle="dropdown">
+                                    <a href="#" class="dropdown-toggle">
                                         <span class="fa-stack fa-lg">
                                           <i class="fa fa-circle fa-stack-2x"></i>
                                           <i class="fa fa-calendar fa-stack-1x fa-inverse"></i>
@@ -233,9 +233,9 @@
                                             <span class="context-name">{{ request.event }}</span>
                                             <span class="context-meta">{{ request.event.get_date_range_display }}</span>
                                         </div>
-                                        <span class="caret"></span></a>
+                                    </a>
                                 {% elif request.organizer %}
-                                    <a href="#" class="dropdown-toggle" data-toggle="dropdown">
+                                    <a href="#" class="dropdown-toggle">
                                         <span class="fa-stack fa-lg">
                                           <i class="fa fa-circle fa-stack-2x"></i>
                                           <i class="fa fa-group fa-stack-1x fa-inverse"></i>
@@ -244,9 +244,9 @@
                                             <span class="context-name">{{ request.organizer }}</span>
                                             <span class="context-meta">{% trans "Organizer account" %}</span>
                                         </div>
-                                        <span class="caret"></span></a>
+                                    </a>
                                 {% else %}
-                                    <a href="#" class="dropdown-toggle" data-toggle="dropdown">
+                                    <a href="#" class="dropdown-toggle">
                                         <span class="fa-stack fa-lg">
                                           <i class="fa fa-circle fa-stack-2x"></i>
                                           <i class="fa fa-user fa-stack-1x fa-inverse"></i>
@@ -255,21 +255,8 @@
                                         <div class="context-indicator">
                                             <span class="context-name">{{ request.user }}</span>
                                         </div>
-                                        <span class="caret"></span></a>
+                                    </a>
                                 {% endif %}
-                                <ul class="dropdown-menu event-dropdown" role="menu" data-event-typeahead
-                                    data-source="{% url "control:nav.typeahead" %}"
-                                    {% if request.event %}
-                                        data-organizer="{{ request.organizer.id }}"
-                                    {% endif %}>
-                                    <li class="query-holder">
-                                        <div class="form-box">
-                                            <input type="text" class="form-control" id="event-dropdown-field"
-                                                   placeholder="{% trans "Search for events" %}"
-                                                   data-typeahead-query autocomplete="off">
-                                        </div>
-                                    </li>
-                                </ul>
                             {% endblock %}
                         </div>
                         <ul class="nav" id="side-menu">

--- a/src/pretix/static/pretixcontrol/js/ui/popover.js
+++ b/src/pretix/static/pretixcontrol/js/ui/popover.js
@@ -10,6 +10,7 @@ $(function () {
     const logoutParams = new URLSearchParams({ back: backUrl });
 
     const dashboardPath = `/control/`;
+    const orderPath = `/control/settings/orders/`;
     const eventPath = `/control/events/`;
     const organizerPath = `/control/organizers/`;
 
@@ -27,13 +28,18 @@ $(function () {
                         </a>
                     </div>
                     <div class="profile-menu">
+                        <a href="${basePath}${orderPath}" target="_self" class="btn btn-outline-success">
+                            <i class="fa fa-shopping-cart"></i> ${window.gettext('My Orders')}
+                        </a>
+                    </div>
+                    <div class="profile-menu">
                         <a href="${basePath}${eventPath}" target="_self" class="btn btn-outline-success">
-                            <i class="fa fa-calendar"></i> ${window.gettext('My Event')}
+                            <i class="fa fa-calendar"></i> ${window.gettext('My Events')}
                         </a>
                     </div>
                      <div class="profile-menu">
                         <a href="${basePath}${organizerPath}" target="_self" class="btn btn-outline-success">
-                            <i class="fa fa-users"></i> ${window.gettext('Organizer')}
+                            <i class="fa fa-users"></i> ${window.gettext('Organizers')}
                         </a>
                     </div>
                     <div class="profile-menu separator"></div>


### PR DESCRIPTION
This PR resolves #436 
- Delete dropdown, but continue to show the name of the user, event, organizer

![image](https://github.com/user-attachments/assets/5941230b-4fa6-4655-8136-dc7d66ca03e4)

![image](https://github.com/user-attachments/assets/b477b26f-5dfe-4a52-bd47-8b68d01e6467)

![image](https://github.com/user-attachments/assets/bc01c896-0ab7-47d4-9cb3-e92241e6e2e9)

- Rename "User settings" to "Account", rename "Events" to "My events"

![image](https://github.com/user-attachments/assets/bbfe45c7-2c38-40f5-a97c-f98a2fa108aa)

- Add "My Orders" below "Dashboard"
- Fix "My Event" to "My Events"
- Fix "Organizer" to "Organizers"

![image](https://github.com/user-attachments/assets/c7dd5d2a-e195-4bd8-8733-0fcd70f394b2)

## Summary by Sourcery

Enhancements:
- Remove dropdown menus in the organizer area and display user, event, and organizer names directly.