### PR TITLE
Talk Permission lable fix in enext

### DIFF
--- a/app/eventyay/agenda/templates/agenda/base.html
+++ b/app/eventyay/agenda/templates/agenda/base.html
@@ -14,7 +14,7 @@
 {% endblock custom_header %}
 
 {% block nav_link %}
-    {% has_perm "schedule.list_schedule" request.user request.event as can_view_schedule %}
+    {% has_perm "base.list_schedule" request.user request.event as can_view_schedule %}
     {% if can_view_schedule %}
         {{ request.event.urls.schedule }}
     {% else %}

--- a/app/eventyay/agenda/views/featured.py
+++ b/app/eventyay/agenda/views/featured.py
@@ -14,7 +14,7 @@ def sneakpeek_redirect(request, *args, **kwargs):
 
 class FeaturedView(EventPermissionRequired, TemplateView):
     template_name = 'agenda/featured.html'
-    permission_required = 'submission.list_featured_submission'
+    permission_required = 'base.list_featured_submission'
 
     @context
     def talks(self):
@@ -40,7 +40,7 @@ class FeaturedView(EventPermissionRequired, TemplateView):
 
     def dispatch(self, request, *args, **kwargs):
         can_see_featured = self.has_permission()
-        can_schedule = request.user.has_perm('schedule.list_schedule', request.event)
+        can_schedule = request.user.has_perm('base.list_schedule', request.event)
 
         if not can_see_featured and can_schedule:
             return HttpResponseRedirect(request.event.urls.schedule)

--- a/app/eventyay/agenda/views/feed.py
+++ b/app/eventyay/agenda/views/feed.py
@@ -24,7 +24,7 @@ class ScheduleFeed(Feed):
     description_template = 'agenda/feed/description.html'
 
     def get_object(self, request, *args, **kwargs):
-        if not request.user.has_perm('schedule.list_schedule', request.event):
+        if not request.user.has_perm('base.list_schedule', request.event):
             raise Http404()
         return request.event
 

--- a/app/eventyay/agenda/views/schedule.py
+++ b/app/eventyay/agenda/views/schedule.py
@@ -71,7 +71,7 @@ class ScheduleMixin:
 
 
 class ExporterView(EventPermissionRequired, ScheduleMixin, TemplateView):
-    permission_required = 'schedule.list_schedule'
+    permission_required = 'base.list_schedule'
 
     def get(self, request, *args, **kwargs):
         url = resolve(self.request.path_info)
@@ -90,7 +90,7 @@ class ExporterView(EventPermissionRequired, ScheduleMixin, TemplateView):
 
 class ScheduleView(PermissionRequired, ScheduleMixin, TemplateView):
     template_name = 'agenda/schedule.html'
