### PR TITLE
Added an events filter to my events page on eventyay-common

### DIFF
--- a/src/pretix/eventyay_common/templates/eventyay_common/event/index.html
+++ b/src/pretix/eventyay_common/templates/eventyay_common/event/index.html
@@ -4,6 +4,7 @@
 {% load bootstrap3 %}
 {% load static %}
 {% load eventsignal %}
+{% load urlreplace %}
 {% block title %}{{ request.event.name }}{% endblock %}
 {% block content %}
     <nav id="event-nav" class="header-nav">
@@ -25,6 +26,37 @@
     </nav>
 
     {% eventsignal request.event "pretix.control.signals.event_dashboard_top" request=request %}
+    <div class="panel panel-default">
+        <div class="panel-heading">
+            <h3 class="panel-title">{% trans "Filter" %}</h3>
+        </div>
+        <div class="panel-body">
+            <form class="" action="" method="get">
+                <div class="row filter-form">
+                    <div class="col-md-3 col-sm-6 col-xs-12">
+                        {% bootstrap_field filter_form.query layout='inline' %}
+                    </div>
+                    <div class="col-md-3 col-sm-6 col-xs-12">
+                        {% bootstrap_field filter_form.status layout='inline' %}
+                    </div>
+                    <div class="col-md-3 col-sm-6 col-xs-12">
+                        {% bootstrap_field filter_form.organizer layout='inline' %}
+                    </div>
+                    {% for mf in meta_fields %}
+                        <div class="col-md-3 col-sm-6 col-xs-12">
+                            {% bootstrap_field mf layout='inline' %}
+                        </div>
+                    {% endfor %}
+                </div>
+                <div class="text-right">
+                    <button class="btn btn-primary" type="submit">
+                        <span class="fa fa-filter"></span>
+                        <span class="hidden-md">{% trans "Filter" %}</span>
+                    </button>
+                </div>
+            </form>
+        </div>
+    </div>
     {% if actions|length > 0 %}
         <div class="panel panel-danger">
             <div class="panel-heading">
@@ -62,7 +94,7 @@
         </form>
     {% endif %}
     <br>
-    {% include "eventyay_common/event/fragment_dashboard.html" %}
+    {%include "eventyay_common/event/fragment_dashboard.html" %}
     {% if not request.event.has_subevents or subevent %}
         {% include "pretixcontrol/event/fragment_timeline.html" %}
     {% endif %}
@@ -80,7 +112,7 @@
                 {% elif w.link %}
                     <a href="{{ w.link }}" class="widget">
                         {% if w.lazy %}
-                            <span class="fa fa-cog fa-4x´"></span>
+                            <span class="fa fa-cog fa-4x"></span>
                         {% else %}
                             {{ w.content|safe }}
                         {% endif %}

--- a/src/pretix/eventyay_common/templates/eventyay_common/events/index.html
+++ b/src/pretix/eventyay_common/templates/eventyay_common/events/index.html
@@ -5,6 +5,34 @@
 {% block title %}{% trans "Events management" %}{% endblock %}
 {% block content %}
     <h1>{% trans "Events" %}</h1>
+
+    <!-- Filter box always visible -->
+    <div class="panel panel-default" style="margin-bottom: 30px;">
+    <div class="panel-heading">
+        <h3 class="panel-title">{% trans "Filter" %}</h3>
+    </div>
+    <div class="panel-body">
+        <form action="" method="get">
+            <div class="row filter-form" style="align-items: flex-end;">
+                <div class="col-md-4 col-sm-6 col-xs-12">
+                    {% bootstrap_field filter_form.query layout='inline' placeholder=_("Event name") %}
+                </div>
+                <div class="col-md-3 col-sm-6 col-xs-12">
+                    {% bootstrap_field filter_form.status layout='inline' placeholder=_("All events") %}
+                </div>
+                <div class="col-md-3 col-sm-6 col-xs-12">
+                    {% bootstrap_field filter_form.organizer layout='inline' placeholder=_("All organizers") %}
+                </div>
+                <div class="col-md-2 col-sm-6 col-xs-12 text-right">
+                    <button type="submit" class="btn btn-primary" style="width: 100%;">
+                        <span class="fa fa-filter"></span>
+                        {% trans "Filter" %}
+                    </button>
+                </div>
+            </div>
+        </form>
+    </div>
+    </div>
     {% if events|length == 0 and not filter_form.filtered %}
         <div class="empty-collection">
             <p>
@@ -12,36 +40,12 @@
                     You currently do not have access to any events.
                 {% endblocktrans %}
             </p>
-
             <a href='{% url "eventyay_common:events.add" %}' class="btn btn-primary btn-lg">
                 <span class="fa fa-plus"></span>
                 {% trans "Create a new event" %}
             </a>
         </div>
     {% else %}
-        <div class="panel panel-default">
-            <div class="panel-heading">
-                <h3 class="panel-title">{% trans "Filter" %}</h3>
-            </div>
-            <div class="panel-body">
-                <form class="" action="" method="get">
-                    <div class="row filter-form">
-                        <div class="col-md-3 col-sm-6 col-xs-12">
-                            {% bootstrap_field filter_form.query layout='inline' %}
-                        </div>
-                        <div class="col-md-3 col-sm-6 col-xs-12">
-                            {% bootstrap_field filter_form.organizer layout='inline' %}
-                        </div>
-                    </div>
-                    <div class="text-right">
-                        <button class="btn btn-primary" type="submit">
-                            <span class="fa fa-filter"></span>
-                            <span class="hidden-md">{% trans "Filter" %}</span>
-                        </button>
-                    </div>
-                </form>
-            </div>
-        </div>
         <p>
             <a href='{% url "eventyay_common:events.add" %}' class="btn btn-default">
                 <span class="fa fa-plus"></span>

--- a/src/pretix/eventyay_common/templates/eventyay_common/events/index.html
+++ b/src/pretix/eventyay_common/templates/eventyay_common/events/index.html
@@ -6,7 +6,7 @@
 {% block content %}
     <h1>{% trans "Events" %}</h1>
 
-    <!-- Filter box always visible -->
+    <!--Filter box always visible-->
     <div class="panel panel-default" style="margin-bottom: 30px;">
     <div class="panel-heading">
         <h3 class="panel-title">{% trans "Filter" %}</h3>

--- a/src/pretix/eventyay_common/views/event.py
+++ b/src/pretix/eventyay_common/views/event.py
@@ -141,6 +141,8 @@ class EventList(PaginationMixin, ListView):
                         else 100
                     ),
                 )
+        print("DEBUG filter_form fields:", list(self.filter_form.fields.keys()))
+
         return ctx
 
     @cached_property


### PR DESCRIPTION
Added a filter box to my events page on eventyay-common similar to that of eventyay-control.
Fixes #662

## Summary by Sourcery

Add a filter panel to the My Events page and correct HTML icon markup

New Features:
- Introduce a filter panel with query, status, organizer, and meta-fields controls on the My Events page

Bug Fixes:
- Fix stray backtick in the fa-cog icon HTML markup