### PR TITLE
Hide Stripe, Banktransfer if not enabled

### DIFF
--- a/src/pretix/control/forms/event.py
+++ b/src/pretix/control/forms/event.py
@@ -1527,8 +1527,11 @@ class QuickSetupForm(I18nForm):
         )
         kwargs["locales"] = self.locales
         super().__init__(*args, **kwargs)
-        if not self.obj.settings.payment_stripe_connect_client_id:
+        plugins_active = self.obj.get_plugins()
+        if ('eventyay_stripe' not in plugins_active) or (not self.obj.settings.payment_stripe_connect_client_id):
             del self.fields["payment_stripe__enabled"]
+        if ('pretix.plugins.banktransfer' not in plugins_active):
+            del self.fields['payment_banktransfer__enabled']
         self.fields["payment_banktransfer_bank_details"].required = False
         for f in self.fields.values():
             if "data-required-if" in f.widget.attrs:

--- a/src/pretix/control/templates/pretixcontrol/event/quick_setup.html
+++ b/src/pretix/control/templates/pretixcontrol/event/quick_setup.html
@@ -166,22 +166,23 @@
                         Here are just two of them as examples, you can add more in the "Settings" part of your event.
                     {% endblocktrans %}
                 </p>
-                {% bootstrap_field form.payment_banktransfer__enabled layout="control" label_class="sr-only" field_class="col-md-12" %}
-                <div data-display-dependency="#id_payment_banktransfer__enabled">
-                    {% bootstrap_field form.payment_banktransfer_bank_details_type layout="control" %}
-                    {% bootstrap_field form.payment_banktransfer_bank_details_sepa_name layout="control" %}
-                    {% bootstrap_field form.payment_banktransfer_bank_details_sepa_iban layout="control" %}
-                    {% bootstrap_field form.payment_banktransfer_bank_details_sepa_bic layout="control" %}
-                    {% bootstrap_field form.payment_banktransfer_bank_details_sepa_bank layout="control" %}
-                    {% bootstrap_field form.payment_banktransfer_bank_details layout="control" %}
-                </div>
+                {% if form.payment_banktransfer__enabled %}
+                    {% bootstrap_field form.payment_banktransfer__enabled layout="control" label_class="sr-only" field_class="col-md-12" %}
+                    <div data-display-dependency="#id_payment_banktransfer__enabled">
+                        {% bootstrap_field form.payment_banktransfer_bank_details_type layout="control" %}
+                        {% bootstrap_field form.payment_banktransfer_bank_details_sepa_name layout="control" %}
+                        {% bootstrap_field form.payment_banktransfer_bank_details_sepa_iban layout="control" %}
+                        {% bootstrap_field form.payment_banktransfer_bank_details_sepa_bic layout="control" %}
+                        {% bootstrap_field form.payment_banktransfer_bank_details_sepa_bank layout="control" %}
+                        {% bootstrap_field form.payment_banktransfer_bank_details layout="control" %}
+                    </div>
+                {% endif %}
                 {% if form.payment_stripe__enabled %}
                     {% bootstrap_field form.payment_stripe__enabled layout="control" label_class="sr-only" field_class="col-md-12" %}
                     <div data-display-dependency="#id_payment_stripe__enabled">
                         <div class="alert alert-info">
                             {% blocktrans trimmed %}
-                                After you saved this page, we will redirect you to Stripe to create or connect an account
-                                there. Once you completed this, you will be taken back to pretix.
+                                After the setup, please go to the Payment area and set up the Stripe connection.
                             {% endblocktrans %}
                         </div>
                     </div>

--- a/src/pretix/eventyay_common/tasks.py
+++ b/src/pretix/eventyay_common/tasks.py
@@ -49,7 +49,7 @@ def send_organizer_webhook(self, user_id, organizer):
     try:
         # Send the POST request with the payload and the headers
         response = requests.post(
-            settings.TALK_HOSTNAME + "/webhook/organiser/",
+            urljoin(settings.TALK_HOSTNAME, "webhook/organiser/"),
             json=payload,
             headers=headers,
         )


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/3ad3706b-ba9f-4136-ad42-6ae25ef8feb4)
If Stripe or Banktransfer is not enabled, hide payment options in Payment area.

![image](https://github.com/user-attachments/assets/43edb3bf-29f1-4835-91b6-4bb1afcfa643)
If a user skips the "Set Up Event" step and later enables Stripe or Bank Transfer, the payment options will appear when the user revisits the "Set Up Event" step.
![image](https://github.com/user-attachments/assets/a89f5782-dddd-4aa7-a132-26fe3a7b8fe0)
The Stripe payment option also requires the admin to input the Connect Client ID in the admin settings.

This PR resolves #499

## Summary by Sourcery

Hide Stripe and bank transfer payment options if they are not enabled. Update the Stripe setup instructions to redirect users to the Payment area after the initial setup.  Use urljoin for organizer webhook URL.