### PR TITLE
Fix documentation for Wikimedia SSO

### DIFF
--- a/src/pretix/plugins/socialauth/templates/socialauth/social_auth_settings.html
+++ b/src/pretix/plugins/socialauth/templates/socialauth/social_auth_settings.html
@@ -50,7 +50,11 @@
                                 <td colspan="2">
                                     <div class="form-group">
                                         <label class="col-sm-3 control-label">
-                                            {% trans "Client ID (Consumer token)" %}
+                                            {% if provider == "mediawiki" %}
+                                                {% trans "Client Application Key" %}
+                                            {% else %}
+                                                {% trans "Client ID" %}
+                                            {% endif %}
                                         </label>
                                         <div class="col-sm-9">
                                             <input type="text" class="form-control" name="{{ provider }}_client_id" value="{{ settings.client_id }}">
@@ -58,7 +62,11 @@
                                     </div>
                                     <div class="form-group">
                                         <label class="col-sm-3 control-label">
-                                            {% trans "Secret (Consumer secret)" %}
+                                            {% if provider == "mediawiki" %}
+                                                {% trans "Client Application Secret" %}
+                                            {% else %}
+                                                {% trans "Secret" %}
+                                            {% endif %}
                                         </label>
                                         <div class="col-sm-9">
                                             <input type="password" class="form-control" name="{{ provider }}_secret" value="{{ settings.secret }}">

--- a/src/pretix/plugins/socialauth/templates/socialauth/social_setup.html
+++ b/src/pretix/plugins/socialauth/templates/socialauth/social_setup.html
@@ -65,19 +65,33 @@
             <li>{% trans "Register your OAuth application at:" %} 
                 <a href="https://meta.wikimedia.org/wiki/Special:OAuthConsumerRegistration/propose">MediaWiki OAuth Consumer Registration</a>
             </li>
-            <li>{% trans "Set the callback URL to:" %} 
-                {% with callback_url=tickets_domain|add:"/accounts/mediawiki/login/callback/" %}
-                    <code>{{ callback_url }}</code>
-                {% endwith %}
+            <li>
+                {% trans "On the form enter" %}
+                <ol type="a">
+                    <li>{% trans "an application name" %}</li>
+                    <li>{% trans "an description description" %}</li>
+                    <li>
+                        {% trans 'Set Oauth "callback" URL to:' %}
+                        {% with callback_url=tickets_domain|add:"/accounts/mediawiki/login/callback/" %}
+                            <code>{{ callback_url }}</code>
+                        {% endwith %}
+                    </li>
+                    <li>{% trans "Contact Email address" %}</li>
+                    <li>{% trans 'Tick "Client is confidential"' %}</li>
+                    <li>{% trans 'Tick "Authorization code"' %}</li>
+                    <li>{% trans 'Tick "Refresh token"' %}</li>
+                    <li>{% trans 'Choose "Request authorization for specific permissions."' %}</li>
+                    <li>{% trans 'In the section "Applicable grants" select "Basic Rights" and "Access private information"' %}</li>
+                    <li>{% trans "Finally tick the box to accept the terms and submit." %}</li>
+                </ol>
             </li>
-            <li>{% trans "Carefully read and follow the instructions on the registration page. Tick option: access private information." %}</li>
-            <li>{% trans "The registered application will return:" %}
+            <li>{% trans "On the next page copy the registered application will return the OAuth access information:" %}
                 <ul>
-                    <li>{% trans "One consumer token (client id)" %}</li>
-                    <li>{% trans "One consumer secret" %}</li>
+                    <li>{% trans "Client application key" %}</li>
+                    <li>{% trans "Client application secret" %}</li>
                 </ul>
             </li>
-            <li>{% trans "Add the consumer key and consumer secret to your Eventyay admin settings" %}</li>
+            <li>{% trans "Add the client application key and client application secret to your Eventyay social auth settings" %}</li>
         </ol>
 
         <strong>{% trans "After Approval" %}</strong>

--- a/src/pretix/plugins/socialauth/templates/socialauth/social_setup.html
+++ b/src/pretix/plugins/socialauth/templates/socialauth/social_setup.html
@@ -24,9 +24,7 @@
                 <a href="https://medium.com/@tony.infisical/guide-to-using-oauth-2-0-to-access-google-apis-dead94d6866d">Guide to using OAuth 2.0 to access Google APIs</a>
             </li>
             <li>{% trans "Set the callback URL to:" %} 
-                {% with callback_url=tickets_domain|add:"/accounts/google/login/callback/" %}
-                    <code>{{ callback_url }}</code>
-                {% endwith %}
+                <code>{{ "https://app.eventyay.com/tickets/accounts/google/login/callback/" }}</code>
             </li>
             <li>{% trans "Add the client ID and client secret to admin settings" %}</li>
         </ul>
@@ -40,9 +38,7 @@
         <p>{% trans "Instructions:" %}</p>
         <ul>
             <li>{% trans "Set the callback URL to:" %} 
-                {% with callback_url=tickets_domain|add:"/accounts/github/login/callback/" %}
-                    <code>{{ callback_url }}</code>
-                {% endwith %}
+                <code>{{ "https://app.eventyay.com/tickets/accounts/github/login/callback/" }}</code>
             </li>
             <li>{% trans "Add the client ID and client secret to admin settings" %}</li>
         </ul>
