### PR TITLE
Chore: remove Create Organizer option in tickets area and enable all users in the common area to create organizers

### DIFF
--- a/src/pretix/control/templates/pretixcontrol/organizers/index.html
+++ b/src/pretix/control/templates/pretixcontrol/organizers/index.html
@@ -20,12 +20,6 @@
             </button>
         </div>
     </form>
-    <p>
-        <a href='{% url "control:organizers.add" %}' class="btn btn-default">
-            <span class="fa fa-plus"></span>
-            {% trans "Create a new organizer" %}
-        </a>
-    </p>
 	<table class="table table-condensed table-hover">
 		<thead>
 			<tr>

--- a/src/pretix/eventyay_common/templates/eventyay_common/organizers/index.html
+++ b/src/pretix/eventyay_common/templates/eventyay_common/organizers/index.html
@@ -18,14 +18,12 @@
             </button>
         </div>
     </form>
-    {% if staff_session %}
         <p>
             <a href='{% url "eventyay_common:organizers.add" %}' class="btn btn-default">
                 <span class="fa fa-plus"></span>
                 {% trans "Create a new organizer" %}
             </a>
         </p>
-    {% endif %}
 	<table class="table table-condensed table-hover">
 		<thead>
 			<tr>

--- a/src/pretix/eventyay_common/views/organizer.py
+++ b/src/pretix/eventyay_common/views/organizer.py
@@ -50,11 +50,6 @@ class OrganizerCreate(CreateView):
     template_name = 'eventyay_common/organizers/create.html'
     context_object_name = 'organizer'
 
-    def dispatch(self, request, *args, **kwargs):
-        if not request.user.has_active_staff_session(self.request.session.session_key):
-            raise PermissionDenied()
-        return super().dispatch(request, *args, **kwargs)
-
     @transaction.atomic
     def form_valid(self, form):
         messages.success(self.request, _('New organizer is created.'))


### PR DESCRIPTION
Solves #651

## Summary by Sourcery

Remove staff-session based permission checks and filters to allow any common-area user to manage organizers, and remove the organizer creation option from the control panel.

Enhancements:
- Enable all users in the common area to list and create organizers by removing staff-session checks and filters in views and templates
- Remove the "Create a new organizer" button from the control panel organizers list