### PR TITLE
Auto config video component

### DIFF
--- a/src/pretix/eventyay_common/tasks.py
+++ b/src/pretix/eventyay_common/tasks.py
@@ -114,6 +114,7 @@ def send_event_webhook(self, user_id, event, action):
         "locales": event.get("locales"),
         "user_email": user.email,
         "action": action,
+        "is_video_creation": event.get("is_video_creation"),
     }
     headers = get_header_token(user_id)
 
@@ -166,6 +167,9 @@ def create_world(self, is_video_creation, event_data):
         "title": title,
         "timezone": event_timezone,
         "locale": locale,
+        "traits": {
+            'attendee': 'eventyay-video-event-{}'.format(event_slug),
+        }
     }
 
     headers = {"Authorization": "Bearer " + token}

--- a/src/pretix/eventyay_common/views/event.py
+++ b/src/pretix/eventyay_common/views/event.py
@@ -234,6 +234,7 @@ class EventCreateView(SafeSessionWizardView):
                 "timezone": str(basics_data.get("timezone")),
                 "locale": basics_data.get("locale"),
                 "locales": foundation_data.get("locales"),
+                "is_video_creation": foundation_data.get("is_video_creation"),
             }
             send_event_webhook.delay(
                 user_id=self.request.user.id, event=event_dict, action="create"
@@ -268,6 +269,7 @@ class EventCreateView(SafeSessionWizardView):
                         "timezone": str(basics_data.get("timezone")),
                         "locale": event.settings.locale,
                         "locales": event.settings.locales,
+                        "is_video_creation": foundation_data.get("is_video_creation"),
                     }
                     send_event_webhook.delay(
                         user_id=self.request.user.id, event=event_dict, action="create"
@@ -408,6 +410,7 @@ class EventUpdate(
                         "timezone": str(event.settings.timezone),
                         "locale": event.settings.locale,
                         "locales": event.settings.locales,
+                        "is_video_creation": event.is_video_creation,
                     }
                     send_event_webhook.delay(
                         user_id=self.request.user.id, event=event_dict, action="update"


### PR DESCRIPTION
This PR resolved #465.

- Add the is_video_creation field in the response for send_event_webhook to resolve issues related to enabling the video plugin for the talk project when the user selects is_video_creation during the event creation process in the ticket project.
- Add the attendee permission field in the response for create_world to resolve issues related to granting automatic permission for accessing the video project.

## Summary by Sourcery

Add support for video plugin activation and automate attendee permissions for video projects.

New Features:
- Introduce the 'is_video_creation' field in the event webhook response to support video plugin activation during event creation.

Enhancements:
- Add 'attendee' permission field in the create_world response to automate access permissions for the video project.