### PR TITLE
Fix error 500 for MediaWiki user without email

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -102,7 +102,7 @@ dependencies = [
         'eventyay-paypal @ git+https://your_token@github.com/fossasia/eventyay-tickets-paypal.git@master',
         'django_celery_beat==2.7.0',
         'cron-descriptor==1.4.5',
-        'django-allauth[socialaccount]==65.3.0',
+        'django-allauth[socialaccount] @ git+https://codeberg.org/quan/django-allauth.git@f151589949',
         'eventyay-stripe @ git+https://github.com/fossasia/eventyay-tickets-stripe.git@master',
         'pydantic==2.10.4'
 ]


### PR DESCRIPTION
Fixes https://github.com/fossasia/eventyay-talk/issues/269

by using our [fork](https://codeberg.org/quan/django-allauth/src/branch/fix/non-email-mediawiki) of django-allauth, where we [fix](https://codeberg.org/quan/django-allauth/commit/f15158994950512f2295f9b519e0a35f507c70a7) a bug regarding MediaWiki.

With this fix, after logging-in, user will be asked for missing email address, instead of throwing error 500.

![image](https://github.com/user-attachments/assets/29b99b85-32fa-4c4b-b9c8-452dff9388fa)

## Summary by Sourcery

Fixes a bug where MediaWiki users without an email address would cause a 500 error upon login. The fix involves using a fork of django-allauth that handles this specific case, prompting the user to provide an email address after logging in.

Bug Fixes:
- Fixes a bug where MediaWiki users without an email address would cause a 500 error upon login.
- Prompts the user to provide an email address after logging in, instead of throwing an error.