### PR TITLE
fix(i18n): configure STATICI18N to include core eventyay app packages

### DIFF
--- a/app/eventyay/config/settings.py
+++ b/app/eventyay/config/settings.py
@@ -899,6 +899,17 @@ STATICFILES_FINDERS = (
     'compressor.finders.CompressorFinder',
 )
 STATICI18N_ROOT = os.path.join(BASE_DIR, 'static')
+STATICI18N_OUTPUT_DIR = 'jsi18n'
+STATICI18N_PACKAGES = (
+    'eventyay.common',
+    'eventyay.presale',
+    'eventyay.control',
+    'eventyay.base',
+    'eventyay.eventyay_common',
+    'eventyay.agenda',
+    'eventyay.orga',
+    'eventyay.submission',
+)
 FRONTEND_DIR = BASE_DIR / 'frontend'
 
 VITE_DEV_SERVER_PORT = 8080


### PR DESCRIPTION
The production server was failing with 
```
ValueError: Missing staticfiles manifest entry for 'jsi18n/it/djangojs.js'
``` 
because `collectstatic` couldn’t generate locale-specific JavaScript files.
This update adds all relevant Eventyay app modules (`common`, `presale`, `control`, `base`, etc.) to `STATICI18N_PACKAGES`, allowing `collectstatic` to correctly locate their locale directories and generate the necessary `djangojs.js` files for each language, ensuring the static manifest is complete and preventing the missing manifest error in production.

Now after running `collectstatic` the files appear as expected

<img width="1888" height="469" alt="image" src="https://github.com/user-attachments/assets/dc4b7dc7-86a8-4941-9204-5087ef2b5d45" />

## Summary by Sourcery

Configure STATICI18N settings to include core Eventyay app packages and set the output directory, enabling locale-specific djangojs.js files to be generated and preventing missing staticfiles manifest errors in production.

Bug Fixes:
- Add core Eventyay modules to STATICI18N_PACKAGES so collectstatic can locate their locale directories and generate djangojs.js files without manifest errors.

Enhancements:
- Introduce STATICI18N_OUTPUT_DIR set to 'jsi18n' to standardize the output location for generated locale JavaScript files.