### PR TITLE
Admin Section: Add Events Overview and Enhance View

### DIFF
--- a/src/pretix/control/navigation.py
+++ b/src/pretix/control/navigation.py
@@ -502,13 +502,19 @@ def get_admin_navigation(request):
         return []
     nav = [
         {
-            'label': _('Dashboard'),
+            'label': _('Admin Dashboard'),
             'url': reverse('control:admin.dashboard'),
             'active': 'dashboard' in url.url_name,
             'icon': 'dashboard',
         },
         {
-            'label': _('Organizers'),
+            'label': _('All Events'),
+            'url': reverse('control:admin.events'),
+            'active': 'events' in url.url_name,
+            'icon': 'calendar',
+        },
+        {
+            'label': _('All Organizers'),
             'url': reverse('control:admin.organizers'),
             'active': 'organizers' in url.url_name,
             'icon': 'group',

--- a/src/pretix/control/templates/pretixcontrol/admin/dashboard.html
+++ b/src/pretix/control/templates/pretixcontrol/admin/dashboard.html
@@ -2,5 +2,5 @@
 {% load i18n %}
 {% block title %}{% trans "Dashboard" %}{% endblock %}
 {% block content %}
-    <h1>{% trans "Dashboard" %}</h1>
+    <h1>{% trans "Admin Dashboard" %}</h1>
 {% endblock %}

--- a/src/pretix/control/templates/pretixcontrol/admin/events/index.html
+++ b/src/pretix/control/templates/pretixcontrol/admin/events/index.html
@@ -1,0 +1,164 @@
+{% extends "pretixcontrol/admin/base.html" %}
+{% load i18n %}
+{% load urlreplace %}
+{% load bootstrap3 %}
+{% block title %}{% trans "Events" %}{% endblock %}
+{% block content %}
+    <h1>{% trans "Events" %}</h1>
+    <p>{% trans "The list below shows all events you have administrative access to. Click on the event name to access event details." %}</p>
+    {% if events|length == 0 and not filter_form.filtered %}
+        <div class="empty-collection">
+            <p>
+                {% blocktrans trimmed %}
+                    You currently do not have access to any events.
+                {% endblocktrans %}
+            </p>
+
+            <a href='{% url "control:events.add" %}' class="btn btn-primary btn-lg">
+                <span class="fa fa-plus"></span>
+                {% trans "Create a new event" %}
+            </a>
+        </div>
+    {% else %}
+        <div class="panel panel-default">
+            <div class="panel-heading">
+                <h3 class="panel-title">{% trans "Filter" %}</h3>
+            </div>
+            <div class="panel-body">
+                <form class="" action="" method="get">
+                    <div class="row filter-form">
+                        <div class="col-md-3 col-sm-6 col-xs-12">
+                            {% bootstrap_field filter_form.query layout='inline' %}
+                        </div>
+                        <div class="col-md-3 col-sm-6 col-xs-12">
+                            {% bootstrap_field filter_form.status layout='inline' %}
+                        </div>
+                        <div class="col-md-3 col-sm-6 col-xs-12">
+                            {% bootstrap_field filter_form.organizer layout='inline' %}
+                        </div>
+                        {% for mf in meta_fields %}
+                            <div class="col-md-3 col-sm-6 col-xs-12">
+                                {% bootstrap_field mf layout='inline' %}
+                            </div>
+                        {% endfor %}
+                    </div>
+                    <div class="text-right">
+                        <button class="btn btn-primary" type="submit">
+                            <span class="fa fa-filter"></span>
+                            <span class="hidden-md">{% trans "Filter" %}</span>
+                        </button>
+                    </div>
+                </form>
+            </div>
+        </div>
+        <p>
+            <a href='{% url "control:events.add" %}' class="btn btn-default">
+                <span class="fa fa-plus"></span>
+                {% trans "Create a new event" %}
+            </a>
+        </p>
+        <table class="table table-condensed table-hover">
+            <thead>
+            <tr>
+                <th>
+                    {% trans "Event name" %}
+                </th>
+                {% if not hide_orga %}
+                    <th>
+                        {% trans "Organizer" %}
+                        <a href="?{% url_replace request 'ordering' '-organizer' %}"><i class="fa fa-caret-down"></i></a>
+                        <a href="?{% url_replace request 'ordering' 'organizer' %}"><i class="fa fa-caret-up"></i></a>
+                    </th>
+                {% endif %}
+                <th>
+                    {% trans "Start date" %}
+                    <a href="?{% url_replace request 'ordering' '-date_from' %}"><i class="fa fa-caret-down"></i></a>
+                    <a href="?{% url_replace request 'ordering' 'date_from' %}"><i class="fa fa-caret-up"></i></a>
+                    /
+                    {% trans "End date" %}
+                    <a href="?{% url_replace request 'ordering' '-date_to' %}"><i class="fa fa-caret-down"></i></a>
+                    <a href="?{% url_replace request 'ordering' 'date_to' %}"><i class="fa fa-caret-up"></i></a>
+                </th>
+                <th>
+                    {% trans "Paid tickets per quota" %}
+                </th>
+                <th>
+                    {% trans "Status" %}
+                    <a href="?{% url_replace request 'ordering' '-live' %}"><i class="fa fa-caret-down"></i></a>
+                    <a href="?{% url_replace request 'ordering' 'live' %}"><i class="fa fa-caret-up"></i></a>
+                </th>
+                <th class="text-right flip">
+                </th>
+            </tr>
+            </thead>
+            <tbody>
+            {% for e in events %}
+                <tr>
+                    <td class="event-name-col">
+                        <strong><a href='{% url "control:event.index" organizer=e.organizer.slug event=e.slug %}'>{{ e.name }}</a></strong>
+                        <br><small>{{ e.slug }}</small>
+                        {% for k, v in e.meta_data.items %}
+                            {% if v %}
+                                <small class="text-muted">&middot; {{ k }}: {{ v }}</small>
+                            {% endif %}
+                        {% endfor %}
+                    </td>
+                    {% if not hide_orga %}<td>{{ e.organizer }}</td>{% endif %}
+                    <td class="event-date-col">
+                        {% if e.has_subevents %}
+                            {{ e.min_from|default_if_none:""|date:"SHORT_DATETIME_FORMAT" }}
+                        {% else %}
+                            {{ e.get_short_date_from_display }}
+                        {% endif %}
+                        {% if e.has_subevents %}
+                            <span class="label label-default">{% trans "Series" %}</span>
+                        {% endif %}
+                        {% if e.settings.show_date_to and e.date_to %}
+                             –<br>
+                            {% if e.has_subevents %}
+                                {{ e.max_fromto|default_if_none:e.max_from|default_if_none:e.max_to|default_if_none:""|date:"SHORT_DATETIME_FORMAT" }}
+                            {% else %}
+                                {{ e.get_short_date_to_display }}
+                            {% endif %}
+                        {% endif %}
+                        {% if e.settings.timezone != request.timezone %}
+                            <span class="fa fa-globe text-muted" data-toggle="tooltip" title="{{ e.timezone }}"></span>
+                        {% endif %}
+                    </td>
+                    <td>
+                        {% for q in e.first_quotas|slice:":3" %}
+                            {% include "pretixcontrol/fragment_quota_box_paid.html" with quota=q %}
+                        {% endfor %}
+                        {% if e.first_quotas|length > 3 %}
+                            <a href='{% url "control:event.items.quotas" organizer=e.organizer.slug event=e.slug %}'
+                                    class="quotabox-more" data-toggle="tooltip" title="{% trans "More quotas" %}"
+                                    data-placement="top">
+                                &middot;&middot;&middot;
+                            </a>
+                        {% endif %}
+                    </td>
+                    <td>
+                        {% if not e.live %}
+                            <span class="label label-danger">{% trans "Shop disabled" %}</span>
+                        {% elif e.presale_has_ended %}
+                            <span class="label label-warning">{% trans "Presale over" %}</span>
+                        {% elif not e.presale_is_running %}
+                            <span class="label label-warning">{% trans "Presale not started" %}</span>
+                        {% else %}
+                            <span class="label label-success">{% trans "On sale" %}</span>
+                        {% endif %}
+                    </td>
+                    <td class="text-right flip">
+                        <a href='{% url "control:event.index" organizer=e.organizer.slug event=e.slug %}'
+                                class="btn btn-sm btn-default" title='{% trans "Open event dashboard" %}'
+                                data-toggle="tooltip">
+                            <span class="fa fa-eye"></span>
+                        </a>
+                    </td>
+                </tr>
+            {% endfor %}
+            </tbody>
+        </table>
+        {% include "pretixcontrol/pagination.html" %}
+    {% endif %}
+{% endblock %}

--- a/src/pretix/control/urls.py
+++ b/src/pretix/control/urls.py
@@ -332,6 +332,7 @@ urlpatterns = [
     url(r'^admin/', include([
         url(r'^$', admin.AdminDashboard.as_view(), name='admin.dashboard'),
         url(r'^organizers/$', admin.OrganizerList.as_view(), name='admin.organizers'),
+        url(r'^events/$', admin.AdminEventList.as_view(), name='admin.events'),
         url(r'^sudo/(?P<id>\d+)/$', user.EditStaffSession.as_view(), name='admin.user.sudo.edit'),
         url(r'^sudo/sessions/$', user.StaffSessionList.as_view(), name='admin.user.sudo.list'),
         url(r'^users/$', users.UserListView.as_view(), name='admin.users'),

--- a/src/pretix/control/views/admin.py
+++ b/src/pretix/control/views/admin.py
@@ -5,6 +5,7 @@ from pretix.base.models import Organizer
 from pretix.control.forms.filter import OrganizerFilterForm
 from pretix.control.permissions import AdministratorPermissionRequiredMixin
 from pretix.control.views import PaginationMixin
+from pretix.control.views.main import EventList
 
 
 class AdminDashboard(AdministratorPermissionRequiredMixin, TemplateView):
@@ -37,3 +38,8 @@ class OrganizerList(PaginationMixin, ListView):
     @cached_property
     def filter_form(self):
         return OrganizerFilterForm(data=self.request.GET, request=self.request)
+
+
+class AdminEventList(EventList):
+    """ Inherit from EventList to add a custom template for the admin event list. """
+    template_name = 'pretixcontrol/admin/events/index.html'


### PR DESCRIPTION
This PR resolves #437 Admin Section: Add Events Overview and Enhance View

1. Rename Dashboard to "Admin Dashboard"
2. Add left-side panel menu item "All Events" similar to the events overview on the personal organizer pages but for all events.
3. Rename "Organizers" to "All Organizers"

![image](https://github.com/user-attachments/assets/df076e77-e011-440c-968e-6ffdaeb0147c)

## Summary by Sourcery

Enhance the admin section by adding an 'All Events' overview and renaming existing sections for clarity and consistency.

New Features:
- Introduce a new 'All Events' section in the admin panel, providing an overview of all events accessible to administrators.

Enhancements:
- Rename 'Dashboard' to 'Admin Dashboard' for clarity in the admin section.
- Rename 'Organizers' to 'All Organizers' in the admin navigation for consistency.