### PR TITLE
Updated top-left logo and text to match the design of the talk-component

### DIFF
--- a/src/pretix/static/pretixcontrol/scss/main.scss
+++ b/src/pretix/static/pretixcontrol/scss/main.scss
@@ -33,10 +33,28 @@ footer {
 nav.navbar {
     margin: 0;
 }
+
 .navbar-brand img {
-    height: 100%;
-    width: auto;
-    display: inline;
+    height: 30px ;
+    width: auto ;
+    margin-right: 8px ;
+    display: inline-block ;
+    vertical-align: middle ;
+}
+
+.navbar-brand {
+    font-weight: 500 ;
+    font-size: 19px ;
+    display: flex ;
+    align-items: center ;
+    line-height: 30px ;
+    color: #ffffff ;
+    text-decoration: none ;
+    
+    &:hover, &:focus {
+        color: #ffffff ;
+        text-decoration: none ;
+    }
 }
 
 #side-menu img.fa-img {

--- a/src/pretix/static/pretixcontrol/scss/main.scss
+++ b/src/pretix/static/pretixcontrol/scss/main.scss
@@ -35,7 +35,7 @@ nav.navbar {
 }
 
 .navbar-brand {
-    font-weight: 500; 
+    font-weight: 600; 
     padding-top: 0.3125rem; 
     padding-bottom: 0.3125rem;
     display: flex;

--- a/src/pretix/static/pretixcontrol/scss/main.scss
+++ b/src/pretix/static/pretixcontrol/scss/main.scss
@@ -41,7 +41,7 @@ nav.navbar {
     display: flex;
     align-items: center;
     color: $navbar-inverse-link-color;
-    font-size: 2rem;
+    font-size: 1.75rem;
     white-space: nowrap;
     
     &:hover,

--- a/src/pretix/static/pretixcontrol/scss/main.scss
+++ b/src/pretix/static/pretixcontrol/scss/main.scss
@@ -34,27 +34,37 @@ nav.navbar {
     margin: 0;
 }
 
-.navbar-brand img {
-    height: 30px ;
-    width: auto ;
-    margin-right: 8px ;
-    display: inline-block ;
-    vertical-align: middle ;
+.navbar-brand {
+    display: flex;
+    align-items: center;
+    color: $navbar-inverse-link-color;
+    padding: 0 !important;
+    font-size: 1.75rem;
+    line-height: 30px;
+    font-weight: 500;
+    white-space: nowrap;
+    
+    &:hover,
+    &:focus {
+        color: $navbar-inverse-link-hover-color;
+        text-decoration: none;
+       
+        outline: none;
+        box-shadow: 0 0 0 0px rgba($navbar-inverse-link-hover-color, 0.5);
+    }
 }
 
-.navbar-brand {
-    font-weight: 500 ;
-    font-size: 19px ;
-    display: flex ;
-    align-items: center ;
-    line-height: 30px ;
-    color: #ffffff ;
-    text-decoration: none ;
-    
-    &:hover, &:focus {
-        color: #ffffff ;
-        text-decoration: none ;
-    }
+.navbar-brand img {
+    height: 30px;
+    width: auto;
+    margin-right: 0.5rem;
+    margin-left: 1rem;
+    display: inline-block;
+    vertical-align: middle;
+}
+
+.navbar-brand span {
+    margin-top: -0.625rem; // -10px equivalent to match eventyay-talk
 }
 
 #side-menu img.fa-img {

--- a/src/pretix/static/pretixcontrol/scss/main.scss
+++ b/src/pretix/static/pretixcontrol/scss/main.scss
@@ -35,13 +35,13 @@ nav.navbar {
 }
 
 .navbar-brand {
+    font-weight: 500; 
+    padding-top: 0.3125rem; 
+    padding-bottom: 0.3125rem;
     display: flex;
     align-items: center;
     color: $navbar-inverse-link-color;
-    padding: 0 !important;
-    font-size: 1.75rem;
-    line-height: 30px;
-    font-weight: 500;
+    font-size: 2rem;
     white-space: nowrap;
     
     &:hover,


### PR DESCRIPTION
Solves: [#730 ](https://github.com/fossasia/eventyay-tickets/issues/730) Modifying existing ".navbar-brand img" and  Added new ".navbar-brand" in main.scss file to make the "eventyay" look as same as that in the eventyay-talk.
<img width="253" alt="Screenshot 2025-06-07 at 10 50 34 PM" src="https://github.com/user-attachments/assets/c1fca08d-66fa-4e6f-9018-6dfcff437a8c" />

## Summary by Sourcery

Update navbar brand appearance by adjusting the logo size and spacing, and adding text styling to match the eventyay-talk design

Enhancements:
- Refine .navbar-brand img dimensions, margin, and vertical alignment
- Introduce .navbar-brand rules for font weight, size, color, and hover behavior