### PR TITLE
Remove the duplicate word "times" in vouchers.py's helper text

### DIFF
--- a/src/pretix/control/forms/vouchers.py
+++ b/src/pretix/control/forms/vouchers.py
@@ -287,7 +287,7 @@ class VoucherBulkForm(VoucherForm):
             'max_usages': _('Maximum usages per voucher')
         }
         help_texts = {
-            'max_usages': _('Number of times times EACH of these vouchers can be redeemed.')
+            'max_usages': _('Number of times EACH of these vouchers can be redeemed.')
         }
 
     def __init__(self, *args, **kwargs):


### PR DESCRIPTION
Fixing [issue 720 duplicate word in helper text](https://github.com/fossasia/eventyay-tickets/issues/720)