### PR TITLE
Improve error message when exporting orders failed

### DIFF
--- a/src/pretix/base/services/export.py
+++ b/src/pretix/base/services/export.py
@@ -1,9 +1,11 @@
+import logging
 from typing import Any, Dict
 
 from django.conf import settings
 from django.core.files.base import ContentFile
 from django.utils.timezone import override
 from django.utils.translation import gettext
+from reportlab.platypus.doctemplate import LayoutError
 
 from pretix.base.i18n import LazyLocaleException, language
 from pretix.base.models import (
@@ -25,6 +27,8 @@ from pretix.base.signals import (
 )
 from pretix.celery_app import app
 
+logger = logging.getLogger(__name__)
+
 
 class ExportError(LazyLocaleException):
     pass
@@ -45,7 +49,14 @@ def export(self, event: Event, fileid: str, provider: str, form_data: Dict[str, 
         for receiver, response in responses:
             ex = response(event, set_progress)
             if ex.identifier == provider:
-                d = ex.render(form_data)
+                try:
+                    d = ex.render(form_data)
+                except LayoutError as e:
+                    logger.exception('Error while making PDF.')
+                    msg = gettext(
+                        'Your data table is too big for a PDF page. Please reduce the amount of data you are exporting.'
+                    )
+                    raise ExportError(msg) from e
                 if d is None:
                     raise ExportError(gettext('Your export did not contain any data.'))
                 file.filename, file.type, data = d

--- a/src/pretix/plugins/checkinlists/exporters.py
+++ b/src/pretix/plugins/checkinlists/exporters.py
@@ -387,7 +387,8 @@ class PDFCheckinList(ReportlabExportMixin, CheckInListMixin, BaseExporter):
             try:
                 ian = op.order.invoice_address.name
                 iac = op.order.invoice_address.company
-            except:
+            except AttributeError as e:
+                logger.error('Error accessing invoice address for order position %s: %s', op.pk, e)
                 ian = ''
                 iac = ''
 

--- a/src/pretix/plugins/checkinlists/exporters.py
+++ b/src/pretix/plugins/checkinlists/exporters.py
@@ -313,7 +313,7 @@ class PDFCheckinList(ReportlabExportMixin, CheckInListMixin, BaseExporter):
     def get_story(self, doc, form_data):
         cl = self.event.checkin_lists.get(pk=form_data['list'])
 
-        questions = list(Question.objects.filter(event=self.event, id__in=form_data['questions']))
+        questions = tuple(Question.objects.filter(event=self.event, id__in=form_data['questions']))
 
         headlinestyle = self.get_style()
         headlinestyle.fontSize = 15


### PR DESCRIPTION
Improve #747 , context #746 

When user picks too many questions to print, the table is too big to render in a page of PDF file. Currently, user is thrown "Internal Server Error". This PR is to provide a more informative message.

![image](https://github.com/user-attachments/assets/6fccf6b4-a33b-4e9e-abd2-f5d78c2a08d1)

## Summary by Sourcery

Catch PDF layout errors during order export to present a user-friendly message, refactor exporter URL generation with type annotations, and enforce immutable question collections in check-in list exports.

Bug Fixes:
- Handle LayoutError in export service to display an informative message when the data table is too large for a PDF page.

Enhancements:
- Add return type hints to exporter methods and simplify error URL construction using query parameters.
- Convert question queryset to a tuple in check-in list exporter for immutability.