### PR TITLE
Fix broken settings form due to imbalance brackets

### DIFF
--- a/src/pretix/control/forms/global_settings.py
+++ b/src/pretix/control/forms/global_settings.py
@@ -241,48 +241,41 @@ class GlobalSettingsForm(SettingsForm):
                         max_digits=10,
                         help_text=_('A percentage fee will be charged for each ticket sold.'),
                         validators=[MinValueValidator(0)],
+                    )
+                ),
+                (
+                    'payment_stripe_connect_publishable_key',
+                    forms.CharField(
+                        label=_('Stripe Connect: Publishable key'),
+                        required=False,
+                        validators=(StripeKeyValidator('pk_live_'),),
                     ),
-                    (
-                        'payment_stripe_connect_publishable_key',
-                        forms.CharField(
-                            label=_('Stripe Connect: Publishable key'),
-                            required=False,
-                            validators=(StripeKeyValidator('pk_live_'),),
-                        ),
+                ),
+                (
+                    'payment_stripe_connect_test_secret_key',
+                    SecretKeySettingsField(
+                        label=_('Stripe Connect: Secret key (test)'),
+                        required=False,
+                        validators=(StripeKeyValidator(['sk_test_', 'rk_test_']),),
                     ),
-                    (
-                        'payment_stripe_connect_test_secret_key',
-                        SecretKeySettingsField(
-                            label=_('Stripe Connect: Secret key (test)'),
-                            required=False,
-                            validators=(StripeKeyValidator(['sk_test_', 'rk_test_']),),
-                        ),
+                ),
+                (
+                    'payment_stripe_connect_test_publishable_key',
+                    forms.CharField(
+                        label=_('Stripe Connect: Publishable key (test)'),
+                        required=False,
+                        validators=(StripeKeyValidator('pk_test_'),),
                     ),
-                    (
-                        'payment_stripe_connect_test_publishable_key',
-                        forms.CharField(
-                            label=_('Stripe Connect: Publishable key (test)'),
-                            required=False,
-                            validators=(StripeKeyValidator('pk_test_'),),
-                        ),
-                    ),
-                    (
-                        'stripe_webhook_secret_key',
-                        SecretKeySettingsField(
-                            label=_('Stripe Webhook: Secret key'),
-                            required=False,
-                        ),
-                    ),
-                    (
-                        'ticket_fee_percentage',
-                        forms.DecimalField(
-                            label=_('Ticket fee percentage'),
-                            required=False,
-                            decimal_places=2,
-                            max_digits=10,
-                            help_text=_('A percentage fee will be charged for each ticket sold.'),
-                            validators=[MinValueValidator(0)],
-                        ),
+                ),
+                (
+                    'ticket_fee_percentage',
+                    forms.DecimalField(
+                        label=_('Ticket fee percentage'),
+                        required=False,
+                        decimal_places=2,
+                        max_digits=10,
+                        help_text=_('A percentage fee will be charged for each ticket sold.'),
+                        validators=[MinValueValidator(0)],
                     ),
                 ),
             ]


### PR DESCRIPTION
The brackets are imbalance, causing failure to make `OrderedDict` (I don't know why it has not been caught).
Btw, a field is duplicate in settings form.

## Summary by Sourcery

Fix parentheses imbalance in the global settings form and remove a duplicated field entry.

Bug Fixes:
- Resolve mismatched parentheses in the settings form definition that prevented form creation
- Remove duplicate Stripe Connect publishable key field from the settings form