### PR TITLE
Add links to specific event components | missing Home button

### DIFF
--- a/src/pretix/control/context.py
+++ b/src/pretix/control/context.py
@@ -14,6 +14,7 @@ from pretix.control.navigation import (
     get_organizer_navigation,
 )
 
+from ..eventyay_common.views.event import EventCreatedFor
 from ..helpers.i18n import (
     get_javascript_format, get_javascript_output_format, get_moment_locale,
 )
@@ -55,6 +56,12 @@ def _default_context(request):
             settings.TALK_HOSTNAME + "/orga/event/" + request.event.slug + "/settings"
         )
         ctx['is_video_enabled'] = is_video_enabled(request.event)
+        ctx["is_talk_event_created"] = False
+        if (
+            request.event.settings.create_for == EventCreatedFor.BOTH.value
+            or request.event.settings.talk_schedule_public is not None
+        ):
+            ctx["is_talk_event_created"] = True
     ctx['html_head'] = "".join(_html_head)
 
     _js_payment_weekdays_disabled = '[]'

--- a/src/pretix/control/templates/pretixcontrol/event/component_link.html
+++ b/src/pretix/control/templates/pretixcontrol/event/component_link.html
@@ -1,21 +1,23 @@
 {% load i18n %}
 <div class="navigation-button">
-    <a href='{% url "eventyay_common:event.update" organizer=request.organizer.slug event=request.event.slug %}' class="header-nav btn btn-outline-success">
-        <i class="fa fa-home"></i> {% trans "Home" %}
-    </a>
-    <a href="#" class="header-nav btn btn-outline-success active">
-        <i class="fa fa-ticket"></i> {% trans "Tickets" %}
-    </a>
-    {% if is_talk_event_created %}
-    <a href="{{ talk_edit_url }}" class="header-nav btn btn-outline-success">
-        <i class="fa fa-group"></i> {% trans "Talk" %}
-    </a>
-    {% endif %}
-    {% if is_video_enabled %}
-        <a class="header-nav btn btn-outline-success"
-           href='{% url "eventyay_common:event.create_access_to_video" organizer=request.organizer.slug event=request.event.slug %}'
-           title="{% trans 'Access videos related to this event' %}">
-            <i class="fa fa-video-camera"></i> {% trans "Videos" %}
+    {% if request.organizer and request.event %}
+        <a href='{% url "eventyay_common:event.update" organizer=request.organizer.slug event=request.event.slug %}' class="header-nav btn btn-outline-success">
+            <i class="fa fa-home"></i> {% trans "Home" %}
         </a>
+        <a href="#" class="header-nav btn btn-outline-success active">
+            <i class="fa fa-ticket"></i> {% trans "Tickets" %}
+        </a>
+        {% if is_talk_event_created %}
+        <a href="{{ talk_edit_url }}" class="header-nav btn btn-outline-success">
+            <i class="fa fa-group"></i> {% trans "Talk" %}
+        </a>
+        {% endif %}
+        {% if is_video_enabled %}
+            <a class="header-nav btn btn-outline-success"
+               href='{% url "eventyay_common:event.create_access_to_video" organizer=request.organizer.slug event=request.event.slug %}'
+               title="{% trans 'Access videos related to this event' %}">
+                <i class="fa fa-video-camera"></i> {% trans "Videos" %}
+            </a>
+        {% endif %}
     {% endif %}
 </div>

--- a/src/pretix/control/templates/pretixcontrol/event/component_link.html
+++ b/src/pretix/control/templates/pretixcontrol/event/component_link.html
@@ -1,20 +1,20 @@
 {% load i18n %}
 <div class="navigation-button">
+    <a href='{% url "eventyay_common:event.update" organizer=request.organizer.slug event=request.event.slug %}' class="header-nav btn btn-outline-success">
+        <i class="fa fa-home"></i> {% trans "Home" %}
+    </a>
     <a href="#" class="header-nav btn btn-outline-success active">
         <i class="fa fa-ticket"></i> {% trans "Tickets" %}
     </a>
+    {% if is_talk_event_created %}
     <a href="{{ talk_edit_url }}" class="header-nav btn btn-outline-success">
         <i class="fa fa-group"></i> {% trans "Talk" %}
     </a>
+    {% endif %}
     {% if is_video_enabled %}
         <a class="header-nav btn btn-outline-success"
            href='{% url "eventyay_common:event.create_access_to_video" organizer=request.organizer.slug event=request.event.slug %}'
            title="{% trans 'Access videos related to this event' %}">
-            <i class="fa fa-video-camera"></i> {% trans "Videos" %}
-        </a>
-    {% else %}
-        <a class="header-nav btn btn-outline-success disabled" href="#" disabled
-           title="{% trans 'Videos are not available because the plugin is inactive or missing settings for this event' %}">
             <i class="fa fa-video-camera"></i> {% trans "Videos" %}
         </a>
     {% endif %}

