### PR TITLE
chore(ci): add Docker PR workflow for enext branch

### DIFF
--- a/.github/workflows/enext-docker-pr.yml
+++ b/.github/workflows/enext-docker-pr.yml
@@ -1,0 +1,29 @@
+name: Docker PR Build (enext)
+
+on:
+  pull_request:
+    branches: [enext]
+
+jobs:
+  build_docker_image:
+    name: Build Docker image for enext PR
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@2b51285047da1547ffb1b2203d8be4c0af6b1f20
+
+      - name: Build Docker image
+        uses: docker/build-push-action@5cd11c3a4ced054e52742c5fd54dca954e0edd85
+        with:
+          context: ./app
+          file: ./app/Dockerfile.prod
+          push: false
+          tags: eventyay-next:${{ github.sha }}
+          build-args: |
+            GITHUB_TOKEN=${{ secrets.EVENTYAY_TOKEN }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max


### PR DESCRIPTION
This PR introduces a new workflow for building Docker images when pull requests are made to the `enext` branch.