### PR TITLE
Update documentation branding: change copyright, links, and config se…

### DIFF
--- a/doc/_templates/index.html
+++ b/doc/_templates/index.html
@@ -109,7 +109,7 @@
             <a href="https://eventyay.com" target="_blank">
                 <strong>Project website</strong>
             </a>
-            <p>eventyay.com is your gateway to the eventyay project, offering premier commercial hosting services all in one place.</p>
+            <p>eventyay.com is your gateway tso the eventyay project, offering premier commercial hosting services all in one place.</p>
         </div>
     </div>
     <div class="sectionbox">
@@ -148,9 +148,9 @@
         </div>
         <div class="text">
             <a href="https://twitter.com/eventyay" target="_blank">
-                <strong>Twitter</strong>
+                <strong>X</strong>
             </a>
-            <p>Keep in touch and stay up to date by following our project account on Twitter.</p>
+            <p>Keep in touch and stay up to date by following our project account on X.</p>
         </div>
     </div>
     <div class="clearfix"></div>

--- a/doc/_themes/pretix_theme/footer.html
+++ b/doc/_themes/pretix_theme/footer.html
@@ -13,7 +13,7 @@
   <hr/>
 
   <div role="contentinfo">
-    <p>
+    <p style="font-size: 0.85em;">
     {%- if show_copyright %}
       {%- if hasdoc('copyright') %}
         {% trans path=pathto('copyright'), copyright=copyright|e %}&copy; <a href="{{ path }}">Copyright</a> {{ copyright }}.{% endtrans %}

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -71,8 +71,8 @@ source_suffix = '.rst'
 master_doc = 'index'
 
 # General information about the project.
-project = 'pretix'
-copyright = '2014-{}, Raphael Michel'.format(date.today().year)
+project = 'eventyay'
+copyright = '2025 Apache 2.0 License by contributors'
 
 # The version info for the project you're documenting, acts as replacement for
 # |version| and |release|, also used in various other places throughout the


### PR DESCRIPTION
This PR addresses issue #514 by making the following changes:
Completed:
- Changed "Twitter" to "X" in index.html with correct link
- Updated copyright notice to "2025 Apache 2.0 License by contributors" and reduced font size
- Updated project name in conf.py from 'pretix' to 'eventyay'
- Set logo_only to False (eventyay uses text-based branding like the website)
- All links verified (blog, GitHub, issue reporting)

Questions for maintainers:
- The first task was marked DONE but I found many remaining "pretix" references in config.rst and other technical documentation files. Should these be changed? Many appear to be code paths/technical references.
- I could not locate eventyay logo or favicon files. The website uses text-based branding. Should I add logo/favicon files, or leave it as text-based?