--- a/src/pretix/eventyay_common/templates/eventyay_common/event/settings.html
+++ b/src/pretix/eventyay_common/templates/eventyay_common/event/settings.html
@@ -23,18 +23,15 @@
                    class="header-nav btn btn-outline-success">
                     <i class="fa fa-ticket"></i> {% trans "Tickets" %}
                 </a>
+                {% if is_talk_event_created %}
                 <a href="{{ talk_edit_url }}" class="header-nav btn btn-outline-success">
                     <i class="fa fa-group"></i> {% trans "Talk" %}
                 </a>
+                {% endif %}
                 {% if is_video_enabled %}
                     <a class="header-nav btn btn-outline-success"
                        href='{% url "eventyay_common:event.create_access_to_video" organizer=request.organizer.slug event=request.event.slug %}'
                        title="{% trans 'Access videos related to this event' %}">
-                        <i class="fa fa-video-camera"></i> {% trans "Videos" %}
-                    </a>
-                {% else %}
-                    <a class="header-nav btn btn-outline-success disabled" href="#" disabled
-                       title="{% trans 'Videos are not available because the plugin is inactive or missing settings for this event' %}">
                         <i class="fa fa-video-camera"></i> {% trans "Videos" %}
                     </a>
                 {% endif %}

--- a/src/pretix/eventyay_common/templates/eventyay_common/events/create_foundation.html
+++ b/src/pretix/eventyay_common/templates/eventyay_common/events/create_foundation.html
@@ -7,13 +7,21 @@
         <div class="col-md-9">
             <div class="radio">
                 <label>
-                    <input type="radio" name="create_for" value="tickets" {% if create_for == 'tickets' %}checked{% endif %}>
+                    <input
+                        type="radio"
+                        name="create_for"
+                        value="{{ event_creation_for_choice.TICKET }}"
+                        {% if create_for == event_creation_for_choice.TICKET %}checked{% endif %}
+                    >
                     <strong>{% trans "Tickets system" %}</strong>
                 </label>
             </div>
             <div class="radio">
                 <label>
-                    <input type="radio" name="create_for" value="talk" {% if create_for == 'talk' %}checked{% endif %} disabled>
+                    <input
+                        type="radio" name="create_for"
+                        value={{ event_creation_for_choice.TALK }}
+                        {% if create_for == event_creation_for_choice.TALK %}checked{% endif %} disabled>
                     <strong>{% trans "Talk system" %}</strong>
                     <div class="help-block">
                         {% blocktrans trimmed %}
@@ -24,7 +32,10 @@
             </div>
             <div class="radio">
                 <label>
-                    <input type="radio" name="create_for" value="all" {% if create_for == 'all' %}checked{% endif %}>
+                    <input
+                        type="radio" name="create_for"
+                        value={{ event_creation_for_choice.BOTH }}
+                        {% if create_for == event_creation_for_choice.BOTH %}checked{% endif %}>
                     <strong>{% trans "Both tickets and talk system" %}</strong>
                 </label>
             </div>

--- a/src/pretix/eventyay_common/templates/eventyay_common/events/create_foundation.html
+++ b/src/pretix/eventyay_common/templates/eventyay_common/events/create_foundation.html
@@ -20,7 +20,7 @@
                 <label>
                     <input
                         type="radio" name="create_for"
-                        value={{ event_creation_for_choice.TALK }}
+                        value="{{ event_creation_for_choice.TALK }}"
                         {% if create_for == event_creation_for_choice.TALK %}checked{% endif %} disabled>
                     <strong>{% trans "Talk system" %}</strong>
                     <div class="help-block">
@@ -34,7 +34,7 @@
                 <label>
                     <input
                         type="radio" name="create_for"
-                        value={{ event_creation_for_choice.BOTH }}
+                        value="{{ event_creation_for_choice.BOTH }}"
                         {% if create_for == event_creation_for_choice.BOTH %}checked{% endif %}>
                     <strong>{% trans "Both tickets and talk system" %}</strong>
                 </label>

--- a/src/pretix/eventyay_common/views/event.py
+++ b/src/pretix/eventyay_common/views/event.py
@@ -174,6 +174,7 @@ class EventCreateView(SafeSessionWizardView):
             context["organizer"] = self.get_cleaned_data_for_step("foundation").get(
                 "organizer"
             )
+        context["event_creation_for_choice"] = {e.name: e.value for e in EventCreatedFor}
         return context
 
     def render(self, form=None, **kwargs):

--- a/src/pretix/eventyay_common/views/event.py
+++ b/src/pretix/eventyay_common/views/event.py
@@ -40,7 +40,7 @@ from pretix.helpers.plugin_enable import is_video_enabled
 
 class EventCreatedFor(Enum):
     BOTH = "all"
-    TICKET = "ticket"
+    TICKET = "tickets"
     TALK = "talk"
 
 

--- a/src/pretix/eventyay_common/views/event.py
+++ b/src/pretix/eventyay_common/views/event.py
@@ -1,5 +1,6 @@
 import datetime as dt
 from datetime import datetime, timezone as tz