@@ -65,6 +61,7 @@
             <li>{% trans "Register your OAuth application at:" %} 
                 <a href="https://meta.wikimedia.org/wiki/Special:OAuthConsumerRegistration/propose">MediaWiki OAuth Consumer Registration</a>
             </li>
+            <li>{% trans 'Click "Propose new OAuth 2.0 client"' %}</li>
             <li>
                 {% trans "On the form enter" %}
                 <ol type="a">
@@ -72,9 +69,7 @@
                     <li>{% trans "an description description" %}</li>
                     <li>
                         {% trans 'Set Oauth "callback" URL to:' %}
-                        {% with callback_url=tickets_domain|add:"/accounts/mediawiki/login/callback/" %}
-                            <code>{{ callback_url }}</code>
-                        {% endwith %}
+                        <code>{{ "https://app.eventyay.com/tickets/accounts/mediawiki/login/callback/" }}</code>
                     </li>
                     <li>{% trans "Contact Email address" %}</li>
                     <li>{% trans 'Tick "Client is confidential"' %}</li>

--- a/src/pretix/plugins/socialauth/templates/socialauth/social_setup.html
+++ b/src/pretix/plugins/socialauth/templates/socialauth/social_setup.html
@@ -24,7 +24,9 @@
                 <a href="https://medium.com/@tony.infisical/guide-to-using-oauth-2-0-to-access-google-apis-dead94d6866d">Guide to using OAuth 2.0 to access Google APIs</a>
             </li>
             <li>{% trans "Set the callback URL to:" %} 
-                <code>{{ "https://app.eventyay.com/tickets/accounts/google/login/callback/" }}</code>
+                {% with callback_url=tickets_domain|add:"/accounts/google/login/callback/" %}
+                    <code>{{ callback_url }}</code>
+                {% endwith %}
             </li>
             <li>{% trans "Add the client ID and client secret to admin settings" %}</li>
         </ul>
@@ -38,7 +40,9 @@
         <p>{% trans "Instructions:" %}</p>
         <ul>
             <li>{% trans "Set the callback URL to:" %} 
-                <code>{{ "https://app.eventyay.com/tickets/accounts/github/login/callback/" }}</code>
+                {% with callback_url=tickets_domain|add:"/accounts/github/login/callback/" %}
+                    <code>{{ callback_url }}</code>
+                {% endwith %}
             </li>
             <li>{% trans "Add the client ID and client secret to admin settings" %}</li>
         </ul>
@@ -69,7 +73,9 @@
                     <li>{% trans "an description description" %}</li>
                     <li>
                         {% trans 'Set Oauth "callback" URL to:' %}
-                        <code>{{ "https://app.eventyay.com/tickets/accounts/mediawiki/login/callback/" }}</code>
+                        {% with callback_url=tickets_domain|add:"/accounts/mediawiki/login/callback/" %}
+                            <code>{{ callback_url }}</code>
+                        {% endwith %}
                     </li>
                     <li>{% trans "Contact Email address" %}</li>
                     <li>{% trans 'Tick "Client is confidential"' %}</li>

--- a/src/pretix/plugins/socialauth/views.py
+++ b/src/pretix/plugins/socialauth/views.py
@@ -1,6 +1,6 @@
 import logging
 from enum import StrEnum
-from urllib.parse import urlencode, urlparse, urlunparse
+from urllib.parse import urlencode, urljoin, urlparse, urlunparse
 
 from allauth.socialaccount.adapter import get_adapter
 from allauth.socialaccount.models import SocialApp
@@ -90,6 +90,7 @@ class SocialLoginView(AdministratorPermissionRequiredMixin, TemplateView):
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
         context['login_providers'] = self.gs.settings.get('login_providers', as_type=dict)
+        context['tickets_domain'] = urljoin(settings.SITE_URL, settings.BASE_PATH)
         return context
 
     def post(self, request, *args, **kwargs):

--- a/src/pretix/plugins/socialauth/views.py
+++ b/src/pretix/plugins/socialauth/views.py
@@ -1,6 +1,6 @@
 import logging
 from enum import StrEnum
-from urllib.parse import urlencode, urljoin, urlparse, urlunparse
+from urllib.parse import urlencode, urlparse, urlunparse
 
 from allauth.socialaccount.adapter import get_adapter
 from allauth.socialaccount.models import SocialApp
@@ -90,7 +90,6 @@ class SocialLoginView(AdministratorPermissionRequiredMixin, TemplateView):
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
         context['login_providers'] = self.gs.settings.get('login_providers', as_type=dict)
-        context['tickets_domain'] = urljoin(settings.SITE_URL, settings.BASE_PATH)
         return context
 
     def post(self, request, *args, **kwargs):


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/ab8410c8-36f7-4f5c-8e19-d163ae2861eb)

![image](https://github.com/user-attachments/assets/4b469340-010d-4a8f-b0b3-c98d50e52f41)

This PR resolves #500

## Summary by Sourcery

Update the documentation for setting up Wikimedia single sign-on (SSO) and correct the callback URL for Google, GitHub, and Wikimedia providers.  Standardize the terminology used for client ID and secret across different providers in the settings.

Enhancements:
- Use a fixed callback URL for Google, GitHub, and Wikimedia OAuth applications.

Documentation:
- Improve instructions for setting up MediaWiki OAuth application by adding detailed steps and clarifying terminology.