### PR TITLE
Make "event" link open in the same browser tab

### DIFF
--- a/src/pretix/eventyay_common/templates/eventyay_common/orders/orders.html
+++ b/src/pretix/eventyay_common/templates/eventyay_common/orders/orders.html
@@ -40,7 +40,7 @@
                         </a>
                     </td>
                     <td>
-                        <a href="{% eventurl order.event 'presale:event.index' %}" target='_blank'>{{ order.event.name }}</a>
+                        <a href="{% eventurl order.event 'presale:event.index' %}">{{ order.event.name }}</a>
                     </td>
                     <td>{{ order.datetime|date:"SHORT_DATETIME_FORMAT" }}</td>
                     <td>


### PR DESCRIPTION
## Summary by Sourcery

Bug Fixes:
- Removed the target='_blank' attribute from the event link to prevent opening in a new tab