### PR TITLE
fix(jinja): remove redundant Jinja environment definitions and use unified setup

### DIFF
--- a/app/eventyay/config/settings.py
+++ b/app/eventyay/config/settings.py
@@ -298,7 +298,7 @@ TEMPLATES = (
             BASE_DIR / 'jinja-templates',
         ],
         'OPTIONS': {
-            'environment': 'eventyay.helpers.jinja.environment',
+            'environment': 'eventyay.jinja.environment',
             'extensions': (
                 'jinja2.ext.i18n',
                 'jinja2.ext.do',

--- a/app/eventyay/helpers/jinja.py
+++ b/app/eventyay/helpers/jinja.py
@@ -1,9 +1,6 @@
 from django.urls import reverse
-from django.utils.translation import gettext as django_gettext, ngettext
-from django.utils.formats import date_format
-from jinja2 import Environment, pass_context
+from jinja2 import pass_context
 from jinja2.runtime import Context
-from eventyay.helpers.templatetags.thumb import thumb
 
 
 @pass_context
@@ -20,39 +17,3 @@ def url_for(context: Context, name: str, *args, query_string=None, **kwargs):
     base_url = reverse(name, args=args, kwargs=kwargs, current_app=current_app)
     return f"{base_url}?{query_string}" if query_string else base_url
 
-
-def jinja_gettext(message, **kwargs):
-    text = django_gettext(message)
-    if kwargs:
-        try:
-            text = text % kwargs
-        except Exception:
-            pass
-    return text
-
-
-def format_date(value, format_str="SHORT_DATE_FORMAT"):
-    if not value:
-        return ""
-    try:
-        return date_format(value, format_str)
-    except Exception:
-        return str(value)
-
-
-def environment(**options):
-    env = Environment(**options, autoescape=True)
-
-    env.globals.update({
-        'url_for': url_for,
-        '_': jinja_gettext,
-        'gettext': jinja_gettext,
-        'ngettext': ngettext,
-    })
-
-    env.filters.update({
-        'thumb': thumb,
-        'format_date': format_date,
-    })
-
-    return env

--- a/app/eventyay/jinja.py
+++ b/app/eventyay/jinja.py
@@ -4,6 +4,7 @@ from django.template.defaultfilters import date
 from jinja2 import Environment
 
 from .helpers.jinja import url_for
+from eventyay.helpers.templatetags.thumb import thumb
 
 jj_globals = {
     'url_for': url_for,
@@ -11,6 +12,7 @@ jj_globals = {
 }
 
 jj_filters = {
+    'thumb': thumb,
     'format_date': date,
 }
 


### PR DESCRIPTION
This PR includes :
- Consolidated Jinja configuration into main `eventyay/jinja.py`
- Removed redundant logic and gettext redefinitions from `helpers/jinja.py`
- Updated `settings.py` to ensure consistent environment loading