### PR TITLE
chore: talk admin error page fix

### DIFF
--- a/app/eventyay/control/navigation.py
+++ b/app/eventyay/control/navigation.py
@@ -659,7 +659,7 @@ def get_admin_navigation(request):
         },
         {
             'label': _('Talk admin config'),
-            'url': '/talk/orga/admin/',
+            'url': '/orga/admin/',
             'active': False,
             'icon': 'group',
         },


### PR DESCRIPTION
Fixes #987 

https://github.com/user-attachments/assets/bf826fc8-6ed9-4727-aea3-fd0f9250ec78

## Summary by Sourcery

Bug Fixes:
- Correct the URL of the Talk admin config navigation item from '/talk/orga/admin/' to '/orga/admin/'