### PR TITLE
fix: Tickets General settings crash due to unused kwarg value

### DIFF
--- a/src/pretix/control/forms/event.py
+++ b/src/pretix/control/forms/event.py
@@ -41,7 +41,6 @@ from pretix.control.forms import (
 )
 from pretix.control.forms.widgets import Select2
 from pretix.helpers.countries import CachedCountries
-from pretix.multidomain.models import KnownDomain
 from pretix.multidomain.urlreverse import build_absolute_uri
 from pretix.plugins.banktransfer.payment import BankTransfer
 

--- a/src/pretix/control/forms/event.py
+++ b/src/pretix/control/forms/event.py
@@ -334,23 +334,10 @@ class EventMetaValueForm(forms.ModelForm):
 
 class EventUpdateForm(I18nModelForm):
     def __init__(self, *args, **kwargs):
-        self.domain = kwargs.pop('domain', False)
 
         kwargs.setdefault('initial', {})
         self.instance = kwargs['instance']
-        if self.domain and self.instance:
-            initial_domain = self.instance.domains.first()
-            if initial_domain:
-                kwargs['initial'].setdefault('domain', initial_domain.domainname)
-
         super().__init__(*args, **kwargs)
-        if self.domain:
-            self.fields['domain'] = forms.CharField(
-                max_length=255,
-                label=_('Custom domain'),
-                required=False,
-                help_text=_('You need to configure the custom domain in the webserver beforehand.'),
-            )
         self.fields['sales_channels'] = forms.MultipleChoiceField(
             label=self.fields['sales_channels'].label,
             help_text=self.fields['sales_channels'].help_text,
@@ -360,38 +347,8 @@ class EventUpdateForm(I18nModelForm):
             widget=forms.CheckboxSelectMultiple,
         )
 
-    def clean_domain(self):
-        d = self.cleaned_data['domain']
-        if d:
-            if d == urlparse(settings.SITE_URL).hostname:
-                raise ValidationError(_('You cannot choose the base domain of this installation.'))
-            if KnownDomain.objects.filter(domainname=d).exclude(event=self.instance.pk).exists():
-                raise ValidationError(_('This domain is already in use for a different event or organizer.'))
-        return d
-
     def save(self, commit=True):
         instance = super().save(commit)
-
-        if self.domain:
-            current_domain = instance.domains.first()
-            if self.cleaned_data['domain']:
-                if current_domain and current_domain.domainname != self.cleaned_data['domain']:
-                    current_domain.delete()
-                    KnownDomain.objects.create(
-                        organizer=instance.organizer,
-                        event=instance,
-                        domainname=self.cleaned_data['domain'],
-                    )
-                elif not current_domain:
-                    KnownDomain.objects.create(
-                        organizer=instance.organizer,
-                        event=instance,
-                        domainname=self.cleaned_data['domain'],
-                    )
-            elif current_domain:
-                current_domain.delete()
-            instance.cache.clear()
-
         return instance
 
     def clean_slug(self):

--- a/src/pretix/control/templates/pretixcontrol/event/settings.html
+++ b/src/pretix/control/templates/pretixcontrol/event/settings.html
@@ -25,9 +25,6 @@
         <div class="tabbed-form">
             <fieldset>
                 <legend>{% trans "Basics" %}</legend>
-                {% if form.domain %}
-                    {% bootstrap_field form.domain layout="control" %}
-                {% endif %}
                 {% bootstrap_field form.currency layout="control" %}
                 {% bootstrap_field form.sales_channels layout="control" %}
 

--- a/src/pretix/control/views/event.py
+++ b/src/pretix/control/views/event.py
@@ -241,13 +241,6 @@ class EventUpdate(
             },
         )
 
-    def get_form_kwargs(self):
-        kwargs = super().get_form_kwargs()
-        if self.request.user.has_active_staff_session(self.request.session.session_key):
-            kwargs['change_slug'] = True
-            kwargs['domain'] = True
-        return kwargs
-
     def post(self, request, *args, **kwargs):
         form = self.get_form()
     


### PR DESCRIPTION
Fixes: #798

The PR [#716](https://github.com/fossasia/eventyay-tickets/pull/716) appears to have overlooked handling the admin mode. Previously, admins could edit the event slug and add a custom domain from the Tickets Settings page. However, since those form fields were moved to a shared/common section, this functionality became inaccessible from the Tickets Settings page.

This PR removes the ability for admins to modify the slug and add a custom domain directly from the Tickets Settings page.

## Summary by Sourcery

Remove domain-related form logic and disable admin editing of event slug and custom domain in the tickets general settings page

Bug Fixes:
- Remove unused domain kwarg handling from EventUpdateForm to prevent crashes

Enhancements:
- Disable admin-specific slug and custom domain editing in the tickets settings page