### PR TITLE
fix(docs): Corrected outdated development branch link in README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -22,7 +22,7 @@ Please look through our issues and start contributing.
 Setting Up Eventyay-Tickets
 ---------------------------
 
-Eventyay-Tickets requires a Docker-based setup. Please follow the detailed instructions in the `development setup guide <https://github.com/fossasia/eventyay-docker/blob/development/README.development.md>`_ in the eventyay-docker repository.
+Eventyay-Tickets requires a Docker-based setup. Please follow the detailed instructions in the `development setup guide <https://github.com/fossasia/eventyay-docker/blob/main/README.development.md>`_ in the eventyay-docker repository.
 
 License
 -------


### PR DESCRIPTION
This PR resolves an issue introduced in [#563](https://github.com/fossasia/eventyay-tickets/pull/563), where the `README` contained an outdated link pointing to the non-existent `development` branch in the `eventyay-docker` repository. The link has now been updated to correctly reference the `main` branch.  

#### **Changes Made**  
- Updated `README.development.md` to replace the incorrect `development` branch link with `main`.

## Summary by Sourcery

Documentation:
- Corrected the branch link in README from 'development' to 'main' to ensure accurate documentation