### PR TITLE
feat: deploy Sphinx Documentation automatically to gh-pages using GitHub Actions

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,39 @@
+name: Deploy Sphinx Documentation to GitHub Pages
+
+on:
+  push:
+    branches:
+      - development  # Adjust this to your default branch
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out the repository
+        uses: actions/checkout@v3
+
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.11'
+
+      - name: Install system packages
+        run: |
+          sudo add-apt-repository universe multiverse
+          sudo apt update && sudo apt install enchant-2 libffi-dev libssl-dev libxml2-dev libxslt1-dev gettext libfreetype-dev libjpeg-dev
+
+      - name: Install dependencies
+        run: |
+          pip install -r requirements.txt
+          pip install "Jinja2<3.1" "sphinx==5.0.*"
+        working-directory: doc
+      
+      - name: Build documentation
+        run: make html
+        working-directory: doc  # Adjust to your Sphinx docs directory
+
+      - name: Deploy to GitHub Pages
+        uses: peaceiris/actions-gh-pages@v3
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: doc/_build/html

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,4 +1,5 @@
 include LICENSE
+include CNAME
 include README.rst
 global-include *.proto
 recursive-include src/pretix/static *


### PR DESCRIPTION
fixes #493 (dev branch)

## Screenshot
![image](https://github.com/user-attachments/assets/305cfc1f-5ded-4e97-999a-6196342c0ac3)

## Summary
- added github workflow to build and deploy the documentation automatically to the branch gh-pages
- added version constraints on Jinja2 and Sphinx due to these errors:
    - `ImportError: cannot import name 'environmentfilter' from 'jinja2'` (solved by using `Jinja2<3.1`)
    - `Sphinx version error: The sphinxcontrib.applehelp extension used by this project needs at least Sphinx v5.0;` (solved by using `sphinx==5.0.*`)
- added CNAME file to the root directory.

## Summary by Sourcery

Set up automatic deployment of Sphinx documentation to GitHub Pages on the `development` branch.

New Features:
- Automatically deploy the documentation to gh-pages on push to the development branch.

CI:
- Deploy the documentation to GitHub Pages using GitHub Actions when pushing to the `development` branch.