### PR TITLE
chore(video): remove logout button

### DIFF
--- a/app/eventyay/webapp/src/components/AppBar.vue
+++ b/app/eventyay/webapp/src/components/AppBar.vue
@@ -16,12 +16,10 @@
 			span.display-name(v-if="!isAnonymous") {{ user.profile.display_name }}
 			span.display-name(v-else) {{ $t('AppBar:user-anonymous') }}
 			span.user-caret(role="button", :aria-expanded="String(profileMenuOpen)", aria-haspopup="true", tabindex="0", @click.stop="toggleProfileMenu", @keydown.enter.prevent="toggleProfileMenu", @keydown.space.prevent="toggleProfileMenu", :class="{open: profileMenuOpen}")
-		button.logout-btn(v-if="!isAnonymous", @click="logout", type="button", :aria-label="'Logout'")
-			i.fa.fa-sign-out
 		.profile-dropdown(v-if="profileMenuOpen", role="menu")
 			template(v-for="item in menuItems", :key="item.key")
 				div.menu-separator(v-if="item.separatorBefore")
-				a.menu-item(:class="{danger: item.action === 'logout'}", :href="getItemHref(item)", role="menuitem", @click.prevent="onMenuItem(item)")
+				a.menu-item(:href="getItemHref(item)", role="menuitem", @click.prevent="onMenuItem(item)")
 					span.menu-item-icon(v-if="item.icon" aria-hidden="true")
 						i(:class="iconClasses[item.icon]")
 					span.menu-item-label {{ item.label }}
@@ -71,7 +69,7 @@ const PROFILE_MENU_ITEMS = [
 	{ key: 'organizers', label: 'Organizers', externalPath: 'common/organizers/', icon: 'organizers' },
 	{ key: 'profile', label: 'Profile', route: { name: 'preferences' }, separatorBefore: true, icon: 'profile' },
 	{ key: 'account', label: 'Account', externalPath: 'common/account/general', icon: 'account' },
-	{ key: 'logout', label: 'Logout', action: 'logout', icon: 'logout' }
+	{ key: 'logout', label: 'Logout', action: 'logout', icon: 'logout', separatorBefore: true }
 ]
 
 const emit = defineEmits(['toggleSidebar'])
@@ -349,8 +347,6 @@ onBeforeUnmount(() => {
 				text-decoration: none
 				&:hover, &:focus-visible
 					background: rgba(0,0,0,0.06)
-				&.danger
-					color: #b00020
 				.menu-item-icon
 					color: var(--clr-primary)
 					flex: 0 0 auto
@@ -373,9 +369,6 @@ onBeforeUnmount(() => {
 					white-space: nowrap
 					text-overflow: ellipsis
 					overflow: hidden
-			.menu-item.danger .menu-item-icon,
-			.menu-item.danger .menu-item-icon i
-				color: inherit
 			.menu-separator
 				height: 1px
 				background: rgba(0,0,0,0.08)


### PR DESCRIPTION
Fixes #1312

## Summary by Sourcery

Consolidate logout functionality into the profile dropdown by removing the separate logout button and updating the menu item configuration.

Enhancements:
- Remove standalone logout button from the app bar
- Add separator before the logout entry in the profile dropdown and simplify its rendering