### PR TITLE
enhancement: remove event creation option from /tickets/control/admin/events/

### DIFF
--- a/src/pretix/control/templates/pretixcontrol/admin/events/index.html
+++ b/src/pretix/control/templates/pretixcontrol/admin/events/index.html
@@ -13,11 +13,6 @@
                     You currently do not have access to any events.
                 {% endblocktrans %}
             </p>
-
-            <a href='{% url "control:events.add" %}' class="btn btn-primary btn-lg">
-                <span class="fa fa-plus"></span>
-                {% trans "Create a new event" %}
-            </a>
         </div>
     {% else %}
         <div class="panel panel-default">
@@ -51,12 +46,6 @@
                 </form>
             </div>
         </div>
-        <p>
-            <a href='{% url "control:events.add" %}' class="btn btn-default">
-                <span class="fa fa-plus"></span>
-                {% trans "Create a new event" %}
-            </a>
-        </p>
         <table class="table table-condensed table-hover">
             <thead>
             <tr>


### PR DESCRIPTION
Restricts event creation to the "commons" area only by removing the "Create a New Event" option from /tickets/control/admin/events/

### Before
![Screenshot from 2025-05-26 14-53-04](https://github.com/user-attachments/assets/7ec7fa85-d115-414b-80f1-e9cba80f3b0b)

### After
![Screenshot from 2025-05-26 14-58-06](https://github.com/user-attachments/assets/0ef7ec16-f28a-4814-9d85-8a4b13dd2878)

Fixes #649

## Summary by Sourcery

Restrict event creation to the commons area by removing all “Create a new event” options from tickets-related pages.

Enhancements:
- Remove “Create a new event” button from the tickets dashboard.
- Remove “Create a new event” option on the organizer detail page.
- Remove “Create a new event” link from the admin events list.
- Remove “Create a new event” action from organizer-specific event pages.