### PR TITLE
Added events filter to my events page on eventyay-common

### DIFF
--- a/src/pretix/eventyay_common/templates/eventyay_common/events/index.html
+++ b/src/pretix/eventyay_common/templates/eventyay_common/events/index.html
@@ -30,6 +30,9 @@
                             {% bootstrap_field filter_form.query layout='inline' %}
                         </div>
                         <div class="col-md-3 col-sm-6 col-xs-12">
+                            {% bootstrap_field filter_form.status layout='inline' %}
+                        </div>
+                        <div class="col-md-3 col-sm-6 col-xs-12">
                             {% bootstrap_field filter_form.organizer layout='inline' %}
                         </div>
                     </div>


### PR DESCRIPTION
[#662](https://github.com/fossasia/eventyay-tickets/issues/662) Inserted {% bootstrap_field filter_form.status layout='inline' %} between the query and organizer fields

<img width="1506" alt="Screenshot 2025-06-04 at 8 36 26 AM" src="https://github.com/user-attachments/assets/914ab9ab-d48d-4ec5-b302-f5da73303641" />

## Summary by Sourcery

New Features:
- Add status filter to events page filter form