### PR TITLE
Fixed the signature text according to the requirement.

### DIFF
--- a/src/pretix/base/secrets.py
+++ b/src/pretix/base/secrets.py
@@ -111,7 +111,7 @@ class Sig1TicketSecretGenerator(BaseTicketSecretGenerator):
     The resulting string is REVERSED, to avoid all secrets of same length beginning with the same 10
     characters, which would make it impossible to search for secrets manually.
     """
-    verbose_name = _('signature scheme 1 (for very large events, does not work with pretixSCAN on iOS and '
+    verbose_name = _('signature scheme 1 (for very large events, does not work on all apps in the ecosystem and '
                      'changes semantics of offline scanning – please refer to documentation or support for details)')
     identifier = 'pretix_sig1'
     use_revocation_list = True


### PR DESCRIPTION
![Screenshot from 2025-05-31 22-25-37](https://github.com/user-attachments/assets/5354c79a-c2f0-45ae-8395-3ded0d3a752a)
@mariobehling I have fixed the text for signature scheme on the tickets tab of event organizers.

Fixes- #693

## Summary by Sourcery

Documentation:
- Modify the verbose_name for signature scheme 1 to state it "does not work on all apps in the ecosystem" instead of mentioning only pretixSCAN on iOS