### PR TITLE
Moved email-content to Templates tab under Mails

### DIFF
--- a/src/pretix/control/templates/pretixcontrol/event/mail.html
+++ b/src/pretix/control/templates/pretixcontrol/event/mail.html
@@ -50,43 +50,6 @@
                 </div>
             </fieldset>
             <fieldset>
-                <legend>{% trans "E-mail content" %}</legend>
-                <div class="panel-group" id="questions_group">
-                    {% blocktrans asvar title_placed_order %}Placed order{% endblocktrans %}
-                    {% include "pretixcontrol/event/mail_settings_fragment.html" with pid="order_placed" title=title_placed_order items="mail_text_order_placed,mail_send_order_placed_attendee,mail_text_order_placed_attendee" exclude="mail_send_order_placed_attendee" %}
-
-                    {% blocktrans asvar title_paid_order %}Paid order{% endblocktrans %}
-                    {% include "pretixcontrol/event/mail_settings_fragment.html" with pid="order_paid" title=title_paid_order items="mail_text_order_paid,mail_send_order_paid_attendee,mail_text_order_paid_attendee" exclude="mail_send_order_paid_attendee" %}
-
-                    {% blocktrans asvar title_free_order %}Free order{% endblocktrans %}
-                    {% include "pretixcontrol/event/mail_settings_fragment.html" with pid="order_free" title=title_free_order items="mail_text_order_free,mail_send_order_free_attendee,mail_text_order_free_attendee" exclude="mail_send_order_free_attendee" %}
-
-                    {% blocktrans asvar title_resend_link %}Resend link{% endblocktrans %}
-                    {% include "pretixcontrol/event/mail_settings_fragment.html" with pid="resend_link" title=title_resend_link items="mail_text_resend_link,mail_text_resend_all_links" %}
-
-                    {% blocktrans asvar title_order_changed %}Order changed{% endblocktrans %}
-                    {% include "pretixcontrol/event/mail_settings_fragment.html" with pid="order_changed" title=title_order_changed items="mail_text_order_changed" %}
-
-                    {% blocktrans asvar title_payment_reminder %}Payment reminder{% endblocktrans %}
-                    {% include "pretixcontrol/event/mail_settings_fragment.html" with pid="order_expirew" title=title_payment_reminder items="mail_days_order_expire_warning,mail_text_order_expire_warning" exclude="mail_days_order_expire_warning" %}
-
-                    {% blocktrans asvar title_waiting_list_notification %}Waiting list notification{% endblocktrans %}
-                    {% include "pretixcontrol/event/mail_settings_fragment.html" with pid="waiting_list" title=title_waiting_list_notification items="mail_text_waiting_list" %}
-
-                    {% blocktrans asvar title_order_canceled %}Order canceled{% endblocktrans %}
-                    {% include "pretixcontrol/event/mail_settings_fragment.html" with pid="order_canceled" title=title_order_canceled items="mail_text_order_canceled" %}
-
-                    {% blocktrans asvar title_order_custom_mail %}Order custom mail{% endblocktrans %}
-                    {% include "pretixcontrol/event/mail_settings_fragment.html" with pid="custom_mail" title=title_order_custom_mail items="mail_text_order_custom_mail" %}
-
-                    {% blocktrans asvar title_download_tickets_reminder %}Reminder to download tickets{% endblocktrans %}
-                    {% include "pretixcontrol/event/mail_settings_fragment.html" with pid="ticket_reminder" title=title_download_tickets_reminder items="mail_days_download_reminder,mail_text_download_reminder,mail_send_download_reminder_attendee,mail_text_download_reminder_attendee,mail_sales_channel_download_reminder" exclude="mail_days_download_reminder,mail_send_download_reminder_attendee,mail_sales_channel_download_reminder" %}
-
-                    {% blocktrans asvar title_require_approval %}Order approval process{% endblocktrans %}
-                    {% include "pretixcontrol/event/mail_settings_fragment.html" with pid="ticket_reminder" title=title_require_approval  items="mail_text_order_placed_require_approval,mail_text_order_approved,mail_text_order_approved_free,mail_text_order_denied" %}
-                </div>
-            </fieldset>
-            <fieldset>
                 <legend>{% trans "Email settings" %}</legend>     
                 {% bootstrap_field form.smtp_use_custom layout="control" %}
                 {% bootstrap_field form.email_vendor layout="control" %}

