### PR TITLE
Fix: Update Talk system settings link and label on organizer update page

### DIFF
--- a/src/pretix/eventyay_common/templates/eventyay_common/organizers/edit.html
+++ b/src/pretix/eventyay_common/templates/eventyay_common/organizers/edit.html
@@ -13,7 +13,7 @@
             {% bootstrap_field form.slug layout="horizontal" %}
         </fieldset>
         <fieldset>
-            <h4>{% trans "Setting for Tickets system" %}
+            <h4>{% trans "Settings for Tickets system" %}
                 <a href='{% url "control:organizer.edit" organizer=organizer.slug  %}'
                         class="btn btn-sm btn-default" title='{% trans "Edit" %}'
                         data-toggle="tooltip">
@@ -22,7 +22,7 @@
             </h4>
         </fieldset>
         <fieldset>
-            <h4>{% trans "Setting for Talk system" %}
+            <h4>{% trans "Settings for Talk system" %}
                 <a href='{{ talk_edit_url }}'
                         class="btn btn-sm btn-default" title='{% trans "Edit" %}'
                         data-toggle="tooltip">

--- a/src/pretix/eventyay_common/views/organizer.py
+++ b/src/pretix/eventyay_common/views/organizer.py
@@ -99,7 +99,7 @@ class OrganizerUpdate(UpdateView, OrganizerPermissionRequiredMixin):
 
     def get_context_data(self, **kwargs):
         ctx = super().get_context_data(**kwargs)
-        ctx["talk_edit_url"] = urljoin(settings.TALK_HOSTNAME, f"orga/organiser/{self.object.slug}")
+        ctx["talk_edit_url"] = urljoin(settings.TALK_HOSTNAME, f"orga/organiser/{self.object.slug}/settings/")
         return ctx
 
     @transaction.atomic


### PR DESCRIPTION
This PR fixes two issues:
1. Settings button directs to organiser link instead of organiser settings link
2. Renames "Setting" to "Settings" in both the Talk and Tickets system headers for consistency.

### After applying changes:
![Screenshot from 2025-05-28 19-05-24](https://github.com/user-attachments/assets/9e26609d-ba68-4eaf-a797-e18a43fb7e0f)

![Screenshot from 2025-05-28 19-05-49](https://github.com/user-attachments/assets/690cbef7-5bfc-4381-a020-2ce1cd6269bd)

Fixes #682

## Summary by Sourcery

Fix the Talk system settings link and standardize the header label to "Settings" on the organizer edit page.

Bug Fixes:
- Update Talk system settings button URL to point to the '/settings/' page instead of the main organizer view
- Change header labels from "Setting" to "Settings" in both Tickets and Talk system sections for consistency