### PR TITLE
chore(enext): add css to alert messages in ticketing component

### DIFF
--- a/app/eventyay/config/settings.py
+++ b/app/eventyay/config/settings.py
@@ -18,6 +18,7 @@ from importlib.metadata import entry_points
 from pathlib import Path
 from urllib.parse import urlparse
 import django.conf.locale
+from django.contrib.messages import constants as messages  # NOQA
 from django.utils.translation import gettext_lazy as _
 from django.utils.crypto import get_random_string
 from kombu import Queue
@@ -899,7 +900,13 @@ SECURE_CONTENT_TYPE_NOSNIFF = True
 CSP_DEFAULT_SRC = ("'self'", "'unsafe-eval'")
 SECURE_PROXY_SSL_HEADER = ("HTTP_X_FORWARDED_PROTO", "https")
 
-MESSAGE_STORAGE = "django.contrib.messages.storage.session.SessionStorage"
+MESSAGE_TAGS = {
+    messages.INFO: 'alert-info',
+    messages.ERROR: 'alert-danger',
+    messages.WARNING: 'alert-warning',
+    messages.SUCCESS: 'alert-success',
+}
+MESSAGE_STORAGE = 'django.contrib.messages.storage.session.SessionStorage'
 
 # Template configuration
 template_loaders = (


### PR DESCRIPTION
before:
<img width="860" height="135" alt="before" src="https://github.com/user-attachments/assets/eca76cd4-d40d-4a33-9ace-b414e35a7cdb" />


after:
<img width="860" height="135" alt="after" src="https://github.com/user-attachments/assets/9d03520a-77f4-4c37-95fd-55f115da4fe8" />

## Summary by Sourcery

Enhancements:
- Add MESSAGE_TAGS setting mapping Django message levels to Bootstrap alert-info, alert-danger, alert-warning, and alert-success classes