### PR TITLE
Remove Event and Organizer Webhook

### DIFF
--- a/app/eventyay/eventyay_common/tasks.py
+++ b/app/eventyay/eventyay_common/tasks.py
@@ -36,35 +36,6 @@ logger = logging.getLogger(__name__)
 
 
 @shared_task(bind=True, max_retries=5, default_retry_delay=60)  # Retries up to 5 times with a 60-second delay
-def send_organizer_webhook(self, user_id, organizer):
-    # Define the payload to send to the webhook
-    payload = {
-        'name': organizer.get('name'),
-        'slug': organizer.get('slug'),
-        'action': organizer.get('action'),
-    }
-    # Define the headers, including the Authorization header with the Bearer token
-    headers = get_header_token(user_id)
-
-    try:
-        # Send the POST request with the payload and the headers
-        response = requests.post(
-            urljoin(settings.TALK_HOSTNAME, 'webhook/organiser/'),
-            json=payload,
-            headers=headers,
-        )
-        response.raise_for_status()  # Raise exception for bad status codes
-    except requests.RequestException as e:
-        # Log any errors that occur
-        logger.error('Error sending webhook to talk component: %s', e)
-        # Retry the task if an exception occurs (with exponential backoff by default)
-        try:
-            self.retry(exc=e)
-        except self.MaxRetriesExceededError:
-            logger.error('Max retries exceeded for sending organizer webhook.')
-
-
-@shared_task(bind=True, max_retries=5, default_retry_delay=60)  # Retries up to 5 times with a 60-second delay
 def send_team_webhook(self, user_id, team):
     # Define the payload to send to the webhook
     payload = {
@@ -88,47 +59,6 @@ def send_team_webhook(self, user_id, team):
             headers=headers,
         )
         response.raise_for_status()  # Raise exception for bad status codes
-    except requests.RequestException as e:
-        # Log any errors that occur
-        logger.error('Error sending webhook to talk component: %s', e)
-        # Retry the task if an exception occurs (with exponential backoff by default)
-        try:
-            self.retry(exc=e)
-        except self.MaxRetriesExceededError:
-            logger.error('Max retries exceeded for sending organizer webhook.')
-
-
-@shared_task(
-    bind=True, max_retries=5, default_retry_delay=60, base=SendEventTask
-)  # Retries up to 5 times with a 60-second delay
-def send_event_webhook(self, user_id: int, event: dict, action: str) -> Optional[dict]:
-    # Define the payload to send to the webhook
-    user_model = get_user_model()
-    user = user_model.objects.get(id=user_id)
-    payload = {
-        'organiser_slug': event.get('organiser_slug'),
-        'name': event.get('name'),
-        'slug': event.get('slug'),
-        'date_from': event.get('date_from'),
-        'date_to': event.get('date_to'),
-        'timezone': event.get('timezone'),
-        'locale': event.get('locale'),
-        'locales': event.get('locales'),
-        'user_email': user.email,
-        'action': action,
-        'is_video_creation': event.get('is_video_creation'),
-    }
-    headers = get_header_token(user_id)
-
-    try:
-        # Send the POST request with the payload and the headers
-        response = requests.post(
-            urljoin(settings.TALK_HOSTNAME, 'webhook/event/'),
-            json=payload,
-            headers=headers,
-        )
-        response.raise_for_status()  # Raise exception for bad status codes
-        return response.json()
     except requests.RequestException as e:
         # Log any errors that occur
         logger.error('Error sending webhook to talk component: %s', e)

--- a/app/eventyay/eventyay_common/views/event.py
+++ b/app/eventyay/eventyay_common/views/event.py
@@ -36,7 +36,7 @@ from eventyay.control.views import PaginationMixin, UpdateView
 from eventyay.control.views.event import DecoupleMixin, EventSettingsViewMixin
 from eventyay.control.views.product import MetaDataEditorMixin
 from eventyay.eventyay_common.forms.event import EventCommonSettingsForm
