### PR TITLE
Update Actions

### DIFF
--- a/.github/workflows/style.yml
+++ b/.github/workflows/style.yml
@@ -17,12 +17,12 @@ jobs:
     name: isort
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Set up Python 3.11
-        uses: actions/setup-python@v1
+        uses: actions/setup-python@v5
         with:
           python-version: 3.11
-      - uses: actions/cache@v1
+      - uses: actions/cache@v4
         with:
           path: ~/.cache/pip
           key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements.txt') }}
@@ -42,12 +42,12 @@ jobs:
     name: flake8
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Set up Python 3.11
-        uses: actions/setup-python@v1
+        uses: actions/setup-python@v5
         with:
           python-version: 3.11
-      - uses: actions/cache@v1
+      - uses: actions/cache@v4
         with:
           path: ~/.cache/pip
           key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements.txt') }}


### PR DESCRIPTION
This PR updates the GitHub Actions workflow configuration to replace deprecated action versions with their latest supported versions.  

<img width="1578" alt="image" src="https://github.com/user-attachments/assets/4293acc6-2d1b-45d6-a77a-b68fb98654c5" />

The older versions (`actions/cache@v1`, `actions/checkout@v2`, and `actions/setup-python@v1`) were causing workflow failures due to missing download information.

**Changes Made**

- Updated `actions/checkout` to `v4`
- Updated `actions/setup-python` to `v5`
- Updated `actions/cache` to `v4`  

**Reference** 
- [Github Actions](https://github.com/actions/cache#usage)

## Summary by Sourcery

Update GitHub Actions workflow to use the latest supported action versions

CI:
- Replace deprecated GitHub Actions with their latest versions to resolve workflow failures and ensure compatibility

Chores:
- Update action versions for checkout, setup-python, and cache to their latest supported releases