### PR TITLE
fix(product): Item to product rename for video ticket integration component

### DIFF
--- a/app/eventyay/eventyay_common/base_tasks.py
+++ b/app/eventyay/eventyay_common/base_tasks.py
@@ -165,8 +165,8 @@ class CreateWorldTask(Task):
             'venueless_secret': jwt_config['secret'],
             'venueless_issuer': jwt_config['issuer'],
             'venueless_audience': jwt_config['audience'],
-            'venueless_all_items': True,
-            'venueless_items': [],
+            'venueless_all_products': True,
+            'venueless_products': [],
             'venueless_questions': [],
         }
 

--- a/app/eventyay/multidomain/urlreverse.py
+++ b/app/eventyay/multidomain/urlreverse.py
@@ -161,24 +161,24 @@ def build_absolute_uri(obj, urlname, kwargs=None):
 
 def build_join_video_url(event: Event, order: Order) -> str:
     # Get list order position id
-    order_item_ids = [position.item_id for position in order.positions.all()]
+    order_product_ids = [position.product_id for position in order.positions.all()]
     # Check if video allow all positions
-    if event.settings.venueless_all_items:
+    if event.settings.venueless_all_products:
         position = order.positions.first()
         return generate_video_token_url_from_order(event, order, position)
-    common_item_id = next(
-        (item for item in order_item_ids if item in event.settings.venueless_items),
+    common_product_id = next(
+        (product for product in order_product_ids if product in event.settings.venueless_products),
         None,
     )
     # Get position object
-    position = order.positions.filter(item_id=common_item_id).first() if common_item_id else None
-    # Check if any item in order item is allowed to join
-    if any(item in event.settings.venueless_items for item in order_item_ids):
+    position = order.positions.filter(product_id=common_product_id).first() if common_product_id else None
+    # Check if any product in order product is allowed to join
+    if any(product in event.settings.venueless_products for product in order_product_ids):
         return generate_video_token_url_from_order(event, order, position)
-    logger.error('order %s does not have any item that is allowed to join the event.', order.code)
+    logger.error('order %s does not have any product that is allowed to join the event.', order.code)
     # Log more to help debugging
-    logger.info('Order items: %s', order_item_ids)
-    logger.info('Event allowed items: %s', event.settings.venueless_items)
+    logger.info('Order products: %s', order_product_ids)
+    logger.info('Event allowed products: %s', event.settings.venueless_products)
     return ''
 
 
@@ -219,16 +219,16 @@ def generate_video_token_url(event: Event, customer_code: str, position: OrderPo
             {
                 'eventyay-video-event-{}'.format(event.slug),
                 'eventyay-video-subevent-{}'.format(position.subevent_id),
-                'eventyay-video-item-{}'.format(position.item_id),
+                'eventyay-video-product-{}'.format(position.product_id),
                 'eventyay-video-variation-{}'.format(position.variation_id),
-                'eventyay-video-category-{}'.format(position.item.category_id),
+                'eventyay-video-category-{}'.format(position.product.category_id),
             }
-            | {'eventyay-video-item-{}'.format(p.item_id) for p in position.addons.all()}
+            | {'eventyay-video-product-{}'.format(p.product_id) for p in position.addons.all()}
             | {'eventyay-video-variation-{}'.format(p.variation_id) for p in position.addons.all() if p.variation_id}
             | {
-                'eventyay-video-category-{}'.format(p.item.category_id)
+                'eventyay-video-category-{}'.format(p.product.category_id)
                 for p in position.addons.all()
-                if p.item.category_id
+                if p.product.category_id
             }
         ),
     }

--- a/app/eventyay/plugins/eventyay-ticket-video/pretix_venueless/signals.py
+++ b/app/eventyay/plugins/eventyay-ticket-video/pretix_venueless/signals.py
@@ -22,7 +22,7 @@ def w_order_info(sender: Event, request, order: Order, **kwargs):
 
     positions = [
         p for p in order.positions.filter(
-            item__admission=True, addon_to__isnull=True
+            product__admission=True, addon_to__isnull=True
         )
     ]
     positions = [
@@ -30,7 +30,7 @@ def w_order_info(sender: Event, request, order: Order, **kwargs):
         if (
                 not sender.settings.venueless_start or sender.settings.venueless_start.datetime(p.subevent or sender) <= now()
         ) and (
-            sender.settings.venueless_all_items or p.item_id in (p.event.settings.venueless_items or[])
+            sender.settings.venueless_all_products or p.product_id in (p.event.settings.venueless_products or[])
         )
     ]
     if not positions:
@@ -52,9 +52,9 @@ def w_pos_info(sender: Event, request, order: Order, position, **kwargs):
                                                         sender.settings.venueless_allow_pending))
             or not order.positions.exists()
             or position.canceled
-            or not position.item.admission
+            or not position.product.admission
             or (
-                not sender.settings.venueless_all_items and position.item_id not in (position.event.settings.venueless_items or [])
+                not sender.settings.venueless_all_products and position.product_id not in (position.event.settings.venueless_products or [])
             )
             or not sender.settings.venueless_secret
     ):
@@ -89,9 +89,9 @@ def navbar_info(sender, request, **kwargs):
 
 
 @receiver(signal=event_copy_data, dispatch_uid="venueless_event_copy_data")
