### PR TITLE
fix(translation): Add compilemessages step

### DIFF
--- a/app/Dockerfile.prod
+++ b/app/Dockerfile.prod
@@ -62,7 +62,7 @@ RUN mkdir $APP_HOME/static
 WORKDIR $APP_HOME
 
 # install dependencies
-RUN apt-get update && apt-get install -y --no-install-recommends netcat-traditional nodejs
+RUN apt-get update && apt-get install -y --no-install-recommends netcat-traditional nodejs gettext
 
 # copy entrypoint.prod.sh
 COPY ./entrypoint.prod.sh .

--- a/app/entrypoint.prod.sh
+++ b/app/entrypoint.prod.sh
@@ -8,6 +8,8 @@ done
 
 echo "PostgreSQL started"
 
+echo "============== compiling translation messages ================"
+python manage.py compilemessages
 echo "============== running collectstatic ================"
 python manage.py collectstatic --noinput
 echo "============== running compress ====================="


### PR DESCRIPTION
This pull request updates the production Docker setup and entrypoint script to support Django translation message compilation. The changes ensure that translation files are compiled before static files are collected and compressed, and add the necessary system dependency for this process.

**Internationalization support:**

* Added `gettext` to the list of installed packages in `app/Dockerfile.prod` to provide the tools required for compiling translation messages.
* Updated `app/entrypoint.prod.sh` to run `python manage.py compilemessages` before collecting static files and compressing assets, ensuring translation files are available in production.

## Summary by Sourcery

Add support for compiling Django translation messages in production by including gettext and updating the entrypoint script

Enhancements:
- Compile translation messages before collecting static files and compressing assets in the production entrypoint

Build:
- Include gettext system package in the production Dockerfile for translation support