### PR TITLE
chore: move oauth_tags templates to enext

### DIFF
--- a/app/eventyay/common/templatetags/oauth_tags.py
+++ b/app/eventyay/common/templatetags/oauth_tags.py
@@ -13,7 +13,7 @@ def oauth_login_url(next_url: Optional[str] = None) -> str:
     Generate the OAuth login URL with an optional next parameter.
     Usage: {% oauth_login_url next_url %}
     """
-    base_url = reverse("eventyay_common:oauth2_provider.login")
+    base_url = reverse("eventyay_common:auth.login")
     if next_url:
         return f"{base_url}?next={quote(next_url)}"
     return base_url
@@ -25,7 +25,7 @@ def register_account_url(next_url: Optional[str] = None) -> str:
     Generate the registration URL with an optional next parameter.
     Usage: {% register_account_url next_url %}
     """
-    base_url = reverse("eventyay_common:register.account")
+    base_url = reverse("eventyay_common:auth.register")
     if next_url:
         return f"{base_url}?next={quote(next_url)}"
     return base_url


### PR DESCRIPTION
Before:
If user is not logged in and tries to submit a proposal, django raises oauth_tags error which was not moved.
<img width="1918" height="957" alt="oauth" src="https://github.com/user-attachments/assets/f3c2c019-7f4f-4c15-913a-10e0a45cc374" />

After:
<img width="1918" height="957" alt="oauth_fix" src="https://github.com/user-attachments/assets/a971ac8b-00fd-44db-8d11-a55dfb230c21" />

## Summary by Sourcery

Update OAuth template tags to reference new auth endpoints after migrating templates to the enext module

Bug Fixes:
- Fix missing oauth_tags error by reversing updated login and register URL names in oauth_login_url and register_account_url

Chores:
- Point oauth_tags functions to eventyay_common:auth.login and eventyay_common:auth.register after template move