### PR TITLE
Standardize menu items

### DIFF
--- a/src/pretix/control/navigation.py
+++ b/src/pretix/control/navigation.py
@@ -295,13 +295,13 @@ def get_global_navigation(request):
         return []
     nav = [
         {
-            'label': _('Dashboard'),
+            'label': _('Tickets dashboard'),
             'url': reverse('control:index'),
             'active': (url.url_name == 'index'),
             'icon': 'dashboard',
         },
         {
-            'label': _('My Orders'),
+            'label': _('My orders'),
             'url': reverse('control:user.settings.orders'),
             'active': 'user.settings.orders' in url.url_name,
             'icon': 'shopping-cart',

--- a/src/pretix/control/templates/pretixcontrol/base.html
+++ b/src/pretix/control/templates/pretixcontrol/base.html
@@ -112,7 +112,7 @@
                                 </button>
                             </form>
                         {% else %}
-                            <a href="{% eventurl request.event "presale:event.index" %}" title="{% trans "Go to shop" %}"
+                            <a href="{% eventurl request.event "presale:event.index" %}" title="{% trans "View event" %}"
                                     target="_blank" class="navbar-toggle mobile-navbar-view-link">
                                 <i class="fa fa-eye"></i>
                             </a>
@@ -135,12 +135,12 @@
                                 <form action="{% eventurl request.event "presale:event.auth" %}" method="post" target="_blank">
                                     <input type="hidden" value="{{ new_session }}" name="session">
                                     <button type="submit" class="btn btn-link" id="button-shop">
-                                       <i class="fa fa-eye"></i> {% trans "Go to shop" %}
+                                       <i class="fa fa-eye"></i> {% trans "View event" %}
                                     </button>
                                 </form>
                             {% else %}
-                                <a href="{% eventurl request.event "presale:event.index" %}" title="{% trans "Go to shop" %}"  target="_blank">
-                                    <i class="fa fa-eye"></i> {% trans "Go to shop" %}
+                                <a href="{% eventurl request.event "presale:event.index" %}" title="{% trans "View event" %}"  target="_blank">
+                                    <i class="fa fa-eye"></i> {% trans "View event" %}
                                 </a>
                             {% endif %}
                         </li>

--- a/src/pretix/control/templates/pretixcontrol/dashboard.html
+++ b/src/pretix/control/templates/pretixcontrol/dashboard.html
@@ -2,7 +2,7 @@
 {% load i18n %}
 {% block title %}{% trans "Dashboard" %}{% endblock %}
 {% block content %}
-    <h1>{% trans "Dashboard" %}</h1>
+    <h1>{% trans "Tickets dashboard" %}</h1>
 
     <div class="dropdown-container">
         <input type="text" class="form-control" id="dashboard_query"

--- a/src/pretix/control/templates/pretixcontrol/events/index.html
+++ b/src/pretix/control/templates/pretixcontrol/events/index.html
@@ -4,7 +4,7 @@
 {% load bootstrap3 %}
 {% block title %}{% trans "Events" %}{% endblock %}
 {% block content %}
-    <h1>{% trans "Events" %}</h1>
+    <h1>{% trans "My events" %}</h1>
     <p>{% trans "The list below shows all events you have administrative access to. Click on the event name to access event details." %}</p>
     {% if events|length == 0 and not filter_form.filtered %}
         <div class="empty-collection">

--- a/src/pretix/eventyay_common/context.py
+++ b/src/pretix/eventyay_common/context.py
@@ -70,7 +70,7 @@ def get_global_navigation(request):
             'icon': 'dashboard',
         },
         {
-            'label': _('Events'),
+            'label': _('My events'),
             'url': reverse('eventyay_common:events'),
             'active': 'events' in url.url_name,
             'icon': 'calendar',

--- a/src/pretix/locale/ar/LC_MESSAGES/django.po
+++ b/src/pretix/locale/ar/LC_MESSAGES/django.po
@@ -24299,9 +24299,6 @@ msgstr ""
 #~ msgid "General "
 #~ msgstr "جنرال لواء"
 
-#~ msgid "View event"
-#~ msgstr "الذهاب إلى متجر"
-
 #~ msgid "You haven't created any questions yet."
 #~ msgstr "لم تقم بإنشاء أي أسئلة بعد."
 

--- a/src/pretix/locale/ar/LC_MESSAGES/django.po
+++ b/src/pretix/locale/ar/LC_MESSAGES/django.po
@@ -11784,8 +11784,8 @@ msgstr "تبديل الملاحة"
 #: pretix/control/templates/pretixcontrol/base.html:136
 #: pretix/control/templates/pretixcontrol/base.html:140
 #: pretix/control/templates/pretixcontrol/base.html:141
-msgid "Go to shop"
-msgstr "الذهاب للتسوق"
+msgid "View event"
+msgstr "عرض الحدث"
 
 #: pretix/control/templates/pretixcontrol/base.html:119
 #: pretix/control/templates/pretixcontrol/base.html:147
@@ -24299,7 +24299,7 @@ msgstr ""
 #~ msgid "General "
 #~ msgstr "جنرال لواء"
 
-#~ msgid "Go to Shop"
+#~ msgid "View event"
 #~ msgstr "الذهاب إلى متجر"
 
 #~ msgid "You haven't created any questions yet."

--- a/src/pretix/locale/ca/LC_MESSAGES/django.po
+++ b/src/pretix/locale/ca/LC_MESSAGES/django.po
@@ -11684,7 +11684,7 @@ msgstr ""
 #: pretix/control/templates/pretixcontrol/base.html:136
 #: pretix/control/templates/pretixcontrol/base.html:140
 #: pretix/control/templates/pretixcontrol/base.html:141
-msgid "Go to shop"
+msgid "View event"
 msgstr ""
 
 #: pretix/control/templates/pretixcontrol/base.html:119

--- a/src/pretix/locale/cs/LC_MESSAGES/django.po
+++ b/src/pretix/locale/cs/LC_MESSAGES/django.po
@@ -10435,7 +10435,7 @@ msgstr ""
 #: pretix/control/templates/pretixcontrol/base.html:136
 #: pretix/control/templates/pretixcontrol/base.html:140
 #: pretix/control/templates/pretixcontrol/base.html:141
-msgid "Go to shop"
+msgid "View event"
 msgstr ""
 
 #: pretix/control/templates/pretixcontrol/base.html:119

--- a/src/pretix/locale/da/LC_MESSAGES/django.po
+++ b/src/pretix/locale/da/LC_MESSAGES/django.po
@@ -24317,9 +24317,6 @@ msgstr ""
 #~ msgid "General "
 #~ msgstr "Generelt"
 
-#~ msgid "View event"
-#~ msgstr "Vis butik"
-
 #~ msgid "You haven't created any questions yet."
 #~ msgstr "Du har endnu ikke oprettet nogen spørgsmål."
 

--- a/src/pretix/locale/da/LC_MESSAGES/django.po
+++ b/src/pretix/locale/da/LC_MESSAGES/django.po
@@ -12157,8 +12157,8 @@ msgstr "Vis/skjul navigation"
 #: pretix/control/templates/pretixcontrol/base.html:136
 #: pretix/control/templates/pretixcontrol/base.html:140
 #: pretix/control/templates/pretixcontrol/base.html:141
-msgid "Go to shop"
-msgstr "Vis butik"
+msgid "View event"
+msgstr "se begivenhed"
 
 #: pretix/control/templates/pretixcontrol/base.html:119
 #: pretix/control/templates/pretixcontrol/base.html:147
@@ -24317,7 +24317,7 @@ msgstr ""
 #~ msgid "General "
 #~ msgstr "Generelt"
 
-#~ msgid "Go to Shop"
+#~ msgid "View event"
 #~ msgstr "Vis butik"
 
 #~ msgid "You haven't created any questions yet."

--- a/src/pretix/locale/de/LC_MESSAGES/django.po
+++ b/src/pretix/locale/de/LC_MESSAGES/django.po
@@ -11717,8 +11717,8 @@ msgstr "Navigation umschalten"
 #: pretix/control/templates/pretixcontrol/base.html:136
 #: pretix/control/templates/pretixcontrol/base.html:140
 #: pretix/control/templates/pretixcontrol/base.html:141
-msgid "Go to shop"
-msgstr "Shop aufrufen"
+msgid "View event"
+msgstr "Veranstaltung ansehen"
 
 #: pretix/control/templates/pretixcontrol/base.html:119
 #: pretix/control/templates/pretixcontrol/base.html:147
@@ -24150,7 +24150,7 @@ msgstr "Kosovo"
 #~ msgid "General "
 #~ msgstr "Allgemein "
 
-#~ msgid "Go to Shop"
+#~ msgid "View event"
 #~ msgstr "Shop ansehen"
 
 #~ msgid "You haven't created any questions yet."

--- a/src/pretix/locale/de/LC_MESSAGES/django.po
+++ b/src/pretix/locale/de/LC_MESSAGES/django.po
@@ -24150,9 +24150,6 @@ msgstr "Kosovo"
 #~ msgid "General "
 #~ msgstr "Allgemein "
 
-#~ msgid "View event"
-#~ msgstr "Shop ansehen"
-
 #~ msgid "You haven't created any questions yet."
 #~ msgstr "Sie haben noch keine Fragen erstellt."
 

--- a/src/pretix/locale/de_Informal/LC_MESSAGES/django.po
+++ b/src/pretix/locale/de_Informal/LC_MESSAGES/django.po
@@ -11699,8 +11699,8 @@ msgstr "Navigation umschalten"
 #: pretix/control/templates/pretixcontrol/base.html:136
 #: pretix/control/templates/pretixcontrol/base.html:140
 #: pretix/control/templates/pretixcontrol/base.html:141
-msgid "Go to shop"
-msgstr "Shop aufrufen"
+msgid "View event"
+msgstr "Veranstaltung ansehen"
 
 #: pretix/control/templates/pretixcontrol/base.html:119
 #: pretix/control/templates/pretixcontrol/base.html:147
@@ -24097,7 +24097,7 @@ msgstr "Kosovo"
 #~ msgid "General "
 #~ msgstr "Allgemeines "
 
-#~ msgid "Go to Shop"
+#~ msgid "View event"
 #~ msgstr "Shop ansehen"
 
 #~ msgid "You haven't created any questions yet."

--- a/src/pretix/locale/de_Informal/LC_MESSAGES/django.po
+++ b/src/pretix/locale/de_Informal/LC_MESSAGES/django.po
@@ -24097,9 +24097,6 @@ msgstr "Kosovo"
 #~ msgid "General "
 #~ msgstr "Allgemeines "
 
-#~ msgid "View event"
-#~ msgstr "Shop ansehen"
-
 #~ msgid "You haven't created any questions yet."
 #~ msgstr "Du hast noch keine Fragen erstellt."
 

--- a/src/pretix/locale/django.pot
+++ b/src/pretix/locale/django.pot
@@ -10375,7 +10375,7 @@ msgstr ""
 #: pretix/control/templates/pretixcontrol/base.html:136
 #: pretix/control/templates/pretixcontrol/base.html:140
 #: pretix/control/templates/pretixcontrol/base.html:141
-msgid "Go to shop"
+msgid "View event"
 msgstr ""
 
 #: pretix/control/templates/pretixcontrol/base.html:119

--- a/src/pretix/locale/el/LC_MESSAGES/django.po
+++ b/src/pretix/locale/el/LC_MESSAGES/django.po
@@ -25429,9 +25429,6 @@ msgstr ""
 #~ msgid "General "
 #~ msgstr "Γενικά"
 
-#~ msgid "View event"
-#~ msgstr "Πηγαίνετε στο κατάστημα"
-
 #~ msgid "You haven't created any questions yet."
 #~ msgstr "Δεν έχετε δημιουργήσει ακόμα ερωτήσεις."
 

--- a/src/pretix/locale/el/LC_MESSAGES/django.po
+++ b/src/pretix/locale/el/LC_MESSAGES/django.po
@@ -12355,8 +12355,8 @@ msgstr "Εναλλαγή πλοήγησης"
 #: pretix/control/templates/pretixcontrol/base.html:136
 #: pretix/control/templates/pretixcontrol/base.html:140
 #: pretix/control/templates/pretixcontrol/base.html:141
-msgid "Go to shop"
-msgstr "Πηγαίνετε στο κατάστημα"
+msgid "View event"
+msgstr "προβολή εκδήλωσης"
 
 #: pretix/control/templates/pretixcontrol/base.html:119
 #: pretix/control/templates/pretixcontrol/base.html:147
@@ -25429,7 +25429,7 @@ msgstr ""
 #~ msgid "General "
 #~ msgstr "Γενικά"
 
-#~ msgid "Go to Shop"
+#~ msgid "View event"
 #~ msgstr "Πηγαίνετε στο κατάστημα"
 
 #~ msgid "You haven't created any questions yet."

--- a/src/pretix/locale/es/LC_MESSAGES/django.po
+++ b/src/pretix/locale/es/LC_MESSAGES/django.po
@@ -12366,8 +12366,8 @@ msgstr "Alternar la navegación"
 #: pretix/control/templates/pretixcontrol/base.html:136
 #: pretix/control/templates/pretixcontrol/base.html:140
 #: pretix/control/templates/pretixcontrol/base.html:141
-msgid "Go to shop"
-msgstr "Ir a la tienda"
+msgid "View event"
+msgstr "ver evento"
 
 #: pretix/control/templates/pretixcontrol/base.html:119
 #: pretix/control/templates/pretixcontrol/base.html:147
@@ -25421,7 +25421,7 @@ msgstr ""
 #~ msgid "General "
 #~ msgstr "General"
 
-#~ msgid "Go to Shop"
+#~ msgid "View event"
 #~ msgstr "Ir a la tienda"
 
 #~ msgid "You haven't created any questions yet."

--- a/src/pretix/locale/es/LC_MESSAGES/django.po
+++ b/src/pretix/locale/es/LC_MESSAGES/django.po
@@ -25421,9 +25421,6 @@ msgstr ""
 #~ msgid "General "
 #~ msgstr "General"
 
-#~ msgid "View event"
-#~ msgstr "Ir a la tienda"
-
 #~ msgid "You haven't created any questions yet."
 #~ msgstr "Aún no ha creado ninguna pregunta."
 

--- a/src/pretix/locale/fi/LC_MESSAGES/django.po
+++ b/src/pretix/locale/fi/LC_MESSAGES/django.po
@@ -10495,7 +10495,7 @@ msgstr ""
 #: pretix/control/templates/pretixcontrol/base.html:136
 #: pretix/control/templates/pretixcontrol/base.html:140
 #: pretix/control/templates/pretixcontrol/base.html:141
-msgid "Go to shop"
+msgid "View event"
 msgstr ""
 
 #: pretix/control/templates/pretixcontrol/base.html:119

--- a/src/pretix/locale/fr/LC_MESSAGES/django.po
+++ b/src/pretix/locale/fr/LC_MESSAGES/django.po
@@ -12581,8 +12581,8 @@ msgstr "Basculer la navigation"
 #: pretix/control/templates/pretixcontrol/base.html:136
 #: pretix/control/templates/pretixcontrol/base.html:140
 #: pretix/control/templates/pretixcontrol/base.html:141
-msgid "Go to shop"
-msgstr "Accéder à la boutique"
+msgid "View event"
+msgstr "voir l'événement"
 
 #: pretix/control/templates/pretixcontrol/base.html:119
 #: pretix/control/templates/pretixcontrol/base.html:147
@@ -25894,7 +25894,7 @@ msgstr ""
 #~ msgid "General "
 #~ msgstr "Général"
 
-#~ msgid "Go to Shop"
+#~ msgid "View event"
 #~ msgstr "Accéder à la Boutique"
 
 #~ msgid "You haven't created any questions yet."

--- a/src/pretix/locale/fr/LC_MESSAGES/django.po
+++ b/src/pretix/locale/fr/LC_MESSAGES/django.po
@@ -25894,9 +25894,6 @@ msgstr ""
 #~ msgid "General "
 #~ msgstr "Général"
 
-#~ msgid "View event"
-#~ msgstr "Accéder à la Boutique"
-
 #~ msgid "You haven't created any questions yet."
 #~ msgstr "Vous n'avez pas encore créé de questions."
 

--- a/src/pretix/locale/hu/LC_MESSAGES/django.po
+++ b/src/pretix/locale/hu/LC_MESSAGES/django.po
@@ -10464,7 +10464,7 @@ msgstr ""
 #: pretix/control/templates/pretixcontrol/base.html:136
 #: pretix/control/templates/pretixcontrol/base.html:140
 #: pretix/control/templates/pretixcontrol/base.html:141
-msgid "Go to shop"
+msgid "View event"
 msgstr ""
 
 #: pretix/control/templates/pretixcontrol/base.html:119

--- a/src/pretix/locale/it/LC_MESSAGES/django.po
+++ b/src/pretix/locale/it/LC_MESSAGES/django.po
@@ -10897,7 +10897,7 @@ msgstr ""
 #: pretix/control/templates/pretixcontrol/base.html:136
 #: pretix/control/templates/pretixcontrol/base.html:140
 #: pretix/control/templates/pretixcontrol/base.html:141
-msgid "Go to shop"
+msgid "View event"
 msgstr ""
 
 #: pretix/control/templates/pretixcontrol/base.html:119

--- a/src/pretix/locale/lv/LC_MESSAGES/django.po
+++ b/src/pretix/locale/lv/LC_MESSAGES/django.po
@@ -11135,7 +11135,7 @@ msgstr ""
 #: pretix/control/templates/pretixcontrol/base.html:136
 #: pretix/control/templates/pretixcontrol/base.html:140
 #: pretix/control/templates/pretixcontrol/base.html:141
-msgid "Go to shop"
+msgid "View event"
 msgstr ""
 
 #: pretix/control/templates/pretixcontrol/base.html:119

--- a/src/pretix/locale/nb_NO/LC_MESSAGES/django.po
+++ b/src/pretix/locale/nb_NO/LC_MESSAGES/django.po
@@ -10374,7 +10374,7 @@ msgstr ""
 #: pretix/control/templates/pretixcontrol/base.html:136
 #: pretix/control/templates/pretixcontrol/base.html:140
 #: pretix/control/templates/pretixcontrol/base.html:141
-msgid "Go to shop"
+msgid "View event"
 msgstr ""
 
 #: pretix/control/templates/pretixcontrol/base.html:119

--- a/src/pretix/locale/nl/LC_MESSAGES/django.po
+++ b/src/pretix/locale/nl/LC_MESSAGES/django.po
@@ -24130,9 +24130,6 @@ msgstr "Kosovo"
 #~ msgid "General "
 #~ msgstr "Algemeen "
 
-#~ msgid "View event"
-#~ msgstr "Ga naar de winkel"
-
 #~ msgid "You haven't created any questions yet."
 #~ msgstr "U heeft nog geen vragen aangemaakt."
 

--- a/src/pretix/locale/nl/LC_MESSAGES/django.po
+++ b/src/pretix/locale/nl/LC_MESSAGES/django.po
@@ -11699,8 +11699,8 @@ msgstr "Navigatie schakelen"
 #: pretix/control/templates/pretixcontrol/base.html:136
 #: pretix/control/templates/pretixcontrol/base.html:140
 #: pretix/control/templates/pretixcontrol/base.html:141
-msgid "Go to shop"
-msgstr "Ga naar de winkel"
+msgid "View event"
+msgstr "Bekijk evenement"
 
 #: pretix/control/templates/pretixcontrol/base.html:119
 #: pretix/control/templates/pretixcontrol/base.html:147
@@ -24130,7 +24130,7 @@ msgstr "Kosovo"
 #~ msgid "General "
 #~ msgstr "Algemeen "
 
-#~ msgid "Go to Shop"
+#~ msgid "View event"
 #~ msgstr "Ga naar de winkel"
 
 #~ msgid "You haven't created any questions yet."

--- a/src/pretix/locale/nl_BE/LC_MESSAGES/django.po
+++ b/src/pretix/locale/nl_BE/LC_MESSAGES/django.po
@@ -10374,7 +10374,7 @@ msgstr ""
 #: pretix/control/templates/pretixcontrol/base.html:136
 #: pretix/control/templates/pretixcontrol/base.html:140
 #: pretix/control/templates/pretixcontrol/base.html:141
-msgid "Go to shop"
+msgid "View event"
 msgstr ""
 
 #: pretix/control/templates/pretixcontrol/base.html:119

--- a/src/pretix/locale/nl_Informal/LC_MESSAGES/django.po
+++ b/src/pretix/locale/nl_Informal/LC_MESSAGES/django.po
@@ -11758,8 +11758,8 @@ msgstr "Navigatie schakelen"
 #: pretix/control/templates/pretixcontrol/base.html:136
 #: pretix/control/templates/pretixcontrol/base.html:140
 #: pretix/control/templates/pretixcontrol/base.html:141
-msgid "Go to shop"
-msgstr "Ga naar de winkel"
+msgid "View event"
+msgstr "Bekijk evenement"
 
 #: pretix/control/templates/pretixcontrol/base.html:119
 #: pretix/control/templates/pretixcontrol/base.html:147
@@ -24259,7 +24259,7 @@ msgstr "Kosovo"
 #~ msgid "General "
 #~ msgstr "Algemeen "
 
-#~ msgid "Go to Shop"
+#~ msgid "View event"
 #~ msgstr "Ga naar de winkel"
 
 #~ msgid "You haven't created any questions yet."

--- a/src/pretix/locale/nl_Informal/LC_MESSAGES/django.po
+++ b/src/pretix/locale/nl_Informal/LC_MESSAGES/django.po
@@ -24259,9 +24259,6 @@ msgstr "Kosovo"
 #~ msgid "General "
 #~ msgstr "Algemeen "
 
-#~ msgid "View event"
-#~ msgstr "Ga naar de winkel"
-
 #~ msgid "You haven't created any questions yet."
 #~ msgstr "Je hebt nog geen vragen aangemaakt."
 

--- a/src/pretix/locale/pl/LC_MESSAGES/django.po
+++ b/src/pretix/locale/pl/LC_MESSAGES/django.po
@@ -10965,7 +10965,7 @@ msgstr ""
 #: pretix/control/templates/pretixcontrol/base.html:136
 #: pretix/control/templates/pretixcontrol/base.html:140
 #: pretix/control/templates/pretixcontrol/base.html:141
-msgid "Go to shop"
+msgid "View event"
 msgstr ""
 
 #: pretix/control/templates/pretixcontrol/base.html:119

--- a/src/pretix/locale/pl_Informal/LC_MESSAGES/django.po
+++ b/src/pretix/locale/pl_Informal/LC_MESSAGES/django.po
@@ -10367,7 +10367,7 @@ msgstr ""
 #: pretix/control/templates/pretixcontrol/base.html:136
 #: pretix/control/templates/pretixcontrol/base.html:140
 #: pretix/control/templates/pretixcontrol/base.html:141
-msgid "Go to shop"
+msgid "View event"
 msgstr ""
 
 #: pretix/control/templates/pretixcontrol/base.html:119

--- a/src/pretix/locale/pt/LC_MESSAGES/django.po
+++ b/src/pretix/locale/pt/LC_MESSAGES/django.po
@@ -10375,7 +10375,7 @@ msgstr ""
 #: pretix/control/templates/pretixcontrol/base.html:136
 #: pretix/control/templates/pretixcontrol/base.html:140
 #: pretix/control/templates/pretixcontrol/base.html:141
-msgid "Go to shop"
+msgid "View event"
 msgstr ""
 
 #: pretix/control/templates/pretixcontrol/base.html:119

--- a/src/pretix/locale/pt_BR/LC_MESSAGES/django.po
+++ b/src/pretix/locale/pt_BR/LC_MESSAGES/django.po
@@ -11273,7 +11273,7 @@ msgstr ""
 #: pretix/control/templates/pretixcontrol/base.html:136
 #: pretix/control/templates/pretixcontrol/base.html:140
 #: pretix/control/templates/pretixcontrol/base.html:141
-msgid "Go to shop"
+msgid "View event"
 msgstr ""
 
 #: pretix/control/templates/pretixcontrol/base.html:119

--- a/src/pretix/locale/pt_PT/LC_MESSAGES/django.po
+++ b/src/pretix/locale/pt_PT/LC_MESSAGES/django.po
@@ -11795,7 +11795,7 @@ msgstr "Alternar navegação"
 #: pretix/control/templates/pretixcontrol/base.html:136
 #: pretix/control/templates/pretixcontrol/base.html:140
 #: pretix/control/templates/pretixcontrol/base.html:141
-msgid "Go to shop"
+msgid "View event"
 msgstr "Ir para a loja"
 
 #: pretix/control/templates/pretixcontrol/base.html:119

--- a/src/pretix/locale/ro/LC_MESSAGES/django.po
+++ b/src/pretix/locale/ro/LC_MESSAGES/django.po
@@ -10376,7 +10376,7 @@ msgstr ""
 #: pretix/control/templates/pretixcontrol/base.html:136
 #: pretix/control/templates/pretixcontrol/base.html:140
 #: pretix/control/templates/pretixcontrol/base.html:141
-msgid "Go to shop"
+msgid "View event"
 msgstr ""
 
 #: pretix/control/templates/pretixcontrol/base.html:119

--- a/src/pretix/locale/ru/LC_MESSAGES/django.po
+++ b/src/pretix/locale/ru/LC_MESSAGES/django.po
@@ -11200,7 +11200,7 @@ msgstr ""
 #: pretix/control/templates/pretixcontrol/base.html:136
 #: pretix/control/templates/pretixcontrol/base.html:140
 #: pretix/control/templates/pretixcontrol/base.html:141
-msgid "Go to shop"
+msgid "View event"
 msgstr ""
 
 #: pretix/control/templates/pretixcontrol/base.html:119

--- a/src/pretix/locale/si/LC_MESSAGES/django.po
+++ b/src/pretix/locale/si/LC_MESSAGES/django.po
@@ -10376,7 +10376,7 @@ msgstr ""
 #: pretix/control/templates/pretixcontrol/base.html:136
 #: pretix/control/templates/pretixcontrol/base.html:140
 #: pretix/control/templates/pretixcontrol/base.html:141
-msgid "Go to shop"
+msgid "View event"
 msgstr ""
 
 #: pretix/control/templates/pretixcontrol/base.html:119

--- a/src/pretix/locale/sl/LC_MESSAGES/django.po
+++ b/src/pretix/locale/sl/LC_MESSAGES/django.po
@@ -10866,7 +10866,7 @@ msgstr ""
 #: pretix/control/templates/pretixcontrol/base.html:136
 #: pretix/control/templates/pretixcontrol/base.html:140
 #: pretix/control/templates/pretixcontrol/base.html:141
-msgid "Go to shop"
+msgid "View event"
 msgstr ""
 
 #: pretix/control/templates/pretixcontrol/base.html:119

--- a/src/pretix/locale/sv/LC_MESSAGES/django.po
+++ b/src/pretix/locale/sv/LC_MESSAGES/django.po
@@ -10909,7 +10909,7 @@ msgstr ""
 #: pretix/control/templates/pretixcontrol/base.html:136
 #: pretix/control/templates/pretixcontrol/base.html:140
 #: pretix/control/templates/pretixcontrol/base.html:141
-msgid "Go to shop"
+msgid "View event"
 msgstr ""
 
 #: pretix/control/templates/pretixcontrol/base.html:119

--- a/src/pretix/locale/tr/LC_MESSAGES/django.po
+++ b/src/pretix/locale/tr/LC_MESSAGES/django.po
@@ -12462,7 +12462,7 @@ msgstr "Gezinmeyi değiştir"
 #: pretix/control/templates/pretixcontrol/base.html:136
 #: pretix/control/templates/pretixcontrol/base.html:140
 #: pretix/control/templates/pretixcontrol/base.html:141
-msgid "Go to shop"
+msgid "View event"
 msgstr "Dükkana git"
 
 #: pretix/control/templates/pretixcontrol/base.html:119
@@ -25394,7 +25394,7 @@ msgstr ""
 #~ msgid "General "
 #~ msgstr "Genel"
 
-#~ msgid "Go to Shop"
+#~ msgid "View event"
 #~ msgstr "Dükkana git"
 
 #~ msgid "You haven't created any questions yet."

--- a/src/pretix/locale/tr/LC_MESSAGES/django.po
+++ b/src/pretix/locale/tr/LC_MESSAGES/django.po
@@ -25394,9 +25394,6 @@ msgstr ""
 #~ msgid "General "
 #~ msgstr "Genel"
 
-#~ msgid "View event"
-#~ msgstr "Dükkana git"
-
 #~ msgid "You haven't created any questions yet."
 #~ msgstr "Henüz hiç soru oluşturmadınız."
 

--- a/src/pretix/locale/ua/LC_MESSAGES/django.po
+++ b/src/pretix/locale/ua/LC_MESSAGES/django.po
@@ -10367,7 +10367,7 @@ msgstr ""
 #: pretix/control/templates/pretixcontrol/base.html:136
 #: pretix/control/templates/pretixcontrol/base.html:140
 #: pretix/control/templates/pretixcontrol/base.html:141
-msgid "Go to shop"
+msgid "View event"
 msgstr ""
 
 #: pretix/control/templates/pretixcontrol/base.html:119

--- a/src/pretix/locale/zh_Hans/LC_MESSAGES/django.po
+++ b/src/pretix/locale/zh_Hans/LC_MESSAGES/django.po
@@ -11601,7 +11601,7 @@ msgstr "切换导航"
 #: pretix/control/templates/pretixcontrol/base.html:136
 #: pretix/control/templates/pretixcontrol/base.html:140
 #: pretix/control/templates/pretixcontrol/base.html:141
-msgid "Go to shop"
+msgid "View event"
 msgstr "去购物"
 
 #: pretix/control/templates/pretixcontrol/base.html:119
@@ -23898,7 +23898,7 @@ msgstr ""
 #~ msgid "General "
 #~ msgstr "一般"
 
-#~ msgid "Go to Shop"
+#~ msgid "View event"
 #~ msgstr "去商店"
 
 #~ msgid "You haven't created any questions yet."

--- a/src/pretix/locale/zh_Hans/LC_MESSAGES/django.po
+++ b/src/pretix/locale/zh_Hans/LC_MESSAGES/django.po
@@ -23898,9 +23898,6 @@ msgstr ""
 #~ msgid "General "
 #~ msgstr "一般"
 
-#~ msgid "View event"
-#~ msgstr "去商店"
-
 #~ msgid "You haven't created any questions yet."
 #~ msgstr "您尚未创建任何问题。"
 

--- a/src/pretix/static/pretixcontrol/js/ui/popover.js
+++ b/src/pretix/static/pretixcontrol/js/ui/popover.js
@@ -29,12 +29,12 @@ $(function () {
                     </div>
                     <div class="profile-menu">
                         <a href="${basePath}${orderPath}" target="_self" class="btn btn-outline-success">
-                            <i class="fa fa-shopping-cart"></i> ${window.gettext('My Orders')}
+                            <i class="fa fa-shopping-cart"></i> ${window.gettext('My orders')}
                         </a>
                     </div>
                     <div class="profile-menu">
                         <a href="${basePath}${eventPath}" target="_self" class="btn btn-outline-success">
-                            <i class="fa fa-calendar"></i> ${window.gettext('My Events')}
+                            <i class="fa fa-calendar"></i> ${window.gettext('My events')}
                         </a>
                     </div>
                      <div class="profile-menu">


### PR DESCRIPTION
This PR resolves #453 
Update label for items

**Rename Dashboard to "Tickets dashboard" a) in page heading, b) in the left sidebar**
![image](https://github.com/user-attachments/assets/dc17c80b-0d71-4240-b64d-ca32a1bc1b4d)

**On the events page https://app-test.eventyay.com/tickets/control/events/ change "Events" to "My events"
In the left sidebar change "My Orders" to "My orders"**
![image](https://github.com/user-attachments/assets/83e80f94-bd19-4654-945e-1d2559cc7d59)


**On the top right drop-down change "My Orders" to "My orders" and "My events" to "My events"**
![image](https://github.com/user-attachments/assets/c664506e-e4be-46ef-8fee-388e61edd847)

**Change "Go to shop" to "View event"**
![image](https://github.com/user-attachments/assets/5921936c-ad41-41da-9d23-4dc8ed2922c8)

**On eventyay common https://app-test.eventyay.com/tickets/common/ change "Events" to "My events"**
![image](https://github.com/user-attachments/assets/d26b015c-33d3-4950-9146-9e29252598de)

## Summary by Sourcery

Enhancements:
- Standardize menu item labels across the application for consistency.