### PR TITLE
fix(permissions): ensure traits are correctly parsed as list for RawSQL ANY clause in RoomQuerySet

### DIFF
--- a/app/eventyay/base/models/room.py
+++ b/app/eventyay/base/models/room.py
@@ -43,6 +43,10 @@ class RoomQuerySet(models.QuerySet):
 
         traits = traits or user.traits
         allow_empty_traits = not user or user.type == User.UserType.PERSON
+        # Ensure traits is always a proper list of strings for SQL parameterization
+        if traits and isinstance(traits, str):
+            # e.g. "(trait1,trait2)" → ["trait1", "trait2"]
+            traits = [t.strip(" '") for t in traits.strip("()").split(",") if t.strip()]
         if event.has_permission_implicit(
             traits=traits,
             permissions=[permission],


### PR DESCRIPTION
This PR fixes a recurring `psycopg.errors.SyntaxError` occurring in WebSocket login and event room queries due to malformed SQL generated from trait-based permissions. The issue arose when `traits` were passed as a single string instead of a list, leading to SQL fragments like `e0.elem#>>'{}' IN '(eventyay-video-variation-None,...)'` instead of a valid `= ANY(ARRAY[...])` expression. The fix normalizes `traits` to a list of strings before building the RawSQL query, ensuring correct parameter binding and eliminating the syntax errors during permission evaluation.

## Summary by Sourcery

Bug Fixes:
- Fix SQL syntax errors by normalizing string traits to a list for the RawSQL ANY clause in room permission queries