### PR TITLE
Add "My Orders" view in eventyay-common

### DIFF
--- a/src/pretix/eventyay_common/forms/filters.py
+++ b/src/pretix/eventyay_common/forms/filters.py
@@ -1,0 +1,22 @@
+from django import forms
+
+from pretix.base.models import Event
+
+
+class UserOrderFilterForm(forms.Form):
+    event = forms.ModelChoiceField(
+        queryset=None,
+        required=False,
+        label="Event",
+        widget=forms.Select(attrs={'class': 'form-control'}),
+        empty_label="Select an Event"
+    )
+
+    def __init__(self, *args, **kwargs):
+        user = kwargs.pop('user', None)  # Get the user from the kwargs
+        super().__init__(*args, **kwargs)
+
+        if user:
+            # Query distinct events based on the user's orders
+            events = Event.objects.filter(orders__email__iexact=user.email).distinct()
+            self.fields['event'].queryset = events

--- a/src/pretix/eventyay_common/navigation.py
+++ b/src/pretix/eventyay_common/navigation.py
@@ -16,6 +16,12 @@ def get_global_navigation(request: HttpRequest) -> List[Dict[str, Any]]:
         return []
     nav = [
         {
+            "label": _("My Orders"),
+            "url": reverse("eventyay_common:orders"),
+            "active": "events" in url.url_name,
+            "icon": "shopping-cart",
+        },
+        {
             "label": _("My Events"),
             "url": reverse("eventyay_common:events"),
             "active": "events" in url.url_name,

--- a/src/pretix/eventyay_common/templates/eventyay_common/orders/fragment_order_status.html
+++ b/src/pretix/eventyay_common/templates/eventyay_common/orders/fragment_order_status.html
@@ -1,0 +1,37 @@
+{% load i18n %}
+{% load bootstrap3 %}
+{% if order.status == "n" %}
+    {% if order.require_approval %}
+        <span class="label label-warning {{ class }}">
+            <span class="fa fa-question-circle"></span>
+            {% trans "Approval pending" %}
+        </span>
+    {% else %}
+        <span data-toggle="tooltip" title="{{ order.expires|date:"SHORT_DATETIME_FORMAT" }}"
+                class="label label-warning {{ class }}">
+            <span class="fa fa-money"></span>
+            {% trans "Pending" %}
+        </span>
+    {% endif %}
+{% elif order.status == "p" %}
+    {% if order.count_positions == 0 %}
+        <span class="label label-info {{ class }}">
+            <span class="fa fa-times"></span>
+            {% trans "Canceled (paid fee)" %}
+        </span>
+    {% else %}
+        <span class="label label-success {{ class }}">
+            <span class="fa fa-check"></span>
+            {% trans "Paid" %}
+            </span>
+    {% endif %}
+{% elif order.status == "e" %} {# expired #}
+    <span class="label label-danger {{ class }}">
+            <span class="fa fa-clock-o"></span>
+        {% trans "Expired" %}</span>
+{% elif order.status == "c" %}
+    <span class="label label-danger {{ class }}">
+            <span class="fa fa-times"></span>
+        {% trans "Canceled" %}
+    </span>
+{% endif %}

--- a/src/pretix/eventyay_common/templates/eventyay_common/orders/orders.html
+++ b/src/pretix/eventyay_common/templates/eventyay_common/orders/orders.html
@@ -1,0 +1,59 @@
+{% extends "eventyay_common/base.html" %}
+{% load i18n %}
+{% load bootstrap3 %}
+{% load eventurl %}
+{% load money %}
+{% block title %}{% trans "My Orders" %}{% endblock %}
+
+{% block content %}
+    <h1>{% trans "My Orders" %}</h1>
+    <div class="row filter-form">
+        <form action="" method="get">
+            <div class="col-md-3 col-xs-6">
+                <!-- Add the event filter here -->
+                {% bootstrap_field filter_form.event layout='inline' %}
+            </div>
+            <div class="col-md-2 col-xs-6">
+                <button type="submit" class="btn btn-primary">
+                    <span class="fa fa-filter"></span>
+                </button>
+            </div>
+        </form>
+    </div>
+    <div class="table-responsive">
+        <table class="table table-condensed table-hover table-quotas">
+            <thead>
+                <tr>
+                    <th>{{ _('Order Code') }}</th>
+                    <th>{{ _('Event') }}</th>
+                    <th>{{ _('Date') }}</th>
+                    <th>{{ _('Order total') }}</th>
+                    <th>{{ _('Status') }}</th>
+                </tr>
+            </thead>
+            <tbody>
+                {% for order in order_list %}
+                <tr>
+                    <td>
+                        <a href="{% abseventurl order.event 'presale:event.order' order=order.code secret=order.secret %}">
+                            {{ order.code }}
+                        </a>
+                    </td>
+                    <td>{{ order.event.name }}</td>
+                    <td>{{ order.datetime|date:"SHORT_DATETIME_FORMAT" }}</td>
+                    <td>
+                        {{ order.total|money:order.event.currency }}
+                    </td>
+                    <td>
+                        {% include "eventyay_common/orders/fragment_order_status.html" with order=order event=order.event %}
+                    </td>
+                </tr>
+                {% empty %}
+                <tr>
+                    <td colspan="5" class="text-center">{{ _('You have no orders.') }}</td>
+                </tr>
+                {% endfor %}
+            </tbody>
+        </table>
+    </div>
+{% endblock %}

--- a/src/pretix/eventyay_common/urls.py
+++ b/src/pretix/eventyay_common/urls.py
@@ -1,8 +1,9 @@
-from django.urls import include, re_path as url
+from django.urls import include, path, re_path as url
 
 from pretix.eventyay_common.views import (
     account, dashboards, event, organizer, team,
 )
+from pretix.eventyay_common.views.orders import MyOrdersView
 
 app_name = 'eventyay_common'
 
@@ -26,5 +27,6 @@ urlpatterns = [
         url(r'^settings/$', event.EventUpdate.as_view(), name='event.update'),
         url(r'^video-access/$', event.VideoAccessAuthenticator.as_view(), name='event.create_access_to_video'),
     ])),
+    path('orders/', MyOrdersView.as_view(), name='orders'),
     url(r'^account/$', account.AccountSettings.as_view(), name='account'),
 ]

