### PR TITLE
Link to event page from My Orders page

### DIFF
--- a/src/pretix/eventyay_common/templates/eventyay_common/orders/orders.html
+++ b/src/pretix/eventyay_common/templates/eventyay_common/orders/orders.html
@@ -24,9 +24,9 @@
         <table class="table table-condensed table-hover table-quotas">
             <thead>
                 <tr>
-                    <th>{{ _('Order Code') }}</th>
+                    <th>{{ _('Order code') }}</th>
                     <th>{{ _('Event') }}</th>
-                    <th>{{ _('Date') }}</th>
+                    <th>{{ _('Order date') }}</th>
                     <th>{{ _('Order total') }}</th>
                     <th>{{ _('Status') }}</th>
                 </tr>
@@ -39,7 +39,9 @@
                             {{ order.code }}
                         </a>
                     </td>
-                    <td>{{ order.event.name }}</td>
+                    <td>
+                        <a href="{% eventurl order.event 'presale:event.index' %}" target='_blank'>{{ order.event.name }}</a>
+                    </td>
                     <td>{{ order.datetime|date:"SHORT_DATETIME_FORMAT" }}</td>
                     <td>
                         {{ order.total|money:order.event.currency }}

--- a/src/pretix/eventyay_common/views/orders.py
+++ b/src/pretix/eventyay_common/views/orders.py
@@ -1,12 +1,12 @@
 from logging import getLogger
 
-from django.views.generic.list import ListView
 from django.db.models import Q
 from django.shortcuts import redirect
+from django.views.generic.list import ListView
 
 from pretix.base.models import Order
-from ..forms.filters import UserOrderFilterForm
 
+from ..forms.filters import UserOrderFilterForm
 
 logger = getLogger(__name__)
 


### PR DESCRIPTION
Resolves #808 

<img width="1046" height="672" alt="image" src="https://github.com/user-attachments/assets/05046774-136a-4add-91b8-ab47edb24d2c" />

## Summary by Sourcery

Enhance the My Orders page by turning event names into clickable links to their event pages, adjust column headings for clarity, and tidy up import ordering in the view.

New Features:
- Link event names on the My Orders page to their event landing pages

Enhancements:
- Update table headers to ‘Order code’ and ‘Order date’ for clarity
- Reorder import statements in orders view for consistent style