### PR TITLE
Remove Account menu item from common dashboard

### DIFF
--- a/src/pretix/eventyay_common/navigation.py
+++ b/src/pretix/eventyay_common/navigation.py
@@ -44,12 +44,6 @@ def get_global_navigation(request: HttpRequest) -> List[MenuItem]:
             "active": "organizers" in url.url_name,
             "icon": "group",
         },
-        {
-            "label": _("Account"),
-            "url": reverse("eventyay_common:account"),
-            "active": "account" in url.url_name,
-            "icon": "user",
-        },
     ]
 
     # Merge plugin-provided navigation items


### PR DESCRIPTION
Fixes: #717 
![717](https://github.com/user-attachments/assets/12b7c55e-2b12-48de-843d-49540e6282e3)

## Summary by Sourcery

Bug Fixes:
- Remove the Account menu item from the common dashboard navigation