### PR TITLE
Better docker development tools

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,6 @@
 FROM python:3.11-bookworm
+ARG UID=15371
+ARG GID=15371
 
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \
@@ -30,7 +32,8 @@ RUN apt-get update && \
 	/usr/sbin/update-locale LANG=C.UTF-8 && \
     mkdir /etc/pretix && \
     mkdir /data && \
-    useradd -ms /bin/bash -d /pretix -u 15371 pretixuser && \
+    groupadd -g $GID pretixuser && \
+    useradd -ms /bin/bash -d /pretix -u $UID -g pretixuser pretixuser && \
     echo 'pretixuser ALL=(ALL) NOPASSWD:SETENV: /usr/bin/supervisord' >> /etc/sudoers && \
     mkdir /static && \
     mkdir /etc/supervisord
@@ -45,6 +48,8 @@ COPY deployment/docker/supervisord /etc/supervisord
 COPY deployment/docker/supervisord.all.conf /etc/supervisord.all.conf
 COPY deployment/docker/supervisord.web.conf /etc/supervisord.web.conf
 COPY deployment/docker/nginx.conf /etc/nginx/nginx.conf
+# TOOD mounting the local pretix will drop this one, not good
+# we need a workaround for that
 COPY deployment/docker/production_settings.py /pretix/src/production_settings.py
 COPY pyproject.toml /pretix/pyproject.toml
 COPY src /pretix/src

--- a/Dockerfile
+++ b/Dockerfile
@@ -48,7 +48,7 @@ COPY deployment/docker/supervisord /etc/supervisord
 COPY deployment/docker/supervisord.all.conf /etc/supervisord.all.conf
 COPY deployment/docker/supervisord.web.conf /etc/supervisord.web.conf
 COPY deployment/docker/nginx.conf /etc/nginx/nginx.conf
-# TOOD mounting the local pretix will drop this one, not good
+# TODO mounting the local pretix will drop this one, not good
 # we need a workaround for that
 COPY deployment/docker/production_settings.py /pretix/src/production_settings.py
 COPY pyproject.toml /pretix/pyproject.toml

--- a/Dockerfile
+++ b/Dockerfile
@@ -48,8 +48,10 @@ COPY deployment/docker/supervisord /etc/supervisord
 COPY deployment/docker/supervisord.all.conf /etc/supervisord.all.conf
 COPY deployment/docker/supervisord.web.conf /etc/supervisord.web.conf
 COPY deployment/docker/nginx.conf /etc/nginx/nginx.conf
-# TODO mounting the local pretix will drop this one, not good
-# we need a workaround for that
+# We are mounting pretix into the dev container, so the following
+# will be actually overwritten.
+# This is fixed in docker-compose-dev.yaml by also mounting the
+# production_settings.py file independently into the src directory.
 COPY deployment/docker/production_settings.py /pretix/src/production_settings.py
 COPY pyproject.toml /pretix/pyproject.toml
 COPY src /pretix/src

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,6 +1,7 @@
 include LICENSE
 include CNAME
 include README.rst
+include Makefile
 global-include *.proto
 recursive-include src/pretix/static *
 recursive-include src/pretix/static.dist *

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
 
-build:
+local:
 	docker buildx build --progress=plain -f Dockerfile --platform=linux/amd64  \
-		-t eventyay/eventyay-ticket:development .
+		-t eventyay/eventyay-ticket:local .

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,5 @@
 
 local:
 	docker buildx build --progress=plain -f Dockerfile --platform=linux/amd64  \
+		--build-arg UID=`id -u` --build-arg GID=`id -g`  \
 		-t eventyay/eventyay-ticket:local .

--- a/deployment/docker/pretix.bash
+++ b/deployment/docker/pretix.bash
@@ -54,7 +54,7 @@ fi
 # for in-docker development, we want logging to be debug, and
 # gunicorn to reload when source files have changed.
 if [ "$1" == "devel" ]; then
-    python3 -m pretix updatestyles
+    make production
     export GUNICORN_LOGLEVEL=debug
     export GUNICORN_RELOAD=true
     exec sudo -E /usr/bin/supervisord -n -c /etc/supervisord.all.conf


### PR DESCRIPTION
* make hard-coded UID/GID in Dockerfile configurable
* add a Makefile to build the local docker image
* Allow pretalx to take argument devel for hot reloading gunicorn

## Summary by Sourcery

Configure UID/GID in the Dockerfile, add a Makefile for local Docker image builds, and allow pretalx to take a 'devel' argument for hot reloading gunicorn and setting debug log level.

Build:
- Add a Makefile to build the local Docker image with configurable UID/GID, and update the Dockerfile to use these arguments when creating the pretixuser.
- Update the Dockerfile to use configurable UID/GID when creating the pretixuser group and user, allowing for better integration with the host system during development and avoiding permission issues when mounting volumes.

Deployment:
- Add a `devel` command to the pretix.bash script to enable hot reloading of gunicorn and set the log level to debug during development within the Docker container.
- Make the UID and GID configurable in the Dockerfile to allow for easier development and avoid permission issues when mounting volumes.