### PR TITLE
enhance(admin): redesign global settings with tabbed layout similar to event settings

### DIFF
--- a/src/pretix/control/forms/global_settings.py
+++ b/src/pretix/control/forms/global_settings.py
@@ -281,6 +281,62 @@ class GlobalSettingsForm(SettingsForm):
             ]
         )
 
+        self.field_groups = [
+            (_('Basics'), [
+                'footer_text',
+                'footer_link',
+                'banner_message',
+                'banner_message_detail',
+            ]),
+            (_('Localization'), [
+                'region',
+            ]),
+            (_('Email'), [
+                'mail_from',
+                'email_vendor',
+                'send_grid_api_key',
+                'smtp_host',
+                'smtp_port',
+                'smtp_username',
+                'smtp_password',
+                'smtp_use_tls',
+                'smtp_use_ssl',
+            ]),
+            (_('Payment Gateways'), [
+                # PayPal (from plugin)
+                'payment_paypal_connect_client_id',  # used only in signals (paypal plugin repo)
+                'payment_paypal_connect_secret_key',  # used only in signals (paypal plugin repo)
+                'payment_paypal_connect_endpoint',  # used only in signals (paypal plugin repo)
+
+                # Stripe
+                'payment_stripe_connect_client_id',  # used only in signals (stripe plugin repo)
+                'payment_stripe_connect_secret_key',
+                'payment_stripe_connect_publishable_key',  # used only in signals (stripe plugin repo)
+                'payment_stripe_connect_test_secret_key',
+                'payment_stripe_connect_test_publishable_key',  # used only in signals (stripe plugin repo)
+                'payment_stripe_connect_app_fee_percent',
+                'payment_stripe_connect_app_fee_max',
+                'payment_stripe_connect_app_fee_min',
+
+                'payment_stripe_secret_key',  # used only in signals (this file)
+                'payment_stripe_publishable_key',
+                'payment_stripe_test_secret_key',  # used only in signals (this file)
+                'payment_stripe_test_publishable_key',  # used only in signals (this file)
+                # new stripe webhook
+                'stripe_webhook_secret_key',
+            ]),
+            (_('Ticket fee'), [
+                'ticket_fee_percentage',
+            ]),
+            (_('Maps'), [
+                'opencagedata_apikey',
+                'mapquest_apikey',
+                'leaflet_tiles',
+                'leaflet_tiles_attribution',
+            ]),
+        ]
+
+
 
 class UpdateSettingsForm(SettingsForm):
     update_check_perform = forms.BooleanField(

--- a/src/pretix/control/templates/pretixcontrol/global_settings.html
+++ b/src/pretix/control/templates/pretixcontrol/global_settings.html
@@ -1,6 +1,7 @@
 {% extends "pretixcontrol/global_settings_base.html" %}
 {% load i18n %}
 {% load bootstrap3 %}
+{% load getitem %}
 {% load static %}
 
 {% block custom_header %}
@@ -11,10 +12,55 @@
     <form action="" method="post" class="form-horizontal" enctype="multipart/form-data">
         {% csrf_token %}
         {% bootstrap_form_errors form %}
-        {% bootstrap_form form layout='control' %}
+        <ul class="nav nav-tabs" role="tablist">
+            {% for group_label, field_names in form.field_groups %}
+                <li role="presentation" class="{% if forloop.first %}active{% endif %}">
+                    <a href="#tab{{ forloop.counter }}" aria-controls="tab{{ forloop.counter }}" role="tab" data-toggle="tab">
+                        {{ group_label }}
+                    </a>
+                </li>
+            {% endfor %}
+        </ul>
+
+        <div class="tab-content">
+            {% for group_label, field_names in form.field_groups %}
+                <div role="tabpanel" class="tab-pane {% if forloop.first %}active{% endif %}" id="tab{{ forloop.counter }}">
+                    {% if group_label == "Payment Gateways" %}
+                        <fieldset>
+                            <legend>{% translate "Stripe" %}</legend>
+                            {% for field_name in field_names %}
+                                {% if "payment_stripe" in field_name or "stripe_webhook" in field_name %}
+                                    {% with form|getitem:field_name as field %}
+                                        {% bootstrap_field field layout='control' %}
+                                    {% endwith %}
+                                {% endif %}
+                            {% endfor %}
+                        </fieldset>
+
+                        <fieldset>
+                            <legend>{% translate "PayPal" %}</legend>
+                            {% for field_name in field_names %}
+                                {% if "payment_paypal" in field_name %}
+                                    {% with form|getitem:field_name as field %}
+                                        {% bootstrap_field field layout='control' %}
+                                    {% endwith %}
+                                {% endif %}
+                            {% endfor %}
+                        </fieldset>
+                    {% else %}
+                        {% for field_name in field_names %}
+                            {% with form|getitem:field_name as field %}
+                                {% bootstrap_field field layout='control' %}
+                            {% endwith %}
+                        {% endfor %}
+                    {% endif %}
+                </div>
+            {% endfor %}
+        </div>
+
         <div class="form-group submit-group">
             <button type="submit" class="btn btn-primary btn-save">
-                {% trans "Save" %}
+                {% translate "Save" %}
             </button>
         </div>
     </form>

--- a/src/pretix/control/templatetags/hierarkey_form.py
+++ b/src/pretix/control/templatetags/hierarkey_form.py
@@ -74,3 +74,8 @@ def propagated(parser, token):
     nodelist = parser.parse(('endpropagated',))
     parser.delete_first_token()
     return PropagatedNode(nodelist, event, [f[1:-1] for f in args], url)
+
+
+@register.filter
+def get_item(dictionary, key):
+    return dictionary.get(key)


### PR DESCRIPTION
#479

https://github.com/user-attachments/assets/daa1bbb4-cf1a-464f-a062-c8d360f74eea



## Summary by Sourcery

Introduce a tabbed layout for global admin settings by grouping fields into logical sections and updating the template to render Bootstrap tabs with separate Stripe and PayPal fieldsets

Enhancements:
- Add field_groups attribute to settings form to organize fields into Basics, Localization, Email, Payment Gateways, Ticket Fee, and Maps sections
- Refactor global_settings template to display fields in Bootstrap nav-tabs with dedicated Stripe and PayPal fieldsets under Payment Gateways
- Implement get_item template filter to facilitate dynamic access to form fields in templates