### PR TITLE
feat: doc deployment

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -3,7 +3,7 @@ name: Deploy Sphinx Documentation to GitHub Pages
 on:
   push:
     branches:
-      - main  # Adjust this to your default branch
+      - master  # Adjust this to your default branch
 
 jobs:
   deploy:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -18,7 +18,7 @@ jobs:
           python-version: '3.11'
 
       - name: Install system packages
-        run: sudo apt update && sudo apt install enchant
+        run: sudo apt update && sudo apt install libffi-dev libssl-dev libxml2-dev libxslt1-dev libenchant1c2a gettext libfreetype-dev libjpeg-dev
 
       - name: Install dependencies
         run: pip install -r requirements.txt

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -21,7 +21,9 @@ jobs:
         run: sudo apt update && sudo apt install libffi-dev libssl-dev libxml2-dev libxslt1-dev libenchant1c2a gettext libfreetype-dev libjpeg-dev
 
       - name: Install dependencies
-        run: pip install -r requirements.txt
+        run: |
+          pip install -r requirements.txt
+          pip install "Jinja2<3.1" "sphinx==5.0.*"
         working-directory: doc
       
       - name: Build documentation

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -18,7 +18,10 @@ jobs:
           python-version: '3.11'
 
       - name: Install dependencies
-        run: pip install -r doc/requirements.txt
+        run: |
+          sudo apt install -y libenchant1c2a gettext libfreetype-dev libjpeg-dev libffi-dev libssl-dev libxml2-dev libxslt1-dev
+          pip install -r doc/requirements.txt
+
 
       - name: Build documentation
         run: make html

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   deploy:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - name: Check out the repository
         uses: actions/checkout@v3

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   deploy:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - name: Check out the repository
         uses: actions/checkout@v3
@@ -18,7 +18,9 @@ jobs:
           python-version: '3.11'
 
       - name: Install system packages
-        run: sudo apt update && sudo apt install libffi-dev libssl-dev libxml2-dev libxslt1-dev libenchant1c2a gettext libfreetype-dev libjpeg-dev
+        run: |
+          sudo add-apt-repository universe multiverse
+          sudo apt update && sudo apt install libffi-dev libssl-dev libxml2-dev libxslt1-dev libenchant1c2a gettext libfreetype-dev libjpeg-dev
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,31 @@
+name: Deploy Sphinx Documentation to GitHub Pages
+
+on:
+  push:
+    branches:
+      - main  # Adjust this to your default branch
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out the repository
+        uses: actions/checkout@v3
+
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.11'
+
+      - name: Install dependencies
+        run: pip install -r doc/requirements.txt
+
+      - name: Build documentation
+        run: make html
+        working-directory: doc  # Adjust to your Sphinx docs directory
+
+      - name: Deploy to GitHub Pages
+        uses: peaceiris/actions-gh-pages@v3
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: doc/_build/html

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Install system packages
         run: |
           sudo add-apt-repository universe multiverse
-          sudo apt update && sudo apt install libffi-dev libssl-dev libxml2-dev libxslt1-dev libenchant1c2a gettext libfreetype-dev libjpeg-dev
+          sudo apt update && sudo apt install enchant-2 libffi-dev libssl-dev libxml2-dev libxslt1-dev gettext libfreetype-dev libjpeg-dev
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -21,7 +21,8 @@ jobs:
         run: sudo apt update && sudo apt install enchant
 
       - name: Install dependencies
-        run: pip3 install -Ur doc/requirements.txt
+        run: pip install -r requirements.txt
+        working-directory: doc
       
       - name: Build documentation
         run: make html

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -17,12 +17,12 @@ jobs:
         with:
           python-version: '3.11'
 
+      - name: Install system packages
+        run: sudo apt update && sudo apt install enchant
+
       - name: Install dependencies
-        run: |
-          sudo apt install -y libenchant1c2a gettext libfreetype-dev libjpeg-dev libffi-dev libssl-dev libxml2-dev libxslt1-dev
-          pip install -r doc/requirements.txt
-
-
+        run: pip3 install -Ur doc/requirements.txt
+      
       - name: Build documentation
         run: make html
         working-directory: doc  # Adjust to your Sphinx docs directory

--- a/CNAME
+++ b/CNAME
@@ -1,0 +1,1 @@
+etickets.eventyay.com


### PR DESCRIPTION
fixes #493 

## Screenshot
![image](https://github.com/user-attachments/assets/305cfc1f-5ded-4e97-999a-6196342c0ac3)

## Summary
- added github workflow to build and deploy the documentation automatically to the branch gh-pages
- added version constraints on Jinja2 and Sphinx due to these errors:
    - `ImportError: cannot import name 'environmentfilter' from 'jinja2'` (solved by using `Jinja2<3.1`)
    - `Sphinx version error: The sphinxcontrib.applehelp extension used by this project needs at least Sphinx v5.0;` (solved by using `sphinx==5.0.*`)
- added CNAME file to the root directory.

## Summary by Sourcery

Set up Sphinx documentation deployment to GitHub Pages on pushes to the master branch.

CI:
- Deploy Sphinx documentation to GitHub Pages on pushes to the master branch.

Deployment:
- Deploy the built Sphinx documentation to GitHub Pages.