### PR TITLE
fix: Github Actions CNAME gets written to dev branch instead of gh-pages branch

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -31,6 +31,10 @@ jobs:
       - name: Build documentation
         run: make html
         working-directory: doc  # Adjust to your Sphinx docs directory
+      
+      - name: Copy CNAME if it exists
+        run: |
+          if [ -f CNAME ]; then cp CNAME doc/_build/html/; fi
 
       - name: Deploy to GitHub Pages
         uses: peaceiris/actions-gh-pages@v3

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,39 @@
+name: Deploy Sphinx Documentation to GitHub Pages
+
+on:
+  push:
+    branches:
+      - development  # Adjust this to your default branch
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out the repository
+        uses: actions/checkout@v3
+
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.11'
+
+      - name: Install system packages
+        run: |
+          sudo add-apt-repository universe multiverse
+          sudo apt update && sudo apt install enchant-2 libffi-dev libssl-dev libxml2-dev libxslt1-dev gettext libfreetype-dev libjpeg-dev
+
+      - name: Install dependencies
+        run: |
+          pip install -r requirements.txt
+          pip install "Jinja2<3.1" "sphinx==5.0.*"
+        working-directory: doc
+      
+      - name: Build documentation
+        run: make html
+        working-directory: doc  # Adjust to your Sphinx docs directory
+
+      - name: Deploy to GitHub Pages
+        uses: peaceiris/actions-gh-pages@v3
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: doc/_build/html

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,4 +1,5 @@
 include LICENSE
+include CNAME
 include README.rst
 global-include *.proto
 recursive-include src/pretix/static *


### PR DESCRIPTION
fixes #525 

## Description
- resolved the issue with CNAME getting written to dev branch instead of gh-pages branch.
- now, the doc domain at eticket.eventyay.com will be accessible.

## Summary by Sourcery

Copy the CNAME file to the gh-pages branch so that the documentation website is accessible at eticket.eventyay.com.

Bug Fixes:
- Fix CNAME file being written to the dev branch instead of the gh-pages branch.

Deployment:
- Deploy the documentation to the gh-pages branch.