### PR TITLE
Fix Speaker Acceptance Confirmation Link Returning 500 Error

### DIFF
--- a/app/eventyay/cfp/views/user.py
+++ b/app/eventyay/cfp/views/user.py
@@ -219,6 +219,9 @@ class SubmissionConfirmView(LoggedInEventPageMixin, SubmissionViewMixin, FormVie
     def dispatch(self, request, *args, **kwargs):
         if request.user.is_anonymous:
             return get_login_redirect(request)
+        self.request = request
+        self.args = args
+        self.kwargs = kwargs
         if not request.user.has_perm('base.is_speaker_submission', self.submission):
             self.template_name = 'cfp/event/user_submission_confirm_error.html'
         return super().dispatch(request, *args, **kwargs)


### PR DESCRIPTION
# Fix Speaker Acceptance Confirmation Link Returning 500 Error


The `SubmissionConfirmView.dispatch()` method tried to access `self.submission` (a cached property) before calling `super().dispatch()`, which caused an `AttributeError` because `self.request` and `self.kwargs` weren't initialized yet.

Modified `dispatch()` to manually initialize `self.request`, `self.args`, and `self.kwargs` before accessing `self.submission`:

```python
def dispatch(self, request, *args, **kwargs):
    if request.user.is_anonymous:
        return get_login_redirect(request)
    
    # Initialize request attributes before accessing self.submission
    self.request = request
    self.args = args
    self.kwargs = kwargs
    
    if not request.user.has_perm('base.is_speaker_submission', self.submission):
        self.template_name = 'cfp/event/user_submission_confirm_error.html'
    return super().dispatch(request, *args, **kwargs)
```

### Before Fix
```
GET /event/me/submissions/CODE/confirm
→ 500 Internal Server Error (AttributeError)
```

### After Fix  
```
GET /event/me/submissions/CODE/confirm
→ 302 Found (redirect to login)
```

Fixes #1276

## Summary by Sourcery

Bug Fixes:
- Initialize self.request, args, and kwargs in SubmissionConfirmView.dispatch to avoid AttributeError when accessing self.submission