--- a/src/pretix/control/views/event.py
+++ b/src/pretix/control/views/event.py
@@ -727,6 +727,44 @@ class MailSettings(EventSettingsViewMixin, EventSettingsFormView):
         ctx['renderers'] = self.request.event.get_html_mail_renderers()
         return ctx
 
+    def get_form(self):
+        form = super().get_form()
+
+        # List of email-content fields to exclude
+        exclude_fields = [
+            'mail_text_order_placed',
+            'mail_send_order_placed_attendee',
+            'mail_text_order_placed_attendee',
+            'mail_text_order_paid',
+            'mail_send_order_paid_attendee',
+            'mail_text_order_paid_attendee',
+            'mail_text_order_free',
+            'mail_send_order_free_attendee',
+            'mail_text_order_free_attendee',
+            'mail_text_resend_link',
+            'mail_text_resend_all_links',
+            'mail_text_order_changed',
+            'mail_days_order_expire_warning',
+            'mail_text_order_expire_warning',
+            'mail_text_waiting_list',
+            'mail_text_order_canceled',
+            'mail_text_order_custom_mail',
+            'mail_text_download_reminder',
+            'mail_send_download_reminder_attendee',
+            'mail_text_download_reminder_attendee',
+            'mail_days_download_reminder',
+            'mail_sales_channel_download_reminder',
+            'mail_text_order_placed_require_approval',
+            'mail_text_order_approved',
+            'mail_text_order_approved_free',
+            'mail_text_order_denied',
+        ]
+
+        for field in exclude_fields:
+            form.fields.pop(field, None)
+
+        return form
+
     @transaction.atomic
     def post(self, request, *args, **kwargs):
         form = self.get_form()

--- a/src/pretix/plugins/sendmail/forms.py
+++ b/src/pretix/plugins/sendmail/forms.py
@@ -14,6 +14,8 @@ from pretix.base.models import CheckinList, Item, Order, SubEvent
 from pretix.control.forms import CachedFileField
 from pretix.control.forms.widgets import Select2, Select2Multiple
 
+MAIL_SEND_ORDER_PLACED_ATTENDEE_HELP = _( 'If the order contains attendees with email addresses different from the person who orders the ' 'tickets, the following email will be sent out to the attendees.' )
+
 def contains_web_channel_validate(value):
     if 'web' not in value:
         raise ValidationError(_("The 'web' sales channel must be selected."))
