### PR TITLE
Fix: Exceptions was swallowed

### DIFF
--- a/app/eventyay/base/forms/auth.py
+++ b/app/eventyay/base/forms/auth.py
@@ -211,7 +211,7 @@ class PasswordForgotForm(forms.Form):
         super().__init__(*args, **kwargs)
 
     def clean_email(self):
-        return self.cleaned_data['email']
+        return self.cleaned_data['email'].lower()
 
 
 class ReauthForm(forms.Form):

--- a/app/eventyay/base/services/mail.py
+++ b/app/eventyay/base/services/mail.py
@@ -51,7 +51,7 @@ from eventyay.celery_app import app
 from eventyay.multidomain.urlreverse import build_absolute_uri
 from eventyay.presale.ical import get_ical
 
-logger = logging.getLogger()
+logger = logging.getLogger(__name__)
 INVALID_ADDRESS = 'invalid-eventyay-mail-address'
 
 

--- a/app/eventyay/base/services/mail.py
+++ b/app/eventyay/base/services/mail.py
@@ -51,7 +51,7 @@ from eventyay.celery_app import app
 from eventyay.multidomain.urlreverse import build_absolute_uri
 from eventyay.presale.ical import get_ical
 
-logger = logging.getLogger('eventyay.base.mail')
+logger = logging.getLogger()
 INVALID_ADDRESS = 'invalid-eventyay-mail-address'
 
 

--- a/app/eventyay/helpers/urls.py
+++ b/app/eventyay/helpers/urls.py
@@ -7,7 +7,8 @@ from django.urls import reverse
 def build_absolute_uri(urlname, args=None, kwargs=None):
     from eventyay.multidomain import maindomain_urlconf
 
+    path = reverse(urlname, args=args, kwargs=kwargs, urlconf=maindomain_urlconf)
     return urljoin(
         settings.SITE_URL,
-        reverse(urlname, args=args, kwargs=kwargs, urlconf=maindomain_urlconf),
+        path,
     )


### PR DESCRIPTION
When working for the "email for forgot password" feature (#850), I found that mosts of errors / exceptions are swallowed. It make it difficult to debug.

This PR is to expose the exceptions, so that we can further debug the email feature.

## Summary by Sourcery

Expose and log exceptions in the forgot password flow instead of swallowing them, refactor password reset functionality into a dedicated helper, and streamline related logging, URL handling, and email normalization.

Bug Fixes:
- Prevent exceptions in the forgot password flow from being silently swallowed and ensure they are properly logged.

Enhancements:
- Extract password reset steps into a new send_password_reset function in the auth view.
- Unify and simplify the informational message displayed after password reset requests.
- Normalize user email input by converting it to lowercase in the authentication form.
- Adjust build_absolute_uri to reuse the resolved path for cleaner URL construction.
- Switch the mail service logger to the root logger for consistent logging.

Chores:
- Add missing logger instantiation in the base auth model.