### PR TITLE
Fix: Blur header image

### DIFF
--- a/src/pretix/helpers/thumb.py
+++ b/src/pretix/helpers/thumb.py
@@ -53,8 +53,9 @@ def create_thumbnail(sourcename, size):
     image = Image.open(BytesIO(source.read()))
     try:
         image.load()
-    except:
-        raise ThumbnailError('Could not load image')
+    except OSError as e:
+        msg = f'Could not load image: {e}'
+        raise ThumbnailError(msg) from e
 
     # before we calc thumbnail, we need to check and apply EXIF-orientation
     image = ImageOps.exif_transpose(image)

--- a/src/pretix/presale/context.py
+++ b/src/pretix/presale/context.py
@@ -90,6 +90,8 @@ def _default_context(request):
                 request.event.settings.presale_css_file
             )
 
+        # FIXME: We should avoid hardcoding truncate length here.
+        # It is not flexible because it requires the media folder to be at "/data/media/".
         ctx["event_logo"] = request.event.settings.get(
             "logo_image", as_type=str, default=""
         )[7:]
@@ -97,8 +99,8 @@ def _default_context(request):
             ctx["social_image"] = request.event.cache.get_or_set(
                 "social_image_url", request.event.social_image, 60
             )
-        except:
-            logger.exception("Could not generate social image")
+        except (ValueError, OSError) as e:
+            logger.error("Could not generate social image. Error: %s", e)
 
         ctx["event"] = request.event
         ctx["languages"] = [

--- a/src/pretix/presale/templates/pretixpresale/base.html
+++ b/src/pretix/presale/templates/pretixpresale/base.html
@@ -5,6 +5,8 @@
 {% load statici18n %}
 {% load thumb %}
 {% load eventurl %}
+
+{% get_media_prefix as MEDIA_PREFIX %}
 <!DOCTYPE html>
 <html{% if rtl %} dir="rtl" class="rtl"{% endif %} lang="{{ html_locale }}">
 <head>
@@ -51,9 +53,10 @@
 </head>
 <body class="nojs" data-locale="{{ request.LANGUAGE_CODE }}" data-now="{% now "U.u" %}" data-datetimeformat="{{ js_datetime_format }}" data-timeformat="{{ js_time_format }}" data-dateformat="{{ js_date_format }}" data-datetimelocale="{{ js_locale }}" data-currency="{{ request.event.currency }}">
 {{ html_page_header|safe }}
-    <div id="top-bg" class="header bg-primary" {% if event_logo %} {% endif %}>
+    <div id="top-bg" class="header bg-primary">
         {% if event_logo %}
-            <img id="header-image" src="{{ event_logo|thumb:'1170x5000' }}" alt="{{ event.name }}" class="event-logo" />
+            {# We use full image because the user may use big screen #}
+            <img id="header-image" src="{{ MEDIA_PREFIX }}{{ event_logo }}" alt="{{ event.name }}" class="event-logo" />
         {% endif %}
 </div>
 <header {% if event_logo %} class="custom-header" {% endif %}>


### PR DESCRIPTION
Fixes #645

After:

![image](https://github.com/user-attachments/assets/2f5e23b6-63bd-4531-bac8-39ef87723a13)


## Summary by Sourcery

Fix header image rendering by using the full-size event logo via the media prefix and tighten image-related error handling.

Bug Fixes:
- Restore header background image by removing thumbnail cropping and loading the full event logo via MEDIA_PREFIX

Enhancements:
- Expose MEDIA_PREFIX in presale templates for proper media path resolution
- Restrict exception catching to specific error types and emit detailed logs for social image generation and thumbnail loading failures