### PR TITLE
Fix form initialization crash in global settings admin panel

### DIFF
--- a/src/pretix/control/forms/global_settings.py
+++ b/src/pretix/control/forms/global_settings.py
@@ -242,47 +242,29 @@ class GlobalSettingsForm(SettingsForm):
                         help_text=_('A percentage fee will be charged for each ticket sold.'),
                         validators=[MinValueValidator(0)],
                     ),
-                    (
-                        'payment_stripe_connect_publishable_key',
-                        forms.CharField(
-                            label=_('Stripe Connect: Publishable key'),
-                            required=False,
-                            validators=(StripeKeyValidator('pk_live_'),),
-                        ),
+                ),
+                (
+                    'payment_stripe_connect_publishable_key',
+                    forms.CharField(
+                        label=_('Stripe Connect: Publishable key'),
+                        required=False,
+                        validators=(StripeKeyValidator('pk_live_'),),
                     ),
-                    (
-                        'payment_stripe_connect_test_secret_key',
-                        SecretKeySettingsField(
-                            label=_('Stripe Connect: Secret key (test)'),
-                            required=False,
-                            validators=(StripeKeyValidator(['sk_test_', 'rk_test_']),),
-                        ),
+                ),
+                (
+                    'payment_stripe_connect_test_secret_key',
+                    SecretKeySettingsField(
+                        label=_('Stripe Connect: Secret key (test)'),
+                        required=False,
+                        validators=(StripeKeyValidator(['sk_test_', 'rk_test_']),),
                     ),
-                    (
-                        'payment_stripe_connect_test_publishable_key',
-                        forms.CharField(
-                            label=_('Stripe Connect: Publishable key (test)'),
-                            required=False,
-                            validators=(StripeKeyValidator('pk_test_'),),
-                        ),
-                    ),
-                    (
-                        'stripe_webhook_secret_key',
-                        SecretKeySettingsField(
-                            label=_('Stripe Webhook: Secret key'),
-                            required=False,
-                        ),
-                    ),
-                    (
-                        'ticket_fee_percentage',
-                        forms.DecimalField(
-                            label=_('Ticket fee percentage'),
-                            required=False,
-                            decimal_places=2,
-                            max_digits=10,
-                            help_text=_('A percentage fee will be charged for each ticket sold.'),
-                            validators=[MinValueValidator(0)],
-                        ),
+                ),
+                (
+                    'payment_stripe_connect_test_publishable_key',
+                    forms.CharField(
+                        label=_('Stripe Connect: Publishable key (test)'),
+                        required=False,
+                        validators=(StripeKeyValidator('pk_test_'),),
                     ),
                 ),
             ]


### PR DESCRIPTION
When try to access https://app.eventyay.com/tickets/control/admin/global/settings/, it shows runtime error (Internal error)

This PR fixes it.
<img width="1920" height="967" alt="gs_form_error" src="https://github.com/user-attachments/assets/3e61f02f-3891-4d73-9377-cd0eda4bbdc3" />
