### PR TITLE
Change the target of "My Orders" link

### DIFF
--- a/src/pretix/control/navigation.py
+++ b/src/pretix/control/navigation.py
@@ -285,12 +285,6 @@ def get_global_navigation(request):
         return []
     nav = [
         {
-            'label': _('My orders'),
-            'url': reverse('control:user.settings.orders'),
-            'active': 'user.settings.orders' in url.url_name,
-            'icon': 'shopping-cart',
-        },
-        {
             'label': _('My events'),
             'url': reverse('control:events'),
             'active': 'events' in url.url_name,

--- a/src/pretix/static/pretixcontrol/js/ui/popover.js
+++ b/src/pretix/static/pretixcontrol/js/ui/popover.js
@@ -13,7 +13,7 @@ $(function () {
     const ticketsPath = `/control/`;
     const talksPath = `${talkHostNamePath}orga/event/`
     const mainDashboardPath = `/common/`;
-    const orderPath = `/control/settings/orders/`;
+    const orderPath = `/common/orders/`;
     const eventPath = `/control/events/`;
     const organizerPath = `/control/organizers/`;
 


### PR DESCRIPTION
Resolves #615 

![image](https://github.com/user-attachments/assets/bb80ddca-e7ed-4c2d-b1aa-7b82df6301a3)

## Summary by Sourcery

Update the "My orders" link to point at the unified `/common/orders/` endpoint and remove the obsolete navigation entry

Enhancements:
- Change the popover’s "My orders" link target from `/control/settings/orders/` to `/common/orders/`
- Remove the "My orders" item from the global control navigation menu