### PR TITLE
Add Vouchers under Products in Navigation Pane

### DIFF
--- a/src/pretix/control/navigation.py
+++ b/src/pretix/control/navigation.py
@@ -113,6 +113,62 @@ def get_event_navigation(request: HttpRequest):
             })
 
     if 'can_change_items' in request.eventpermset:
+        children = [
+            {
+                'label': _('Products'),
+                'url': reverse('control:event.items', kwargs={
+                    'event': request.event.slug,
+                    'organizer': request.event.organizer.slug,
+                }),
+                'active': url.url_name in (
+                    'event.item', 'event.items.add', 'event.items') or "event.item." in url.url_name,
+            },
+            {
+                'label': _('Quotas'),
+                'url': reverse('control:event.items.quotas', kwargs={
+                    'event': request.event.slug,
+                    'organizer': request.event.organizer.slug,
+                }),
+                'active': 'event.items.quota' in url.url_name,
+            },
+            {
+                'label': _('Categories'),
+                'url': reverse('control:event.items.categories', kwargs={
+                    'event': request.event.slug,
+                    'organizer': request.event.organizer.slug,
+                }),
+                'active': 'event.items.categories' in url.url_name,
+            },
+            {
+                'label': _('Questions'),
+                'url': reverse('control:event.items.questions', kwargs={
+                    'event': request.event.slug,
+                    'organizer': request.event.organizer.slug,
+                }),
+                'active': 'event.items.questions' in url.url_name,
+            },
+        ]
+
+        if 'can_view_vouchers' in request.eventpermset:
+            children.extend([
+                {
+                    'label': _('All vouchers'),
+                    'url': reverse('control:event.vouchers', kwargs={
+                        'event': request.event.slug,
+                        'organizer': request.event.organizer.slug,
+                    }),
+                    'active': url.url_name != 'event.vouchers.tags' and "event.vouchers" in url.url_name,
+                },
+                {
+                    'label': _('Voucher Tags'),
+                    'url': reverse('control:event.vouchers.tags', kwargs={
+                        'event': request.event.slug,
+                        'organizer': request.event.organizer.slug,
+                    }),
+                    'active': 'event.vouchers.tags' in url.url_name,
+                },
+            ])
+
         nav.append({
             'label': _('Products'),
             'url': reverse('control:event.items', kwargs={
@@ -121,41 +177,7 @@ def get_event_navigation(request: HttpRequest):
             }),
             'active': False,
             'icon': 'ticket',
-            'children': [
-                {
-                    'label': _('Products'),
-                    'url': reverse('control:event.items', kwargs={
-                        'event': request.event.slug,
-                        'organizer': request.event.organizer.slug,
-                    }),
-                    'active': url.url_name in (
-                        'event.item', 'event.items.add', 'event.items') or "event.item." in url.url_name,
-                },
-                {
-                    'label': _('Quotas'),
-                    'url': reverse('control:event.items.quotas', kwargs={
-                        'event': request.event.slug,
-                        'organizer': request.event.organizer.slug,
-                    }),
-                    'active': 'event.items.quota' in url.url_name,
-                },
-                {
-                    'label': _('Categories'),
-                    'url': reverse('control:event.items.categories', kwargs={
-                        'event': request.event.slug,
-                        'organizer': request.event.organizer.slug,
-                    }),
-                    'active': 'event.items.categories' in url.url_name,
-                },
-                {
-                    'label': _('Questions'),
-                    'url': reverse('control:event.items.questions', kwargs={
-                        'event': request.event.slug,
-                        'organizer': request.event.organizer.slug,
-                    }),
-                    'active': 'event.items.questions' in url.url_name,
-                },
-            ]
+            'children': children
         })
 
     if 'can_view_orders' in request.eventpermset:
@@ -219,35 +241,6 @@ def get_event_navigation(request: HttpRequest):
             'active': False,
             'icon': 'shopping-cart',
             'children': children
-        })
-
-    if 'can_view_vouchers' in request.eventpermset:
-        nav.append({
-            'label': _('Vouchers'),
-            'url': reverse('control:event.vouchers', kwargs={
-                'event': request.event.slug,
-                'organizer': request.event.organizer.slug,
-            }),
-            'active': False,
-            'icon': 'tags',
-            'children': [
-                {
-                    'label': _('All vouchers'),
-                    'url': reverse('control:event.vouchers', kwargs={
-                        'event': request.event.slug,
-                        'organizer': request.event.organizer.slug,
-                    }),
-                    'active': url.url_name != 'event.vouchers.tags' and "event.vouchers" in url.url_name,
-                },
-                {
-                    'label': _('Tags'),
-                    'url': reverse('control:event.vouchers.tags', kwargs={
-                        'event': request.event.slug,
-                        'organizer': request.event.organizer.slug,
-                    }),
-                    'active': 'event.vouchers.tags' in url.url_name,
-                },
-            ]
         })
 
     if 'can_view_orders' in request.eventpermset:


### PR DESCRIPTION
This PR solves #689 and moves Vouchers into Products

**Updated :**
<img width="1578" alt="image" src="https://github.com/user-attachments/assets/b8de3b90-7c0b-47b1-8df5-821f78e8656c" />

**Previous :**
<img width="1578" alt="image" src="https://github.com/user-attachments/assets/ac607d8b-52a0-4f0f-8993-e89f61dec206" />

## Summary by Sourcery

Move vouchers into the Products section of the event navigation, introduce Categories and Questions sub-items, and streamline the menu-building logic.

New Features:
- Group vouchers under the Products navigation pane instead of a standalone Vouchers menu
- Add “Categories” and “Questions” submenus under Products

Enhancements:
- Refactor navigation code to build Products child items dynamically and remove the separate Vouchers entry