### PR TITLE
fix: dropdown event search redirects to unified dashboard instead of tickets dashboard

### DIFF
--- a/app/eventyay/static/pretixpresale/js/ui/popover.js
+++ b/app/eventyay/static/pretixpresale/js/ui/popover.js
@@ -121,7 +121,7 @@ $(function () {
   if (showOrganizerArea) {
     blocks.push(
       `<div class="profile-menu organizer-area">
-          <a href="${basePath}/common/event/${organizerName}/${eventSlug}" target="_self" class="btn btn-outline-success">
+          <a href="${basePath}/control/event/${organizerName}/${eventSlug}" target="_self" class="btn btn-outline-success">
               <i class="fa fa-users"></i> ${window.gettext('Organizer Area')}
           </a>
       </div>`


### PR DESCRIPTION
fixes #1117 : redirect event dropdown to unified dashboard instead of tickets dashboard

- Update serialize_event() in typeahead.py to use eventyay_common:event.index
- Update presale organizer area link to point to unified dashboard
- Ensures consistent navigation behavior across all user roles (organizer, admin, co-organizer)
- Fixes issue where event search dropdown redirected to tickets dashboard instead of main event dashboard

## Summary by Sourcery

Unify event dropdown navigation across user roles to point to the main event dashboard instead of the tickets dashboard and clean up UI styling

Bug Fixes:
- Redirect event search dropdown to the unified event dashboard by updating serialize_event URL
- Fix presale organizer area link to use the unified dashboard path

Enhancements:
- Remove box-shadow styling from the AppBar component for a cleaner UI appearance