### PR TITLE
Fix: "My Orders" menu item active status is broken

### DIFF
--- a/src/pretix/eventyay_common/forms/filters.py
+++ b/src/pretix/eventyay_common/forms/filters.py
@@ -1,4 +1,5 @@
 from django import forms
+from django.utils.translation import gettext_lazy as _
 
 from pretix.base.models import Event
 
@@ -7,9 +8,9 @@ class UserOrderFilterForm(forms.Form):
     event = forms.ModelChoiceField(
         queryset=None,
         required=False,
-        label="Event",
+        label=_('Event'),
         widget=forms.Select(attrs={'class': 'form-control'}),
-        empty_label="Select an Event"
+        empty_label=_('Select an Event')
     )
 
     def __init__(self, *args, **kwargs):

--- a/src/pretix/eventyay_common/navigation.py
+++ b/src/pretix/eventyay_common/navigation.py
@@ -18,7 +18,7 @@ def get_global_navigation(request: HttpRequest) -> List[Dict[str, Any]]:
         {
             "label": _("My Orders"),
             "url": reverse("eventyay_common:orders"),
-            "active": "events" in url.url_name,
+            "active": "orders" in url.url_name,
             "icon": "shopping-cart",
         },
         {


### PR DESCRIPTION
Complement #637 

Before:

![image](https://github.com/user-attachments/assets/5de9f9a0-e95d-47b5-9f0a-212c31225e26)

After:

![image](https://github.com/user-attachments/assets/b2706747-b8ce-4816-a8aa-3289db6c9f70)

## Summary by Sourcery

Fix the active status of the "My Orders" menu item by updating the navigation logic to correctly highlight the menu item when on the orders page

Bug Fixes:
- Corrected the menu item active status condition in navigation to properly highlight 'My Orders' menu

Enhancements:
- Internationalized label texts using translation markers