### PR TITLE
Skip .map files during collectstatic

### DIFF
--- a/app/eventyay/base/storage.py
+++ b/app/eventyay/base/storage.py
@@ -1,0 +1,7 @@
+from django.contrib.staticfiles.storage import ManifestStaticFilesStorage
+
+class NoMapManifestStaticFilesStorage(ManifestStaticFilesStorage):
+    def post_process(self, paths, dry_run=False, **options):
+        # Filter out .map files before processing
+        filtered = {k: v for k, v in paths.items() if not k.endswith('.map')}
+        return super().post_process(filtered, dry_run, **options)

--- a/app/eventyay/config/settings.py
+++ b/app/eventyay/config/settings.py
@@ -874,7 +874,7 @@ STATICFILES_DIRS = [os.path.join(BASE_DIR, 'static')]
 
 
 STATIC_ROOT = BASE_DIR / 'static.dist'
-STATICFILES_STORAGE = 'django.contrib.staticfiles.storage.ManifestStaticFilesStorage'
+STATICFILES_STORAGE = 'eventyay.base.storage.NoMapManifestStaticFilesStorage'
 STATICFILES_FINDERS = (
     'django.contrib.staticfiles.finders.FileSystemFinder',
     'django.contrib.staticfiles.finders.AppDirectoriesFinder',


### PR DESCRIPTION
This PR introduces a custom static file storage backend to exclude `.map` files from `collectstatic`. Source map files generated by npm builds (e.g., in `node_prefix` or frontend bundles) caused `ValueError: Missing staticfiles manifest entry` during production builds.

## Summary by Sourcery

Introduce a custom staticfiles storage backend that filters out `.map` files during collectstatic to avoid manifest entry errors and update settings to use it.

Bug Fixes:
- Prevent missing staticfiles manifest entry errors by excluding .map files from collectstatic

Enhancements:
- Implement NoMapManifestStaticFilesStorage to filter out source map files during post-processing
- Update STATICFILES_STORAGE setting to use the new storage backend