### PR TITLE
Remove 'Create Organizer' option

### DIFF
--- a/src/pretix/control/templates/pretixcontrol/admin/organizers.html
+++ b/src/pretix/control/templates/pretixcontrol/admin/organizers.html
@@ -20,14 +20,7 @@
             </button>
         </div>
     </form>
-    {% if staff_session %}
-        <p>
-            <a href="{% url "control:organizers.add" %}" class="btn btn-default">
-                <span class="fa fa-plus"></span>
-                {% trans "Create a new organizer" %}
-            </a>
-        </p>
-    {% endif %}
+
 	<table class="table table-condensed table-hover">
 		<thead>
 			<tr>

--- a/src/pretix/eventyay_common/views/organizer.py
+++ b/src/pretix/eventyay_common/views/organizer.py
@@ -51,8 +51,7 @@ class OrganizerCreate(CreateView):
     context_object_name = 'organizer'
 
     def dispatch(self, request, *args, **kwargs):
-        if not request.user.has_active_staff_session(self.request.session.session_key):
-            raise PermissionDenied()
+        # Allow all users to create organizers
         return super().dispatch(request, *args, **kwargs)
 
     @transaction.atomic


### PR DESCRIPTION
### 🔄 Changes Made

#### ✅ Frontend Template
**File:** `src/pretix/control/templates/pretixcontrol/admin/organizers.html`
- Removed the block that rendered the “Create Organizer” button for staff users:
  ```django
  {% if staff_session %}
      <a href="{% url "control:organizers.add" %}" class="btn btn-default">
          <span class="fa fa-plus"></span> {% trans "Create a new organizer" %}
      </a>
  {% endif %}
  ```

#### ✅ Backend View
**File:** `src/pretix/eventyay_common/views/organizer.py`
- Updated the `dispatch` method in the `OrganizerCreate` class:
  - **Removed:**
    ```python
    if not request.user.has_active_staff_session(self.request.session.session_key):
        raise PermissionDenied()
    ```
  - **Added:**
    ```python
    # Allow all users to create organizers
    return super().dispatch(request, *args, **kwargs)
    ```

---

## Summary by Sourcery

Remove the staff-session requirement for creating organizers by deleting the permission check in the backend and removing the UI guard for the “Create a new organizer” button in the admin view.

Enhancements:
- Allow all users to create organizers by removing the staff-session permission check in the backend view.
- Remove the conditional rendering of the “Create a new organizer” button in the admin organizers template.