@@ -218,10 +220,7 @@ class MailContentSettingsForm(SettingsForm):
     )
     mail_send_order_placed_attendee = forms.BooleanField(
         label=_('Send an email to attendees'),
-        help_text=_(
-            'If the order contains attendees with email addresses different from the person who orders the '
-            'tickets, the following email will be sent out to the attendees.'
-        ),
+        help_text= MAIL_SEND_ORDER_PLACED_ATTENDEE_HELP,
         required=False,
     )
     mail_text_order_placed_attendee = I18nFormField(
@@ -237,10 +236,7 @@ class MailContentSettingsForm(SettingsForm):
     )
     mail_send_order_paid_attendee = forms.BooleanField(
         label=_('Send an email to attendees'),
-        help_text=_(
-            'If the order contains attendees with email addresses different from the person who orders the '
-            'tickets, the following email will be sent out to the attendees.'
-        ),
+        help_text= MAIL_SEND_ORDER_PLACED_ATTENDEE_HELP,
         required=False,
     )
     mail_text_order_paid_attendee = I18nFormField(
@@ -256,10 +252,7 @@ class MailContentSettingsForm(SettingsForm):
     )
     mail_send_order_free_attendee = forms.BooleanField(
         label=_('Send an email to attendees'),
-        help_text=_(
-            'If the order contains attendees with email addresses different from the person who orders the '
-            'tickets, the following email will be sent out to the attendees.'
-        ),
+        help_text= MAIL_SEND_ORDER_PLACED_ATTENDEE_HELP,
         required=False,
     )
     mail_text_order_free_attendee = I18nFormField(
@@ -325,10 +318,7 @@ class MailContentSettingsForm(SettingsForm):
     )
     mail_send_download_reminder_attendee = forms.BooleanField(
         label=_('Send an email to attendees'),
-        help_text=_(
-            'If the order contains attendees with email addresses different from the person who orders the '
-            'tickets, the following email will be sent out to the attendees.'
-        ),
+        help_text= MAIL_SEND_ORDER_PLACED_ATTENDEE_HELP,
         required=False,
     )
     mail_text_download_reminder_attendee = I18nFormField(
@@ -410,7 +400,7 @@ class MailContentSettingsForm(SettingsForm):
         phs = ['{%s}' % p for p in sorted(get_available_placeholders(self.event, base_parameters).keys())]
         ht = _('Available placeholders: {list}').format(list=', '.join(phs))
         if self.fields[fn].help_text:
-            self.fields[fn].help_text += ' ' + str(ht)
+            self.fields[fn].help_text += f' {str(ht)}'
         else:
             self.fields[fn].help_text = ht
         self.fields[fn].validators.append(PlaceholderValidator(phs))

--- a/src/pretix/plugins/sendmail/forms.py
+++ b/src/pretix/plugins/sendmail/forms.py
@@ -6,13 +6,17 @@ from django.utils.translation import pgettext_lazy
 from django_scopes.forms import SafeModelMultipleChoiceField
 from i18nfield.forms import I18nFormField, I18nTextarea, I18nTextInput
 
+from pretix.base.channels import get_all_sales_channels
 from pretix.base.email import get_available_placeholders
-from pretix.base.forms import PlaceholderValidator
+from pretix.base.forms import PlaceholderValidator, SettingsForm
 from pretix.base.forms.widgets import SplitDateTimePickerWidget
 from pretix.base.models import CheckinList, Item, Order, SubEvent
 from pretix.control.forms import CachedFileField
 from pretix.control.forms.widgets import Select2, Select2Multiple
 
+def contains_web_channel_validate(value):
+    if 'web' not in value:
+        raise ValidationError(_("The 'web' sales channel must be selected."))
 
 class MailForm(forms.Form):
     recipients = forms.ChoiceField(label=_('Send email to'), widget=forms.RadioSelect, initial='orders', choices=[])
@@ -205,3 +209,215 @@ class MailForm(forms.Form):
             del self.fields['subevent']
             del self.fields['subevents_from']
             del self.fields['subevents_to']
+
+class MailContentSettingsForm(SettingsForm):
+    mail_text_order_placed = I18nFormField(
+        label=_('Text sent to order contact address'),
+        required=False,
+        widget=I18nTextarea,
+    )
+    mail_send_order_placed_attendee = forms.BooleanField(
+        label=_('Send an email to attendees'),
+        help_text=_(
+            'If the order contains attendees with email addresses different from the person who orders the '
+            'tickets, the following email will be sent out to the attendees.'
+        ),
+        required=False,
+    )
+    mail_text_order_placed_attendee = I18nFormField(
+        label=_('Text sent to attendees'),
+        required=False,
+        widget=I18nTextarea,
+    )
+
+    mail_text_order_paid = I18nFormField(
+        label=_('Text sent to order contact address'),
+        required=False,
+        widget=I18nTextarea,
+    )
+    mail_send_order_paid_attendee = forms.BooleanField(
+        label=_('Send an email to attendees'),
+        help_text=_(
+            'If the order contains attendees with email addresses different from the person who orders the '
+            'tickets, the following email will be sent out to the attendees.'
+        ),
+        required=False,
+    )
+    mail_text_order_paid_attendee = I18nFormField(
+        label=_('Text sent to attendees'),
+        required=False,
+        widget=I18nTextarea,
+    )
+
+    mail_text_order_free = I18nFormField(
+        label=_('Text sent to order contact address'),
+        required=False,
+        widget=I18nTextarea,
+    )
+    mail_send_order_free_attendee = forms.BooleanField(
+        label=_('Send an email to attendees'),
+        help_text=_(
+            'If the order contains attendees with email addresses different from the person who orders the '
+            'tickets, the following email will be sent out to the attendees.'
+        ),
+        required=False,
+    )
+    mail_text_order_free_attendee = I18nFormField(
+        label=_('Text sent to attendees'),
+        required=False,
+        widget=I18nTextarea,
+    )
+
+    mail_text_resend_link = I18nFormField(
+        label=_('Text (sent by admin)'),
+        required=False,
+        widget=I18nTextarea,
+    )
+    mail_text_resend_all_links = I18nFormField(
+        label=_('Text (requested by user)'),
+        required=False,
+        widget=I18nTextarea,
+    )
+
+    mail_text_order_changed = I18nFormField(
+        label=_('Text'),
+        required=False,
+        widget=I18nTextarea,
+    )
+
+    mail_days_order_expire_warning = forms.IntegerField(
+        label=_('Number of days'),
+        required=True,
+        min_value=0,
+        help_text=_(
+            'This email will be sent out this many days before the order expires. If the '
+            'value is 0, the mail will never be sent.'
+        ),
+    )
+    mail_text_order_expire_warning = I18nFormField(
+        label=_('Text'),
+        required=False,
+        widget=I18nTextarea,
+    )
+
+    mail_text_waiting_list = I18nFormField(
+        label=_('Text'),
+        required=False,
+        widget=I18nTextarea,
+    )
+
+    mail_text_order_canceled = I18nFormField(
+        label=_('Text'),
+        required=False,
+        widget=I18nTextarea,
+    )
+
+    mail_text_order_custom_mail = I18nFormField(
+        label=_('Text'),
+        required=False,
+        widget=I18nTextarea,
+    )
+
+    mail_text_download_reminder = I18nFormField(
+        label=_('Text sent to order contact address'),
+        required=False,
+        widget=I18nTextarea,
+    )
+    mail_send_download_reminder_attendee = forms.BooleanField(
+        label=_('Send an email to attendees'),
+        help_text=_(
+            'If the order contains attendees with email addresses different from the person who orders the '
+            'tickets, the following email will be sent out to the attendees.'
+        ),
+        required=False,
+    )
+    mail_text_download_reminder_attendee = I18nFormField(
+        label=_('Text sent to attendees'),
+        required=False,
+        widget=I18nTextarea,
+    )
+    mail_days_download_reminder = forms.IntegerField(
+        label=_('Number of days'),
+        required=False,
+        min_value=0,
+        help_text=_(
+            'This email will be sent out this many days before the order event starts. If the '
+            'field is empty, the mail will never be sent.'
+        ),
+    )
+    mail_sales_channel_download_reminder = forms.MultipleChoiceField(
+        choices=lambda: [(ident, sc.verbose_name) for ident, sc in get_all_sales_channels().items()],
+        label=_('Sales channels'),
+        help_text=_(
+            'This email will only be send to orders from these sales channels. The online shop must be enabled.'
+        ),
+        widget=forms.CheckboxSelectMultiple(attrs={'class': 'scrolling-multiple-choice'}),
+        validators=[contains_web_channel_validate],
+    )
+
+    mail_text_order_placed_require_approval = I18nFormField(
+        label=_('Received order'),
+        required=False,
+        widget=I18nTextarea,
+    )
+    mail_text_order_approved = I18nFormField(
+        label=_('Approved order'),
+        required=False,
+        widget=I18nTextarea,
+        help_text=_(
+            'This will only be sent out for non-free orders. Free orders will receive the free order '
+            'template from below instead.'
+        ),
+    )
+    mail_text_order_approved_free = I18nFormField(
+        label=_('Approved free order'),
+        required=False,
+        widget=I18nTextarea,
+        help_text=_(
+            'This will only be sent out for free orders. Non-free orders will receive the non-free order '
+            'template from above instead.'
+        ),
+    )
+    mail_text_order_denied = I18nFormField(
+        label=_('Denied order'),
+        required=False,
+        widget=I18nTextarea,
+    )
+
+    base_context = {
+        'mail_text_order_placed': ['event', 'order', 'payment'],
+        'mail_text_order_placed_attendee': ['event', 'order', 'position'],
+        'mail_text_order_placed_require_approval': ['event', 'order'],
+        'mail_text_order_approved': ['event', 'order'],
+        'mail_text_order_approved_free': ['event', 'order'],
+        'mail_text_order_denied': ['event', 'order', 'comment'],
+        'mail_text_order_paid': ['event', 'order', 'payment_info'],
+        'mail_text_order_paid_attendee': ['event', 'order', 'position'],
+        'mail_text_order_free': ['event', 'order'],
+        'mail_text_order_free_attendee': ['event', 'order', 'position'],
+        'mail_text_order_changed': ['event', 'order'],
+        'mail_text_order_canceled': ['event', 'order'],
+        'mail_text_order_expire_warning': ['event', 'order'],
+        'mail_text_order_custom_mail': ['event', 'order'],
+        'mail_text_download_reminder': ['event', 'order'],
+        'mail_text_download_reminder_attendee': ['event', 'order', 'position'],
+        'mail_text_resend_link': ['event', 'order'],
+        'mail_text_waiting_list': ['event', 'waiting_list_entry'],
+        'mail_text_resend_all_links': ['event', 'orders'],
+    }
+
+    def _set_field_placeholders(self, fn, base_parameters):
+        phs = ['{%s}' % p for p in sorted(get_available_placeholders(self.event, base_parameters).keys())]
+        ht = _('Available placeholders: {list}').format(list=', '.join(phs))
+        if self.fields[fn].help_text:
+            self.fields[fn].help_text += ' ' + str(ht)
+        else:
+            self.fields[fn].help_text = ht
+        self.fields[fn].validators.append(PlaceholderValidator(phs))
+
+    def __init__(self, *args, **kwargs):
+        self.event = kwargs.get('obj')
+        super().__init__(*args, **kwargs)
+        for k, v in self.base_context.items():
+            if k in self.fields:
+                self._set_field_placeholders(k, v)

--- a/src/pretix/plugins/sendmail/signals.py
+++ b/src/pretix/plugins/sendmail/signals.py
@@ -13,7 +13,7 @@ def control_nav_import(sender, request=None, **kwargs):
         return []
     return [
         {
-            'label': _('Send out emails'),
+            'label': _('Mails'),
             'url': reverse(
                 'plugins:sendmail:send',
                 kwargs={
@@ -25,7 +25,7 @@ def control_nav_import(sender, request=None, **kwargs):
             'icon': 'envelope',
             'children': [
                 {
-                    'label': _('Send email'),
+                    'label': _('Compose emails'),
                     'url': reverse(
                         'plugins:sendmail:send',
                         kwargs={
@@ -36,7 +36,7 @@ def control_nav_import(sender, request=None, **kwargs):
                     'active': (url.namespace == 'plugins:sendmail' and url.url_name == 'send'),
                 },
                 {
-                    'label': _('Email history'),
+                    'label': _('Sent emails'),
                     'url': reverse(
                         'plugins:sendmail:history',
                         kwargs={
@@ -45,6 +45,17 @@ def control_nav_import(sender, request=None, **kwargs):
                         },
                     ),
                     'active': (url.namespace == 'plugins:sendmail' and url.url_name == 'history'),
+                },
+                {
+                    'label': _('Templates'),
+                    'url': reverse(
+                        'plugins:sendmail:templates',
+                        kwargs={
+                            'event': request.event.slug,
+                            'organizer': request.event.organizer.slug,
+                        },
+                    ),
+                    'active': (url.namespace == 'plugins:sendmail' and url.url_name == 'templates'),
                 },
             ],
         },

--- a/src/pretix/plugins/sendmail/templates/pretixplugins/sendmail/mail_templates.html
+++ b/src/pretix/plugins/sendmail/templates/pretixplugins/sendmail/mail_templates.html
@@ -14,7 +14,7 @@
     </nav>
     {% block inside %}
         <form action="" method="post" class="form-horizontal" enctype="multipart/form-data"
-                mail-preview-url="{% url "control:event.settings.mail.preview" event=request.event.slug organizer=request.event.organizer.slug %}">
+                mail-preview-url="{% url 'control:event.settings.mail.preview' event=request.event.slug organizer=request.event.organizer.slug %}">
             {% csrf_token %}
             {% bootstrap_form_errors form %}
             <div class="form">
@@ -35,7 +35,7 @@
                     {% include "pretixcontrol/event/mail_settings_fragment.html" with pid="order_changed" title=title_order_changed items="mail_text_order_changed" %}
 
                     {% blocktrans asvar title_payment_reminder %}Payment reminder{% endblocktrans %}
-                    {% include "pretixcontrol/event/mail_settings_fragment.html" with pid="order_expirew" title=title_payment_reminder items="mail_days_order_expire_warning,mail_text_order_expire_warning" exclude="mail_days_order_expire_warning" %}
+                    {% include "pretixcontrol/event/mail_settings_fragment.html" with pid="order_expires" title=title_payment_reminder items="mail_days_order_expire_warning,mail_text_order_expire_warning" exclude="mail_days_order_expire_warning" %}
 
                     {% blocktrans asvar title_waiting_list_notification %}Waiting list notification{% endblocktrans %}
                     {% include "pretixcontrol/event/mail_settings_fragment.html" with pid="waiting_list" title=title_waiting_list_notification items="mail_text_waiting_list" %}
@@ -50,7 +50,7 @@
                     {% include "pretixcontrol/event/mail_settings_fragment.html" with pid="ticket_reminder" title=title_download_tickets_reminder items="mail_days_download_reminder,mail_text_download_reminder,mail_send_download_reminder_attendee,mail_text_download_reminder_attendee,mail_sales_channel_download_reminder" exclude="mail_days_download_reminder,mail_send_download_reminder_attendee,mail_sales_channel_download_reminder" %}
 
                     {% blocktrans asvar title_require_approval %}Order approval process{% endblocktrans %}
-                    {% include "pretixcontrol/event/mail_settings_fragment.html" with pid="ticket_reminder" title=title_require_approval  items="mail_text_order_placed_require_approval,mail_text_order_approved,mail_text_order_approved_free,mail_text_order_denied" %}
+                    {% include "pretixcontrol/event/mail_settings_fragment.html" with pid="order_approval" title=title_require_approval  items="mail_text_order_placed_require_approval,mail_text_order_approved,mail_text_order_approved_free,mail_text_order_denied" %}
                 </div>
             </div>
             <div class="form-group submit-group">

--- a/src/pretix/plugins/sendmail/templates/pretixplugins/sendmail/mail_templates.html
+++ b/src/pretix/plugins/sendmail/templates/pretixplugins/sendmail/mail_templates.html
@@ -1,0 +1,63 @@
+{% extends "pretixcontrol/event/settings_base.html" %}
+{% load i18n %}
+{% load bootstrap3 %}
+{% load static %}
+{% block title %}{% translate "Send out emails" %}{% endblock %}
+{% block content %}
+    <nav id="event-nav" class="header-nav">
+        <div class="navigation">
+            <div class="navigation-title">
+                <h1>{% translate "Templates" %}</h1>
+            </div>
+            {% include "pretixcontrol/event/component_link.html" %}
+        </div>
+    </nav>
+    {% block inside %}
+        <form action="" method="post" class="form-horizontal" enctype="multipart/form-data"
+                mail-preview-url="{% url "control:event.settings.mail.preview" event=request.event.slug organizer=request.event.organizer.slug %}">
+            {% csrf_token %}
+            {% bootstrap_form_errors form %}
+            <div class="form">
+                <div class="panel-group" id="questions_group">
+                    {% blocktrans asvar title_placed_order %}Placed order{% endblocktrans %}
+                    {% include "pretixcontrol/event/mail_settings_fragment.html" with pid="order_placed" title=title_placed_order items="mail_text_order_placed,mail_send_order_placed_attendee,mail_text_order_placed_attendee" exclude="mail_send_order_placed_attendee" %}
+
+                    {% blocktrans asvar title_paid_order %}Paid order{% endblocktrans %}
+                    {% include "pretixcontrol/event/mail_settings_fragment.html" with pid="order_paid" title=title_paid_order items="mail_text_order_paid,mail_send_order_paid_attendee,mail_text_order_paid_attendee" exclude="mail_send_order_paid_attendee" %}
+
+                    {% blocktrans asvar title_free_order %}Free order{% endblocktrans %}
+                    {% include "pretixcontrol/event/mail_settings_fragment.html" with pid="order_free" title=title_free_order items="mail_text_order_free,mail_send_order_free_attendee,mail_text_order_free_attendee" exclude="mail_send_order_free_attendee" %}
+
+                    {% blocktrans asvar title_resend_link %}Resend link{% endblocktrans %}
+                    {% include "pretixcontrol/event/mail_settings_fragment.html" with pid="resend_link" title=title_resend_link items="mail_text_resend_link,mail_text_resend_all_links" %}
+
+                    {% blocktrans asvar title_order_changed %}Order changed{% endblocktrans %}
+                    {% include "pretixcontrol/event/mail_settings_fragment.html" with pid="order_changed" title=title_order_changed items="mail_text_order_changed" %}
+
+                    {% blocktrans asvar title_payment_reminder %}Payment reminder{% endblocktrans %}
+                    {% include "pretixcontrol/event/mail_settings_fragment.html" with pid="order_expirew" title=title_payment_reminder items="mail_days_order_expire_warning,mail_text_order_expire_warning" exclude="mail_days_order_expire_warning" %}
+
+                    {% blocktrans asvar title_waiting_list_notification %}Waiting list notification{% endblocktrans %}
+                    {% include "pretixcontrol/event/mail_settings_fragment.html" with pid="waiting_list" title=title_waiting_list_notification items="mail_text_waiting_list" %}
+
+                    {% blocktrans asvar title_order_canceled %}Order canceled{% endblocktrans %}
+                    {% include "pretixcontrol/event/mail_settings_fragment.html" with pid="order_canceled" title=title_order_canceled items="mail_text_order_canceled" %}
+
+                    {% blocktrans asvar title_order_custom_mail %}Order custom mail{% endblocktrans %}
+                    {% include "pretixcontrol/event/mail_settings_fragment.html" with pid="custom_mail" title=title_order_custom_mail items="mail_text_order_custom_mail" %}
+
+                    {% blocktrans asvar title_download_tickets_reminder %}Reminder to download tickets{% endblocktrans %}
+                    {% include "pretixcontrol/event/mail_settings_fragment.html" with pid="ticket_reminder" title=title_download_tickets_reminder items="mail_days_download_reminder,mail_text_download_reminder,mail_send_download_reminder_attendee,mail_text_download_reminder_attendee,mail_sales_channel_download_reminder" exclude="mail_days_download_reminder,mail_send_download_reminder_attendee,mail_sales_channel_download_reminder" %}
+
+                    {% blocktrans asvar title_require_approval %}Order approval process{% endblocktrans %}
+                    {% include "pretixcontrol/event/mail_settings_fragment.html" with pid="ticket_reminder" title=title_require_approval  items="mail_text_order_placed_require_approval,mail_text_order_approved,mail_text_order_approved_free,mail_text_order_denied" %}
+                </div>
+            </div>
+            <div class="form-group submit-group">
+                <button type="submit" class="btn btn-primary btn-save">
+                    {% translate "Save" %}
+                </button>
+            </div>
+        </form>
+    {% endblock %}
+{% endblock %}

--- a/src/pretix/plugins/sendmail/urls.py
+++ b/src/pretix/plugins/sendmail/urls.py
@@ -13,4 +13,9 @@ urlpatterns = [
         views.EmailHistoryView.as_view(),
         name='history',
     ),
+    url(
+        r'^control/event/(?P<organizer>[^/]+)/(?P<event>[^/]+)/sendmail/templates/',
+        views.MailTemplatesView.as_view(),
+        name='templates',
+    ),
 ]

--- a/src/pretix/plugins/sendmail/urls.py
+++ b/src/pretix/plugins/sendmail/urls.py
@@ -1,20 +1,20 @@
-from django.urls import re_path as url
+from django.urls import path
 
 from . import views
 
 urlpatterns = [
-    url(
-        r'^control/event/(?P<organizer>[^/]+)/(?P<event>[^/]+)/sendmail/$',
+    path(
+        'control/event/<str:organizer>/<str:event>/sendmail/',
         views.SenderView.as_view(),
         name='send',
     ),
-    url(
-        r'^control/event/(?P<organizer>[^/]+)/(?P<event>[^/]+)/sendmail/history/',
+    path(
+        'control/event/<str:organizer>/<str:event>/sendmail/history/',
         views.EmailHistoryView.as_view(),
         name='history',
     ),
-    url(
-        r'^control/event/(?P<organizer>[^/]+)/(?P<event>[^/]+)/sendmail/templates/',
+    path(
+        'control/event/<str:organizer>/<str:event>/sendmail/templates/',
         views.MailTemplatesView.as_view(),
         name='templates',
     ),

--- a/src/pretix/plugins/sendmail/views.py
+++ b/src/pretix/plugins/sendmail/views.py
@@ -274,15 +274,15 @@ class MailTemplatesView(EventSettingsViewMixin, EventSettingsFormView):
     @transaction.atomic
     def post(self, request, *args, **kwargs):
         form = self.get_form()
-        if form.is_valid():
-            form.save()
-            if form.has_changed():
-                self.request.event.log_action(
-                    'pretix.event.settings',
-                    user=self.request.user,
-                    data={k: form.cleaned_data.get(k) for k in form.changed_data},
-                )
-            messages.success(self.request, _('Your changes have been saved.'))
-            return redirect(self.get_success_url())
-        else:
+        if not form.is_valid():
             return self.form_invalid(form)
+        
+        form.save()
+        if form.has_changed():
+            self.request.event.log_action(
+                'pretix.event.settings',
+                user=self.request.user,
+                data={k: form.cleaned_data.get(k) for k in form.changed_data},
+            )
+        messages.success(self.request, _('Your changes have been saved.'))
+        return redirect(self.get_success_url())

--- a/src/pretix/plugins/sendmail/views.py
+++ b/src/pretix/plugins/sendmail/views.py
@@ -3,21 +3,25 @@ import logging
 import bleach
 import dateutil
 from django.contrib import messages
+from django.db import transaction
 from django.db.models import Exists, OuterRef, Q
 from django.http import Http404
 from django.shortcuts import redirect
+from django.urls import reverse
 from django.utils.timezone import now
 from django.utils.translation import gettext_lazy as _
 from django.views.generic import FormView, ListView
 
 from pretix.base.email import get_available_placeholders
 from pretix.base.i18n import LazyI18nString, language
-from pretix.base.models import LogEntry, Order, OrderPosition
+from pretix.base.models import Event, LogEntry, Order, OrderPosition
 from pretix.base.models.event import SubEvent
 from pretix.base.services.mail import TolerantDict
 from pretix.base.templatetags.rich_text import markdown_compile_email
 from pretix.control.permissions import EventPermissionRequiredMixin
 from pretix.plugins.sendmail.tasks import send_mails
+from pretix.control.views.event import EventSettingsFormView, EventSettingsViewMixin
+from .forms import MailContentSettingsForm
 
 from . import forms
 
@@ -244,3 +248,41 @@ class EmailHistoryView(EventPermissionRequiredMixin, ListView):
                     pass
 
         return ctx
+
+class MailTemplatesView(EventSettingsViewMixin, EventSettingsFormView):
+    model = Event
+    template_name = 'pretixplugins/sendmail/mail_templates.html'
+    form_class = MailContentSettingsForm
+    permission = 'can_change_event_settings'
+
+    def get_success_url(self) -> str:
+        return reverse(
+            'plugins:sendmail:templates',
+            kwargs={
+                'organizer': self.request.event.organizer.slug,
+                'event': self.request.event.slug,
+            },
+        )
+
+    def form_invalid(self, form):
+        messages.error(
+            self.request,
+            _('We could not save your changes. See below for details.'),
+        )
+        return super().form_invalid(form)
+
+    @transaction.atomic
+    def post(self, request, *args, **kwargs):
+        form = self.get_form()
+        if form.is_valid():
+            form.save()
+            if form.has_changed():
+                self.request.event.log_action(
+                    'pretix.event.settings',
+                    user=self.request.user,
+                    data={k: form.cleaned_data.get(k) for k in form.changed_data},
+                )
+            messages.success(self.request, _('Your changes have been saved.'))
+            return redirect(self.get_success_url())
+        else:
+            return self.form_invalid(form)


### PR DESCRIPTION
fixes: #657

## Summary by Sourcery

Move email content editing out of the main email settings and into a new "Templates" tab under the Sendmail plugin UI, providing a dedicated form and view for configuring all email template texts and placeholders.

New Features:
- Introduce MailContentSettingsForm to manage all event email templates with placeholder support.
- Add MailTemplatesView and URL route to handle the new "Templates" tab for email content.
- Exclude email content fields from the existing email settings form and relocate them to the new Templates interface.
- Update plugin navigation: rename menu items to "Mails", "Compose emails", "Sent emails" and add a "Templates" entry.

Enhancements:
- Enforce selection of the "web" sales channel for download reminder emails via a custom form validator.