### PR TITLE
Build global-nav-menu

### DIFF
--- a/app/Dockerfile.prod
+++ b/app/Dockerfile.prod
@@ -32,6 +32,10 @@ COPY eventyay/static/npm_dir eventyay/static/npm_dir
 RUN mkdir eventyay/static/node_prefix/
 RUN cp -r eventyay/static/npm_dir/* eventyay/static/node_prefix/
 RUN npm install --prefix=eventyay/static/node_prefix
+# global-nav-menu
+COPY eventyay/frontend/global-nav-menu eventyay/frontend/global-nav-menu
+RUN npm ci --prefix=eventyay/frontend/global-nav-menu
+RUN npm run build --prefix=eventyay/frontend/global-nav-menu
 # schedule editor
 COPY eventyay/frontend/schedule-editor eventyay/frontend/schedule-editor
 RUN npm ci --prefix=eventyay/frontend/schedule-editor
@@ -76,6 +80,7 @@ RUN chown -R app:app $APP_HOME
 # Note: The venv path in the builder must match the one in runner.
 COPY --from=builder --chown=app:app $APP_HOME/.venv $APP_HOME/.venv
 COPY --from=builder --chown=app:app $APP_HOME/eventyay/static/node_prefix $APP_HOME/eventyay/static/node_prefix
+COPY --from=builder --chown=app:app $APP_HOME/eventyay/frontend/global-nav-menu/dist $APP_HOME/eventyay/frontend/global-nav-menu/dist
 COPY --from=builder --chown=app:app $APP_HOME/eventyay/frontend/schedule-editor/dist $APP_HOME/eventyay/frontend/schedule-editor/dist
 
 # change to the app user


### PR DESCRIPTION
This PR updates Dockerfile.prod to include the build steps for the `global-nav-menu` frontend, which were previously missing from the Docker build process. The schedule-editor build was already included, but the missing global-nav-menu build caused static file collection issues in production.

Fixes missing directory warnings during collectstatic:
```
(staticfiles.W004) The directory '/home/app/web/eventyay/frontend/global-nav-menu/dist' does not 
```

## Summary by Sourcery

Include building the global-nav-menu frontend assets in the production Docker image to ensure all static files are collected correctly and eliminate missing directory warnings.

Bug Fixes:
- Fix missing directory warnings during Django collectstatic by including the global-nav-menu build artifacts.

Build:
- Add global-nav-menu frontend build step to Dockerfile.prod