### PR TITLE
fix(auth): prevent null data in log entries and pass request to password reset

### DIFF
--- a/app/eventyay/base/models/auth.py
+++ b/app/eventyay/base/models/auth.py
@@ -647,8 +647,8 @@ class User(
         """
         from eventyay.base.models.log import LogEntry
 
-        if data:
-            data = json.dumps(data)
+        if data is None:
+            data = {}
 
         LogEntry.objects.create(
             user=user or person or self,

--- a/app/eventyay/control/views/users.py
+++ b/app/eventyay/control/views/users.py
@@ -118,7 +118,7 @@ class UserResetView(AdministratorPermissionRequiredMixin, RecentAuthenticationRe
     def post(self, request, *args, **kwargs):
         self.object = get_object_or_404(User, pk=self.kwargs.get('id'))
         try:
-            self.object.send_password_reset()
+            self.object.send_password_reset(request)
         except SendMailException:
             messages.error(
                 request,


### PR DESCRIPTION
This PR includes :
- Ensure `LogEntry` creation never inserts NULL by defaulting `data` to {} in `log_action`
- Remove redundant json.dumps() to let Django JSONField handle serialization
- Pass `request` argument to `User.send_password_reset()` in admin user reset view
  to fix missing positional argument error and enable proper reset URL generation

> **This PR fixes the issue with Registration and Password Reset**

## Summary by Sourcery

Prevent null data in log entries by defaulting to an empty dict, clean up JSON serialization handling, and fix the admin password reset flow by passing the request to send_password_reset().

Bug Fixes:
- Default data to an empty dictionary in log_action to prevent NULL log entries
- Pass request to User.send_password_reset() in the admin view to fix missing argument errors and enable proper reset URL generation

Enhancements:
- Remove redundant json.dumps() calls to rely on Django JSONField for serialization