### PR TITLE
fix: bootstrap styling fixes

### DIFF
--- a/app/eventyay/config/settings.py
+++ b/app/eventyay/config/settings.py
@@ -1145,3 +1145,15 @@ if ADMINS:
         'class': 'eventyay.common.exceptions.PretalxAdminEmailHandler',
     }
     LOGGING['loggers']['django.request']['handlers'].append('mail_admins')
+
+BOOTSTRAP3 = {
+    'success_css_class': '',
+    'field_renderers': {
+        'default': 'bootstrap3.renderers.FieldRenderer',
+        'inline': 'bootstrap3.renderers.InlineFieldRenderer',
+        'control': 'eventyay.control.forms.renderers.ControlFieldRenderer',
+        'bulkedit': 'eventyay.control.forms.renderers.BulkEditFieldRenderer',
+        'bulkedit_inline': 'eventyay.control.forms.renderers.InlineBulkEditFieldRenderer',
+        'checkout': 'eventyay.presale.forms.renderers.CheckoutFieldRenderer',
+    },
+}


### PR DESCRIPTION
Fixes #960 
<img width="2056" height="1329" alt="Screenshot 2025-10-08 at 12 30 42 AM" src="https://github.com/user-attachments/assets/d23aaa8e-314d-4f5a-b1e7-aeb7d49df69b" />

## Summary by Sourcery

Switch bootstrap form layouts from the deprecated “control” and bulkedit presets to consistent horizontal and inline styles across the control and presale templates

Enhancements:
- Update all bootstrap_field and bootstrap_form calls to use layout="horizontal" instead of "control"
- Replace bulkedit and bulkedit_inline layouts with the new "horizontal" and "inline" variants for consistency