### PR TITLE
General settings page keep loading eternally if presale start/end is removed

### DIFF
--- a/src/pretix/base/configurations/default_setting.py
+++ b/src/pretix/base/configurations/default_setting.py
@@ -21,6 +21,9 @@ from pretix.api.serializers.fields import (
     ListMultipleChoiceField, UploadedFileField,
 )
 from pretix.api.serializers.i18n import I18nField, I18nURLField
+from pretix.base.configurations.lazy_i18n_string_list_base import (
+    LazyI18nStringList,
+)
 from pretix.base.forms import I18nURLFormField
 from pretix.base.models.tax import TaxRule
 from pretix.base.reldate import (
@@ -31,8 +34,6 @@ from pretix.control.forms import (
     ExtFileField, FontSelect, MultipleLanguagesWidget, SingleLanguageWidget,
 )
 from pretix.helpers.countries import CachedCountries
-
-from .lazy_i18n_string_list_base import LazyI18nStringListBase
 
 
 def country_choice_kwargs():
@@ -1566,8 +1567,8 @@ DEFAULT_SETTINGS = {
         "serializer_class": serializers.URLField,
     },
     "confirm_texts": {
-        "default": LazyI18nStringListBase(),
-        "type": LazyI18nStringListBase,
+        "default": LazyI18nStringList(),
+        "type": LazyI18nStringList,
         "serializer_class": serializers.ListField,
         "serializer_kwargs": lambda: dict(child=I18nField()),
     },

--- a/src/pretix/base/configurations/lazy_i18n_string_list_base.py
+++ b/src/pretix/base/configurations/lazy_i18n_string_list_base.py
@@ -16,3 +16,8 @@ class LazyI18nStringListBase(UserList):
     @classmethod
     def unserialize(cls, s):
         return cls(json.loads(s))
+
+
+class LazyI18nStringList(LazyI18nStringListBase):
+    def __init__(self, init_list=None):
+        super().__init__(init_list)

--- a/src/pretix/base/services/cart.py
+++ b/src/pretix/base/services/cart.py
@@ -13,6 +13,9 @@ from django.utils.translation import gettext as _, pgettext_lazy
 from django_scopes import scopes_disabled
 
 from pretix.base.channels import get_all_sales_channels
+from pretix.base.configurations.lazy_i18n_string_list_base import (
+    LazyI18nStringList,
+)
 from pretix.base.i18n import language
 from pretix.base.models import (
     CartPosition, Event, InvoiceAddress, Item, ItemVariation, Seat,
@@ -27,7 +30,7 @@ from pretix.base.services.locking import LockTimeoutException, NoLockManager
 from pretix.base.services.pricing import get_price
 from pretix.base.services.quotas import QuotaAvailability
 from pretix.base.services.tasks import ProfiledEventTask
-from pretix.base.settings import PERSON_NAME_SCHEMES, LazyI18nStringList
+from pretix.base.settings import PERSON_NAME_SCHEMES
 from pretix.base.signals import validate_cart_addons
 from pretix.base.templatetags.rich_text import rich_text
 from pretix.celery_app import app

--- a/src/pretix/base/settings.py
+++ b/src/pretix/base/settings.py
@@ -10,15 +10,12 @@ from i18nfield.strings import LazyI18nString
 
 from pretix.base.configurations import (
     COUNTRIES_WITH_STATE, CSS_SETTINGS, DEFAULT_SETTINGS, NAME_SALUTION,
-    NAME_SCHEMES, TITLE_GROUP, LazyI18nStringListBase,
+    NAME_SCHEMES, TITLE_GROUP,
+)
+from pretix.base.configurations.lazy_i18n_string_list_base import (
+    LazyI18nStringList,
 )
 from pretix.base.reldate import RelativeDateWrapper
-
-
-class LazyI18nStringList(LazyI18nStringListBase):
-    def __init__(self, init_list=None):
-        super().__init__(init_list)
-
 
 DEFAULTS = DEFAULT_SETTINGS.copy()
 SETTINGS_AFFECTING_CSS = CSS_SETTINGS.copy()

--- a/src/pretix/control/views/event.py
+++ b/src/pretix/control/views/event.py
@@ -30,7 +30,6 @@ from i18nfield.utils import I18nJSONEncoder
 from pytz import timezone
 
 from pretix.base.channels import get_all_sales_channels
-from pretix.base.configurations import LazyI18nStringListBase
 from pretix.base.email import get_available_placeholders
 from pretix.base.models import (
     Event, LogEntry, Order, RequiredAction, TaxRule, Voucher,
@@ -54,11 +53,14 @@ from pretix.helpers.database import rolledback_transaction
 from pretix.multidomain.urlreverse import get_event_domain
 from pretix.presale.style import regenerate_css
 
+from ...base.configurations.lazy_i18n_string_list_base import (
+    LazyI18nStringList,
+)
 from ...base.i18n import language
 from ...base.models.items import (
     Item, ItemCategory, ItemMetaProperty, Question, Quota,
 )
-from ...base.settings import SETTINGS_AFFECTING_CSS, LazyI18nStringList
+from ...base.settings import SETTINGS_AFFECTING_CSS
 from ..logdisplay import OVERVIEW_BANLIST
 from . import CreateView, PaginationMixin, UpdateView
 
@@ -250,7 +252,7 @@ class EventUpdate(DecoupleMixin, EventSettingsViewMixin, EventPermissionRequired
     @cached_property
     def confirm_texts_formset(self):
         initial = [{"text": text, "ORDER": order} for order, text in
-                   enumerate(self.object.settings.get("confirm_texts", as_type=LazyI18nStringListBase))]
+                   enumerate(self.object.settings.get("confirm_texts", as_type=LazyI18nStringList))]
         return ConfirmTextFormset(self.request.POST if self.request.method == "POST" else None, event=self.object,
                                   prefix="confirm-texts", initial=initial)
 


### PR DESCRIPTION
This PR resolves #446 
Rootcause: confirm_texts field in general settings got incorrect import, should use LazyI18nStringList instead of its base class.
Solution: repalce LazyI18nStringListBase with LazyI18nStringList for confirm_texts field type

## Summary by Sourcery

Bug Fixes:
- Fix the eternal loading issue on the general settings page by replacing LazyI18nStringListBase with LazyI18nStringList for the confirm_texts field.