### PR TITLE
Fix KeyError

### DIFF
--- a/src/pretix/control/templates/pretixcontrol/event/tickets.html
+++ b/src/pretix/control/templates/pretixcontrol/event/tickets.html
@@ -43,7 +43,9 @@
                             </a>
                             <h3 class="panel-title">
                                 {% with 'ticketoutput_'|add:provider.identifier|add:'__enabled' as field_name %}
-                                    {% bootstrap_field provider.form|getitem:field_name layout='inline' label=provider.verbose_name %}
+									{% if field_name in provider.form.fields %}
+                                    	{% bootstrap_field provider.form|getitem:field_name layout='inline' label=provider.verbose_name %}
+									{% endif %}
                                 {% endwith %}
                             </h3>
                             <div class="clear"></div>


### PR DESCRIPTION
Check if Key is Valid/Available before rendering

Now `/control/event/<organiser>/<slug>/settings/tickets`
 
<img width="1470" alt="image" src="https://github.com/user-attachments/assets/afdc9a0d-98fb-4ed6-9976-131010bbfef9" />

## Summary by Sourcery

Bug Fixes:
- Fixed an KeyError that occurred when rendering the ticket download settings page when a specific form field was missing.