### PR TITLE
Enable video module by default during event creation

### DIFF
--- a/src/pretix/eventyay_common/views/event.py
+++ b/src/pretix/eventyay_common/views/event.py
@@ -226,7 +226,7 @@ class EventCreateView(SafeSessionWizardView):
                 "timezone": str(basics_data.get("timezone")),
                 "locale": basics_data.get("locale"),
                 "locales": foundation_data.get("locales"),
-                "is_video_creation": foundation_data.get("is_video_creation"),
+                "is_video_creation": foundation_data.get("is_video_creation", True),
             }
             send_event_webhook.delay(
                 user_id=self.request.user.id, event=event_dict, action="create"
@@ -239,7 +239,7 @@ class EventCreateView(SafeSessionWizardView):
                 event.plugins = settings.PRETIX_PLUGINS_DEFAULT
                 event.has_subevents = foundation_data["has_subevents"]
                 if check_create_permission(self.request):
-                    event.is_video_creation = foundation_data["is_video_creation"]
+                    event.is_video_creation = foundation_data.get("is_video_creation", True)
                 else:
                     event.is_video_creation = False
                 event.testmode = True
@@ -261,7 +261,7 @@ class EventCreateView(SafeSessionWizardView):
                         "timezone": str(basics_data.get("timezone")),
                         "locale": event.settings.locale,
                         "locales": event.settings.locales,
-                        "is_video_creation": foundation_data.get("is_video_creation"),
+                        "is_video_creation": foundation_data.get("is_video_creation", True),
                     }
                     send_event_webhook.delay(
                         user_id=self.request.user.id, event=event_dict, action="create"
@@ -278,7 +278,7 @@ class EventCreateView(SafeSessionWizardView):
             token=generate_token(self.request),
         )
         create_world.delay(
-            is_video_creation=foundation_data.get("is_video_creation"), event_data=event_data
+            is_video_creation=foundation_data.get("is_video_creation", True), event_data=event_data
         )
 
         return redirect(reverse("eventyay_common:event.index", kwargs={


### PR DESCRIPTION
Updated `EventCreateView.done()` method to default `is_video_creation` to True
Fixes #647 