### PR TITLE
Rename the mails page heading to match the sidebar menu item

### DIFF
--- a/src/pretix/plugins/sendmail/templates/pretixplugins/sendmail/history.html
+++ b/src/pretix/plugins/sendmail/templates/pretixplugins/sendmail/history.html
@@ -1,12 +1,18 @@
 {% extends "pretixcontrol/event/base.html" %}
 {% load i18n %}
 {% load bootstrap3 %}
-{% block title %}{% trans "Send out emails" %}{% endblock %}
+{% block title %}{% translate "Mails" %}{% endblock %}
 {% block content %}
     <nav id="event-nav" class="header-nav">
         <div class="navigation">
             <div class="navigation-title">
-                <h1>{% trans "Email history" %}</h1>
+                <h1>
+                    {% if logs|length == 0 %}
+                        {% translate "Sent emails" %}
+                    {% else %}
+                        {{ logs|length }} {% translate "Sent emails" %}
+                    {% endif %}
+                </h1>
             </div>
             {% include "pretixcontrol/event/component_link.html" %}
         </div>

--- a/src/pretix/plugins/sendmail/templates/pretixplugins/sendmail/history.html
+++ b/src/pretix/plugins/sendmail/templates/pretixplugins/sendmail/history.html
@@ -7,11 +7,11 @@
         <div class="navigation">
             <div class="navigation-title">
                 <h1>
-                    {% if logs|length == 0 %}
-                        {% translate "Sent emails" %}
-                    {% else %}
-                        {{ logs|length }} {% translate "Sent emails" %}
-                    {% endif %}
+                    {% blocktranslate count log_count=logs|length %}
+                        Sent emails
+                    {% plural %}
+                        {{ log_count }} Sent emails
+                    {% endblocktranslate %}
                 </h1>
             </div>
             {% include "pretixcontrol/event/component_link.html" %}

--- a/src/pretix/plugins/sendmail/templates/pretixplugins/sendmail/mail_templates.html
+++ b/src/pretix/plugins/sendmail/templates/pretixplugins/sendmail/mail_templates.html
@@ -2,7 +2,7 @@
 {% load i18n %}
 {% load bootstrap3 %}
 {% load static %}
-{% block title %}{% translate "Send out emails" %}{% endblock %}
+{% block title %}{% translate "Mails" %}{% endblock %}
 {% block content %}
     <nav id="event-nav" class="header-nav">
         <div class="navigation">

--- a/src/pretix/plugins/sendmail/templates/pretixplugins/sendmail/send_form.html
+++ b/src/pretix/plugins/sendmail/templates/pretixplugins/sendmail/send_form.html
@@ -1,12 +1,12 @@
 {% extends "pretixcontrol/event/base.html" %}
 {% load i18n %}
 {% load bootstrap3 %}
-{% block title %}{% trans "Send out emails" %}{% endblock %}
+{% block title %}{% translate "Mails" %}{% endblock %}
 {% block content %}
     <nav id="event-nav" class="header-nav">
         <div class="navigation">
             <div class="navigation-title">
-                <h1>{% trans "Send out emails" %}</h1>
+                <h1>{% translate "Compose emails" %}</h1>
             </div>
             {% include "pretixcontrol/event/component_link.html" %}
         </div>


### PR DESCRIPTION
fixes: updates asked in #657

## Summary by Sourcery

Align sendmail plugin page headings with the sidebar menu and improve the history page label.

Enhancements:
- Rename title blocks from “Send out emails” to “Mails” in all sendmail templates
- Change history page heading to display a dynamic “Sent emails” count when logs exist or a default label when empty
- Update the compose page heading from “Send out emails” to “Compose emails”