### PR TITLE
Fix NULL constraint violation in LogEntry.data when creating rooms

### DIFF
--- a/app/eventyay/base/models/mixins.py
+++ b/app/eventyay/base/models/mixins.py
@@ -91,6 +91,9 @@ class LogMixin:
             data = json.dumps(data, cls=CustomJSONEncoder, sort_keys=True)
         elif data:
             raise TypeError(f'Logged data should always be a dictionary, not {type(data)}.')
+        else:
+            # If data is None, set it to empty JSON object to satisfy NOT NULL constraint
+            data = '{}'
 
         log_entry = LogEntry.objects.create(
             content_object=content_object or self,


### PR DESCRIPTION
### **Description:**  
This PR resolves an Internal Server Error that was breaking the room creation page (`/orga/event/.../schedule/rooms/new/`). The problem stemmed from `base_logentry.data` receiving a NULL value, which isn't allowed by the database schema.

When `log_action()` gets called without explicitly passing data, it was leaving `data` as `None`. I've added an else block that sets it to an empty JSON object (`'{}'`) instead, so there's always a valid value.

### **Context:**  
Migration 0005 deliberately made the `data` field non-nullable again after migration 0003's nullable approach caused several crashes related to `parsed_data` parsing. This fix maintains that intent by making sure we never try to insert NULL, which keeps `parsed_data` working reliably everywhere it's used—webhooks, email plugins, data shredding, etc.

### **What this fixes:**  
- `data` field always gets a valid JSON string
- No more `NotNullViolation` errors when creating log entries
- `parsed_data` stays consistent throughout the application

## Summary by Sourcery

Bug Fixes:
- Prevent NotNullViolation by defaulting log entry data to an empty JSON object when no data is provided