### PR TITLE
Fix Python path to be used inside Docker

### DIFF
--- a/app/Dockerfile
+++ b/app/Dockerfile
@@ -26,5 +26,9 @@ RUN chmod +x /usr/src/app/entrypoint.sh
 # copy project
 COPY . .
 
+# Expose virtual env
+ENV VIRTUAL_ENV=/usr/src/app/.venv
+ENV PATH="/usr/src/app/.venv/bin:$PATH"
+
 # run entrypoint.sh
 ENTRYPOINT ["/usr/src/app/entrypoint.sh"]

--- a/app/Dockerfile.prod
+++ b/app/Dockerfile.prod
@@ -65,5 +65,9 @@ COPY --from=builder --chown=app:app /usr/src/app/.venv $APP_HOME/.venv
 # change to the app user
 USER app
 
+# Expose virtual env
+ENV VIRTUAL_ENV="$APP_HOME/.venv"
+ENV PATH="$APP_HOME/bin:$PATH"
+
 # run entrypoint.prod.sh
 ENTRYPOINT ["/home/app/web/entrypoint.prod.sh"]


### PR DESCRIPTION
This Python environment is installed with `uv` in PR #840 .
I tested building Docker images.