### PR TITLE
Added text tab in eventyay-common event settings

### DIFF
--- a/src/pretix/control/templates/pretixcontrol/event/settings.html
+++ b/src/pretix/control/templates/pretixcontrol/event/settings.html
@@ -122,10 +122,8 @@
             </fieldset>
             <fieldset>
                 <legend>{% trans "Texts" %}</legend>
-                {% bootstrap_field sform.frontpage_text layout="control" %}
                 {% bootstrap_field sform.presale_has_ended_text layout="control" %}
                 {% bootstrap_field sform.voucher_explanation_text layout="control" %}
-
                 <div class="form-group">
                     <label class="col-md-3 control-label">
                         {% trans "Confirmation text" %}<br>

--- a/src/pretix/eventyay_common/forms/event.py
+++ b/src/pretix/eventyay_common/forms/event.py
@@ -26,6 +26,7 @@ class EventCommonSettingsForm(SettingsForm):
         'hover_button_color',
         'theme_round_borders',
         'primary_font',
+        'frontpage_text',
     ]
 
     def clean(self):

--- a/src/pretix/eventyay_common/templates/eventyay_common/event/settings.html
+++ b/src/pretix/eventyay_common/templates/eventyay_common/event/settings.html
@@ -126,6 +126,10 @@
                 {% bootstrap_field sform.timezone layout="control" %}
             </fieldset>
             <fieldset>
+                <legend>{{ _('Texts') }}</legend>
+                {% bootstrap_field sform.frontpage_text layout="control" %}
+            </fieldset>
+            <fieldset>
                 <legend>{{ _('Design') }}</legend>
                 {% bootstrap_field sform.logo_image layout="control" %}
                 {% bootstrap_field sform.logo_image_large layout="control" %}

--- a/src/pretix/eventyay_common/views/event.py
+++ b/src/pretix/eventyay_common/views/event.py
@@ -442,6 +442,7 @@ class EventUpdate(
                         'is_video_creation': request.event.is_video_creation,
                     }
                     send_event_webhook.delay(user_id=self.request.user.id, event=event_dict, action='update')
+                    messages.success(self.request, _("Your changes have been saved."))
                 return self.form_valid(form)
             else:
                 messages.error(

--- a/src/pretix/eventyay_common/views/event.py
+++ b/src/pretix/eventyay_common/views/event.py
@@ -442,7 +442,7 @@ class EventUpdate(
                         'is_video_creation': request.event.is_video_creation,
                     }
                     send_event_webhook.delay(user_id=self.request.user.id, event=event_dict, action='update')
-                    messages.success(self.request, _("Your changes have been saved."))
+                messages.success(self.request, _("Your changes have been saved."))
                 return self.form_valid(form)
             else:
                 messages.error(


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/08f0539a-72b1-4e49-b842-57855fca32d0)

![image](https://github.com/user-attachments/assets/11c29d43-8c64-49dd-b5ed-2a104330a1d1)

issue-fix: #700 
Created a Text tab in eventyay-common event settings as requested.

## Summary by Sourcery

Introduce a dedicated Texts tab in event settings to configure the frontpage text

New Features:
- Add a Texts fieldset to the eventyay-common event settings for editing the frontpage text

Enhancements:
- Move the frontpage_text input into the new Texts fieldset and remove its duplicate in the pretix control template
- Include frontpage_text in the EventCommonSettingsForm to persist the new setting