### PR TITLE
Fix double slash in URL

### DIFF
--- a/src/pretix/static/pretixcontrol/js/ui/popover.js
+++ b/src/pretix/static/pretixcontrol/js/ui/popover.js
@@ -11,7 +11,7 @@ $(function () {
     const logoutParams = new URLSearchParams({ back: backUrl });
 
     const ticketsPath = `/control/`;
-    const talksPath = `${talkHostNamePath}/orga/event/`
+    const talksPath = `${talkHostNamePath}orga/event/`
     const mainDashboardPath = `/common/`;
     const orderPath = `/control/settings/orders/`;
     const eventPath = `/control/events/`;
@@ -46,7 +46,7 @@ $(function () {
                                 </a>
                             </div>
                         </div>
-                    </div> 
+                    </div>
                     <div class="profile-menu">
                         <a href="${basePath}${orderPath}" target="_self" class="btn btn-outline-success">
                             <i class="fa fa-shopping-cart"></i> ${window.gettext('My orders')}


### PR DESCRIPTION
The previous fix was in *tickets-common*, now it is in *tickets*.

![image](https://github.com/user-attachments/assets/fd835ec4-7314-4e6f-9c43-0513abae303e)

## Summary by Sourcery

Remove double slash in URL path construction for talks and clean up whitespace

Bug Fixes:
- Fixed double slash issue in URL path for talks navigation

Enhancements:
- Simplified URL path concatenation