+from enum import Enum
 
 import jwt
 from django.conf import settings
@@ -35,6 +36,12 @@ from pretix.eventyay_common.utils import (
     check_create_permission, encode_email, generate_token,
 )
 from pretix.helpers.plugin_enable import is_video_enabled
+
+
+class EventCreatedFor(Enum):
+    BOTH = "all"
+    TICKET = "ticket"
+    TALK = "talk"
 
 
 class EventList(PaginationMixin, ListView):
@@ -159,7 +166,7 @@ class EventCreateView(SafeSessionWizardView):
 
     def get_context_data(self, form, **kwargs):
         context = super().get_context_data(form, **kwargs)
-        context["create_for"] = self.storage.extra_data.get("create_for", "all")
+        context["create_for"] = self.storage.extra_data.get("create_for", EventCreatedFor.BOTH.value)
         context["has_organizer"] = self.request.user.teams.filter(
             can_create_events=True
         ).exists()
@@ -206,7 +213,7 @@ class EventCreateView(SafeSessionWizardView):
 
         self.request.organizer = foundation_data["organizer"]
 
-        if create_for == "talk":
+        if create_for == EventCreatedFor.TALK.value:
             event_dict = {
                 "organiser_slug": (
                     foundation_data.get("organizer").slug
@@ -246,7 +253,7 @@ class EventCreateView(SafeSessionWizardView):
                 event.settings.set("timezone", basics_data["timezone"])
                 event.settings.set("locale", basics_data["locale"])
                 event.settings.set("locales", foundation_data["locales"])
-                if create_for == "all":
+                if create_for == EventCreatedFor.BOTH.value:
                     event_dict = {
                         "organiser_slug": event.organizer.slug,
                         "name": event.name.data,
@@ -315,6 +322,13 @@ class EventUpdate(
             talk_host + "/orga/event/" + self.object.slug + "/settings"
         )
         context['is_video_enabled'] = is_video_enabled(self.object)
+        context["is_talk_event_created"] = False
+        if (
+            self.object.settings.create_for == EventCreatedFor.BOTH.value
+            or self.object.settings.talk_schedule_public is not None
+        ):
+            # Ignore case Event is created only for Talk as it not enable yet.
+            context["is_talk_event_created"] = True
         return context
 
     def handle_video_creation(self, form):
@@ -376,7 +390,7 @@ class EventUpdate(
             event = form.instance
             event.date_from = self.reset_timezone(zone, event.date_from)
             event.date_to = self.reset_timezone(zone, event.date_to)
-            if event.settings.create_for and event.settings.create_for == "all":
+            if event.settings.create_for and event.settings.create_for == EventCreatedFor.BOTH.value:
                 event_dict = {
                     "organiser_slug": event.organizer.slug,
                     "name": event.name.data,

--- a/src/pretix/plugins/banktransfer/templates/pretixplugins/banktransfer/refund_export.html
+++ b/src/pretix/plugins/banktransfer/templates/pretixplugins/banktransfer/refund_export.html
@@ -9,7 +9,9 @@
             <div class="navigation-title">
                 <h1>{% trans "Export bank transfer refunds" %}</h1>
             </div>
-            {% include "pretixcontrol/event/component_link.html" %}
+            {% if request.event %}
+                {% include "pretixcontrol/event/component_link.html" %}
+            {% endif %}
         </div>
     </nav>
     <p>

--- a/src/pretix/plugins/banktransfer/templates/pretixplugins/banktransfer/refund_export.html
+++ b/src/pretix/plugins/banktransfer/templates/pretixplugins/banktransfer/refund_export.html
@@ -9,9 +9,7 @@
             <div class="navigation-title">
                 <h1>{% trans "Export bank transfer refunds" %}</h1>
             </div>
-            {% if request.event %}
-                {% include "pretixcontrol/event/component_link.html" %}
-            {% endif %}
+            {% include "pretixcontrol/event/component_link.html" %}
         </div>
     </nav>
     <p>


### PR DESCRIPTION
This PR resolves #391 
Add Home button in ticket and hide talk/video button if it not configured yet

case 1: Video is configured and setting, Event not created in Talk
![image](https://github.com/user-attachments/assets/c388ce04-813c-4acd-a7ca-209989d54da9)

case 2: Video plugin is not enabled and Talk's event is created (check with talk_schedule_public flag in database)
![image](https://github.com/user-attachments/assets/5e2c739c-10ee-48e2-9888-0fdbae701cb6)

## Summary by Sourcery

Add a Home button to the event component navigation and enhance the logic for displaying Talk and Video buttons based on event configuration and plugin status. Refactor event creation logic to use an Enum for better code clarity.

New Features:
- Introduce a Home button in the event component navigation for better accessibility.

Enhancements:
- Refactor event creation logic to use an Enum for specifying event creation types, improving code readability and maintainability.
- Update navigation logic to conditionally display Talk and Video buttons based on event configuration and plugin status.