### PR TITLE
Remove allow all origin for vue

### DIFF
--- a/app/eventyay/frontend/global-nav-menu/vite.config.ts
+++ b/app/eventyay/frontend/global-nav-menu/vite.config.ts
@@ -18,11 +18,5 @@ export default defineConfig({
         assetFileNames: "[ext]/global-nav-menu.[name][extname]",
       }
     }
-  },
-  server: {
-    cors: true,
-    headers: {
-      "Access-Control-Allow-Origin": "*",   // or restrict to your Django domain
-    },
-  },
+  }
 })

--- a/app/eventyay/frontend/schedule-editor/vite.config.js
+++ b/app/eventyay/frontend/schedule-editor/vite.config.js
@@ -49,11 +49,6 @@ export default {
 	server: {
 		host: true,  // binds to all interfaces
 		port: 8080,
-		cors: true,
-		strictPort: true,
-		headers: {
-			"Access-Control-Allow-Origin": "*"
-		  },
 		hmr: {
 			host: 'localhost',
 			protocol: 'ws',  // ensure correct websocket protocol


### PR DESCRIPTION
This PR removes 'Access-Control-Allow-Origin' which was set to all (*), which we forgot to remove in PR #836 as discussed.

## Summary by Sourcery

Enhancements:
- Remove wildcard CORS headers in global-nav-menu and schedule-editor Vite configurations