### PR TITLE
Fix(permission): PostgreSQL syntax error in Room permission query

### DIFF
--- a/app/eventyay/base/models/room.py
+++ b/app/eventyay/base/models/room.py
@@ -112,8 +112,8 @@ class RoomQuerySet(models.QuerySet):
                             TRUE = ALL(
                                 SELECT (
                                     CASE jsonb_typeof(d{i}.elem)
-                                        WHEN 'array' THEN EXISTS(SELECT 1 FROM jsonb_array_elements(d{i}.elem) e{i}(elem) WHERE e{i}.elem#>>'{{}}' = ANY(%s) )
-                                        ELSE d{i}.elem#>>'{{}}' = ANY(%s)
+                                        WHEN 'array' THEN EXISTS(SELECT 1 FROM jsonb_array_elements(d{i}.elem) e{i}(elem) WHERE e{i}.elem#>>'{{}}' = ANY(%s::text[]) )
+                                        ELSE d{i}.elem#>>'{{}}' = ANY(%s::text[])
                                     END
                                 ) FROM jsonb_array_elements( trait_grants->%s ) AS d{i}(elem)
                             ) {ext}


### PR DESCRIPTION
The issue occurred because the `traits` list parameter was being interpreted as a string literal instead of a proper array in the SQL `ANY()` operator.

### Solution
Added explicit `::text[]` type casting to the RawSQL query to ensure PostgreSQL correctly interprets the traits parameter as a text array:
- Changed `= ANY(%s)` to `= ANY(%s::text[])`

This ensures proper array handling even when psycopg converts Python lists during parameterization.

## Summary by Sourcery

Bug Fixes:
- Add explicit ::text[] type casting to ANY() operator in Room permission SQL to fix array interpretation error