### PR TITLE
Adds admin update email notifications and status to global update page

### DIFF
--- a/src/pretix/base/services/update_check.py
+++ b/src/pretix/base/services/update_check.py
@@ -112,7 +112,7 @@ def send_update_notification_email():
                 },
             )
             gs.settings.set('last_notified_release', latest_version)
-            gs.settings.set('last_notification_sent', now().isoformat())
+            gs.settings.set('last_notification_sent', now())
         except Exception as e:
             logger.error('Failed to send update notification email: %s', e)
 

--- a/src/pretix/control/templates/pretixcontrol/global_update.html
+++ b/src/pretix/control/templates/pretixcontrol/global_update.html
@@ -81,7 +81,7 @@
             <div class="form-group">
                 <label class="col-md-2 control-label">{% trans "Admin update email" %}</label>
                 <div class="col-md-10">
-                    <input type="text" name="update_check_email" value="{{ gs.settings.update_check_email }}" class="form-control">
+                    <input type="email" name="update_check_email" value="{{ gs.settings.update_check_email }}" class="form-control">
                     <small class="form-text text-muted">{% trans "We will notify you at this address if we detect that a new update is available." %}</small>
                 </div>
             </div>
@@ -92,14 +92,13 @@
                 </div>
             </div>
         </form>
-        
         <hr/>
         <h4>{% trans "Status" %}</h4>
         <ul>
             <li>{% trans "Current version" %}: {{ gs.settings.update_check_result.version.current|default:"—" }}</li>
             <li>{% trans "Latest version" %}: {{ gs.settings.update_check_result.version.latest|default:"—" }}</li>
             <li>{% trans "Last checked" %}: {{ gs.settings.update_check_last|date:"SHORT_DATETIME_FORMAT"|default:"—" }}</li>
-            <li>{% trans "Last notification sent" %}: {{ gs.settings.last_notification_sent|default:"—" }}</li>
+            <li>{% trans "Last notification sent" %}: {{ gs.settings.last_notification_sent|date:"SHORT_DATETIME_FORMAT"|default:"—" }}</li>
         </ul>
     </fieldset>
     <form action="" method="post" class="form-horizontal" enctype="multipart/form-data">

--- a/src/pretix/control/views/global_settings.py
+++ b/src/pretix/control/views/global_settings.py
@@ -134,12 +134,10 @@ class UpdateCheckView(StaffMemberRequiredMixin, FormView):
                     {}
                 )
                     messages.success(self.request, _('Test email sent successfully.'))
-                    gs.settings.set('last_notification_sent', now().isoformat())
                 except Exception as e:
                     messages.error(self.request, _('SMTP error: {0}').format(str(e)))
             return redirect(self.get_success_url())
         return super().post(request, *args, **kwargs)
-        
 
     def form_valid(self, form):
         form.save()


### PR DESCRIPTION
Implements email notifications and status info on /admin/global/update/ as described in #1127.

- Stores an admin update email in global settings
- Sends a notification once per new release tag when an update is available
- Adds "Send test email" and shows current/latest version, last checked, and last notification timestamps

## Summary by Sourcery

Add support for admin-configurable update notification emails with test functionality and track notification history, and implement email dispatch when a new release is detected.

New Features:
- Allow administrators to configure an update notification email and send test emails from the global update page
- Send notification emails to the configured address once per new release when an update is available

Enhancements:
- Display update status including current/latest version, last checked time, and last notification timestamp on the global update page