### PR TITLE
chore: logout url fix

### DIFF
--- a/app/eventyay/static/eventyay-common/js/ui/popover.js
+++ b/app/eventyay/static/eventyay-common/js/ui/popover.js
@@ -20,7 +20,7 @@ $(function () {
     const accountPath = `/common/account/`;
     const adminPath = `/control/admin/`;
 
-    const logoutPath = `/control/logout?${logoutParams}`;
+    const logoutPath = `/common/logout/?${logoutParams}`;
 
     const options = {
     html: true,

--- a/app/eventyay/static/pretixcontrol/js/ui/popover.js
+++ b/app/eventyay/static/pretixcontrol/js/ui/popover.js
@@ -18,7 +18,7 @@ $(function () {
     const accountPath = `/common/account/`;
     const adminPath = `/control/admin/`;
 
-    const logoutPath = `/control/logout?${logoutParams}`;
+    const logoutPath = `/common/logout/?${logoutParams}`;
 
     const options = {
         html: true,

--- a/app/eventyay/static/pretixpresale/js/ui/popover.js
+++ b/app/eventyay/static/pretixpresale/js/ui/popover.js
@@ -39,7 +39,7 @@ $(function () {
 
     // Constructing logout path using URLSearchParams
     let logoutParams = new URLSearchParams({ back: backUrl });
-    var logoutPath = `/control/logout?${logoutParams}`;
+    var logoutPath = `/common/logout/?${logoutParams}`;
 
     var profilePath = `/control/settings/`;
     var orderPath = `/control/settings/orders/`;


### PR DESCRIPTION
Testing this may require a hard reload

## Summary by Sourcery

Fix logout URL path in popover UI scripts across modules to point to the correct /common/logout/ endpoint

Bug Fixes:
- Update logout URLs in eventyay-common popover script to use /common/logout/
- Update logout URLs in pretixcontrol popover script to use /common/logout/
- Update logout URLs in pretixpresale popover script to use /common/logout/