### PR TITLE
Event Tickets Dashboard: Add an info box for the organizer and teams

### DIFF
--- a/src/pretix/control/templates/pretixcontrol/event/fragment_info_box.html
+++ b/src/pretix/control/templates/pretixcontrol/event/fragment_info_box.html
@@ -6,13 +6,13 @@
 </div>
 <div class="panel-body timeline">
     <div class="info-row">
-        {% trans "This event is organized by" %} <strong>{{ request.organizer }}</strong>
+        {% trans "This event is organized by" %} <strong><a href="{% url 'control:organizer' request.organizer.slug %}">{{ request.organizer }}</a></strong>
     </div>
     <div class="info-row">
         {% trans "Teams of the organizer are" %} 
         <span></span>
-        {% for name in organizer_teams %}
-            <strong>{{ name }}</strong>
+        {% for id, name in organizer_teams %}
+            <strong><a href="{% url 'control:organizer.team' request.organizer.slug id %}">{{ name }}</a></strong>
             {% if not forloop.last %}, {% endif %}
         {% endfor %}
     </div>

--- a/src/pretix/control/templates/pretixcontrol/event/fragment_info_box.html
+++ b/src/pretix/control/templates/pretixcontrol/event/fragment_info_box.html
@@ -1,18 +1,18 @@
 {% load i18n %}
 <div class="panel-heading">
-    <h3 class="panel-title" style="padding-left: 20px;">
+    <h3 class="panel-title">
         {% trans "Event organizer" %}
     </h3>
 </div>
 <div class="panel-body timeline">
-    <div class="info-row" style="padding-left: 20px;">
-        {% trans "This event is organized by" %} <strong>{{ request.event.organizer }}</strong>
+    <div class="info-row">
+        {% trans "This event is organized by" %} <strong>{{ request.organizer }}</strong>
     </div>
-    <div class="info-row" style="padding-left: 20px;">
+    <div class="info-row">
         {% trans "Teams of the organizer are" %} 
-        <span style="display: inline-block; width: 10px;"></span>
-        {% for team in request.event.organizer.teams.all %}
-            <strong>{{ team.name }}</strong>
+        <span></span>
+        {% for name in organizer_teams %}
+            <strong>{{ name }}</strong>
             {% if not forloop.last %}, {% endif %}
         {% endfor %}
     </div>

--- a/src/pretix/control/templates/pretixcontrol/event/fragment_info_box.html
+++ b/src/pretix/control/templates/pretixcontrol/event/fragment_info_box.html
@@ -1,0 +1,19 @@
+{% load i18n %}
+<div class="panel-heading">
+    <h3 class="panel-title" style="padding-left: 20px;">
+        {% trans "Event organizer" %}
+    </h3>
+</div>
+<div class="panel-body timeline">
+    <div class="info-row" style="padding-left: 20px;">
+        {% trans "This event is organized by" %} <strong>{{ request.event.organizer }}</strong>
+    </div>
+    <div class="info-row" style="padding-left: 20px;">
+        {% trans "Teams of the organizer are" %} 
+        <span style="display: inline-block; width: 10px;"></span>
+        {% for team in request.event.organizer.teams.all %}
+            <strong>{{ team.name }}</strong>
+            {% if not forloop.last %}, {% endif %}
+        {% endfor %}
+    </div>
+</div>

--- a/src/pretix/control/templates/pretixcontrol/event/fragment_timeline.html
+++ b/src/pretix/control/templates/pretixcontrol/event/fragment_timeline.html
@@ -1,36 +1,34 @@
 {% load i18n %}
