### PR TITLE
bug: mention not showing names

### DIFF
--- a/app/eventyay/webapp/src/components/Chat.vue
+++ b/app/eventyay/webapp/src/components/Chat.vue
@@ -230,6 +230,7 @@ async function showUserCard(event, user, placement = 'left-start') {
 		font-weight: 500
 		border-radius: 4px
 		padding: 0 2px
+		margin: 0 2px
 		cursor: pointer
 		&::before
 			content: '@'

--- a/app/eventyay/webapp/src/components/ChatContent.vue
+++ b/app/eventyay/webapp/src/components/ChatContent.vue
@@ -16,7 +16,8 @@ markdownIt.renderer.rules.link_open = (tokens, idx, options, env, self) => {
 }
 markdownIt.use(markdownEmoji)
 
-const mentionRegex = /(@[0-9a-fA-F]{8}\b-[0-9a-fA-F]{4}\b-[0-9a-fA-F]{4}\b-[0-9a-fA-F]{4}\b-[0-9a-fA-F]{12})/g
+const uuidPattern = '[0-9a-fA-F]{8}\\b-[0-9a-fA-F]{4}\\b-[0-9a-fA-F]{4}\\b-[0-9a-fA-F]{4}\\b-[0-9a-fA-F]{12}'
+const mentionRegex = new RegExp(`(@(?:${uuidPattern}|[0-9]+))`, 'g')
 
 export async function contentToPlainText(content) {
 	const parts = content.split(mentionRegex)


### PR DESCRIPTION
Fixes #1288 
<img width="2056" height="1329" alt="Screenshot 2025-11-15 at 12 21 56 PM" src="https://github.com/user-attachments/assets/5e2476aa-0977-477b-9234-a8a510505a82" />

## Summary by Sourcery

Fix mention parsing and styling so user names correctly appear for both UUID and numeric mentions

Bug Fixes:
- Extend mention regex to match both UUIDs and numeric user IDs
- Add margin around mention elements for proper spacing