### PR TITLE
chore: Use npm ci instead of npm install in webappbuild target

### DIFF
--- a/app/Makefile
+++ b/app/Makefile
@@ -35,6 +35,6 @@ npminstall:
 	OUT_DIR=$(shell pwd)/eventyay/static npm run build --prefix=eventyay/frontend/schedule-editor
 
 webappbuild:
-	npm install --prefix=eventyay/webapp
+	npm ci --prefix=eventyay/webapp
 	OUT_DIR=$(shell pwd)/eventyay/static npm run build --prefix=eventyay/webapp
 


### PR DESCRIPTION
## Description
Switches the `webappbuild` Makefile target to use `npm ci` instead of `npm install` to avoid unnecessary updates to `package-lock.json`.

## Rationale
`npm install` was rewriting the lockfile on every run. Using `npm ci` ensures clean, reproducible installs and keeps the lockfile intact—consistent with other frontend build targets.

## Changes
- Replaced `npm install` with `npm ci` in `app/Makefile`

## Testing
- [x] `make webappbuild` runs successfully  
- [x] `package-lock.json` remains unchanged

## Summary by Sourcery

Build:
- Replace npm install with npm ci in the webappbuild Makefile target