### PR TITLE
chore: added compatibility towards mac os and reduced gid conflicts

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -36,7 +36,7 @@ RUN apt-get update && \
 	/usr/sbin/update-locale LANG=C.UTF-8 && \
     mkdir /etc/pretix && \
     mkdir /data && \
-    groupadd -g $GID pretixuser && \
+    groupadd -o -g $GID pretixuser && \
     useradd -ms /bin/bash -d /pretix -u $UID -g pretixuser pretixuser && \
     echo 'pretixuser ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers && \
     mkdir /static && \


### PR DESCRIPTION
added -o option to facilitate mac users non-breaking 
adding the -o option to groupadd -o -g $GID pretalxuser allows the reuse of an existing GID (Group ID). particularly useful in case of containers

## Summary by Sourcery

Build:
- Add -o flag to groupadd command in Dockerfile to enable non-unique GID reuse and reduce conflicts.