### PR TITLE
Add links to specific event components | Changes link to dashboard

### DIFF
--- a/src/pretix/control/context.py
+++ b/src/pretix/control/context.py
@@ -53,7 +53,7 @@ def _default_context(request):
         for receiver, response in html_head.send(request.event, request=request):
             _html_head.append(response)
         ctx["talk_edit_url"] = (
-            settings.TALK_HOSTNAME + "/orga/event/" + request.event.slug + "/settings"
+            settings.TALK_HOSTNAME + "/orga/event/" + request.event.slug
         )
         ctx['is_video_enabled'] = is_video_enabled(request.event)
         ctx["is_talk_event_created"] = False

--- a/src/pretix/eventyay_common/templates/eventyay_common/event/settings.html
+++ b/src/pretix/eventyay_common/templates/eventyay_common/event/settings.html
@@ -19,7 +19,7 @@
                 <a href="#" class="header-nav btn btn-outline-success active">
                     <i class="fa fa-home"></i> {% trans "Home" %}
                 </a>
-                <a href='{% url "control:event.settings" organizer=request.organizer.slug event=request.event.slug %}'
+                <a href='{% url "control:event.index" organizer=request.organizer.slug event=request.event.slug %}'
                    class="header-nav btn btn-outline-success">
                     <i class="fa fa-ticket"></i> {% trans "Tickets" %}
                 </a>

--- a/src/pretix/eventyay_common/views/event.py
+++ b/src/pretix/eventyay_common/views/event.py
@@ -323,7 +323,7 @@ class EventUpdate(
         context["sform"] = self.sform
         talk_host = settings.TALK_HOSTNAME
         context["talk_edit_url"] = (
-            talk_host + "/orga/event/" + self.object.slug + "/settings"
+            talk_host + "/orga/event/" + self.object.slug
         )
         context['is_video_enabled'] = is_video_enabled(self.object)
         context["is_talk_event_created"] = False


### PR DESCRIPTION
This PR solves comment https://github.com/fossasia/eventyay-tickets/issues/391#issuecomment-2495404988
component will link to dashboard page instead of settings page.

## Summary by Sourcery

Enhancements:
- Update event component links to direct to the dashboard page instead of the settings page.