### PR TITLE
fix: missing error message at event creation with paid tickets

### DIFF
--- a/src/pretix/control/views/event.py
+++ b/src/pretix/control/views/event.py
@@ -1318,7 +1318,25 @@ class QuickSetupView(FormView):
         if form.is_valid() and self.formset.is_valid():
             return self.form_valid(form)
         else:
-            messages.error(self.request, _('We could not save your changes. See below for details.'))
+            plugins_active = self.request.event.get_plugins()
+            payment_plugins = {
+                'pretix.plugins.banktransfer',
+                'pretix.plugins.stripe',
+                'pretix.plugins.paypal',
+                'pretix.plugins.manualpayment',
+            }
+            if not payment_plugins.intersection(plugins_active):
+                messages.error(
+                    self.request,
+                _("""We could not save your changes. See below for details.
+
+                To start accepting orders, please activate a payment option.
+                ->Open "Plugins" and switch on one or more payment plugins.
+                ->Then go to the "Payments" tab to configure your chosen methods.
+                Save your changes to begin accepting payments.""")
+                )
+            else:
+                messages.error(self.request, _('We could not save your changes. See below for details.'))
             return self.form_invalid(form)
 
     @transaction.atomic


### PR DESCRIPTION
Fixes #621

## Summary by Sourcery

Bug Fixes:
- Display a specific error guiding users to enable and configure payment plugins if no payment method is active during event creation.