### PR TITLE
enhancement: Use event creation method in common module only

### DIFF
--- a/src/pretix/control/templates/pretixcontrol/dashboard.html
+++ b/src/pretix/control/templates/pretixcontrol/dashboard.html
@@ -16,7 +16,7 @@
     <div class="dashboard">
         {% if can_create_event %}
             <div class="widget-small widget-container">
-                <a href="{% url "control:events.add" %}" class="widget">
+                <a href="{% url "eventyay_common:events.add" %}" class="widget">
                     <div class="newevent"><span class="fa fa-plus-circle"></span>{% trans "Create a new event" %}</div>
                 </a>
             </div>

--- a/src/pretix/control/templates/pretixcontrol/organizers/detail.html
+++ b/src/pretix/control/templates/pretixcontrol/organizers/detail.html
@@ -7,7 +7,7 @@
     </h1>
     {% if "can_create_events" in request.orgapermset %}
         <p>
-            <a href="{% url "control:events.add" %}?organizer={{ request.organizer.slug }}" class="btn btn-primary">
+            <a href="{% url "eventyay_common:events.add" %}?organizer={{ request.organizer.slug }}" class="btn btn-primary">
                 <span class="fa fa-plus"></span>
                 {% trans "Create a new event" %}
             </a>


### PR DESCRIPTION
Changed links on organizers and default ticket control views for creating a new event it uses the common link now to create an event

Fixes #646

## Summary by Sourcery

Use the common module’s event creation URL in dashboard and organizer templates instead of the local control route

Enhancements:
- Replace direct control:events.add links with eventyay_common:events.add in the dashboard view
- Replace direct control:events.add links with eventyay_common:events.add in the organizer detail view