-from eventyay.eventyay_common.tasks import create_world, send_event_webhook
+from eventyay.eventyay_common.tasks import create_world
 from eventyay.eventyay_common.utils import (
     EventCreatedFor,
     check_create_permission,
@@ -228,56 +228,40 @@ class EventCreateView(SafeSessionWizardView):
         has_permission = check_create_permission(self.request)
         final_is_video_creation = foundation_data.get('is_video_creation', True) and has_permission
 
-        if create_for == EventCreatedFor.TALK:
-            event_dict = {
-                'organiser_slug': (foundation_data.get('organizer').slug if foundation_data.get('organizer') else None),
-                'name': (basics_data.get('name').data if basics_data.get('name') else None),
-                'slug': basics_data.get('slug'),
-                'is_public': False,
-                'date_from': str(basics_data.get('date_from')),
-                'date_to': str(basics_data.get('date_to')),
-                'timezone': str(basics_data.get('timezone')),
-                'locale': basics_data.get('locale'),
-                'locales': foundation_data.get('locales'),
-                'is_video_creation': final_is_video_creation,
-            }
-            send_event_webhook.delay(user_id=self.request.user.id, event=event_dict, action='create')
-        else:
-            with transaction.atomic(), language(basics_data['locale']):
-                event = form_dict['basics'].instance
-                event.organizer = foundation_data['organizer']
-                event.plugins = settings.PRETIX_PLUGINS_DEFAULT
-                event.has_subevents = foundation_data['has_subevents']
-                event.is_video_creation = final_is_video_creation
-                event.testmode = True
-                form_dict['basics'].save()
+        with transaction.atomic(), language(basics_data['locale']):
+            event = form_dict['basics'].instance
+            event.organizer = foundation_data['organizer']
+            event.plugins = settings.PRETIX_PLUGINS_DEFAULT
+            event.has_subevents = foundation_data['has_subevents']
+            event.is_video_creation = final_is_video_creation
+            event.testmode = True
+            form_dict['basics'].save()
 
-                with scope(organizer=event.organizer):
-                    event.checkin_lists.create(name=_('Default'), all_products=True)
-                event.set_defaults()
-                event.settings.set('timezone', basics_data['timezone'])
-                event.settings.set('locale', basics_data['locale'])
-                event.settings.set('locales', foundation_data['locales'])
-                if create_for == EventCreatedFor.BOTH:
-                    event_dict = {
-                        'organiser_slug': event.organizer.slug,
-                        'name': event.name.data,
-                        'slug': event.slug,
-                        'is_public': event.live,
-                        'date_from': str(event.date_from),
-                        'date_to': str(event.date_to),
-                        'timezone': str(basics_data.get('timezone')),
-                        'locale': event.settings.locale,
-                        'locales': event.settings.locales,
-                        'is_video_creation': final_is_video_creation,
-                    }
-                    send_event_webhook.delay(user_id=self.request.user.id, event=event_dict, action='create')
-                event.settings.set('create_for', create_for)
+            with scope(organizer=event.organizer):
+                event.checkin_lists.create(name=_('Default'), all_products=True)
+            event.set_defaults()
+            event.settings.set('timezone', basics_data['timezone'])
+            event.settings.set('locale', basics_data['locale'])
+            event.settings.set('locales', foundation_data['locales'])
+            if create_for == EventCreatedFor.BOTH:
+                event_dict = {
+                    'organiser_slug': event.organizer.slug,
+                    'name': event.name.data,
+                    'slug': event.slug,
+                    'is_public': event.live,
+                    'date_from': str(event.date_from),
+                    'date_to': str(event.date_to),
+                    'timezone': str(basics_data.get('timezone')),
+                    'locale': event.settings.locale,
+                    'locales': event.settings.locales,
+                    'is_video_creation': final_is_video_creation,
+                }
+            event.settings.set('create_for', create_for)
 
-                event.log_action(
-                        action='eventyay.event.added',
-                        user=self.request.user,
-                    )
+            event.log_action(
+                    action='eventyay.event.added',
+                    user=self.request.user,
+                )
 
         # The user automatically creates a world when selecting the add video option in the create ticket form.
         event_data = dict(
@@ -378,22 +362,6 @@ class EventUpdate(
             messages.error(self.request, _('You do not have permission to perform this action.'))
             return False
 
-        send_event_webhook.delay(
-            user_id=self.request.user.id,
-            event={
-                'organiser_slug': self.request.event.organizer.slug,
-                'name': self.request.event.name.data,
-                'slug': self.request.event.slug,
-                'date_from': str(self.request.event.date_from),
-                'date_to': str(self.request.event.date_to),
-                'timezone': str(self.request.event.settings.timezone),
-                'locale': self.request.event.settings.locale,
-                'locales': self.request.event.settings.locales,
-                'is_video_creation': self.request.event.is_video_creation,
-            },
-            action='create',
-        )
-
         return True
 
     def enable_video_system(self, request: HttpRequest) -> bool:
@@ -436,19 +404,6 @@ class EventUpdate(
                 event = form.instance
                 event.date_from = self.reset_timezone(zone, event.date_from)
                 event.date_to = self.reset_timezone(zone, event.date_to)
-                if event.settings.create_for and event.settings.create_for == EventCreatedFor.BOTH:
-                    event_dict = {
-                        'organiser_slug': event.organizer.slug,
-                        'name': event.name.data,
-                        'slug': event.slug,
-                        'date_from': str(event.date_from),
-                        'date_to': str(event.date_to),
-                        'timezone': str(event.settings.timezone),
-                        'locale': event.settings.locale,
-                        'locales': event.settings.locales,
-                        'is_video_creation': request.event.is_video_creation,
-                    }
-                    send_event_webhook.delay(user_id=self.request.user.id, event=event_dict, action='update')
                 return self.form_valid(form)
             else:
                 messages.error(

--- a/app/eventyay/eventyay_common/views/organizer.py
+++ b/app/eventyay/eventyay_common/views/organizer.py
@@ -16,7 +16,6 @@ from eventyay.control.views import CreateView, PaginationMixin, UpdateView
 
 from ...control.forms.organizer_forms import OrganizerForm, OrganizerUpdateForm
 from ...control.permissions import OrganizerPermissionRequiredMixin
-from ..tasks import send_organizer_webhook
 
 logger = logging.getLogger(__name__)
 
@@ -75,13 +74,6 @@ class OrganizerCreate(CreateView):
             can_change_vouchers=True,
         )
         # Trigger webhook in talk to create organiser in talk component
-        organizer_data = {
-            'name': self.object.name,
-            'slug': self.object.slug,
-            'action': 'create',
-        }
-        send_organizer_webhook.delay(user_id=self.request.user.id, organizer=organizer_data)
-
         team.members.add(self.request.user)
         return response
 
@@ -115,12 +107,6 @@ class OrganizerUpdate(UpdateView, OrganizerPermissionRequiredMixin):
     @transaction.atomic
     def form_valid(self, form):
         response = super().form_valid(form)
-        organizer_data = {
-            'name': self.object.name,
-            'slug': self.object.slug,
-            'action': 'update',
-        }
-        send_organizer_webhook.delay(user_id=self.request.user.id, organizer=organizer_data)
         return response
 
     def get_success_url(self) -> str:


### PR DESCRIPTION
Previously, event creation in **eventyay-tickets** triggered a webhook (`send_event_webhook`) to notify the **eventyay-talk**. This was required when Tickets, Talk, and Video were separate systems with independent databases, so events had to be synchronized across components via HTTP calls.

With the **enext** unification, Tickets and Talk now share the same Django project and database. This makes the webhook redundant, since event data is already available across all components without needing external sync.

This PR removes all webhook calls during event and organizer creation/update.

## Summary by Sourcery

Remove redundant event and organizer webhook integration following the unification of Tickets and Talk into a single project and database.

Chores:
- Remove send_event_webhook task and all its invocation points in event creation and update flows
- Remove send_organizer_webhook task and its calls in organizer creation and update views