### PR TITLE
Rename Stripe settings keys from stripe_connect_ to stripe_

### DIFF
--- a/src/pretix/control/forms/event.py
+++ b/src/pretix/control/forms/event.py
@@ -1528,7 +1528,7 @@ class QuickSetupForm(I18nForm):
         kwargs["locales"] = self.locales
         super().__init__(*args, **kwargs)
         plugins_active = self.obj.get_plugins()
-        if ('eventyay_stripe' not in plugins_active) or (not self.obj.settings.payment_stripe_connect_client_id):
+        if ('eventyay_stripe' not in plugins_active) or (not self.obj.settings.payment_stripe_client_id):
             del self.fields["payment_stripe__enabled"]
         if ('pretix.plugins.banktransfer' not in plugins_active):
             del self.fields['payment_banktransfer__enabled']

--- a/src/pretix/control/forms/global_settings.py
+++ b/src/pretix/control/forms/global_settings.py
@@ -144,7 +144,7 @@ class GlobalSettingsForm(SettingsForm):
         self.fields['banner_message_detail'].widget.attrs['rows'] = '3'
         self.fields = OrderedDict(list(self.fields.items()) + [
             (
-                'payment_stripe_connect_secret_key',
+                'payment_stripe_secret_key',
                 SecretKeySettingsField(
                     label=_('Stripe Connect: Secret key'),
                     required=False,
@@ -154,7 +154,7 @@ class GlobalSettingsForm(SettingsForm):
                 )
             ),
             (
-                'payment_stripe_connect_publishable_key',
+                'payment_stripe_publishable_key',
                 forms.CharField(
                     label=_('Stripe Connect: Publishable key'),
                     required=False,
@@ -164,7 +164,7 @@ class GlobalSettingsForm(SettingsForm):
                 )
             ),
             (
-                'payment_stripe_connect_test_secret_key',
+                'payment_stripe_test_secret_key',
                 SecretKeySettingsField(
                     label=_('Stripe Connect: Secret key (test)'),
                     required=False,
@@ -174,7 +174,7 @@ class GlobalSettingsForm(SettingsForm):
                 )
             ),
             (
-                'payment_stripe_connect_test_publishable_key',
+                'payment_stripe_test_publishable_key',
                 forms.CharField(
                     label=_('Stripe Connect: Publishable key (test)'),
                     required=False,

--- a/src/pretix/helpers/stripe_utils.py
+++ b/src/pretix/helpers/stripe_utils.py
@@ -35,10 +35,10 @@ def get_stripe_key(key_type: str) -> str:
 
     try:
         prod_key = getattr(
-            gs.settings, "payment_stripe_connect_{}_key".format(key_type), None
+            gs.settings, "payment_stripe_{}_key".format(key_type), None
         )
         test_key = getattr(
-            gs.settings, "payment_stripe_connect_test_{}_key".format(key_type), None
+            gs.settings, "payment_stripe_test_{}_key".format(key_type), None
         )
     except AttributeError as e:
         logger.error("Missing attribute for Stripe %s key: %s", key_type, str(e))


### PR DESCRIPTION
Resolve part of #609

## Summary by Sourcery

Enhancements:
- Update Stripe-related settings key names to use a more concise naming convention