### PR TITLE
Move URLs from "/common/" to "/"

### DIFF
--- a/app/eventyay/config/urls.py
+++ b/app/eventyay/config/urls.py
@@ -29,8 +29,8 @@ control_patterns = [
     url(r'^control/', include((eventyay.control.urls, 'control'))),
 ]
 
-common_patterns = [
-    url(r'^common/', include((eventyay.eventyay_common.urls, 'common'))),
+eventyay_common_patterns = [
+    path('', include((eventyay.eventyay_common.urls, 'common'))),
 ]
 
 
@@ -51,8 +51,7 @@ common_patterns = (
     base_patterns
     + control_patterns
     + debug_patterns
-    + common_patterns
+    + eventyay_common_patterns
     + page_patterns
     + admin_patterns
 )
-

--- a/app/eventyay/eventyay_common/urls.py
+++ b/app/eventyay/eventyay_common/urls.py
@@ -1,4 +1,5 @@
 from django.http import HttpResponse
+from django.views.generic import TemplateView
 from django.urls import path, reverse
 from django.utils.html import escape
 
@@ -7,10 +8,9 @@ from eventyay.eventyay_common.views import auth
 app_name = 'eventyay_common'
 
 
-def dashboard_view(request):
-    logout_url = reverse('eventyay_common:auth.logout')
-    content = f'<p>Welcome to the common dashboard. <a href="{escape(logout_url)}">Logout</a></p>'
-    return HttpResponse(content)
+class DashboardView(TemplateView):
+    template_name = 'pretixpresale/index.html'
+
 
 urlpatterns = [
     path('logout/', auth.logout, name='auth.logout'),
@@ -19,6 +19,6 @@ urlpatterns = [
     path('register/', auth.register, name='auth.register'),
     path('forgot/', auth.Forgot.as_view(), name='auth.forgot'),
     path('forgot/recover/', auth.Recover.as_view(), name='auth.forgot.recover'),
-    
-    path('', dashboard_view, name='dashboard'),
+
+    path('', DashboardView.as_view(), name='dashboard'),
 ]


### PR DESCRIPTION
Resolve #842 

Note that, the view at "/forgot/" to reset password is not working: Don't know if any email message is sent. Maybe because we haven't finished moving code from old place to new place. Will fix later. It will involve redoing email settings to prevent sending email to Internet in development.

<img width="852" height="705" alt="image" src="https://github.com/user-attachments/assets/bde4cfff-ab9c-4cea-bad2-be50f04b55eb" />

<img width="852" height="705" alt="image" src="https://github.com/user-attachments/assets/f61c4e58-6e67-40c6-94ac-f24d93f21349" />


## Summary by Sourcery

Restructure routing to expose eventyay_common at the root path, overhaul the dashboard and refine the forgot password flow.

Enhancements:
- Include eventyay_common URL patterns at root by removing the '/common/' prefix and renaming the pattern list for clarity
- Replace the simple dashboard_view function with a class-based TemplateView using the 'pretixpresale/index.html' template
- Refactor Forgot password view to use f-strings for Redis operations, switch to parameterized logging, add info logs for repeated reset attempts and sent emails, and update the redirect to use the proper namespace