### PR TITLE
chore:redis localhost fix

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,6 +18,7 @@ services:
 
   redis:
     image: redis:latest
+    platform: linux/amd64
     container_name: eventyay-next-redis
     restart: unless-stopped
     volumes:


### PR DESCRIPTION
## Summary by Sourcery

Add a fallback mechanism for Redis connections in settings and update Celery and Redis configurations to use it, while ensuring the Redis container runs on the linux/amd64 platform.

Enhancements:
- Introduce redis_fallback_url to automatically choose between the Redis container and localhost
- Update REDIS_URL, CELERY_BROKER_URL, and CELERY_RESULT_BACKEND to use config fallbacks via redis_fallback_url

Build:
- Specify linux/amd64 platform for the Redis service in docker-compose