### PR TITLE
Add dedicated WebSocket container with Daphne for real-time features

### DIFF
--- a/deployment/docker-compose.yml
+++ b/deployment/docker-compose.yml
@@ -19,6 +19,23 @@ services:
       - db
       - redis
 
+  websocket:
+    image: eventyay/eventyay-next:enext
+    container_name: eventyay-next-websocket
+    command: daphne -b 0.0.0.0 -p 8001 eventyay.config.routing:application
+    volumes:
+      - ./data/data:/data
+      - ./eventyay.cfg:/etc/eventyay.cfg:ro
+    ports:
+      - 8001:8001
+    expose:
+      - 8001
+    env_file:
+      - ./.env
+    depends_on:
+      - db
+      - redis
+
   worker:
     image: eventyay/eventyay-next:enext
     container_name: eventyay-next-worker

--- a/deployment/nginx/enext-direct
+++ b/deployment/nginx/enext-direct
@@ -1,9 +1,25 @@
 server {
-	server_name next.eventyay.com;        
+	server_name next.eventyay.com;
 
 	access_log /var/log/nginx/enext-access.log;
         error_log /var/log/nginx/enext-error.log;
 
+	# WebSocket connections - route to daphne
+	location /ws/ {
+		proxy_pass http://127.0.0.1:8001;
+		proxy_http_version 1.1;
+		proxy_set_header Upgrade $http_upgrade;
+		proxy_set_header Connection "upgrade";
+		proxy_set_header Host $http_host;
+		proxy_set_header X-Real-IP $remote_addr;
+		proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+		proxy_set_header X-Forwarded-Proto $scheme;
+		proxy_redirect off;
+		proxy_buffering off;
+		proxy_read_timeout 86400;
+	}
+
+	# Regular HTTP requests - route to gunicorn
         location / {
         	proxy_pass http://127.0.0.1:8000;
 		proxy_set_header Host $http_host;


### PR DESCRIPTION
### Overview

Fixes WebSocket connection errors (Not Found: /ws/event/<slug>/) by adding a Daphne service for WebSockets while keeping Gunicorn for HTTP. Nginx now routes /ws/* to Daphne and all other requests to Gunicorn.

### Problem

Gunicorn (WSGI) doesn’t support WebSockets, causing real-time features like chat, polls, and Q&A to fail.

### Solution

- Gunicorn (8000): HTTP traffic
- Daphne (8001): WebSockets
- Nginx: Routes and upgrades /ws/* requests
- Added timeouts and upgrade headers

### Result

1. WebSocket features work again
2. No impact on existing HTTP setup
3. Easy rollback and no DB/code changes

## Summary by Sourcery

Add a dedicated WebSocket container using Daphne and update Nginx routing to restore real-time features while retaining existing HTTP setup through Gunicorn.

New Features:
- Introduce a dedicated Daphne container for handling WebSocket connections.

Enhancements:
- Update Nginx configuration to route /ws/* paths to the Daphne service with proper WebSocket upgrade and timeout headers.
- Keep Gunicorn serving HTTP traffic on port 8000 while offloading real-time traffic to Daphne on port 8001 without code or DB changes.