-    permission_required = 'schedule.view_schedule'
+    permission_required = 'base.view_schedule'
 
     def get_text(self, request, **kwargs):
         data = ScheduleData(
@@ -121,7 +121,7 @@ class ScheduleView(PermissionRequired, ScheduleMixin, TemplateView):
 
     def dispatch(self, request, **kwargs):
         if not self.has_permission() and self.request.user.has_perm(
-            'submission.list_featured_submission', self.request.event
+            'base.list_featured_submission', self.request.event
         ):
             messages.success(request, _('Our schedule is not live yet.'))
             return HttpResponseRedirect(self.request.event.urls.featured)
@@ -221,7 +221,7 @@ class ScheduleNoJsView(ScheduleView):
 
 class ChangelogView(EventPermissionRequired, TemplateView):
     template_name = 'agenda/changelog.html'
-    permission_required = 'schedule.list_schedule'
+    permission_required = 'base.list_schedule'
 
     @context
     def schedules(self):

--- a/app/eventyay/agenda/views/speaker.py
+++ b/app/eventyay/agenda/views/speaker.py
@@ -27,7 +27,7 @@ from eventyay.base.models import TalkQuestionTarget
 class SpeakerList(EventPermissionRequired, Filterable, ListView):
     context_object_name = 'speakers'
     template_name = 'agenda/speakers.html'
-    permission_required = 'schedule.list_schedule'
+    permission_required = 'base.list_schedule'
     default_filters = ('user__fullname__icontains',)
 
     def get_queryset(self):
@@ -50,7 +50,7 @@ class SpeakerList(EventPermissionRequired, Filterable, ListView):
 
 class SpeakerView(PermissionRequired, TemplateView):
     template_name = 'agenda/speaker.html'
-    permission_required = 'person.view_speakerprofile'
+    permission_required = 'base.view_speakerprofile'
     slug_field = 'code'
 
     @context
@@ -93,14 +93,14 @@ class SpeakerRedirect(DetailView):
     def dispatch(self, request, **kwargs):
         speaker = self.get_object()
         profile = speaker.profiles.filter(event=self.request.event).first()
-        if profile and self.request.user.has_perm('person.view_speakerprofile', profile):
+        if profile and self.request.user.has_perm('base.view_speakerprofile', profile):
             return redirect(profile.urls.public.full())
         raise Http404()
 
 
 class SpeakerTalksIcalView(PermissionRequired, DetailView):
     context_object_name = 'profile'
-    permission_required = 'person.view_speakerprofile'
+    permission_required = 'base.view_speakerprofile'
     slug_field = 'code'
 
     def get_object(self, queryset=None):

--- a/app/eventyay/agenda/views/talk.py
+++ b/app/eventyay/agenda/views/talk.py
@@ -29,7 +29,7 @@ from eventyay.base.models import Submission, SubmissionStates
 
 
 class TalkMixin(PermissionRequired):
-    permission_required = 'submission.view_public_submission'
+    permission_required = 'base.view_public_submission'
 
     def get_queryset(self):
         return self.request.event.submissions.prefetch_related(
@@ -90,7 +90,7 @@ class TalkView(TalkMixin, TemplateView):
 
         ctx = super().get_context_data(**kwargs)
         schedule = self.request.event.current_schedule or self.request.event.wip_schedule
-        if not self.request.user.has_perm('schedule.view_schedule', schedule):
+        if not self.request.user.has_perm('base.view_schedule', schedule):
             return ctx
         qs = schedule.talks.filter(room__isnull=False).select_related('room') if schedule else TalkSlot.objects.none()
         ctx['talk_slots'] = qs.filter(submission=self.submission).order_by('start').select_related('room')
@@ -184,7 +184,7 @@ class SingleICalView(EventPageMixin, TalkMixin, View):
 
 class FeedbackView(TalkMixin, FormView):
     form_class = FeedbackForm
-    permission_required = 'submission.view_feedback_page_submission'
+    permission_required = 'base.view_feedback_page_submission'
 
     def get_queryset(self):
         return self.request.event.submissions.prefetch_related(
@@ -201,7 +201,7 @@ class FeedbackView(TalkMixin, FormView):
     @context
     @cached_property
     def can_give_feedback(self):
-        return self.request.user.has_perm('submission.give_feedback_submission', self.talk)
+        return self.request.user.has_perm('base.give_feedback_submission', self.talk)
 
     @context
     @cached_property
@@ -250,7 +250,7 @@ class TalkSocialMediaCard(SocialMediaCardMixin, TalkView):
 
 
 class OnlineVideoJoin(EventPermissionRequired, View):
-    permission_required = 'agenda.view_schedule'
+    permission_required = 'base.view_schedule'
 
     def get(self, request, *args, **kwargs):
         # First check video is configured or not

--- a/app/eventyay/agenda/views/utils.py
+++ b/app/eventyay/agenda/views/utils.py
@@ -16,8 +16,8 @@ logger = logging.getLogger(__name__)
 
 def is_visible(exporter, request, public=False):
     if not public:
-        return request.user.has_perm('schedule.orga_view_schedule', request.event)
-    if not request.user.has_perm('schedule.list_schedule', request.event):
+        return request.user.has_perm('base.orga_view_schedule', request.event)
+    if not request.user.has_perm('base.list_schedule', request.event):
         return False
     if hasattr(exporter, 'is_public'):
         with suppress(Exception):
@@ -59,7 +59,7 @@ def encode_email(email):
 
 
 def get_schedule_exporter_content(request, exporter_name, schedule):
-    is_organizer = request.user.has_perm('schedule.orga_view_schedule', request.event)
+    is_organizer = request.user.has_perm('base.orga_view_schedule', request.event)
     exporter = find_schedule_exporter(request, exporter_name, public=not is_organizer)
     if not exporter:
         return

--- a/app/eventyay/agenda/views/widget.py
+++ b/app/eventyay/agenda/views/widget.py
@@ -82,13 +82,13 @@ def widget_data(request, event, version=None):
         response['Access-Control-Allow-Origin'] = '*'
         response['Access-Control-Allow-Headers'] = 'authorization,content-type'
         return response
-    if not request.user.has_perm('schedule.view_widget_schedule', event):
+    if not request.user.has_perm('base.view_widget_schedule', event):
         raise Http404()
 
     version = version or unquote(request.GET.get('v') or '')
     schedule = None
     if version and version == 'wip':
-        if not request.user.has_perm('schedule.orga_view_schedule', event):
+        if not request.user.has_perm('base.orga_view_schedule', event):
             raise Http404()
         schedule = request.event.wip_schedule
     elif version:
@@ -113,7 +113,7 @@ def widget_script(request, event):
     # /<event>/widget/schedule.js path, as it cuts down the transferred data
     # by about 80% for the schedule.js file, which is the largest file on the
     # main schedule page).
-    if not request.user.has_perm('schedule.view_widget_schedule', request.event):
+    if not request.user.has_perm('base.view_widget_schedule', request.event):
         raise Http404()
 
     file_path = finders.find(WIDGET_PATH)

--- a/app/eventyay/base/apps.py
+++ b/app/eventyay/base/apps.py
@@ -15,7 +15,7 @@ class EventyayBaseConfig(AppConfig):
         from django.conf import settings
 
         try:
-            from .celery_app import app as celery_app  # NOQA
+            from eventyay.celery_app import app as celery_app  # NOQA
         except ImportError:
             pass
 
@@ -27,6 +27,6 @@ class EventyayBaseConfig(AppConfig):
 
 default_app_config = 'eventyay.base.EventyayBaseConfig'
 try:
-    import pretix.celery_app as celery  # NOQA
+    import eventyay.celery_app as celery  # NOQA
 except ImportError:
     pass

--- a/app/eventyay/base/models/organizer.py
+++ b/app/eventyay/base/models/organizer.py
@@ -385,7 +385,13 @@ class Team(LoggedModel, TimestampedModel, RulesModelMixin, models.Model, metacla
 
     def permission_set(self) -> set:
         attribs = dir(self)
-        return {a for a in attribs if a.startswith('can_') and self.has_permission(a)}
+        return {
+            attr
+            for attr in attribs
+            if (attr.startswith("can_") or attr.startswith("is_"))
+            and getattr(self, attr, False) is True
+            and self.has_permission(attr)
+        }
 
     @property
     def can_change_settings(self):  # Legacy compatiblilty

--- a/app/eventyay/cfp/templates/cfp/event/cfp.html
+++ b/app/eventyay/cfp/templates/cfp/event/cfp.html
@@ -8,8 +8,8 @@
 
 {% block content %}
     {% with cfp=request.event.cfp %}
-        {% has_perm "submission.list_featured_submission" request.user request.event as can_view_featured_submissions %}
-        {% has_perm "event.update_event" request.user request.event as can_edit_cfp %}
+        {% has_perm "base.list_featured_submission" request.user request.event as can_view_featured_submissions %}
+        {% has_perm "base.update_event" request.user request.event as can_edit_cfp %}
         <div class="d-flex align-items-start">
             <h1>{{ cfp.headline|default:"" }}</h1>
             {% if can_edit_cfp %}

--- a/app/eventyay/cfp/templates/cfp/event/index.html
+++ b/app/eventyay/cfp/templates/cfp/event/index.html
@@ -7,7 +7,7 @@
 
 {% block content %}
     {% with cfp=request.event.cfp %}
-        {% has_perm "submission.list_featured_submission" request.user request.event as can_view_featured_submissions %}
+        {% has_perm "base.list_featured_submission" request.user request.event as can_view_featured_submissions %}
         {% if request.event.landing_page_text %}{{ request.event.landing_page_text|rich_text }}{% endif %}
         <div class="url-links">
             {% if has_submissions or request.user.is_anonymous %}

--- a/app/eventyay/cfp/templates/cfp/event/submission_base.html
+++ b/app/eventyay/cfp/templates/cfp/event/submission_base.html
@@ -43,7 +43,7 @@
             {{ wizard.management_form }}
             <div class="d-flex align-items-start">
                 <h2>{% block submission_step_title %}{{ title|default:'' }}{% endblock submission_step_title %}</h2>
-                {% has_perm "event.update_event" request.user request.event as can_edit_cfp %}
+                {% has_perm "base.update_event" request.user request.event as can_edit_cfp %}
                 {% if can_edit_cfp %}{% block orga_edit_link %}{% orga_edit_link request.event.cfp.urls.editor %}{% endblock %}{% endif %}
             </div>
             {% block submission_step_text %}<p>{{ text|rich_text }}</p>{% endblock %}

--- a/app/eventyay/cfp/templates/cfp/event/user_submission_edit.html
+++ b/app/eventyay/cfp/templates/cfp/event/user_submission_edit.html
@@ -20,7 +20,7 @@
 {% endblock cfp_header %}
 
 {% block content %}
-    {% has_perm "submission.add_speaker_submission" request.user submission as can_invite_speakers %}
+    {% has_perm "base.add_speaker_submission" request.user submission as can_invite_speakers %}
 
     {% include "cfp/includes/user_submission_header.html" %}
 

--- a/app/eventyay/cfp/views/event.py
+++ b/app/eventyay/cfp/views/event.py
@@ -13,7 +13,7 @@ from eventyay.talk_rules.event import get_events_for_user
 
 
 class EventPageMixin(PermissionRequired):
-    permission_required = 'event.view_event'
+    permission_required = 'base.view_event'
 
     def get_permission_object(self):
         return getattr(self.request, 'event', None)

--- a/app/eventyay/cfp/views/user.py
+++ b/app/eventyay/cfp/views/user.py
@@ -111,11 +111,11 @@ class ProfileView(LoggedInEventPageMixin, TemplateView):
 
 
 class SubmissionViewMixin:
-    permission_required = 'submission.update_submission'
+    permission_required = 'base.update_submission'
 
     def has_permission(self):
         return super().has_permission() or self.request.user.has_perm(
-            'submission.orga_list_submission', self.request.event
+            'base.orga_list_submission', self.request.event
         )
 
     def dispatch(self, request, *args, **kwargs):
@@ -168,14 +168,14 @@ class SubmissionsWithdrawView(LoggedInEventPageMixin, SubmissionViewMixin, Detai
     template_name = 'cfp/event/user_submission_withdraw.html'
     model = Submission
     context_object_name = 'submission'
-    permission_required = 'submission.is_speaker_submission'
+    permission_required = 'base.is_speaker_submission'
 
     def get_permission_object(self):
         return self.get_object()
 
     def post(self, request, *args, **kwargs):
         obj = self.get_object()
-        if self.request.user.has_perm('submission.withdraw_submission', obj):
+        if self.request.user.has_perm('base.withdraw_submission', obj):
             if obj.state == SubmissionStates.ACCEPTED:
                 with override(obj.event.locale):
                     obj.event.send_orga_mail(
@@ -219,7 +219,7 @@ class SubmissionConfirmView(LoggedInEventPageMixin, SubmissionViewMixin, FormVie
     def dispatch(self, request, *args, **kwargs):
         if request.user.is_anonymous:
             return get_login_redirect(request)
-        if not request.user.has_perm('submission.is_speaker_submission', self.submission):
+        if not request.user.has_perm('base.is_speaker_submission', self.submission):
             self.template_name = 'cfp/event/user_submission_confirm_error.html'
         return super().dispatch(request, *args, **kwargs)
 
@@ -245,7 +245,7 @@ class SubmissionConfirmView(LoggedInEventPageMixin, SubmissionViewMixin, FormVie
     def form_valid(self, form):
         submission = self.submission
         form.save()
-        if self.request.user.has_perm('submission.confirm_submission', submission):
+        if self.request.user.has_perm('base.confirm_submission', submission):
             submission.confirm(person=self.request.user)
             messages.success(self.request, phrases.cfp.submission_confirmed)
         elif submission.state == SubmissionStates.CONFIRMED:
@@ -276,8 +276,8 @@ class SubmissionsEditView(LoggedInEventPageMixin, SubmissionViewMixin, UpdateVie
     model = Submission
     form_class = InfoForm
     context_object_name = 'submission'
-    permission_required = 'submission.view_submission'
-    write_permission_required = 'submission.update_submission'
+    permission_required = 'base.view_submission'
+    write_permission_required = 'base.update_submission'
 
     def get_permission_object(self):
         return self.object
@@ -435,7 +435,7 @@ class DeleteAccountView(LoggedInEventPageMixin, View):
 class SubmissionInviteView(LoggedInEventPageMixin, SubmissionViewMixin, FormView):
     form_class = SubmissionInvitationForm
     template_name = 'cfp/event/user_submission_invitation.html'
-    permission_required = 'submission.add_speaker_submission'
+    permission_required = 'base.add_speaker_submission'
 
     def get_permission_object(self):
         return self.get_object()
@@ -479,7 +479,7 @@ class SubmissionInviteAcceptView(LoggedInEventPageMixin, DetailView):
     @context
     @cached_property
     def can_accept_invite(self):
-        return self.request.user.has_perm('submission.add_speaker_submission', self.get_object())
+        return self.request.user.has_perm('base.add_speaker_submission', self.get_object())
 
     def post(self, request, *args, **kwargs):
         if not self.can_accept_invite:

--- a/app/eventyay/common/templates/common/base.html
+++ b/app/eventyay/common/templates/common/base.html
@@ -106,7 +106,7 @@
                         {% block header_right %}{% endblock header_right %}
                         {% if request.event and request.user.is_authenticated and not is_html_export %}
                             <details id="user-dropdown-label" class="dropdown" aria-haspopup="menu" role="menu">
-                                {% has_perm "event.orga_access_event" request.user request.event as can_see_orga_area %}
+                                {% has_perm "base.orga_access_event" request.user request.event as can_see_orga_area %}
                                 <summary>
                                     {{ request.user.get_display_name }} <i class="fa fa-caret-down ml-1"></i>
                                 </summary>

--- a/app/eventyay/orga/context_processors.py
+++ b/app/eventyay/orga/context_processors.py
@@ -68,7 +68,7 @@ def orga_events(request):
     if (
         not request.event.is_public
         and request.event.custom_domain
-        and request.user.has_perm('event.view_event', request.event)
+        and request.user.has_perm('base.view_event', request.event)
     ):
         child_session_key = f'child_session_{request.event.pk}'
         child_session = request.session.get(child_session_key)

--- a/app/eventyay/orga/permissions.py
+++ b/app/eventyay/orga/permissions.py
@@ -3,4 +3,4 @@ import rules
 from eventyay.talk_rules.event import can_change_event_settings
 
 # Legacy for plugins. TODO remove after v2025.1.0
-rules.add_perm('orga.change_settings', can_change_event_settings)
+rules.add_perm('base.change_settings', can_change_event_settings)

--- a/app/eventyay/orga/tasks.py
+++ b/app/eventyay/orga/tasks.py
@@ -14,7 +14,7 @@ logger = logging.getLogger(__name__)
 def generate_sso_token(user_email):
     jwt_payload = {
         'email': user_email,
-        'has_perms': 'orga.edit_schedule',
+        'has_perms': 'base.edit_schedule',
         'exp': datetime.now(timezone.utc) + timedelta(hours=1),
         'iat': datetime.now(timezone.utc),
     }

--- a/app/eventyay/orga/templates/orga/base.html
+++ b/app/eventyay/orga/templates/orga/base.html
@@ -202,11 +202,11 @@
                     {% endblock %}
                 </div>
                 {% if request.event %}
-                    {% has_perm "event.orga_access_event" request.user request.event as can_see_orga_area %}
-                    {% has_perm "submission.orga_update_submission" request.user request.event as can_see_orga_exclusive %}
-                    {% has_perm "event.update_team" request.user request.event as can_change_teams %}
-                    {% has_perm "event.update_event" request.user request.event as can_change_settings %}
-                    {% has_perm "person.orga_list_speakerprofile" request.user request.event as can_view_speakers %}
+                    {% has_perm "base.orga_access_event" request.user request.event as can_see_orga_area %}
+                    {% has_perm "base.orga_update_submission" request.user request.event as can_see_orga_exclusive %}
+                    {% has_perm "base.update_team" request.user request.event as can_change_teams %}
+                    {% has_perm "base.update_event" request.user request.event as can_change_settings %}
+                    {% has_perm "base.orga_list_speakerprofile" request.user request.event as can_view_speakers %}
                     {% if can_see_orga_exclusive %}
                         {% if can_change_settings %}
                             <div class="nav-fold">
@@ -435,8 +435,8 @@
                         <i class="fa fa-cog"></i>
                         <span>{% translate "Settings" %}</span>
                     </a>
-                    {% has_perm "event.update_team" request.user request.organizer as can_change_teams %}
-                    {% has_perm "event.view_organizer" request.user request.organizer as can_view_speakers %}
+                    {% has_perm "base.update_team" request.user request.organizer as can_change_teams %}
+                    {% has_perm "base.view_organizer" request.user request.organizer as can_view_speakers %}
                     {% if can_change_teams %}
                         <a class="nav-link {% if "/teams/" in request.path %} active{% endif %}" href="{% url "orga:organizer.teams.list" organizer=request.organizer.slug %}">
                             <i class="fa fa-users"></i>
@@ -453,7 +453,7 @@
                         {% include "orga/includes/sidebar_nav.html" %}
                     {% endfor %}
                 {% else %}  {# elif request.organizer #}
-                    {% has_perm "event.view_any_organizer" request.user request as can_see_organizer_lists %}
+                    {% has_perm "base.view_any_organizer" request.user request as can_see_organizer_lists %}
                     {% if can_see_organizer_lists %}
                         <a class="nav-link {% if request.path == "/orga/event/" %} active{% endif %}" href="{% url "orga:event.list" %}">
                             <i class="fa fa-calendar-o"></i>

--- a/app/eventyay/orga/templates/orga/event/dashboard.html
+++ b/app/eventyay/orga/templates/orga/event/dashboard.html
@@ -12,8 +12,8 @@
 {% endblock stylesheets %}
 
 {% block content %}
-    {% has_perm "person.orga_list_speakerprofile" request.user request.event as can_view_speakers %}
-    {% has_perm "event.update_event" request.user request.event as can_change_settings %}
+    {% has_perm "base.orga_list_speakerprofile" request.user request.event as can_view_speakers %}
+    {% has_perm "base.update_event" request.user request.event as can_change_settings %}
     {% if "congratulations" in request.GET %}
         <div class="alert alert-success congratulations">
             <span></span>

--- a/app/eventyay/orga/templates/orga/event_list.html
+++ b/app/eventyay/orga/templates/orga/event_list.html
@@ -14,7 +14,7 @@
 {% endblock stylesheets %}
 
 {% block content %}
-    {% has_perm "event.create_event" request.user request.user as can_create_event %}
+    {% has_perm "base.create_event" request.user request.user as can_create_event %}
 
     {% if current_orga_events or past_orga_events or can_create_event %}
         <form class="mb-4 m-2">

--- a/app/eventyay/orga/templates/orga/review/bulk.html
+++ b/app/eventyay/orga/templates/orga/review/bulk.html
@@ -15,7 +15,7 @@
 {% block extra_title %}{% translate "Reviews" %} :: {% endblock extra_title %}
 
 {% block content %}
-    {% has_perm "person.reviewer_list_speakerprofile" request.user request.event as can_view_speakers %}
+    {% has_perm "base.reviewer_list_speakerprofile" request.user request.event as can_view_speakers %}
     <div class="alert alert-info">
         {% if next_submission %}
             {% blocktranslate trimmed count count=missing_reviews %}

--- a/app/eventyay/orga/templates/orga/review/dashboard.html
+++ b/app/eventyay/orga/templates/orga/review/dashboard.html
@@ -21,8 +21,8 @@
 {% block extra_title %}{% translate "Reviews" %} :: {% endblock extra_title %}
 
 {% block content %}
-    {% has_perm "submission.create_review" request.user request.event as can_review %}
-    {% has_perm "person.reviewer_list_speakerprofile" request.user request.event as can_view_speakers %}
+    {% has_perm "base.create_review" request.user request.event as can_review %}
+    {% has_perm "base.reviewer_list_speakerprofile" request.user request.event as can_view_speakers %}
     <div class="alert alert-info">
         <div>
             {% if can_review and next_submission %}

--- a/app/eventyay/orga/templates/orga/speaker/form.html
+++ b/app/eventyay/orga/templates/orga/speaker/form.html
@@ -19,9 +19,9 @@
 {% endblock alternate_link %}
 
 {% block content %}
-    {% has_perm "person.update_speakerprofile" request.user form.instance as can_edit_speaker %}
-    {% has_perm "mail.send_queuedmail" request.user request.event as can_send_mails %}
-    {% has_perm "person.mark_arrived_speakerprofile" request.user request.event as can_mark_speaker %}
+    {% has_perm "base.update_speakerprofile" request.user form.instance as can_edit_speaker %}
+    {% has_perm "base.send_queuedmail" request.user request.event as can_send_mails %}
+    {% has_perm "base.mark_arrived_speakerprofile" request.user request.event as can_mark_speaker %}
     <h2 class="d-flex justify-content-between align-items-baseline">
         {% include "orga/includes/user_name.html" with user=form.instance.user lightbox=True %}
         <span class="ml-2">

--- a/app/eventyay/orga/templates/orga/speaker/list.html
+++ b/app/eventyay/orga/templates/orga/speaker/list.html
@@ -33,7 +33,7 @@
         </p>
     {% endif %}
 
-    {% has_perm "person.mark_arrived_speakerprofile" request.user request.event as can_mark_speaker %}
+    {% has_perm "base.mark_arrived_speakerprofile" request.user request.event as can_mark_speaker %}
     <div class="table-responsive-md">
         <table class="table table-sm table-flip table-sticky">
             <thead>

--- a/app/eventyay/orga/templates/orga/submission/base.html
+++ b/app/eventyay/orga/templates/orga/submission/base.html
@@ -8,7 +8,7 @@
 
 {% block extra_title %}
     {% block submission_title %}{% endblock submission_title %}
-    {% has_perm "person.orga_list_speakerprofile" request.user request.event as can_view_speakers %}
+    {% has_perm "base.orga_list_speakerprofile" request.user request.event as can_view_speakers %}
     {% if can_view_speakers %}{{ submission.title }}{% else %}{{ submission.anonymised.title|default:submission.title }}{% endif %} ::
 {% endblock extra_title %}
 
@@ -18,11 +18,11 @@
 
 {% block content %}
     {% if submission %}
-        {% has_perm "submission.update_submission" request.user submission as can_edit_submission %}
-        {% has_perm "submission.view_reviews_submission" request.user submission as can_view_reviews %}
-        {% has_perm "submission.review_submission" request.user submission as can_review %}
-        {% has_perm "person.orga_list_speakerprofile" request.user request.event as can_view_speakers %}
-        {% has_perm "mail.send_queuedmail" request.user request.event as can_send_mails %}
+        {% has_perm "base.update_submission" request.user submission as can_edit_submission %}
+        {% has_perm "base.view_reviews_submission" request.user submission as can_view_reviews %}
+        {% has_perm "base.review_submission" request.user submission as can_review %}
+        {% has_perm "base.orga_list_speakerprofile" request.user request.event as can_view_speakers %}
+        {% has_perm "base.send_queuedmail" request.user request.event as can_send_mails %}
         <div id="main-title" class="d-md-flex justify-content-between">
             <h2>
                 <span>

--- a/app/eventyay/orga/templates/orga/submission/comments.html
+++ b/app/eventyay/orga/templates/orga/submission/comments.html
@@ -13,7 +13,7 @@
 {% endblock scripts %}
 
 {% block submission_content %}
-    {% has_perm 'submission.add_submissioncomment' request.user submission as can_add_comment %}
+    {% has_perm 'base.add_submissioncomment' request.user submission as can_add_comment %}
 
     <div class="comments-list">
         {% if not comments %}
@@ -31,7 +31,7 @@
                     <div class="text-muted ml-auto">
                         {{ comment.created|date:"SHORT_DATETIME_FORMAT" }}
                     </div>
-                    {% has_perm 'submission.delete_submissioncomment' request.user comment as can_delete_comment %}
+                    {% has_perm 'base.delete_submissioncomment' request.user comment as can_delete_comment %}
                     {% if can_delete_comment %}
                         <a href="{{ comment.urls.delete }}" class="btn btn-sm btn-danger ml-2">
                             <i class="fa fa-trash" title="{{ phrases.base.delete_button }}"></i>

--- a/app/eventyay/orga/templates/orga/submission/content.html
+++ b/app/eventyay/orga/templates/orga/submission/content.html
@@ -19,8 +19,8 @@
 {% endblock scripts %}
 
 {% block submission_content %}
-    {% has_perm "mail.send_queuedmail" request.user request.event as can_send_mails %}
-    {% has_perm "submission.list_all_review" request.user request.event as can_view_all_reviews %}
+    {% has_perm "base.send_queuedmail" request.user request.event as can_send_mails %}
+    {% has_perm "base.list_all_review" request.user request.event as can_view_all_reviews %}
     <form method="post" enctype="multipart/form-data">
         <fieldset>
             {% if not submission %}

--- a/app/eventyay/orga/templates/orga/submission/feedbacks_list.html
+++ b/app/eventyay/orga/templates/orga/submission/feedbacks_list.html
@@ -20,7 +20,7 @@
         </h4>
 
         {% for entry in submission.list %}
-            {% has_perm "submission.view_feedback_submission" request.user entry.talk as can_see_feedback %}
+            {% has_perm "base.view_feedback_submission" request.user entry.talk as can_see_feedback %}
             {% if can_see_feedback %}
                 <div class="card mb-2">
                     <div class="card-body pb-0">{{ entry.review|rich_text }}</div>

--- a/app/eventyay/orga/templates/orga/submission/list.html
+++ b/app/eventyay/orga/templates/orga/submission/list.html
@@ -21,10 +21,10 @@
 {% block extra_title %}{{ page_obj.paginator.count }} {% blocktranslate trimmed count count=page_obj.paginator.count %}session{% plural %}sessions{% endblocktranslate %} :: {% endblock extra_title %}
 
 {% block content %}
-    {% has_perm "submission.create_submission" request.user request.event as can_create_submission %}
-    {% has_perm "submission.state_change_submission" request.user request.event as can_change_submission %}
-    {% has_perm "person.orga_list_speakerprofile" request.user request.event as can_view_speakers %}
-    {% has_perm "mail.send_queuedmail" request.user request.event as can_send_mails %}
+    {% has_perm "base.create_submission" request.user request.event as can_create_submission %}
+    {% has_perm "base.state_change_submission" request.user request.event as can_change_submission %}
+    {% has_perm "base.orga_list_speakerprofile" request.user request.event as can_view_speakers %}
+    {% has_perm "base.send_queuedmail" request.user request.event as can_send_mails %}
     <h2 class="d-flex align-items-center">
         <span>
             {{ page_obj.paginator.count }}

--- a/app/eventyay/orga/templates/orga/submission/review.html
+++ b/app/eventyay/orga/templates/orga/submission/review.html
@@ -16,9 +16,9 @@
 {% endblock scripts %}
 
 {% block submission_content %}
-    {% has_perm "submission.view_all_reviews_submission" request.user submission as can_view_other_reviews %}
-    {% has_perm "submission.list_reviewers_review" request.user submission as can_view_reviewer_names %}
-    {% has_perm "person.reviewer_list_speakerprofile" request.user submission as no_anonymisation %}
+    {% has_perm "base.view_all_reviews_submission" request.user submission as can_view_other_reviews %}
+    {% has_perm "base.list_reviewers_review" request.user submission as can_view_reviewer_names %}
+    {% has_perm "base.reviewer_list_speakerprofile" request.user submission as no_anonymisation %}
     {% if request.user in submission.speakers.all %}
         <div class="alert alert-error">
             <span>

--- a/app/eventyay/orga/templates/orga/submission/speakers.html
+++ b/app/eventyay/orga/templates/orga/submission/speakers.html
@@ -10,9 +10,9 @@
 {% block submission_title %}{% translate "Speakers" %} :: {% endblock submission_title %}
 
 {% block submission_content %}
-    {% has_perm "submission.update_submission" request.user submission as can_edit_speakers %}
-    {% has_perm "mail.send_queuedmail" request.user request.event as can_send_mails %}
-    {% has_perm "person.mark_arrived_speakerprofile" request.user request.event as can_mark_speaker %}
+    {% has_perm "base.update_submission" request.user submission as can_edit_speakers %}
+    {% has_perm "base.send_queuedmail" request.user request.event as can_send_mails %}
+    {% has_perm "base.mark_arrived_speakerprofile" request.user request.event as can_mark_speaker %}
     {% if can_edit_speakers %}<div class="alert">
         <form method="POST" class="form d-flex w-100 flex-column">
             {% csrf_token %}

--- a/app/eventyay/orga/views/admin.py
+++ b/app/eventyay/orga/views/admin.py
@@ -22,7 +22,7 @@ from eventyay.base.models import User
 
 class AdminDashboard(PermissionRequired, TemplateView):
     template_name = 'orga/admin/admin.html'
-    permission_required = 'person.administrator_user'
+    permission_required = 'base.administrator_user'
 
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
@@ -53,7 +53,7 @@ class AdminDashboard(PermissionRequired, TemplateView):
 
 class UpdateCheckView(PermissionRequired, FormView):
     template_name = 'orga/admin/update.html'
-    permission_required = 'person.administrator_user'
+    permission_required = 'base.administrator_user'
     form_class = UpdateSettingsForm
 
     def post(self, request, *args, **kwargs):
@@ -87,7 +87,7 @@ class UpdateCheckView(PermissionRequired, FormView):
 
 class AdminUserList(PermissionRequired, ListView):
     template_name = 'orga/admin/user_list.html'
-    permission_required = 'person.administrator_user'
+    permission_required = 'base.administrator_user'
     model = User
     context_object_name = 'users'
     paginate_by = '250'
@@ -125,7 +125,7 @@ class AdminUserList(PermissionRequired, ListView):
 
 class AdminUserDetail(PermissionRequired, DetailView):
     template_name = 'orga/admin/user_detail.html'
-    permission_required = 'person.administrator_user'
+    permission_required = 'base.administrator_user'
     model = User
     context_object_name = 'user'
     slug_url_kwarg = 'code'

--- a/app/eventyay/orga/views/cards.py
+++ b/app/eventyay/orga/views/cards.py
@@ -106,7 +106,7 @@ class SubmissionCard(Flowable):
 
 
 class SubmissionCards(EventPermissionRequired, View):
-    permission_required = 'submission.orga_update_submission'
+    permission_required = 'base.orga_update_submission'
 
     def get_queryset(self):
         return (

--- a/app/eventyay/orga/views/cfp.py
+++ b/app/eventyay/orga/views/cfp.py
@@ -285,7 +285,7 @@ class QuestionView(OrderActionMixin, OrgaCRUDView):
 
 
 class CfPQuestionToggle(PermissionRequired, View):
-    permission_required = 'base.update_question'
+    permission_required = 'base.update_talkquestion'
 
     def get_object(self) -> TalkQuestion:
         return TalkQuestion.all_objects.filter(event=self.request.event, pk=self.kwargs.get('pk')).first()
@@ -301,7 +301,7 @@ class CfPQuestionToggle(PermissionRequired, View):
 
 class CfPQuestionRemind(EventPermissionRequired, FormView):
     template_name = 'orga/cfp/question/remind.html'
-    permission_required = 'base.orga_view_question'
+    permission_required = 'base.orga_view_talkquestion'
     form_class = ReminderFilterForm
 
     def get_form_kwargs(self):

--- a/app/eventyay/orga/views/cfp.py
+++ b/app/eventyay/orga/views/cfp.py
@@ -55,8 +55,8 @@ class CfPTextDetail(PermissionRequired, ActionFromUrl, UpdateView):
     form_class = CfPForm
     model = CfP
     template_name = 'orga/cfp/text.html'
-    permission_required = 'event.update_event'
-    write_permission_required = 'event.update_event'
+    permission_required = 'base.update_event'
+    write_permission_required = 'base.update_event'
 
     @context
     def tablist(self):
@@ -285,7 +285,7 @@ class QuestionView(OrderActionMixin, OrgaCRUDView):
 
 
 class CfPQuestionToggle(PermissionRequired, View):
-    permission_required = 'submission.update_question'
+    permission_required = 'base.update_question'
 
     def get_object(self) -> TalkQuestion:
         return TalkQuestion.all_objects.filter(event=self.request.event, pk=self.kwargs.get('pk')).first()
@@ -301,7 +301,7 @@ class CfPQuestionToggle(PermissionRequired, View):
 
 class CfPQuestionRemind(EventPermissionRequired, FormView):
     template_name = 'orga/cfp/question/remind.html'
-    permission_required = 'submission.orga_view_question'
+    permission_required = 'base.orga_view_question'
     form_class = ReminderFilterForm
 
     def get_form_kwargs(self):
@@ -388,7 +388,7 @@ class SubmissionTypeView(OrderActionMixin, OrgaCRUDView):
 
 
 class SubmissionTypeDefault(PermissionRequired, View):
-    permission_required = 'submission.update_submissiontype'
+    permission_required = 'base.update_submissiontype'
 
     def get_object(self):
         return get_object_or_404(self.request.event.submission_types, pk=self.kwargs.get('pk'))
@@ -478,7 +478,7 @@ class AccessCodeSend(PermissionRequired, UpdateView):
     form_class = AccessCodeSendForm
     context_object_name = 'access_code'
     template_name = 'orga/cfp/submitteraccesscode/send.html'
-    permission_required = 'submission.view_submitteraccesscode'
+    permission_required = 'base.view_submitteraccesscode'
 
     def get_success_url(self) -> str:
         return self.request.event.cfp.urls.access_codes
@@ -510,7 +510,7 @@ class AccessCodeSend(PermissionRequired, UpdateView):
 @method_decorator(csp_update({'SCRIPT_SRC': "'self' 'unsafe-eval'"}), name='dispatch')
 class CfPFlowEditor(EventPermissionRequired, TemplateView):
     template_name = 'orga/cfp/flow.html'
-    permission_required = 'event.update_event'
+    permission_required = 'base.update_event'
 
     def get_context_data(self, **kwargs):
         ctx = super().get_context_data(**kwargs)

--- a/app/eventyay/orga/views/dashboard.py
+++ b/app/eventyay/orga/views/dashboard.py
@@ -217,8 +217,8 @@ class EventDashboardView(EventPermissionRequired, TemplateView):
         result['go_to_target'] = 'schedule' if stages['REVIEW']['phase'] == 'done' else 'cfp'
         _now = now()
         today = _now
-        can_change_settings = self.request.user.has_perm('event.change_settings.event', event)
-        can_change_submissions = self.request.user.has_perm('submission.orga_update_submission', event)
+        can_change_settings = self.request.user.has_perm('base.change_settings.event', event)
+        can_change_submissions = self.request.user.has_perm('base.orga_update_submission', event)
         result['tiles'] = self.get_cfp_tiles(_now, can_change_submissions=can_change_submissions)
         if today < event.date_from:
             days = (event.date_from - today).days

--- a/app/eventyay/orga/views/event.py
+++ b/app/eventyay/orga/views/event.py
@@ -58,8 +58,8 @@ from eventyay.submission.tasks import recalculate_all_review_scores
 
 
 class EventSettingsPermission(EventPermissionRequired):
-    permission_required = 'event.update_event'
-    write_permission_required = 'event.update_event'
+    permission_required = 'base.update_event'
+    write_permission_required = 'base.update_event'
 
     @property
     def permission_object(self):
@@ -500,7 +500,7 @@ def condition_copy(wizard):
 
 
 class EventWizard(PermissionRequired, SensibleBackWizardMixin, SessionWizardView):
-    permission_required = 'event.create_event'
+    permission_required = 'base.create_event'
     file_storage = FileSystemStorage(location=Path(settings.MEDIA_ROOT) / 'new_event')
     form_list = [
         ('initial', EventWizardInitialForm),
@@ -627,7 +627,7 @@ class EventWizard(PermissionRequired, SensibleBackWizardMixin, SessionWizardView
 
 
 class EventDelete(PermissionRequired, ActionConfirmMixin, TemplateView):
-    permission_required = 'person.administrator_user'
+    permission_required = 'base.administrator_user'
     model = Event
     action_text = (
         _(

--- a/app/eventyay/orga/views/mails.py
+++ b/app/eventyay/orga/views/mails.py
@@ -60,7 +60,7 @@ class OutboxList(EventPermissionRequired, Sortable, Filterable, PaginationMixin,
     )
     sortable_fields = ('to', 'subject', 'pk')
     paginate_by = 25
-    permission_required = 'mail.list_queuedmail'
+    permission_required = 'base.list_queuedmail'
 
     def get_queryset(self):
         qs = (
@@ -98,7 +98,7 @@ class SentMail(EventPermissionRequired, Sortable, Filterable, PaginationMixin, L
     default_sort_field = '-sent'
     sortable_fields = ('to', 'subject', 'sent')
     paginate_by = 25
-    permission_required = 'mail.list_queuedmail'
+    permission_required = 'base.list_queuedmail'
 
     def get_filter_form(self):
         return QueuedMailFilterForm(self.request.GET, event=self.request.event, sent=True)
@@ -119,7 +119,7 @@ class SentMail(EventPermissionRequired, Sortable, Filterable, PaginationMixin, L
 
 
 class OutboxSend(ActionConfirmMixin, OutboxList):
-    permission_required = 'mail.send_queuedmail'
+    permission_required = 'base.send_queuedmail'
     action_object_name = ''
     action_confirm_label = phrases.base.send
     action_confirm_color = 'success'
@@ -184,7 +184,7 @@ class OutboxSend(ActionConfirmMixin, OutboxList):
 
 
 class MailDelete(PermissionRequired, ActionConfirmMixin, TemplateView):
-    permission_required = 'mail.delete_queuedmail'
+    permission_required = 'base.delete_queuedmail'
     action_object_name = ''
 
     def get_permission_object(self):
@@ -243,7 +243,7 @@ class MailDelete(PermissionRequired, ActionConfirmMixin, TemplateView):
 
 
 class OutboxPurge(ActionConfirmMixin, OutboxList):
-    permission_required = 'mail.delete_queuedmail'
+    permission_required = 'base.delete_queuedmail'
     action_object_name = ''
 
     @context
@@ -273,8 +273,8 @@ class MailDetail(PermissionRequired, ActionFromUrl, CreateOrUpdateView):
     model = QueuedMail
     form_class = MailDetailForm
     template_name = 'orga/mails/outbox_form.html'
-    write_permission_required = 'mail.update_queuedmail'
-    permission_required = 'mail.view_queuedmail'
+    write_permission_required = 'base.update_queuedmail'
+    permission_required = 'base.view_queuedmail'
 
     def get_object(self, queryset=None) -> QueuedMail:
         return self.request.event.queued_mails.filter(pk=self.kwargs.get('pk')).first()
@@ -306,7 +306,7 @@ class MailDetail(PermissionRequired, ActionFromUrl, CreateOrUpdateView):
 
 
 class MailCopy(PermissionRequired, View):
-    permission_required = 'mail.send_queuedmail'
+    permission_required = 'base.send_queuedmail'
 
     def get_object(self) -> QueuedMail:
         return get_object_or_404(self.request.event.queued_mails, pk=self.kwargs.get('pk'))
@@ -319,7 +319,7 @@ class MailCopy(PermissionRequired, View):
 
 
 class MailPreview(PermissionRequired, View):
-    permission_required = 'mail.send_queuedmail'
+    permission_required = 'base.send_queuedmail'
 
     def get_object(self) -> QueuedMail:
         return get_object_or_404(self.request.event.queued_mails, pk=self.kwargs.get('pk'))
@@ -331,11 +331,11 @@ class MailPreview(PermissionRequired, View):
 
 class ComposeMailChoice(EventPermissionRequired, TemplateView):
     template_name = 'orga/mails/compose_choice.html'
-    permission_required = 'mail.send_queuedmail'
+    permission_required = 'base.send_queuedmail'
 
 
 class ComposeMailBaseView(EventPermissionRequired, FormView):
-    permission_required = 'mail.send_queuedmail'
+    permission_required = 'base.send_queuedmail'
 
     def get_form_kwargs(self):
         kwargs = super().get_form_kwargs()
@@ -421,7 +421,7 @@ class ComposeMailBaseView(EventPermissionRequired, FormView):
 class ComposeTeamsMail(ComposeMailBaseView):
     form_class = WriteTeamsMailForm
     template_name = 'orga/mails/compose_reviewer_mail_form.html'
-    permission_required = 'event.update_team'
+    permission_required = 'base.update_team'
 
     def dispatch(self, request, *args, **kwargs):
         # Gotta handle errors directly here, as these emails are always sent directly
@@ -460,7 +460,7 @@ class ComposeSessionMail(ComposeMailBaseView):
 class ComposeDraftReminders(EventPermissionRequired, FormView):
     form_class = DraftRemindersForm
     template_name = 'orga/mails/send_draft_reminders.html'
-    permission_required = 'mail.send_queuedmail'
+    permission_required = 'base.send_queuedmail'
 
     def get_form_kwargs(self):
         kwargs = super().get_form_kwargs()

--- a/app/eventyay/orga/views/organizer.py
+++ b/app/eventyay/orga/views/organizer.py
@@ -44,7 +44,7 @@ class TeamView(OrgaCRUDView):
     template_namespace = "orga/organizer"
     url_name = "organizer.teams"
     context_object_name = "team"
-    permission_required = "event.update_team"
+    permission_required = "base.update_team"
 
     def get_queryset(self):
         return self.request.organizer.teams.all().order_by("-all_events", "-id")
@@ -154,7 +154,7 @@ class TeamView(OrgaCRUDView):
 
 
 class InviteMixin(PermissionRequired):
-    permission_required = "event.update_team"
+    permission_required = "base.update_team"
     model = TeamInvite
 
     def get_permission_object(self):
@@ -223,7 +223,7 @@ class TeamResend(InviteMixin, ActionConfirmMixin, DetailView):
 
 
 class TeamMemberMixin(PermissionRequired):
-    permission_required = "event.update_team"
+    permission_required = "base.update_team"
 
     def get_permission_object(self):
         return self.request.organizer
@@ -300,7 +300,7 @@ class TeamResetPassword(TeamMemberMixin, ActionConfirmMixin, TemplateView):
 class OrganizerDetail(PermissionRequired, CreateOrUpdateView):
     template_name = "orga/organizer/detail.html"
     model = Organizer
-    permission_required = "event.update_organizer"
+    permission_required = "base.update_organizer"
     form_class = OrganizerForm
 
     def get_object(self, queryset=None):
@@ -324,7 +324,7 @@ class OrganizerDetail(PermissionRequired, CreateOrUpdateView):
 
 
 class OrganizerDelete(PermissionRequired, ActionConfirmMixin, DetailView):
-    permission_required = "person.administrator_user"
+    permission_required = "base.administrator_user"
     model = Organizer
     action_text = (
         _(
@@ -385,7 +385,7 @@ def get_speaker_access_events_for_user(*, user, organizer):
                 for event in team_events:
                     if event.pk in events or event.pk in no_access_events:
                         continue
-                    if user.has_perm("person.orga_list_speakerprofile", event):
+                    if user.has_perm("base.orga_list_speakerprofile", event):
                         events.add(event.pk)
                     else:
                         no_access_events.add(event.pk)
@@ -397,7 +397,7 @@ class OrganizerSpeakerList(
     PermissionRequired, Sortable, Filterable, PaginationMixin, ListView
 ):
     template_name = "orga/organizer/speaker_list.html"
-    permission_required = "event.view_organizer"
+    permission_required = "base.view_organizer"
     context_object_name = "speakers"
     default_filters = ("email__icontains", "fullname__icontains")
     sortable_fields = ("email", "fullname", "accepted_submission_count", "submission_count")

--- a/app/eventyay/orga/views/plugins.py
+++ b/app/eventyay/orga/views/plugins.py
@@ -12,7 +12,7 @@ from eventyay.common.views.mixins import EventPermissionRequired
 
 class EventPluginsView(EventPermissionRequired, TemplateView):
     template_name = 'orga/plugins.html'
-    permission_required = 'event.update_event'
+    permission_required = 'base.update_event'
 
     @context
     @cached_property

--- a/app/eventyay/orga/views/review.py
+++ b/app/eventyay/orga/views/review.py
@@ -41,7 +41,7 @@ from eventyay.talk_rules.submission import (
 
 class ReviewDashboard(EventPermissionRequired, BaseSubmissionList):
     template_name = 'orga/review/dashboard.html'
-    permission_required = 'submission.list_review'
+    permission_required = 'base.list_review'
     paginate_by = 100
     max_page_size = 100_000
     usable_states = (
@@ -171,19 +171,19 @@ class ReviewDashboard(EventPermissionRequired, BaseSubmissionList):
     @context
     @cached_property
     def can_change_submissions(self):
-        return self.request.user.has_perm('submission.orga_update_submission', self.request.event)
+        return self.request.user.has_perm('base.orga_update_submission', self.request.event)
 
     @context
     @cached_property
     def can_accept_submissions(self):
         return self.request.event.submissions.filter(
             state=SubmissionStates.SUBMITTED
-        ).exists() and self.request.user.has_perm('submission.accept_or_reject_submission', self.request.event)
+        ).exists() and self.request.user.has_perm('base.accept_or_reject_submission', self.request.event)
 
     @context
     @cached_property
     def can_see_all_reviews(self):
-        return self.request.user.has_perm('submission.list_all_review', self.request.event)
+        return self.request.user.has_perm('base.list_all_review', self.request.event)
 
     @context
     @cached_property
@@ -270,7 +270,7 @@ class ReviewDashboard(EventPermissionRequired, BaseSubmissionList):
             except (Submission.DoesNotExist, ValueError):
                 total['error'] += 1
                 continue
-            if not request.user.has_perm('submission.' + value + '_submission', submission):
+            if not request.user.has_perm('base.' + value + '_submission', submission):
                 total['error'] += 1
                 continue
             if pending:
@@ -298,7 +298,7 @@ class ReviewDashboard(EventPermissionRequired, BaseSubmissionList):
 
 class BulkReview(EventPermissionRequired, TemplateView):
     template_name = 'orga/review/bulk.html'
-    permission_required = 'submission.create_review'
+    permission_required = 'base.create_review'
     paginate_by = None
 
     @context
@@ -422,16 +422,16 @@ class ReviewViewMixin:
         if self.request.user in self.submission.speakers.all():
             return True
         if self.object and self.object.pk:
-            return not self.request.user.has_perm('submission.update_review', self.get_object())
-        return not self.request.user.has_perm('submission.review_submission', self.get_object() or self.submission)
+            return not self.request.user.has_perm('base.update_review', self.get_object())
+        return not self.request.user.has_perm('base.review_submission', self.get_object() or self.submission)
 
 
 class ReviewSubmission(ReviewViewMixin, PermissionRequired, CreateOrUpdateView):
     form_class = ReviewForm
     model = Review
     template_name = 'orga/submission/review.html'
-    permission_required = 'submission.view_reviews_submission'
-    write_permission_required = 'submission.review_submission'
+    permission_required = 'base.view_reviews_submission'
+    write_permission_required = 'base.review_submission'
 
     @context
     @cached_property
@@ -590,7 +590,7 @@ class ReviewSubmission(ReviewViewMixin, PermissionRequired, CreateOrUpdateView):
 
 class ReviewSubmissionDelete(EventPermissionRequired, ReviewViewMixin, ActionConfirmMixin, TemplateView):
     template_name = 'orga/submission/review_delete.html'
-    permission_required = 'submission.delete_review'
+    permission_required = 'base.delete_review'
 
     def get_permission_object(self):
         return self.object
@@ -610,7 +610,7 @@ class ReviewSubmissionDelete(EventPermissionRequired, ReviewViewMixin, ActionCon
 
 
 class RegenerateDecisionMails(EventPermissionRequired, ActionConfirmMixin, TemplateView):
-    permission_required = 'submission.accept_or_reject_submission'
+    permission_required = 'base.accept_or_reject_submission'
     action_title = _('Regenerate decision emails')
     action_confirm_label = _('Regenerate decision emails')
     action_confirm_color = 'success'
@@ -654,7 +654,7 @@ class RegenerateDecisionMails(EventPermissionRequired, ActionConfirmMixin, Templ
 
 class ReviewAssignment(EventPermissionRequired, FormView):
     template_name = 'orga/review/assignment.html'
-    permission_required = 'event.update_event'
+    permission_required = 'base.update_event'
 
     @cached_property
     def form_type(self):
@@ -700,7 +700,7 @@ class ReviewAssignment(EventPermissionRequired, FormView):
 
 class ReviewAssignmentImport(EventPermissionRequired, FormView):
     template_name = 'orga/review/assignment-import.html'
-    permission_required = 'event.update_event'
+    permission_required = 'base.update_event'
     form_class = ReviewAssignImportForm
 
     def get_form_kwargs(self):
@@ -716,7 +716,7 @@ class ReviewAssignmentImport(EventPermissionRequired, FormView):
 
 
 class ReviewExport(EventPermissionRequired, FormView):
-    permission_required = 'event.update_event'
+    permission_required = 'base.update_event'
     template_name = 'orga/review/export.html'
     form_class = ReviewExportForm
 

--- a/app/eventyay/orga/views/schedule.py
+++ b/app/eventyay/orga/views/schedule.py
@@ -51,7 +51,7 @@ logger = logging.getLogger(__name__)
 @method_decorator(csp_update({'SCRIPT_SRC': SCRIPT_SRC, 'DEFAULT_SRC': DEFAULT_SRC}), name='dispatch')
 class ScheduleView(EventPermissionRequired, TemplateView):
     template_name = 'orga/schedule/index.html'
-    permission_required = 'schedule.orga_view_schedule'
+    permission_required = 'base.orga_view_schedule'
 
     def get_context_data(self, **kwargs):
         result = super().get_context_data(**kwargs)
@@ -71,7 +71,7 @@ class ScheduleView(EventPermissionRequired, TemplateView):
 
 class ScheduleExportView(EventPermissionRequired, FormView):
     template_name = 'orga/schedule/export.html'
-    permission_required = 'event.update_event'
+    permission_required = 'base.update_event'
     form_class = ScheduleExportForm
 
     def get_form_kwargs(self):
@@ -100,7 +100,7 @@ class ScheduleExportView(EventPermissionRequired, FormView):
 
 
 class ScheduleExportTriggerView(EventPermissionRequired, View):
-    permission_required = 'event.update_event'
+    permission_required = 'base.update_event'
 
     def post(self, request, event):
         if not settings.CELERY_TASK_ALWAYS_EAGER:
@@ -122,7 +122,7 @@ class ScheduleExportTriggerView(EventPermissionRequired, View):
 
 
 class ScheduleExportDownloadView(EventPermissionRequired, View):
-    permission_required = 'event.update_event'
+    permission_required = 'base.update_event'
 
     def get(self, request, event):
         try:
@@ -140,7 +140,7 @@ class ScheduleExportDownloadView(EventPermissionRequired, View):
 
 class ScheduleReleaseView(EventPermissionRequired, FormView):
     form_class = ScheduleReleaseForm
-    permission_required = 'schedule.release_schedule'
+    permission_required = 'base.release_schedule'
     template_name = 'orga/schedule/release.html'
 
     def get_form_kwargs(self):
@@ -177,7 +177,7 @@ class ScheduleReleaseView(EventPermissionRequired, FormView):
 
 
 class ScheduleResetView(EventPermissionRequired, View):
-    permission_required = 'schedule.release_schedule'
+    permission_required = 'base.release_schedule'
 
     def dispatch(self, request, event):
         super().dispatch(request, event)
@@ -195,7 +195,7 @@ class ScheduleResetView(EventPermissionRequired, View):
 
 
 class ScheduleToggleView(EventPermissionRequired, View):
-    permission_required = 'event.update_event'
+    permission_required = 'base.update_event'
 
     def dispatch(self, request, event):
         super().dispatch(request, event)
@@ -225,7 +225,7 @@ class ScheduleToggleView(EventPermissionRequired, View):
 
 
 class ScheduleResendMailsView(EventPermissionRequired, View):
-    permission_required = 'schedule.release_schedule'
+    permission_required = 'base.release_schedule'
 
     def dispatch(self, request, event):
         super().dispatch(request, event)
@@ -290,7 +290,7 @@ def serialize_slot(slot, warnings=None):
 
 
 class TalkList(EventPermissionRequired, View):
-    permission_required = 'schedule.release_schedule'
+    permission_required = 'base.release_schedule'
 
     def get(self, request, event):
         version = self.request.GET.get('version')
@@ -341,7 +341,7 @@ class TalkList(EventPermissionRequired, View):
 
 
 class ScheduleWarnings(EventPermissionRequired, View):
-    permission_required = 'schedule.release_schedule'
+    permission_required = 'base.release_schedule'
 
     def get(self, request, event):
         return JsonResponse(
@@ -353,7 +353,7 @@ class ScheduleWarnings(EventPermissionRequired, View):
 
 
 class ScheduleAvailabilities(EventPermissionRequired, View):
-    permission_required = 'schedule.release_schedule'
+    permission_required = 'base.release_schedule'
 
     def get(self, request, event):
         return JsonResponse(
@@ -405,7 +405,7 @@ class ScheduleAvailabilities(EventPermissionRequired, View):
 
 
 class TalkUpdate(PermissionRequired, View):
-    permission_required = 'schedule.update_talkslot'
+    permission_required = 'base.update_talkslot'
 
     def get_object(self):
         return self.request.event.wip_schedule.talks.filter(pk=self.kwargs.get('pk')).first()
@@ -458,7 +458,7 @@ class TalkUpdate(PermissionRequired, View):
 
 
 class QuickScheduleView(PermissionRequired, UpdateView):
-    permission_required = 'schedule.update_talkslot'
+    permission_required = 'base.update_talkslot'
     form_class = QuickScheduleForm
     template_name = 'orga/schedule/quick.html'
 

--- a/app/eventyay/orga/views/speaker.py
+++ b/app/eventyay/orga/views/speaker.py
@@ -44,7 +44,7 @@ class SpeakerList(EventPermissionRequired, Sortable, Filterable, PaginationMixin
     default_filters = ('user__email__icontains', 'user__fullname__icontains')
     sortable_fields = ('user__email', 'user__fullname')
     default_sort_field = 'user__fullname'
-    permission_required = 'person.orga_list_speakerprofile'
+    permission_required = 'base.orga_list_speakerprofile'
 
     def get_filter_form(self):
         any_arrived = SpeakerProfile.objects.filter(event=self.request.event, has_arrived=True).exists()
@@ -127,8 +127,8 @@ class SpeakerDetail(SpeakerViewMixin, ActionFromUrl, CreateOrUpdateView):
     template_name = 'orga/speaker/form.html'
     form_class = SpeakerProfileForm
     model = User
-    permission_required = 'person.orga_list_speakerprofile'
-    write_permission_required = 'person.update_speakerprofile'
+    permission_required = 'base.orga_list_speakerprofile'
+    write_permission_required = 'base.update_speakerprofile'
 
     def get_success_url(self) -> str:
         return self.profile.orga_urls.base
@@ -163,8 +163,8 @@ class SpeakerDetail(SpeakerViewMixin, ActionFromUrl, CreateOrUpdateView):
             speaker=speaker,
             event=self.request.event,
             for_reviewers=(
-                not self.request.user.has_perm('submission.orga_update_submission', self.request.event)
-                and self.request.user.has_perm('submission.list_review', self.request.event)
+                not self.request.user.has_perm('base.orga_update_submission', self.request.event)
+                and self.request.user.has_perm('base.list_review', self.request.event)
             ),
         )
 
@@ -188,7 +188,7 @@ class SpeakerDetail(SpeakerViewMixin, ActionFromUrl, CreateOrUpdateView):
 
 
 class SpeakerPasswordReset(SpeakerViewMixin, ActionConfirmMixin, DetailView):
-    permission_required = 'person.update_speakerprofile'
+    permission_required = 'base.update_speakerprofile'
     model = User
     context_object_name = 'speaker'
     action_confirm_icon = 'key'
@@ -221,7 +221,7 @@ class SpeakerPasswordReset(SpeakerViewMixin, ActionConfirmMixin, DetailView):
 
 
 class SpeakerToggleArrived(SpeakerViewMixin, View):
-    permission_required = 'person.update_speakerprofile'
+    permission_required = 'base.update_speakerprofile'
 
     def dispatch(self, request, event, code):
         self.profile.has_arrived = not self.profile.has_arrived
@@ -260,7 +260,7 @@ class SpeakerInformationView(OrgaCRUDView):
 
 
 class SpeakerExport(EventPermissionRequired, FormView):
-    permission_required = 'event.update_event'
+    permission_required = 'base.update_event'
     template_name = 'orga/speaker/export.html'
     form_class = SpeakerExportForm
 

--- a/app/eventyay/orga/views/submission.py
+++ b/app/eventyay/orga/views/submission.py
@@ -123,7 +123,7 @@ class ReviewerSubmissionFilter:
 
 class SubmissionStateChange(SubmissionViewMixin, FormView):
     form_class = SubmissionStateChangeForm
-    permission_required = 'submission.state_change_submission'
+    permission_required = 'base.state_change_submission'
     template_name = 'orga/submission/state_change.html'
     TARGETS = {
         'submit': SubmissionStates.SUBMITTED,
@@ -214,7 +214,7 @@ class SubmissionStateChange(SubmissionViewMixin, FormView):
 
 
 class SubmissionSpeakersDelete(SubmissionViewMixin, View):
-    permission_required = 'submission.update_submission'
+    permission_required = 'base.update_submission'
 
     def dispatch(self, request, *args, **kwargs):
         super().dispatch(request, *args, **kwargs)
@@ -231,7 +231,7 @@ class SubmissionSpeakersDelete(SubmissionViewMixin, View):
 
 class SubmissionSpeakers(ReviewerSubmissionFilter, SubmissionViewMixin, FormView):
     template_name = 'orga/submission/speakers.html'
-    permission_required = 'person.orga_list_speakerprofile'
+    permission_required = 'base.orga_list_speakerprofile'
     form_class = AddSpeakerInlineForm
 
     @context
@@ -272,7 +272,7 @@ class SubmissionContent(ActionFromUrl, ReviewerSubmissionFilter, SubmissionViewM
     model = Submission
     form_class = SubmissionForm
     template_name = 'orga/submission/content.html'
-    permission_required = 'submission.orga_list_submission'
+    permission_required = 'base.orga_list_submission'
 
     def get_object(self):
         try:
@@ -285,8 +285,8 @@ class SubmissionContent(ActionFromUrl, ReviewerSubmissionFilter, SubmissionViewM
     @cached_property
     def write_permission_required(self):
         if self.kwargs.get('code'):
-            return 'submission.update_submission'
-        return 'submission.create_submission'
+            return 'base.update_submission'
+        return 'base.create_submission'
 
     @context
     def size_warning(self):
@@ -335,8 +335,8 @@ class SubmissionContent(ActionFromUrl, ReviewerSubmissionFilter, SubmissionViewM
             'submission': submission,
             'event': self.request.event,
             'for_reviewers': (
-                not self.request.user.has_perm('submission.orga_update_submission', self.request.event)
-                and self.request.user.has_perm('submission.list_review', self.request.event)
+                not self.request.user.has_perm('base.orga_update_submission', self.request.event)
+                and self.request.user.has_perm('base.list_review', self.request.event)
             ),
             'readonly': form_kwargs['read_only'],
         }
@@ -394,8 +394,8 @@ class SubmissionContent(ActionFromUrl, ReviewerSubmissionFilter, SubmissionViewM
 
     def get_permission_required(self):
         if 'code' in self.kwargs:
-            return ['submission.orga_list_submission']
-        return ['submission.create_submission']
+            return ['base.orga_list_submission']
+        return ['base.create_submission']
 
     @property
     def permission_object(self):
@@ -450,7 +450,7 @@ class SubmissionContent(ActionFromUrl, ReviewerSubmissionFilter, SubmissionViewM
         kwargs['event'] = self.request.event
         instance = kwargs.get('instance')
         kwargs['anonymise'] = getattr(instance, 'pk', None) and not self.request.user.has_perm(
-            'person.orga_list_speakerprofile', instance
+            'base.orga_list_speakerprofile', instance
         )
         kwargs['read_only'] = kwargs['read_only'] or kwargs['anonymise']
         return kwargs
@@ -458,7 +458,7 @@ class SubmissionContent(ActionFromUrl, ReviewerSubmissionFilter, SubmissionViewM
     @context
     @cached_property
     def can_edit(self):
-        return self.object and self.request.user.has_perm('submission.orga_update_submission', self.request.event)
+        return self.object and self.request.user.has_perm('base.orga_update_submission', self.request.event)
 
 
 class BaseSubmissionList(Sortable, ReviewerSubmissionFilter, PaginationMixin, ListView):
@@ -491,7 +491,7 @@ class BaseSubmissionList(Sortable, ReviewerSubmissionFilter, PaginationMixin, Li
 
     def get_default_filters(self, *args, **kwargs):
         default_filters = {'code__icontains', 'title__icontains'}
-        if self.request.user.has_perm('person.orga_list_speakerprofile', self.request.event):
+        if self.request.user.has_perm('base.orga_list_speakerprofile', self.request.event):
             default_filters.add('speakers__fullname__icontains')
         return default_filters
 
@@ -509,7 +509,7 @@ class BaseSubmissionList(Sortable, ReviewerSubmissionFilter, PaginationMixin, Li
 
 class SubmissionList(EventPermissionRequired, BaseSubmissionList):
     template_name = 'orga/submission/list.html'
-    permission_required = 'submission.orga_list_submission'
+    permission_required = 'base.orga_list_submission'
     paginate_by = 25
     default_sort_field = 'state'
     secondary_sort = {'state': ('pending_state',)}
@@ -535,7 +535,7 @@ class FeedbackList(SubmissionViewMixin, PaginationMixin, ListView):
     template_name = 'orga/submission/feedback_list.html'
     context_object_name = 'feedback'
     paginate_by = 25
-    permission_required = 'submission.view_feedback_submission'
+    permission_required = 'base.view_feedback_submission'
 
     def get_queryset(self):
         return self.submission.feedback.all().order_by('pk')
@@ -555,7 +555,7 @@ class FeedbackList(SubmissionViewMixin, PaginationMixin, ListView):
 
 
 class ToggleFeatured(SubmissionViewMixin, View):
-    permission_required = 'submission.orga_update_submission'
+    permission_required = 'base.orga_update_submission'
 
     def get_permission_object(self):
         return self.object or self.request.event
@@ -567,7 +567,7 @@ class ToggleFeatured(SubmissionViewMixin, View):
 
 
 class ApplyPending(SubmissionViewMixin, View):
-    permission_required = 'submission.state_change_submission'
+    permission_required = 'base.state_change_submission'
 
     def post(self, request, *args, **kwargs):
         submission = self.object
@@ -579,7 +579,7 @@ class ApplyPending(SubmissionViewMixin, View):
 
 
 class Anonymise(SubmissionViewMixin, UpdateView):
-    permission_required = 'submission.orga_update_submission'
+    permission_required = 'base.orga_update_submission'
     template_name = 'orga/submission/anonymise.html'
     form_class = AnonymiseForm
 
@@ -605,7 +605,7 @@ class Anonymise(SubmissionViewMixin, UpdateView):
 
 class SubmissionHistory(SubmissionViewMixin, ListView):
     template_name = 'orga/submission/history.html'
-    permission_required = 'person.administrator_user'
+    permission_required = 'base.administrator_user'
     paginate_by = 200
     context_object_name = 'log_entries'
 
@@ -636,7 +636,7 @@ class SubmissionHistory(SubmissionViewMixin, ListView):
 
 
 class SubmissionFeed(PermissionRequired, Feed):
-    permission_required = 'submission.orga_list_submission'
+    permission_required = 'base.orga_list_submission'
     feed_type = feedgenerator.Atom1Feed
 
     def get_object(self, request, *args, **kwargs):
@@ -672,7 +672,7 @@ class SubmissionFeed(PermissionRequired, Feed):
 
 class SubmissionStats(EventPermissionRequired, TemplateView):
     template_name = 'orga/submission/stats.html'
-    permission_required = 'submission.orga_list_submission'
+    permission_required = 'base.orga_list_submission'
 
     @context
     def show_submission_types(self):
@@ -867,7 +867,7 @@ class AllFeedbacksList(EventPermissionRequired, PaginationMixin, ListView):
     model = Feedback
     context_object_name = 'feedback'
     template_name = 'orga/submission/feedbacks_list.html'
-    permission_required = 'submission.orga_list_submission'
+    permission_required = 'base.orga_list_submission'
     paginate_by = 25
 
     def get_queryset(self):
@@ -892,8 +892,8 @@ class TagView(OrgaCRUDView):
 
 class CommentList(SubmissionViewMixin, FormView):
     template_name = 'orga/submission/comments.html'
-    permission_required = 'submission.view_submissioncomment'
-    write_permission_required = 'submission.add_submissioncomment'
+    permission_required = 'base.view_submissioncomment'
+    write_permission_required = 'base.add_submissioncomment'
     form_class = SubmissionCommentForm
 
     def get_form_kwargs(self):
@@ -914,7 +914,7 @@ class CommentList(SubmissionViewMixin, FormView):
 
 
 class CommentDelete(SubmissionViewMixin, ActionConfirmMixin, TemplateView):
-    permission_required = 'submission.delete_submissioncomment'
+    permission_required = 'base.delete_submissioncomment'
 
     @property
     def action_back_url(self):
@@ -940,7 +940,7 @@ class CommentDelete(SubmissionViewMixin, ActionConfirmMixin, TemplateView):
 
 
 class ApplyPendingBulk(EventPermissionRequired, BaseSubmissionList):
-    permission_required = 'submission.state_change_submission'
+    permission_required = 'base.state_change_submission'
     template_name = 'orga/submission/apply_pending.html'
 
     @cached_property

--- a/app/eventyay/schedule/exporters.py
+++ b/app/eventyay/schedule/exporters.py
@@ -364,7 +364,7 @@ class FavedICalExporter(BaseExporter):
         return (
             'agenda' in request.resolver_match.namespaces
             and request.user.is_authenticated
-            and request.user.has_perm('schedule.list_schedule', request.event)
+            and request.user.has_perm('base.list_schedule', request.event)
         )
 
     def render(self, request, **kwargs):

--- a/app/eventyay/talk_rules/event.py
+++ b/app/eventyay/talk_rules/event.py
@@ -43,7 +43,9 @@ def can_change_teams(user, obj):
         return True
     if event := getattr(obj, 'event', None):
         return check_team_permission(user, event, 'can_change_teams')
-    return user.teams.filter(organizer=obj.organizer, can_change_teams=True).exists()
+
+    organizer = getattr(obj, 'organizer', obj)
+    return user.teams.filter(organizer=organizer, can_change_teams=True).exists()
 
 
 @rules.predicate

--- a/app/eventyay/talk_rules/person.py
+++ b/app/eventyay/talk_rules/person.py
@@ -28,7 +28,7 @@ def is_only_reviewer(user, obj):
 @rules.predicate
 def can_mark_speakers_arrived(user, obj):
     event = obj.event
-    return (event.date_from - dt.timedelta(days=3)) <= now().date() <= event.date_to
+    return (event.date_from - dt.timedelta(days=3)) <= now() <= event.date_to
 
 
 @rules.predicate

--- a/app/eventyay/talk_rules/submission.py
+++ b/app/eventyay/talk_rules/submission.py
@@ -178,7 +178,7 @@ def questions_for_user(event, user):
     from eventyay.base.models import TalkQuestionTarget
     from eventyay.talk_rules.orga import can_view_speaker_names
 
-    if user.has_perm('submission.update_question', event):
+    if user.has_perm('base.update_question', event):
         # Organizers with edit permissions can see everything
         return event.talkquestions(manager='all_objects').all()
     if not user.is_anonymous and is_only_reviewer(user, event) and can_view_speaker_names(user, event):
@@ -186,7 +186,7 @@ def questions_for_user(event, user):
             Q(is_visible_to_reviewers=True) | Q(target=TalkQuestionTarget.REVIEWER),
             active=True,
         )
-    if user.has_perm('submission.orga_list_question', event):
+    if user.has_perm('base.orga_list_question', event):
         # Other team members can either view all active talkquestions
         # or only talkquestions open to reviewers
         return event.talkquestions(manager='all_objects').all()
@@ -194,7 +194,7 @@ def questions_for_user(event, user):
     # Now we are left with anonymous users or users with very limited permissions.
     # They can see all public (non-reviewer) talkquestions if they are already publicly
     # visible in the schedule. Otherwise, nothing.
-    if user.has_perm('submission.list_question', event):
+    if user.has_perm('base.list_question', event):
         return event.talkquestions.all().filter(is_public=True)
     return event.talkquestions.none()
 
@@ -234,12 +234,12 @@ def submissions_for_user(event, user):
     if not user.is_anonymous:
         if is_only_reviewer(user, event):
             return limit_for_reviewers(event.submissions.all(), event, user)
-        if user.has_perm('submission.orga_list_submission', event):
+        if user.has_perm('base.orga_list_submission', event):
             return event.submissions.all()
 
     # Fall through: both anon users and users without permissions
     # get here, e.g. speakers or attendees.
-    if user.has_perm('schedule.list_schedule', event):
+    if user.has_perm('base.list_schedule', event):
         return event.current_schedule.slots
     return event.submissions.none()
 

--- a/app/eventyay/talk_rules/submission.py
+++ b/app/eventyay/talk_rules/submission.py
@@ -178,7 +178,7 @@ def questions_for_user(event, user):
     from eventyay.base.models import TalkQuestionTarget
     from eventyay.talk_rules.orga import can_view_speaker_names
 
-    if user.has_perm('base.update_question', event):
+    if user.has_perm('base.update_talkquestion', event):
         # Organizers with edit permissions can see everything
         return event.talkquestions(manager='all_objects').all()
     if not user.is_anonymous and is_only_reviewer(user, event) and can_view_speaker_names(user, event):
@@ -186,15 +186,16 @@ def questions_for_user(event, user):
             Q(is_visible_to_reviewers=True) | Q(target=TalkQuestionTarget.REVIEWER),
             active=True,
         )
-    if user.has_perm('base.orga_list_question', event):
+    if user.has_perm('base.orga_list_talkquestion', event):
         # Other team members can either view all active talkquestions
         # or only talkquestions open to reviewers
+        return
         return event.talkquestions(manager='all_objects').all()
 
     # Now we are left with anonymous users or users with very limited permissions.
     # They can see all public (non-reviewer) talkquestions if they are already publicly
     # visible in the schedule. Otherwise, nothing.
-    if user.has_perm('base.list_question', event):
+    if user.has_perm('base.list_talkquestion', event):
         return event.talkquestions.all().filter(is_public=True)
     return event.talkquestions.none()
 


### PR DESCRIPTION
- Substitutes stale app_lable as 'base' app.
- Tweaked some functions/methods to work in enext.

## Summary by Sourcery

Replace outdated permission strings in views and templates with a unified 'base' namespace and apply assorted compatibility tweaks for the enext environment.

Bug Fixes:
- Fix stale permission_required labels by switching from legacy app labels (submission, mail, event, person, schedule, etc.) to the unified 'base' namespace across views and templates.

Enhancements:
- Extend Organizer.permission_set to include attributes prefixed with 'is_' as well as 'can_' when reporting permissions.
- Update Celery imports to reference eventyay.celery_app for proper module resolution.
- Adjust time comparison in speaker arrival predicate to use timezone-aware datetime operations.