### PR TITLE
fix: join video button

### DIFF
--- a/app/eventyay/static/pretixpresale/js/ui/popover.js
+++ b/app/eventyay/static/pretixpresale/js/ui/popover.js
@@ -99,7 +99,7 @@ $(function () {
 
   // Constructing logout path using URLSearchParams
   const logoutParams = new URLSearchParams({ back: backUrl });
-  const logoutPath = `/control/logout?${logoutParams}`;
+  const logoutPath = `/common/logout?${logoutParams}`;
 
   const profilePath = '/common/account/';
   const orderPath = '/common/orders/';


### PR DESCRIPTION
Fixes #1308
Should this be accessible to everyone? like people without tickets, etc, currently, people without tickets are restricted

## Summary by Sourcery

Fix join video button by migrating video settings retrieval to event.settings schema and ensuring proper token URL construction, and correct the logout path in the popover UI

Bug Fixes:
- Use event.settings instead of deprecated venueless_settings for video join view and update token URL generation accordingly
- Correct logout URL path in popover script to /common/logout