### PR TITLE
Enable redis

### DIFF
--- a/app/eventyay.cfg
+++ b/app/eventyay.cfg
@@ -37,16 +37,15 @@ tls = True
 ssl = False
 
 # redis stream:
-# 0 and 1 and 2 are used by eventyay-talk
-#[redis]
-#location=redis://eventyay-redis/3
-#; Remove the following line if you are unsure about your redis' security
-#; to reduce impact if redis gets compromised.
-#sessions=true
+[redis]
+location=redis://eventyay-next-redis/0
+; Remove the following line if you are unsure about your redis' security
+; to reduce impact if redis gets compromised.
+sessions=true
 
-#[celery]
-#backend=redis://eventyay-redis/4
-#broker=redis://eventyay-redis/5
+[celery]
+backend=redis://eventyay-next-redis/1
+broker=redis://eventyay-next-redis/2
 
 [django]
 secret=CHANGEME

--- a/deployment/docker-compose.yml
+++ b/deployment/docker-compose.yml
@@ -1,4 +1,4 @@
-name: eventyay
+name: eventyay-next
 
 services:
   web:
@@ -19,6 +19,8 @@ services:
       - ./.env
     depends_on:
       - db
+      - redis
+
   db:
     image: postgres:15
     container_name: eventyay-next-db
@@ -26,6 +28,16 @@ services:
       - ./data/postgres:/var/lib/postgresql/data/
     env_file:
       - ./.env
+
+  redis:
+    image: redis:latest
+    container_name: eventyay-next-redis
+    restart: unless-stopped
+    volumes:
+      - rd:/data
+    healthcheck:
+      test: [ "CMD", "redis-cli", "--raw", "incr", "ping" ]
+
   watchtower:
     image: containrrr/watchtower
     container_name: eventyay-next-watchtower
@@ -38,4 +50,7 @@ services:
       WATCHTOWER_POLL_INTERVAL: 600
       WATCHTOWER_NOTIFICATION_URL: ${WATCHTOWER_NOTIFICATION_URL}
     command: watchtower eventyay-next-web --cleanup
+
+volumes:
+  rd:
 


### PR DESCRIPTION
## Summary by Sourcery

Enable Redis integration for session storage and Celery processes by configuring the application settings and adding a Redis service to the Docker Compose setup

New Features:
- Enable Redis for session storage
- Configure Redis as the Celery result backend and broker

Enhancements:
- Rename Docker Compose project to eventyay-next
- Add and configure a Redis service with persistent volume and health check
- Make the web service depend on Redis