-<div class="panel panel-default items">
-    <div class="panel-heading">
-        <h3 class="panel-title">
-            {% trans "Your timeline" %}
-        </h3>
-    </div>
-    <div class="panel-body timeline">
-        {% regroup timeline by date as tl_list %}
-        {% for day in tl_list %}
-            <div class="row {% if day.grouper < today %}text-muted{% endif %}">
-                <div class="col-date">
-                    <strong>{{ day.grouper|date:"SHORT_DATE_FORMAT" }}</strong>
-                </div>
-                <div class="col-event">
-                    {% for e in day.list %}
-                        <strong class="">{{ e.time|date:"TIME_FORMAT" }}</strong>
-                        &nbsp;
-                        <span class="{% if e.time < nearly_now %}text-muted{% endif %}">
-                            {{ e.entry.description }}
-                        </span>
-                        {% if e.entry.edit_url %}
-                            &nbsp;
-                            <a href="{{ e.entry.edit_url }}" class="text-muted">
-                                <span class="fa fa-edit"></span>
-                            </a>
-                        {% endif %}
-                        {% if forloop.revcounter > 1 %}
-                            <br/>
-                        {% endif %}
-                    {% endfor %}
-                </div>
+<div class="panel-heading">
+    <h3 class="panel-title">
+        {% trans "Your timeline" %}
+    </h3>
+</div>
+<div class="panel-body timeline">
+    {% regroup timeline by date as tl_list %}
+    {% for day in tl_list %}
+        <div class="row {% if day.grouper < today %}text-muted{% endif %}">
+            <div class="col-date">
+                <strong>{{ day.grouper|date:"SHORT_DATE_FORMAT" }}</strong>
             </div>
-        {% endfor %}
-    </div>
+            <div class="col-event">
+                {% for e in day.list %}
+                    <strong class="">{{ e.time|date:"TIME_FORMAT" }}</strong>
+                    &nbsp;
+                    <span class="{% if e.time < nearly_now %}text-muted{% endif %}">
+                        {{ e.entry.description }}
+                    </span>
+                    {% if e.entry.edit_url %}
+                        &nbsp;
+                        <a href="{{ e.entry.edit_url }}" class="text-muted">
+                            <span class="fa fa-edit"></span>
+                        </a>
+                    {% endif %}
+                    {% if forloop.revcounter > 1 %}
+                        <br/>
+                    {% endif %}
+                {% endfor %}
+            </div>
+        </div>
+    {% endfor %}
 </div>

--- a/src/pretix/control/templates/pretixcontrol/event/index.html
+++ b/src/pretix/control/templates/pretixcontrol/event/index.html
@@ -108,13 +108,13 @@
             {% include "pretixcontrol/event/fragment_subevent_choice_simple.html" %}
         </form>
     {% endif %}
-    <div class="dashboard">
+    <div class="dashboard custom">
         {% if not request.event.has_subevents or subevent %}
-            <div class="panel panel-default items widget-small widget-container no-padding">
+            <div class="panel panel-default items widget-container widget-small no-padding column"">
                 {% include "pretixcontrol/event/fragment_timeline.html" %}
             </div>
         {% endif %}
-        <div class="panel panel-default items widget-small widget-container no-padding">
+        <div class="panel panel-default items widget-container widget-small no-padding last-column"">
             {% include "pretixcontrol/event/fragment_info_box.html" %}
         </div>
     </div>

--- a/src/pretix/control/templates/pretixcontrol/event/index.html
+++ b/src/pretix/control/templates/pretixcontrol/event/index.html
@@ -108,9 +108,16 @@
             {% include "pretixcontrol/event/fragment_subevent_choice_simple.html" %}
         </form>
     {% endif %}
-    {% if not request.event.has_subevents or subevent %}
-        {% include "pretixcontrol/event/fragment_timeline.html" %}
-    {% endif %}
+    <div class="dashboard">
+        {% if not request.event.has_subevents or subevent %}
+            <div class="panel panel-default items widget-small widget-container">
+                {% include "pretixcontrol/event/fragment_timeline.html" %}
+            </div>
+        {% endif %}
+        <div class="panel panel-default items widget-small widget-container">
+            {% include "pretixcontrol/event/fragment_info_box.html" %}
+        </div>
+    </div>
     <div class="dashboard">
         {% for w in widgets %}
             <div class="widget-container widget-{{ w.display_size|default:"small" }} {% if w.lazy %}widget-lazy-loading{% endif %}" data-lazy-id="{{ w.lazy }}">

--- a/src/pretix/control/templates/pretixcontrol/event/index.html
+++ b/src/pretix/control/templates/pretixcontrol/event/index.html
@@ -110,11 +110,11 @@
     {% endif %}
     <div class="dashboard">
         {% if not request.event.has_subevents or subevent %}
-            <div class="panel panel-default items widget-small widget-container">
+            <div class="panel panel-default items widget-small widget-container no-padding">
                 {% include "pretixcontrol/event/fragment_timeline.html" %}
             </div>
         {% endif %}
