### PR TITLE
Update pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,140 +1,148 @@
 [project]
-name = "eventyay"
-dynamic = ["version"]
-description = "the open source event solution"
-readme = "README.rst"
-requires-python = ">=3.11"
-license = {file = "LICENSE"}
-keywords = ["tickets", "events", "web", "shop", "ecommerce"]
-authors = [ {name = "eventyay", email = "info@eventyay.com"}, ]
-maintainers = [ {name = "eventyay", email = "info@eventyay.com"}, ]
+name = 'eventyay'
+dynamic = ['version']
+description = 'the open source event solution'
+readme = 'README.rst'
+requires-python = '>=3.11'
+license = { file = 'LICENSE' }
+keywords = ['tickets', 'events', 'web', 'shop', 'ecommerce']
+authors = [
+    { name = 'eventyay', email = 'info@eventyay.com' },
+]
+maintainers = [
+    { name = 'eventyay', email = 'info@eventyay.com' },
+]
 classifiers = [
-  "Development Status :: 5 - Production/Stable",
-  "Intended Audience :: Developers",
-  "Intended Audience :: Other Audience",
-  "Topic :: Internet :: WWW/HTTP :: Dynamic Content",
-  "Environment :: Web Environment",
-  "License :: OSI Approved :: Apache License, Version 2.0",
-  "Programming Language :: Python :: 3.11",
-  "Framework :: Django :: 5.1",
+  'Development Status :: 5 - Production/Stable',
+  'Intended Audience :: Developers',
+  'Intended Audience :: Other Audience',
+  'Topic :: Internet :: WWW/HTTP :: Dynamic Content',
+  'Environment :: Web Environment',
+  'License :: OSI Approved :: Apache License, Version 2.0',
+  'Programming Language :: Python :: 3.11',
+  'Framework :: Django :: 5.1',
 ]
 dependencies = [
-        'Django==5.1.*',
-        'djangorestframework==3.15.*',
-        'python-dateutil==2.9.*',
-        'isoweek',
-        'requests==2.31.*',
-        'pytz',
-        'django-bootstrap3==24.3',
-        'django-formset-js-improved==0.5.0.3',
-        'django-compressor==4.5.1',
-        'django-hierarkey==1.2.*',
-        'django-filter==24.3',
-        'django-scopes==2.0.*',
-        'django-localflavor==4.0',
-        'django-cors-headers',
-        'reportlab==4.2.*',
-        'Pillow==11.0.*',
-        'pypdf==5.1.*',
-        'django-libsass==0.9',
-        'libsass==0.23.*',
-        'django-otp==1.5.*',
-        'webauthn==2.2.*',
-        'django-formtools==2.5.1',
-        "celery==5.4.*",
-        'kombu==5.3.*',
-        'django-statici18n==2.5.*',
-        'css-inline==0.14.*',
-        'BeautifulSoup4==4.12.*',
-        'lxml',
-        'static3==0.7.*',
-        'dj-static',
-        'csscompressor',
-        'django-markup',
-        'markdown==3.7',
-        'bleach==5.0.*',
-        'sentry-sdk==2.19.*',
-        'babel',
-        'pycparser==2.22',
-        'django-redis==5.4.*',
-        'redis==5.0.*',
-        'fakeredis==2.26.*',
-        'stripe==11.3.*',
-        'chardet==5.2.*',
-        'mt-940==4.30.*',
-        'django-i18nfield==1.9.*,>=1.9.4',
-        'psycopg2-binary==2.9.9',
-        'tqdm==4.*',
-        'vobject==0.9.*',
-        'pycountry',
-        'django-countries==7.6.*',
-        'pyuca', # for better sorting of country names in django-countries
-        'defusedcsv>=1.1.0',
-        'vat_moss_forked==2020.3.20.0.11.0',
-        'jsonschema',
-        'django-hijack==3.7.*',
-        'openpyxl==3.1.*',
-        'django-oauth-toolkit==2.4.*',
-        'oauthlib==3.2.*',
-        'django-phonenumber-field==7.3.*',
-        'phonenumberslite==8.13.*',
-        'python-bidi==0.6.*',  # Support for Arabic in reportlab
-        'arabic-reshaper==3.0.0',  # Support for Arabic in reportlab
-        'packaging',
-        'tlds>=2020041600',
-        'text-unidecode==1.*',
-        'protobuf==5.28.*',
-        'cryptography>=3.4.2',
-        'pycryptodome==3.20.*',
-        'sepaxml==2.6.*',
-        'geoip2==4.*',
-        'sendgrid==6.11.*',
-        'importlib_metadata==8.*',
-        'qrcode==7.4.*',
-        'pretix-pages @ git+https://github.com/fossasia/eventyay-ticket-pages.git@master',
-        'pretix-venueless @ git+https://github.com/fossasia/eventyay-ticket-video.git@master',
-        'django-sso==3.0.2',
-        'PyJWT~=2.8.0',
-        'exhibitors @ git+https://github.com/fossasia/eventyay-tickets-exhibitors.git@master',
-        'pyvat==1.3.18',
-        # Note: To install eventyay-stripe/Paypal dependencies, replace {your_token} with your GitHub token
-        # Access is required to the private repositories, if you don't have access, you can remove the dependencies
-        'eventyay-paypal @ git+https://your_token@github.com/fossasia/eventyay-tickets-paypal.git@master',
-        'django_celery_beat==2.7.0',
-        'cron-descriptor==1.4.5',
-        'django-allauth[socialaccount] @ git+https://codeberg.org/quan/django-allauth.git@f151589949',
-        'eventyay-stripe @ git+https://github.com/fossasia/eventyay-tickets-stripe.git@master',
-        'pydantic==2.10.4'
+    'Django==5.1.*',
+    'djangorestframework==3.15.*',
+    'python-dateutil==2.9.*',
+    'isoweek',
+    'requests==2.31.*',
+    'pytz',
+    'django-bootstrap3==24.3',
+    'django-formset-js-improved==0.5.0.3',
+    'django-compressor==4.5.1',
+    'django-hierarkey==1.2.*',
+    'django-filter==24.3',
+    'django-scopes==2.0.*',
+    'django-localflavor==4.0',
+    'django-cors-headers',
+    'reportlab==4.2.*',
+    'Pillow==11.0.*',
+    'pypdf==5.1.*',
+    'django-libsass==0.9',
+    'libsass==0.23.*',
+    'django-otp==1.5.*',
+    'webauthn==2.2.*',
+    'django-formtools==2.5.1',
+    'celery==5.4.*',
+    'kombu==5.3.*',
+    'django-statici18n==2.5.*',
+    'css-inline==0.14.*',
+    'BeautifulSoup4==4.12.*',
+    'lxml',
+    'static3==0.7.*',
+    'dj-static',
+    'csscompressor',
+    'django-markup',
+    'markdown==3.7',
+    'bleach==5.0.*',
+    'sentry-sdk==2.19.*',
+    'babel',
+    'pycparser==2.22',
+    'django-redis==5.4.*',
+    'redis==5.0.*',
+    'fakeredis==2.26.*',
+    'stripe==11.3.*',
+    'chardet==5.2.*',
+    'mt-940==4.30.*',
+    'django-i18nfield==1.9.*,>=1.9.4',
+    'psycopg2-binary==2.9.9',
+    'tqdm==4.*',
+    'vobject==0.9.*',
+    'pycountry',
+    'django-countries==7.6.*',
+    'pyuca',  # for  better sorting of country names in django-countries
+    'defusedcsv>=1.1.0',
+    'vat_moss_forked==2020.3.20.0.11.0',
+    'jsonschema',
+    'django-hijack==3.7.*',
+    'openpyxl==3.1.*',
+    'django-oauth-toolkit==2.4.*',
+    'oauthlib==3.2.*',
+    'django-phonenumber-field==7.3.*',
+    'phonenumberslite==8.13.*',
+    'python-bidi==0.6.*',  # Support for Arabic  iin reportlab
+    'arabic-reshaper==3.0.0',  # Support for Arabic iin reportlab
+    'packaging',
+    'tlds>=2020041600',
+    'text-unidecode==1.*',
+    'protobuf==5.28.*',
+    'cryptography>=3.4.2',
+    'pycryptodome==3.20.*',
+    'sepaxml==2.6.*',
+    'geoip2==4.*',
+    'sendgrid==6.11.*',
+    'importlib_metadata==8.*',
+    'qrcode==7.4.*',
+    'pretix-pages @ git+https://github.com/fossasia/eventyay-ticket-pages.git@master',
+    'pretix-venueless @ git+https://github.com/fossasia/eventyay-ticket-video.git@master',
+    'django-sso==3.0.2',
+    'PyJWT~=2.8.0',
+    'exhibitors @ git+https://github.com/fossasia/eventyay-tickets-exhibitors.git@master',
+    'pyvat==1.3.18',
+    # Note: To install eventyay-stripe/Paypal dependencies, replace {your_token} with your GitHub token
+    # Access is required to the private repositories, if you don't have access, you can remove the dependencies
+    'eventyay-paypal @ git+https://your_token@github.com/fossasia/eventyay-tickets-paypal.git@master',
+    'django_celery_beat==2.7.0',
+    'cron-descriptor==1.4.5',
+    'django-allauth[socialaccount] @ git+https://codeberg.org/quan/django-allauth.git@f151589949',
+    'eventyay-stripe @ git+https://github.com/fossasia/eventyay-tickets-stripe.git@master',
+    'pydantic==2.10.4'
 ]
 
 [project.optional-dependencies]
