### PR TITLE
Added status field in events table

### DIFF
--- a/src/pretix/eventyay_common/templates/eventyay_common/events/index.html
+++ b/src/pretix/eventyay_common/templates/eventyay_common/events/index.html
@@ -81,6 +81,9 @@
                     <a href="?{% url_replace request 'ordering' '-live' %}"><i class="fa fa-caret-down"></i></a>
                     <a href="?{% url_replace request 'ordering' 'live' %}"><i class="fa fa-caret-up"></i></a>
                 </th>
+                <th>
+                    {% trans "Status" %}
+                </th>
                 <th class="text-right flip">
                     {% trans "Actions" %}
                 </th>
@@ -136,6 +139,14 @@
                             <span class="label label-warning">{% trans "Presale not started" %}</span>
                         {% else %}
                             <span class="label label-success">{% trans "On sale" %}</span>
+                        {% endif %}
+                    </td>
+                    <td>
+                        {% if e.status %}
+                            {% if e.status == "upcoming" %}{% trans "Upcoming" %}
+                            {% elif e.status == "live" %}{% trans "Live" %}
+                            {% elif e.status == "ended" %}{% trans "Ended" %}
+                            {% else %}{{ e.status }}{% endif %}
                         {% endif %}
                     </td>
                     <td class="text-right flip">

--- a/src/pretix/eventyay_common/views/event.py
+++ b/src/pretix/eventyay_common/views/event.py
@@ -15,8 +15,9 @@ from django.shortcuts import redirect
 from django.urls import reverse
 from django.utils.functional import cached_property
 from django.utils.translation import gettext_lazy as _
+from django.utils import timezone
 from django.views.generic import ListView
-from pytz import timezone
+#from pytz import timezone
 from rest_framework import views
 
 from pretix.base.forms import SafeSessionWizardView
@@ -137,6 +138,16 @@ class EventList(PaginationMixin, ListView):
                     100,
                     (round(q.cached_availability_paid_orders / q.size * 100) if q.size > 0 else 100),
                 )
+        now = timezone.now()
+        for event in ctx["events"]:
+            if event.date_from > now:
+                event.status = "upcoming"
+            elif event.date_from <= now <= (event.date_to or event.date_from):
+                event.status = "live"
+            elif event.date_to and event.date_to < now:
+                event.status = "ended"
+            else:
+                event.status = "upcoming"  
         return ctx
 
     @cached_property


### PR DESCRIPTION
Added a status field in events table in eventyay-common/events
![image](https://github.com/user-attachments/assets/d0ec72c3-32a4-4847-b3b6-4839baf1f427)

Issue-fix: #764

## Summary by Sourcery

Add dynamic status field to events listing

Enhancements:
- Compute event status (upcoming, live, ended) based on current date in the view context
- Display the computed status in a new "Status" column in the events table UI