### PR TITLE
fix(translation): Add step for compiling JS translation messages

### DIFF
--- a/app/entrypoint.prod.sh
+++ b/app/entrypoint.prod.sh
@@ -10,6 +10,8 @@ echo "PostgreSQL started"
 
 echo "============== compiling translation messages ================"
 python manage.py compilemessages
+echo "============== compiling JS translation messages ================"
+python manage.py compilejsi18n
 echo "============== running collectstatic ================"
 python manage.py collectstatic --noinput
 echo "============== running compress ====================="

--- a/app/eventyay/static/jsi18n/en/djangojs.js
+++ b/app/eventyay/static/jsi18n/en/djangojs.js
@@ -93,10 +93,10 @@
     "FIRST_DAY_OF_WEEK": 0,
     "MONTH_DAY_FORMAT": "F j",
     "NUMBER_GROUPING": 3,
-    "SHORT_DATETIME_FORMAT": "Y-m-d H:i",
-    "SHORT_DATE_FORMAT": "Y-m-d",
+    "SHORT_DATETIME_FORMAT": "m/d/Y P",
+    "SHORT_DATE_FORMAT": "m/d/Y",
     "THOUSAND_SEPARATOR": ",",
-    "TIME_FORMAT": "H:i",
+    "TIME_FORMAT": "P",
     "TIME_INPUT_FORMATS": [
       "%H:%M:%S",
       "%H:%M:%S.%f",


### PR DESCRIPTION
This PR updates the production entrypoint script to run `python manage.py compilejsi18n` after `compilemessages`. Without this step, the compiled `.mo` translation files were not being converted into the corresponding JavaScript translation catalogs (`djangojs.js`), causing missing locale assets in the static manifest and leading to errors for non-English languages in production. Running both ensures that all translations are properly compiled and available for both backend and frontend use.

## Summary by Sourcery

Include JavaScript translation compilation in the production entrypoint and update English JS translation date/time formats.

Bug Fixes:
- Prevent missing locale assets in production by running compilejsi18n after compilemessages.

Enhancements:
- Standardize English JS translations with US-style date ('m/d/Y') and 12-hour time ('P') formats.