-memcached = ["pylibmc"]
-dev = [
-            'django-debug-toolbar==4.4.*',
-            'pycodestyle==2.12.*',
-            'pyflakes==3.2.*',
-            'flake8==7.1.*',
-            'pep8-naming==0.14.*',
-            'coveralls',
-            'coverage',
-            'pytest==7.2.*',
-            'pytest-django==4.*',
-            'pytest-xdist==3.6.*',
-            'isort==5.13.*',
-            'pytest-mock==3.14.*',
-            'pytest-rerunfailures==14.*',
-            'responses',
-            'potypo',
-            'freezegun',
-            'pytest-cache',
-            'pytest-cov',
-            'pytest-sugar',
+memcached = ['pylibmc']
+
+
+# new dependency groups
+
+[project.dependency-groups.dev]
+dependencies = [
+    'django-debug-toolbar==4.4.*',
+    'pycodestyle==2.12.*',
+    'pyflakes==3.2.*',
+    'flake8==7.1.*',
+    'pep8-naming==0.14.*',
+    'coveralls',
+    'coverage',
+    'pytest==7.2.*',
+    'pytest-django==4.*',
+    'pytest-xdist==3.6.*',
+    'isort==5.13.*',
+    'pytest-mock==3.14.*',
+    'pytest-rerunfailures==14.*',
+    'responses',
+    'potypo',
+    'freezegun',
+    'pytest-cache',
+    'pytest-cov',
+    'pytest-sugar',
 ]
 
-[project.entry-points."distutils.commands"]
-build = "setup:CustomBuild"
-build_ext = "setup:CustomBuildExt"
-
+[project.entry-points.'distutils.commands']
+build = 'setup:CustomBuild'
+build_ext = 'setup:CustomBuildExt'
 
 [build-system]
 requires = [
@@ -145,18 +153,20 @@ requires = [
 ]
 
 [project.urls]
-homepage = "https://eventyay.com"
-repository = "https://github.com/fossasia/eventyay-tickets.git"
-documentation = "https://eventyay.com"
-changelog = "https://eventyay.com"
+homepage = 'https://eventyay.com'
+repository = 'https://github.com/fossasia/eventyay-tickets.git'
+documentation = 'https://eventyay.com'
+changelog = 'https://eventyay.com'
 
 [tool.setuptools]
 include-package-data = true
 
 [tool.setuptools.dynamic]
-version = {attr = "pretix.__version__"}
+version = { attr = 'pretix.__version__' }
 
 [tool.setuptools.packages.find]
-where = ["src"]
-include = ["pretix*"]
+where = ['src']
+include = ['pretix*']
 namespaces = false
+
+

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,148 +1,153 @@
 [project]
-name = 'eventyay'
-dynamic = ['version']
-description = 'the open source event solution'
-readme = 'README.rst'
-requires-python = '>=3.11'
-license = { file = 'LICENSE' }
-keywords = ['tickets', 'events', 'web', 'shop', 'ecommerce']
-authors = [
-    { name = 'eventyay', email = 'info@eventyay.com' },
-]
-maintainers = [
-    { name = 'eventyay', email = 'info@eventyay.com' },
-]
+name = "eventyay"
+dynamic = ["version"]
+description = "the open source event solution"
+readme = "README.rst"
+requires-python = ">=3.11"
+license = {file = "LICENSE"}
+keywords = ["tickets", "events", "web", "shop", "ecommerce"]
+authors = [ {name = "eventyay", email = "info@eventyay.com"}, ]
+maintainers = [ {name = "eventyay", email = "info@eventyay.com"}, ]
 classifiers = [
-  'Development Status :: 5 - Production/Stable',
-  'Intended Audience :: Developers',
-  'Intended Audience :: Other Audience',
-  'Topic :: Internet :: WWW/HTTP :: Dynamic Content',
-  'Environment :: Web Environment',
-  'License :: OSI Approved :: Apache License, Version 2.0',
-  'Programming Language :: Python :: 3.11',
-  'Framework :: Django :: 5.1',
+  "Development Status :: 5 - Production/Stable",
+  "Intended Audience :: Developers",
+  "Intended Audience :: Other Audience",
+  "Topic :: Internet :: WWW/HTTP :: Dynamic Content",
+  "Environment :: Web Environment",
+  "License :: OSI Approved :: Apache License, Version 2.0",
+  "Programming Language :: Python :: 3.11",
+  "Framework :: Django :: 5.1",
 ]
 dependencies = [
-    'Django==5.1.*',
-    'djangorestframework==3.15.*',
-    'python-dateutil==2.9.*',
-    'isoweek',
-    'requests==2.31.*',
-    'pytz',
-    'django-bootstrap3==24.3',
-    'django-formset-js-improved==0.5.0.3',
-    'django-compressor==4.5.1',
-    'django-hierarkey==1.2.*',
-    'django-filter==24.3',
-    'django-scopes==2.0.*',
-    'django-localflavor==4.0',
-    'django-cors-headers',
-    'reportlab==4.2.*',
-    'Pillow==11.0.*',
-    'pypdf==5.1.*',
-    'django-libsass==0.9',
-    'libsass==0.23.*',
-    'django-otp==1.5.*',
-    'webauthn==2.2.*',
-    'django-formtools==2.5.1',
-    'celery==5.4.*',
-    'kombu==5.3.*',
-    'django-statici18n==2.5.*',
-    'css-inline==0.14.*',
-    'BeautifulSoup4==4.12.*',
-    'lxml',
-    'static3==0.7.*',
-    'dj-static',
-    'csscompressor',
-    'django-markup',
-    'markdown==3.7',
-    'bleach==5.0.*',
-    'sentry-sdk==2.19.*',
-    'babel',
-    'pycparser==2.22',
-    'django-redis==5.4.*',
-    'redis==5.0.*',
-    'fakeredis==2.26.*',
-    'stripe==11.3.*',
-    'chardet==5.2.*',
-    'mt-940==4.30.*',
-    'django-i18nfield==1.9.*,>=1.9.4',
-    'psycopg2-binary==2.9.9',
-    'tqdm==4.*',
-    'vobject==0.9.*',
-    'pycountry',
-    'django-countries==7.6.*',
-    'pyuca',  # for  better sorting of country names in django-countries
-    'defusedcsv>=1.1.0',
-    'vat_moss_forked==2020.3.20.0.11.0',
-    'jsonschema',
-    'django-hijack==3.7.*',
-    'openpyxl==3.1.*',
-    'django-oauth-toolkit==2.4.*',
-    'oauthlib==3.2.*',
-    'django-phonenumber-field==7.3.*',
-    'phonenumberslite==8.13.*',
-    'python-bidi==0.6.*',  # Support for Arabic  iin reportlab
-    'arabic-reshaper==3.0.0',  # Support for Arabic iin reportlab
-    'packaging',
-    'tlds>=2020041600',
-    'text-unidecode==1.*',
-    'protobuf==5.28.*',
-    'cryptography>=3.4.2',
-    'pycryptodome==3.20.*',
-    'sepaxml==2.6.*',
-    'geoip2==4.*',
-    'sendgrid==6.11.*',
-    'importlib_metadata==8.*',
-    'qrcode==7.4.*',
-    'pretix-pages @ git+https://github.com/fossasia/eventyay-ticket-pages.git@master',
-    'pretix-venueless @ git+https://github.com/fossasia/eventyay-ticket-video.git@master',
-    'django-sso==3.0.2',
-    'PyJWT~=2.8.0',
-    'exhibitors @ git+https://github.com/fossasia/eventyay-tickets-exhibitors.git@master',
-    'pyvat==1.3.18',
-    # Note: To install eventyay-stripe/Paypal dependencies, replace {your_token} with your GitHub token
-    # Access is required to the private repositories, if you don't have access, you can remove the dependencies
-    'eventyay-paypal @ git+https://your_token@github.com/fossasia/eventyay-tickets-paypal.git@master',
-    'django_celery_beat==2.7.0',
-    'cron-descriptor==1.4.5',
-    'django-allauth[socialaccount] @ git+https://codeberg.org/quan/django-allauth.git@f151589949',
-    'eventyay-stripe @ git+https://github.com/fossasia/eventyay-tickets-stripe.git@master',
-    'pydantic==2.10.4'
+        'Django==5.1.*',
+        'djangorestframework==3.15.*',
+        'python-dateutil==2.9.*',
+        'isoweek',
+        'requests==2.31.*',
+        'pytz',
+        'django-bootstrap3==24.3',
+        'django-formset-js-improved==0.5.0.3',
+        'django-compressor==4.5.1',
+        'django-hierarkey==1.2.*',
+        'django-filter==24.3',
+        'django-scopes==2.0.*',
+        'django-localflavor==4.0',
+        'django-cors-headers',
+        'reportlab==4.2.*',
+        'Pillow==11.0.*',
+        'pypdf==5.1.*',
+        'django-libsass==0.9',
+        'libsass==0.23.*',
+        'django-otp==1.5.*',
+        'webauthn==2.2.*',
+        'django-formtools==2.5.1',
+        "celery==5.4.*",
+        'kombu==5.3.*',
+        'django-statici18n==2.5.*',
+        'css-inline==0.14.*',
+        'BeautifulSoup4==4.12.*',
+        'lxml',
+        'static3==0.7.*',
+        'dj-static',
+        'csscompressor',
+        'django-markup',
+        'markdown==3.7',
+        'bleach==5.0.*',
+        'sentry-sdk==2.19.*',
+        'babel',
+        'pycparser==2.22',
+        'django-redis==5.4.*',
+        'redis==5.0.*',
+        'fakeredis==2.26.*',
+        'stripe==11.3.*',
+        'chardet==5.2.*',
+        'mt-940==4.30.*',
+        'django-i18nfield==1.9.*,>=1.9.4',
+        'psycopg2-binary==2.9.9',
+        'tqdm==4.*',
+        'vobject==0.9.*',
+        'pycountry',
+        'django-countries==7.6.*',
+        'pyuca', # for better sorting of country names in django-countries
+        'defusedcsv>=1.1.0',
+        'vat_moss_forked==2020.3.20.0.11.0',
+        'jsonschema',
+        'django-hijack==3.7.*',
+        'openpyxl==3.1.*',
+        'django-oauth-toolkit==2.4.*',
+        'oauthlib==3.2.*',
+        'django-phonenumber-field==7.3.*',
+        'phonenumberslite==8.13.*',
+        'python-bidi==0.6.*',  # Support for Arabic in reportlab
+        'arabic-reshaper==3.0.0',  # Support for Arabic in reportlab
+        'packaging',
+        'tlds>=2020041600',
+        'text-unidecode==1.*',
+        'protobuf==5.28.*',
+        'cryptography>=3.4.2',
+        'pycryptodome==3.20.*',
+        'sepaxml==2.6.*',
+        'geoip2==4.*',
+        'sendgrid==6.11.*',
+        'importlib_metadata==8.*',
+        'qrcode==7.4.*',
+        'pretix-pages @ git+https://github.com/fossasia/eventyay-ticket-pages.git@master',
+        'pretix-venueless @ git+https://github.com/fossasia/eventyay-ticket-video.git@master',
+        'django-sso==3.0.2',
+        'PyJWT~=2.8.0',
+        'exhibitors @ git+https://github.com/fossasia/eventyay-tickets-exhibitors.git@master',
+        'pyvat==1.3.18',
+        # Note: To install eventyay-stripe/Paypal dependencies, replace {your_token} with your GitHub token
+        # Access is required to the private repositories, if you don't have access, you can remove the dependencies
+        'eventyay-paypal @ git+https://your_token@github.com/fossasia/eventyay-tickets-paypal.git@master',
+        'django_celery_beat==2.7.0',
+        'cron-descriptor==1.4.5',
+        'django-allauth[socialaccount] @ git+https://codeberg.org/quan/django-allauth.git@f151589949',
+        'eventyay-stripe @ git+https://github.com/fossasia/eventyay-tickets-stripe.git@master',
+        'pydantic==2.10.4'
 ]
 
 [project.optional-dependencies]
-memcached = ['pylibmc']
+memcached = ["pylibmc"]
 
-
-# new dependency groups
-
-[project.dependency-groups.dev]
+[project.dependency-groups.docs]
 dependencies = [
-    'django-debug-toolbar==4.4.*',
-    'pycodestyle==2.12.*',
-    'pyflakes==3.2.*',
-    'flake8==7.1.*',
-    'pep8-naming==0.14.*',
-    'coveralls',
-    'coverage',
-    'pytest==7.2.*',
-    'pytest-django==4.*',
-    'pytest-xdist==3.6.*',
-    'isort==5.13.*',
-    'pytest-mock==3.14.*',
-    'pytest-rerunfailures==14.*',
-    'responses',
-    'potypo',
-    'freezegun',
-    'pytest-cache',
-    'pytest-cov',
-    'pytest-sugar',
+            'sphinx==6.2.*',
+            'sphinx_rtd_theme==1.2.*',
 ]
 
-[project.entry-points.'distutils.commands']
-build = 'setup:CustomBuild'
-build_ext = 'setup:CustomBuildExt'
+[project.dependency-groups.test]
+dependencies = [
+            'django-debug-toolbar==4.4.*',
+            'pytest==7.2.*',
+            'pytest-django==4.*',
+            'pytest-xdist==3.6.*',
+            'pytest-mock==3.14.*',
+            'pytest-rerunfailures==14.*',
+            'pytest-cache',
+            'pytest-cov',
+            'pytest-sugar',
+            'coveralls',
+            'coverage',
+            'freezegun',
+]
+
+[project.dependency-groups.lint]
+dependencies = [
+            'pycodestyle==2.12.*',
+            'pyflakes==3.2.*',
+            'flake8==7.1.*',
+            'pep8-naming==0.14.*',
+            'isort==5.13.*',
+            'ruff',
+            'potypo',
+            'responses',
+]
+
+[project.entry-points."distutils.commands"]
+build = "setup:CustomBuild"
+build_ext = "setup:CustomBuildExt"
+
 
 [build-system]
 requires = [
@@ -153,20 +158,20 @@ requires = [
 ]
 
 [project.urls]
-homepage = 'https://eventyay.com'
-repository = 'https://github.com/fossasia/eventyay-tickets.git'
-documentation = 'https://eventyay.com'
-changelog = 'https://eventyay.com'
+homepage = "https://eventyay.com"
+repository = "https://github.com/fossasia/eventyay-tickets.git"
+documentation = "https://eventyay.com"
+changelog = "https://eventyay.com"
 
 [tool.setuptools]
 include-package-data = true
 
 [tool.setuptools.dynamic]
-version = { attr = 'pretix.__version__' }
+version = {attr = "pretix.__version__"}
 
 [tool.setuptools.packages.find]
-where = ['src']
-include = ['pretix*']
+where = ["src"]
+include = ["pretix*"]
 namespaces = false
 
 


### PR DESCRIPTION
Here the updated configuration is ready for uv to manage dependencies.
Production libraries remain in the main dependencies list, while development tools have been moved from the dev feature (in [project.optional-dependencies]) into a dedicated dependency group ([project.dependency-groups.dev]). This separation is what uv (and modern practices) recommend.

here please let me know for any further changes and correction made, Also being new to open source, please suggest me with projects and issues to contribute.

## Summary by Sourcery

Enhancements:
- Separates development dependencies into a dedicated dependency group.