### PR TITLE
fix: preserve frontend built assets in local Docker setup

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,7 +9,11 @@ services:
     volumes:
       - ./app/eventyay:/usr/src/app/eventyay
       - /usr/src/app/eventyay/static/webapp
+      - /usr/src/app/eventyay/static/global-nav-menu
+      - /usr/src/app/eventyay/static/schedule-editor
       - /usr/src/app/eventyay/webapp/node_modules
+      - /usr/src/app/eventyay/frontend/global-nav-menu/node_modules
+      - /usr/src/app/eventyay/frontend/schedule-editor/node_modules
     ports:
       - 8000:8000
     env_file:
@@ -26,7 +30,11 @@ services:
     volumes:
       - ./app/eventyay:/usr/src/app/eventyay
       - /usr/src/app/eventyay/static/webapp
+      - /usr/src/app/eventyay/static/global-nav-menu
+      - /usr/src/app/eventyay/static/schedule-editor
       - /usr/src/app/eventyay/webapp/node_modules
+      - /usr/src/app/eventyay/frontend/global-nav-menu/node_modules
+      - /usr/src/app/eventyay/frontend/schedule-editor/node_modules
     env_file:
       - ./.env.dev
     environment:


### PR DESCRIPTION
Added volume mounts for global-nav-menu and schedule-editor to prevent local source directory from overwriting built assets in the Docker container.

This ensures frontend apps work correctly in local development environment.

- Added volume mounts for static/global-nav-menu and static/schedule-editor
- Added volume mounts for frontend node_modules directories
- Matches existing pattern used for webapp

Fixes frontend asset loading issues in local Docker compose setup.

## Summary by Sourcery

Update local Docker Compose setup to prevent source directory mounts from overwriting built frontend assets by adding volume mounts for global-nav-menu and schedule-editor static files and node_modules, ensuring development environment works correctly.

Bug Fixes:
- Fix frontend asset loading in local Docker Compose by preserving built assets with additional volume mounts

Build:
- Add volume mounts for static/global-nav-menu, static/schedule-editor, and their node_modules directories in docker-compose.yml