-def event_copy_data_r(sender, other, item_map, question_map, **kwargs):
-    sender.settings['venueless_items'] = [
-        item_map[item].pk for item in other.settings.get('venueless_items', default=[]) if item in item_map
+def event_copy_data_r(sender, other, product_map, question_map, **kwargs):
+    sender.settings['venueless_products'] = [
+        product_map[product].pk for product in other.settings.get('venueless_products', default=[]) if product in product_map
     ]
     sender.settings['venueless_questions'] = [
         question_map[q].pk for q in other.settings.get('venueless_questions', default=[]) if q in question_map
@@ -100,14 +100,14 @@ def event_copy_data_r(sender, other, item_map, question_map, **kwargs):
 
 @receiver(signal=product_copy_data, dispatch_uid="venueless_product_copy_data")
 def product_copy_data_r(sender, source, target, **kwargs):
-    items = sender.settings.get('venueless_items') or []
-    items.append(target.pk)
-    sender.settings['venueless_items'] = items
+    products = sender.settings.get('venueless_products') or []
+    products.append(target.pk)
+    sender.settings['venueless_products'] = products
 
 
 settings_hierarkey.add_default('venueless_start', None, RelativeDateWrapper)
 settings_hierarkey.add_default('venueless_text', None, LazyI18nString)
 settings_hierarkey.add_default('venueless_allow_pending', 'False', bool)
-settings_hierarkey.add_default('venueless_all_items', 'True', bool)
-settings_hierarkey.add_default('venueless_items', '[]', list)
+settings_hierarkey.add_default('venueless_all_products', 'True', bool)
+settings_hierarkey.add_default('venueless_products', '[]', list)
 settings_hierarkey.add_default('venueless_questions', '[]', list)

--- a/app/eventyay/plugins/eventyay-ticket-video/pretix_venueless/views.py
+++ b/app/eventyay/plugins/eventyay-ticket-video/pretix_venueless/views.py
@@ -54,15 +54,15 @@ class VenuelessSettingsForm(SettingsForm):
         label=_('Allow users to access the live event before their order is paid'),
         required=False,
     )
-    venueless_all_items = forms.BooleanField(
+    venueless_all_products = forms.BooleanField(
         label=_('Allow buyers of all admission products'),
         required=False
     )
-    venueless_items = forms.ModelMultipleChoiceField(
+    venueless_products = forms.ModelMultipleChoiceField(
         widget=forms.CheckboxSelectMultiple(
             attrs={
                 'class': 'scrolling-multiple-choice',
-                'data-inverse-dependency': '<[name$=venueless_all_items]'
+                'data-inverse-dependency': '<[name$=venueless_all_products]'
             }
         ),
         label=_('Limit to products'),
@@ -94,7 +94,7 @@ class VenuelessSettingsForm(SettingsForm):
     def __init__(self, *args, **kwargs):
         event = kwargs['obj']
         super().__init__(*args, **kwargs)
-        self.fields['venueless_items'].queryset = event.products.all()
+        self.fields['venueless_products'].queryset = event.products.all()
         self.fields['venueless_questions'].queryset = event.questions.all()
 
     def clean(self):
@@ -144,7 +144,7 @@ class OrderPositionJoin(EventViewMixin, OrderPositionDetailMixin, View):
                 (self.order.status != Order.STATUS_PAID and not (self.order.status == Order.STATUS_PENDING and
                                                                  request.event.settings.venueless_allow_pending))
                 or self.position.canceled
-                or not self.position.item.admission
+                or not self.position.product.admission
         )
         if forbidden:
             raise PermissionDenied()
@@ -180,18 +180,18 @@ class OrderPositionJoin(EventViewMixin, OrderPositionDetailMixin, View):
                 {
                     'eventyay-video-event-{}'.format(request.event.slug),
                     'eventyay-video-subevent-{}'.format(self.position.subevent_id),
-                    'eventyay-video-item-{}'.format(self.position.item_id),
+                    'eventyay-video-product-{}'.format(self.position.product_id),
                     'eventyay-video-variation-{}'.format(self.position.variation_id),
-                    'eventyay-video-category-{}'.format(self.position.item.category_id),
+                    'eventyay-video-category-{}'.format(self.position.product.category_id),
                 } | {
-                    'eventyay-video-item-{}'.format(p.item_id)
+                    'eventyay-video-product-{}'.format(p.product_id)
                     for p in self.position.addons.all()
                 } | {
                     'eventyay-video-variation-{}'.format(p.variation_id)
                     for p in self.position.addons.all() if p.variation_id
                 } | {
-                    'eventyay-video-category-{}'.format(p.item.category_id)
-                    for p in self.position.addons.all() if p.item.category_id
+                    'eventyay-video-category-{}'.format(p.product.category_id)
+                    for p in self.position.addons.all() if p.product.category_id
                 }
             )
         }

--- a/app/eventyay/presale/views/event.py
+++ b/app/eventyay/presale/views/event.py
@@ -878,7 +878,7 @@ class JoinOnlineVideoView(EventViewMixin, View):
         # Check if Event allow all ticket type to join
         if self.request.event.settings.venueless_all_items:
             return True, None, order_list[0]
-        list_allow_ticket_type = self.request.event.settings.venueless_items
+        list_allow_ticket_type = self.request.event.settings.venueless_products
         if not list_allow_ticket_type:
             # no ticket allow to join
             return False, None, None


### PR DESCRIPTION
This PR resolves the issue encountered in the current deployment while placing an order due to a naming conflict.
<img width="1578" height="1030" alt="image" src="https://github.com/user-attachments/assets/3ca45eca-fb48-494f-ab84-adffb8c7bebc" />

## Summary by Sourcery

Rename all item references to product in the Venueless ticket video integration to fix naming conflicts when placing orders.

Bug Fixes:
- Rename settings keys, defaults, and form fields from venueless_all_items/venueless_items to venueless_all_products/venueless_products
- Update URL construction, signal handlers, permission checks, and video token generation to use product_id and product.category instead of item_id