-        <div class="panel panel-default items widget-small widget-container">
+        <div class="panel panel-default items widget-small widget-container no-padding">
             {% include "pretixcontrol/event/fragment_info_box.html" %}
         </div>
     </div>

--- a/src/pretix/control/views/dashboards.py
+++ b/src/pretix/control/views/dashboards.py
@@ -389,7 +389,7 @@ def event_index(request, organizer, event):
     ]
     ctx['today'] = now().astimezone(request.event.timezone).date()
     ctx['nearly_now'] = now().astimezone(request.event.timezone) - timedelta(seconds=20)
-    ctx['organizer_teams'] = request.organizer.teams.values_list('name', flat=True)
+    ctx['organizer_teams'] = request.organizer.teams.values_list('id', 'name')
     resp = render(request, 'pretixcontrol/event/index.html', ctx)
     # resp['Content-Security-Policy'] = "style-src 'unsafe-inline'"
     return resp

--- a/src/pretix/control/views/dashboards.py
+++ b/src/pretix/control/views/dashboards.py
@@ -321,7 +321,6 @@ def event_index(request, organizer, event):
                                                                   'can_change_event_settings', request=request)
     can_view_vouchers = request.user.has_event_permission(request.organizer, request.event, 'can_view_vouchers',
                                                           request=request)
-
     widgets = []
     if can_view_orders:
         for r, result in event_dashboard_widgets.send(sender=request.event, subevent=subevent, lazy=True):
@@ -390,6 +389,7 @@ def event_index(request, organizer, event):
     ]
     ctx['today'] = now().astimezone(request.event.timezone).date()
     ctx['nearly_now'] = now().astimezone(request.event.timezone) - timedelta(seconds=20)
+    ctx['organizer_teams'] = request.organizer.teams.values_list('name', flat=True)
     resp = render(request, 'pretixcontrol/event/index.html', ctx)
     # resp['Content-Security-Policy'] = "style-src 'unsafe-inline'"
     return resp

--- a/src/pretix/static/eventyay-common/scss/custom.scss
+++ b/src/pretix/static/eventyay-common/scss/custom.scss
@@ -29,4 +29,5 @@
 
 .dashboard .widget-container.no-padding {
     padding: 0;
+    background: none;
 }

--- a/src/pretix/static/eventyay-common/scss/custom.scss
+++ b/src/pretix/static/eventyay-common/scss/custom.scss
@@ -27,7 +27,41 @@
     }
 }
 
+
+.custom {
+    margin-left: 0px;
+    margin-right: 0px;
+  }
+
 .dashboard .widget-container.no-padding {
     padding: 0;
     background: none;
+    border: 1px solid #e5e5e5;
+}
+
+.dashboard .widget-container.widget-small.no-padding.column {
+    padding: 0;
+    background: none;
+    border-color: #e5e5e5;
+    margin-right: 10px;
+}
+
+.dashboard .widget-container.widget-small.no-padding.last-column {
+    padding: 0;
+    background: none;
+    border-color: #e5e5e5;
+    margin-right: 0px;
+}
+
+@media (max-width: $screen-sm-max) {
+    .dashboard .widget-container.widget-small.no-padding.column {
+        width: 100%;
+        margin-right: 0px;
+    }
+}
+
+@media (max-width: $screen-xs-max) {
+    .dashboard .widget-container.widget-small.no-padding.column {
+        margin-right: 0px;
+    }
 }

--- a/src/pretix/static/eventyay-common/scss/custom.scss
+++ b/src/pretix/static/eventyay-common/scss/custom.scss
@@ -26,3 +26,7 @@
         }
     }
 }
+
+.dashboard .widget-container.no-padding {
+    padding: 0;
+}


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/181619e7-51d7-4d6b-9723-8c89fb8c126e)
Add info box "Event organizer"


![image](https://github.com/user-attachments/assets/d0006061-e38d-4690-a21c-33e407b01954)
![image](https://github.com/user-attachments/assets/f1a5ecd6-0054-4aa3-9e01-0a020f630460)

When click to organizer and teams will return these views.

This PR resolves #478

## Summary by Sourcery

New Features:
- Add an info box to the event dashboard displaying the event organizer and their teams.

## Summary by Sourcery

New Features:
- Display the event organizer and their teams in an info box on the event dashboard.