### PR TITLE
fix(email): Fixes for Email

### DIFF
--- a/app/eventyay/base/email.py
+++ b/app/eventyay/base/email.py
@@ -276,7 +276,7 @@ class TemplateBasedMailRenderer(BaseHTMLMailRenderer):
         if order:
             htmlctx['order'] = order
             positions = list(
-                order.positions.select_related('item', 'variation', 'subevent', 'addon_to').annotate(
+                order.positions.select_related('product', 'variation', 'subevent', 'addon_to').annotate(
                     has_addons=Count('addons')
                 )
             )
@@ -285,7 +285,7 @@ class TemplateBasedMailRenderer(BaseHTMLMailRenderer):
                 for k, v in groupby(
                     positions,
                     key=lambda op: (
-                        op.item,
+                        op.product,
                         op.variation,
                         op.subevent,
                         op.attendee_name,
@@ -715,7 +715,7 @@ def base_placeholders(sender: Event, **kwargs):
         SimpleFunctionalMailTextPlaceholder(
             'product',
             ['waiting_list_entry'],
-            lambda waiting_list_entry: waiting_list_entry.item.name,
+            lambda waiting_list_entry: waiting_list_entry.product.name,
             _('Sample Admission Ticket'),
         ),
         SimpleFunctionalMailTextPlaceholder(

--- a/app/eventyay/jinja-templates/eventyay/email/base.jinja
+++ b/app/eventyay/jinja-templates/eventyay/email/base.jinja
@@ -197,7 +197,7 @@
             <table cellpadding='20'><tr><td align='center'>
           <![endif]-->
           {% if event %}
-            <h2><a href="{{ url_for('presale:event.index', event=event) }}" target='_blank'>{{ event.name }}</a></h2>
+            <h2><a href="{{ url_for('presale:event.index', organizer=event.organizer.slug, event=event.slug) }}" target='_blank'>{{ event.name }}</a></h2>
           {% else %}
             <h2><a href='{{ site_url }}' target='_blank'>{{ site }}</a></h2>
           {% endif %}

--- a/app/eventyay/jinja-templates/eventyay/email/order_details.jinja
+++ b/app/eventyay/jinja-templates/eventyay/email/order_details.jinja
@@ -132,7 +132,7 @@
     </tr>
   </table>
   <div class="order-button">
-    <a href="{{ url_for('presale:event.order.open', event=event, hash=order.email_confirm_hash, order=order.code, secret=order.secret) }}" class="button">
+	<a href="{{ url_for('presale:event.order.open', organizer=event.organizer.slug, event=event.slug, order=order.code, secret=order.secret, hash=order.email_confirm_hash()) }}" class="button">
       {{ _('View order details') }}
     </a>
   </div>

--- a/app/eventyay/plugins/sendmail/tasks.py
+++ b/app/eventyay/plugins/sendmail/tasks.py
@@ -15,7 +15,7 @@ def send_mails(
     subject: dict,
     message: dict,
     orders: list,
-    items: list,
+    products: list,
     recipients: str,
     filter_checkins: bool,
     not_checked_in: bool,
@@ -41,7 +41,7 @@ def send_mails(
                 if p.addon_to_id is not None:
                     continue
 
-                if p.item_id not in items and not any(a.item_id in items for a in p.addons.all()):
+                if p.product_id not in products and not any(a.product_id in products for a in p.addons.all()):
                     continue
 
                 if filter_checkins:

--- a/app/eventyay/plugins/sendmail/templates/pretixplugins/sendmail/history.html
+++ b/app/eventyay/plugins/sendmail/templates/pretixplugins/sendmail/history.html
@@ -33,8 +33,8 @@
                         {% for status in log.parsed_data.sendto %}
                             {{ status }}{% if forloop.revcounter > 1 %},{% endif %}
                         {% endfor %}
-                        {% if log.pdata.items %}
-                            <br/><span class="fa fa-shopping-cart fa-fw"></span> {{ log.pdata.items|join:", " }}
+                        {% if log.pdata.products %}
+                            <br/><span class="fa fa-shopping-cart fa-fw"></span> {{ log.pdata.products|join:", " }}
                         {% endif %}
                         {% if log.pdata.filter_checkins %}
                             {% if log.pdata.not_checked_in %}


### PR DESCRIPTION
This PR includes:
- `Item` to `Product` rename in email components.
- Updated `base.jinja` to pass `organizer` and `event` slugs explicitly when generating
  event URLs to prevent NoReverseMatch errors in email previews.
- Fixed `order_details.jinja` to include organizer slug and call `email_confirm_hash()`
  correctly while reversing `presale:event.order.open` URLs.
- These changes ensure consistent URL resolution and proper rendering in email layout previews.

Email Preview without NoReverseMatch errors:
<img width="1578" height="1030" alt="image" src="https://github.com/user-attachments/assets/0e0a85fc-d634-41ed-ad28-d235c14ee56a" />

## Summary by Sourcery

Align email components with the renamed Product model and fix URL generation in email templates to prevent NoReverseMatch errors

Bug Fixes:
- Replace sendmail views, tasks, and rendering logic to use products instead of items
- Update Jinja email templates to explicitly pass organizer and event slugs and call email_confirm_hash() correctly when reversing URLs