### PR TITLE
 Add celery.py

### DIFF
--- a/app/eventyay/celery.py
+++ b/app/eventyay/celery.py
@@ -1,0 +1,11 @@
+import os
+
+from celery import Celery
+
+os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'eventyay.config.settings')
+
+from django.conf import settings
+
+app = Celery('eventyay')
+app.config_from_object('django.conf:settings', namespace='CELERY')
+app.autodiscover_tasks(lambda: settings.INSTALLED_APPS)

--- a/app/eventyay/config/settings.py
+++ b/app/eventyay/config/settings.py
@@ -87,8 +87,8 @@ ROOT_URLCONF = 'eventyay.multidomain.maindomain_urlconf'
 
 HAS_CELERY = config.has_option('celery', 'broker')
 if HAS_CELERY:
-    CELERY_BROKER_URL = config.get('celery', 'broker')
-    CELERY_RESULT_BACKEND = config.get('celery', 'backend')
+    CELERY_BROKER_URL = config.get('celery', 'broker') if not DEBUG else 'redis://localhost:6379/2'
+    CELERY_RESULT_BACKEND = config.get('celery', 'backend') if not DEBUG else 'redis://localhost:6379/1'
     CELERY_TASK_ALWAYS_EAGER = False
 else:
     CELERY_TASK_ALWAYS_EAGER = True
@@ -668,12 +668,12 @@ if HAS_REDIS:
 
     CACHES['redis'] = {
         'BACKEND': 'django_redis.cache.RedisCache',
-        'LOCATION': config.get('redis', 'location'),
+        'LOCATION': config.get('redis', 'location') if not DEBUG else 'redis://localhost:6379/0',
         'OPTIONS': redis_options,
     }
     CACHES['redis_sessions'] = {
         'BACKEND': 'django_redis.cache.RedisCache',
-        'LOCATION': config.get('redis', 'location'),
+        'LOCATION': config.get('redis', 'location') if not DEBUG else 'redis://localhost:6379/0',
         'TIMEOUT': 3600 * 24 * 30,
         'OPTIONS': redis_options,
     }


### PR DESCRIPTION
* Added a new `app/eventyay/celery.py` file to initialize and configure the Celery application, including autodiscovering tasks from installed Django apps.
* Updated Celery settings in `app/eventyay/config/settings.py` to use local Redis URLs for the broker and result backend when `DEBUG` is enabled, making local development easier.

## Summary by Sourcery

Initialize the Celery application and simplify local Redis configuration for development

New Features:
- Add celery.py to bootstrap a Celery app with Django settings and autodiscover tasks

Enhancements:
- Use local Redis URLs for Celery broker, result backend, and Django caches when DEBUG is enabled