--- a/src/pretix/eventyay_common/views/orders.py
+++ b/src/pretix/eventyay_common/views/orders.py
@@ -1,0 +1,47 @@
+from logging import getLogger
+
+from django.views.generic.list import ListView
+from django.db.models import Q
+from django.shortcuts import redirect
+
+from pretix.base.models import Order
+from ..forms.filters import UserOrderFilterForm
+
+
+logger = getLogger(__name__)
+
+
+class MyOrdersView(ListView):
+    template_name = 'eventyay_common/orders/orders.html'
+    paginate_by = 20
+
+    def get_queryset(self):
+        user = self.request.user
+        qs = Order.objects.filter(
+            Q(email__iexact=user.email)
+        ).select_related('event').order_by('-datetime')
+
+        # Filter by event if provided
+        filter_form = UserOrderFilterForm(self.request.GET, user=user)
+        if filter_form.is_valid():
+            event = filter_form.cleaned_data['event']
+            if event:
+                qs = qs.filter(event=event)
+
+        return qs
+
+    def get_context_data(self, **kwargs):
+        ctx = super().get_context_data(**kwargs)
+        ctx['filter_form'] = UserOrderFilterForm(self.request.GET, user=self.request.user)
+        return ctx
+
+    def get(self, request, *args, **kwargs):
+        filter_form = UserOrderFilterForm(self.request.GET, user=self.request.user)
+        # If filter form is invalid, strip the 'event' from URL and redirect to this new URL.
+        if not filter_form.is_valid():
+            new_url_query = request.GET.copy()
+            new_url_query.pop('event', None)
+            new_url = request.path + '?' + new_url_query.urlencode()
+            logger.info('To redirect to "%s" because the filter values are invalid.', new_url)
+            return redirect(new_url)
+        return super().get(request, *args, **kwargs)


### PR DESCRIPTION
Resolve #615 

![image](https://github.com/user-attachments/assets/812f06f4-6967-40e8-a768-410fb5b88b7a)

## Summary by Sourcery

Add a "My Orders" view to allow users to view and filter their past orders across events

New Features:
- Implement a new orders page that lists all orders for a logged-in user
- Add event filtering functionality for orders

Enhancements:
- Create a reusable order status fragment for consistent order status display