### PR TITLE
fix(urls): remove duplicate plugin namespace from config to restore dynamic plugin resolution

### DIFF
--- a/app/eventyay/config/urls.py
+++ b/app/eventyay/config/urls.py
@@ -60,14 +60,6 @@ orga_patterns = [
 # Note: agenda and cfp patterns are now included under {organizer}/{event} in maindomain_urlconf.py
 # They are no longer at the root level
 
-# Plugin patterns - explicitly registered for better code traceability
-# Social Auth plugin needs to be accessible at root level for OAuth callbacks
-raw_plugin_patterns = [
-    path('', include(('eventyay.plugins.socialauth.urls', 'socialauth'))),
-]
-
-plugin_patterns = [path('', include((raw_plugin_patterns, 'plugins')))]
-
 debug_patterns = []
 
 if settings.DEBUG and importlib.util.find_spec('debug_toolbar'):
@@ -82,5 +74,4 @@ common_patterns = (
     + page_patterns
     + admin_patterns
     + orga_patterns
-    + plugin_patterns
 )


### PR DESCRIPTION
This PR fixes a server-side error during control panel rendering:

```
eventyay-next-web | django.urls.exceptions.NoReverseMatch: 'returnurl' is not a registered namespace inside 'plugins'
```
<img width="1582" height="1034" alt="Screenshot 2025-11-13 at 01 14 08" src="https://github.com/user-attachments/assets/3587bdcd-a9a0-4850-9e1e-1866c4f6618e" />


This occurred because `eventyay/config/urls.py` defined a redundant `plugin_patterns` entry that shadowed dynamically discovered plugins.
Removed the extra `plugins` namespace so that `maindomain_urlconf.py` solely manages plugin URL registration.

Now all plugin routes — including `plugins:returnurl:settings` — resolve correctly, and the control dashboard loads without errors.

## Summary by Sourcery

Remove the redundant plugin namespace from config URLs to restore dynamic plugin route resolution and prevent NoReverseMatch errors in the control panel

Bug Fixes:
- Remove duplicate plugin_patterns entry in eventyay/config/urls.py to fix plugin URL resolution errors

Enhancements:
- Rely solely on maindomain_urlconf for plugin registration by deleting obsolete plugin_patterns code