### PR TITLE
fix: restore profile preferences

### DIFF
--- a/app/eventyay/webapp/src/components/AppBar.vue
+++ b/app/eventyay/webapp/src/components/AppBar.vue
@@ -70,7 +70,7 @@ const PROFILE_MENU_ITEMS = [
 	{ key: 'organizers', label: 'Organizers', externalPath: 'common/organizers/', icon: 'organizers' },
 	{ key: 'profile', label: 'Profile', route: { name: 'preferences' }, separatorBefore: true, icon: 'profile' },
 	{ key: 'account', label: 'Account', externalPath: 'common/account/general', icon: 'account' },
-	{ key: 'logout', label: 'Logout', action: 'logout', separatorBefore: true, icon: 'logout' }
+	{ key: 'logout', label: 'Logout', action: 'logout', icon: 'logout' }
 ]
 
 const emit = defineEmits(['toggleSidebar'])


### PR DESCRIPTION
Fixes #1139 
<img width="2056" height="1329" alt="Screenshot 2025-10-31 at 2 46 28 AM" src="https://github.com/user-attachments/assets/efbebf1e-b158-4c39-9c5b-96d129fe71dc" />

## Summary by Sourcery

Restore profile preferences entry in the application bar by adding a profile icon and menu item linking to the preferences page

New Features:
- Add 'Profile' menu item in the profile dropdown that routes to the preferences page

Enhancements:
- Introduce a new 'profile' icon in the icon classes
- Move the menu separator before the newly added 'Profile' item instead of 'Account'