### PR TITLE
Fix Reauth Issue

### DIFF
--- a/app/eventyay/common/consts.py
+++ b/app/eventyay/common/consts.py
@@ -1,2 +1,2 @@
 # Last time (in seconds) a user was forced to log in again
-KEY_LAST_FORCE_LOGIN = 'pretix_auth_login_time'
+KEY_LAST_FORCE_LOGIN = 'eventyay_auth_login_time'

--- a/app/eventyay/control/middleware.py
+++ b/app/eventyay/control/middleware.py
@@ -121,7 +121,7 @@ class PermissionMiddleware:
             return self._login_redirect(request)
         except SessionReauthRequired:
             if url_name not in ('user.reauth', 'auth.logout'):
-                return redirect(reverse('eventyay_common:user.reauth') + '?next=' + quote(request.get_full_path()))
+                return redirect(reverse('control:user.reauth') + '?next=' + quote(request.get_full_path()))
 
         if not request.user.require_2fa and settings.EVENTYAY_OBLIGATORY_2FA and url_name not in self.EXCEPTIONS_2FA:
             page_2fa_setting_url = reverse('eventyay_common:account.2fa')

--- a/app/eventyay/control/views/user.py
+++ b/app/eventyay/control/views/user.py
@@ -43,7 +43,7 @@ class RecentAuthenticationRequiredMixin:
     max_time = 3600
 
     def dispatch(self, request, *args, **kwargs):
-        tdelta = time.time() - request.session.get('pretix_auth_login_time', 0)
+        tdelta = time.time() - request.session.get('eventyay_auth_login_time', 0)
         if tdelta > self.max_time:
             return redirect(reverse('control:user.reauth') + '?next=' + quote(request.get_full_path()))
         return super().dispatch(request, *args, **kwargs)
@@ -110,8 +110,8 @@ class ReauthView(TemplateView):
 
         if valid:
             t = int(time.time())
-            request.session['pretix_auth_login_time'] = t
-            request.session['pretix_auth_last_used'] = t
+            request.session['eventyay_auth_login_time'] = t
+            request.session['eventyay_auth_last_used'] = t
             next_url = get_auth_backends()[request.user.auth_backend].get_next_url(request)
             if next_url and url_has_allowed_host_and_scheme(next_url, allowed_hosts=None):
                 return redirect(next_url)
@@ -126,7 +126,7 @@ class ReauthView(TemplateView):
         if u and u == request.user:
             next_url = backend.get_next_url(request)
             t = int(time.time())
-            request.session['pretix_auth_login_time'] = t
+            request.session['eventyay_auth_login_time'] = t
             request.session['pretix_auth_last_used'] = t
             if next_url and url_has_allowed_host_and_scheme(next_url, allowed_hosts=None):
                 return redirect(next_url)


### PR DESCRIPTION
This PR fixes a issue relating to `reauth`, that was causing an Internal Server Error
```
django.urls.exceptions.NoReverseMatch: Reverse for 'user.reauth' not found. 'user.reauth' is not a valid view function or pattern name.
[18:03:35] ERROR    Internal Server Error: /control/                log.py:253
```
This was due to `reauth` was being accessed from `eventyay_common` instead of `control` and the `Reauth` view was expecting a flag `pretix_auth_login_time` which was renamed to `eventyay_auth_login_time`

## Summary by Sourcery

Fix reauthentication routing and session key mismatches to prevent internal server errors

Bug Fixes:
- Use correct URL namespace for user.reauth reverse lookups in middleware and views
- Rename authentication session keys from pretix_auth_login_time and pretix_auth_last_used to eventyay_auth_login_time and eventyay_auth_last_used
- Update constant KEY_LAST_FORCE_LOGIN to match the new session key name