### PR TITLE
Fix: WebSocket Disconnect Due to SQL Error in Room Permission Check

### DIFF
--- a/app/eventyay/base/models/room.py
+++ b/app/eventyay/base/models/room.py
@@ -99,9 +99,6 @@ class RoomQuerySet(models.QuerySet):
                     ext = " AND jsonb_array_length(trait_grants->%s) > 0"
                     ext_args.append(role)
 
-                # Build IN clause with proper placeholders for each trait
-                in_placeholders = ','.join(['%s'] * len(traits))
-
                 qs = qs.annotate(
                     **{
                         f"has_role_{i}": RawSQL(
@@ -111,8 +108,8 @@ class RoomQuerySet(models.QuerySet):
                             TRUE = ALL(
                                 SELECT (
                                     CASE jsonb_typeof(d{i}.elem)
-                                        WHEN 'array' THEN EXISTS(SELECT 1 FROM jsonb_array_elements(d{i}.elem) e{i}(elem) WHERE e{i}.elem#>>'{"{}"}' IN ({in_placeholders}) )
-                                        ELSE d{i}.elem#>>'{"{}"}' IN ({in_placeholders})
+                                        WHEN 'array' THEN EXISTS(SELECT 1 FROM jsonb_array_elements(d{i}.elem) e{i}(elem) WHERE e{i}.elem#>>'{{}}' = ANY(%s) )
+                                        ELSE d{i}.elem#>>'{{}}' = ANY(%s)
                                     END
                                 ) FROM jsonb_array_elements( trait_grants->%s ) AS d{i}(elem)
                             ) {ext}
@@ -120,8 +117,8 @@ class RoomQuerySet(models.QuerySet):
                             (
                                 role,  # ? check
                                 role,  # IS NOT NULL check
-                                *traits,  # IN check - expand traits as individual params
-                                *traits,  # IN check - expand traits as individual params
+                                traits,  # = ANY check (array for first case)
+                                traits,  # = ANY check (array for second case)
                                 role,  # jsonb_array_elements
                                 *ext_args,
                             ),


### PR DESCRIPTION
This PR fixes a WebSocket disconnect issue caused by an invalid SQL IN clause in RoomQuerySet.with_permission() (app/eventyay/base/models/room.py). When attendees had multiple traits, the query passed the traits list as a single string, causing a PostgreSQL syntax error and forcing the WebSocket to close.

The fix replaces the broken IN (...) construction with PostgreSQL’s = ANY(%s), which correctly handles trait lists as arrays. After this change, permission checks run without errors and attendees can access video rooms normally.

Resolves #1141

## Summary by Sourcery

Bug Fixes:
- Replace invalid SQL IN clause with = ANY(%s) to correctly handle trait arrays in room permission queries and prevent WebSocket disconnects.