### PR TITLE
Let user inside container run sudo without password

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,6 +8,7 @@ RUN apt-get update && \
             build-essential \
             gettext \
             git \
+            less \
             libffi-dev \
             libjpeg-dev \
             libmemcached-dev \
@@ -25,6 +26,9 @@ RUN apt-get update && \
             npm && \
     curl -fsSL https://deb.nodesource.com/setup_22.x | sudo -E bash - && \
     apt-get install -y nodejs && \
+    wget https://github.com/helix-editor/helix/releases/download/25.01.1/helix_25.1.1-1_amd64.deb && \
+    apt-get install -y ./helix_25.1.1-1_amd64.deb && \
+    rm -f helix_25.1.1-1_amd64.deb && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/* && \
     dpkg-reconfigure locales && \
@@ -34,7 +38,7 @@ RUN apt-get update && \
     mkdir /data && \
     groupadd -g $GID pretixuser && \
     useradd -ms /bin/bash -d /pretix -u $UID -g pretixuser pretixuser && \
-    echo 'pretixuser ALL=(ALL) NOPASSWD:SETENV: /usr/bin/supervisord' >> /etc/sudoers && \
+    echo 'pretixuser ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers && \
     mkdir /static && \
     mkdir /etc/supervisord
 


### PR DESCRIPTION
Sometimes we need to enter Docker container to debug, but we lack some utilities. For example, when working on #615, every time I modify the _.html_ files, the change are not reflected, I have to enter the container to restart the Django application to make the change reflected.

This PR does:
- Allow the default user (`pretixuser`) to run `sudo` without password.
- Add `less`, Helix editor to view text files.

## Summary by Sourcery

Enhance Docker container development environment by allowing sudo access and adding debugging utilities

New Features:
- Allow default user to run sudo without password

Bug Fixes:
- Expand sudo permissions to help with debugging and development tasks

Enhancements:
- Add Helix editor for text file editing
- Install less utility for file viewing