### PR TITLE
Fix: Hide unpublished sessions from talk component menu

### DIFF
--- a/app/eventyay/webapp/src/components/RoomsSidebar.vue
+++ b/app/eventyay/webapp/src/components/RoomsSidebar.vue
@@ -146,8 +146,7 @@ export default {
 					rooms.videoChat.push(room)
 				} else if (room.modules.some(module => ['livestream.native', 'livestream.youtube', 'livestream.iframe'].includes(module.type))) {
 					let session
-					// Only show session information if the schedule is published
-					if (this.$features.enabled('schedule-control') && this.hasPublishedSchedule) {
+					if (this.$features.enabled('schedule-control')) {
 						session = this.currentSessionPerRoom?.[room.id]?.session
 					}
 					const notifications = this.notificationCount(room.modules.find(m => m.type === 'chat.native')?.channel_id)
@@ -186,11 +185,6 @@ export default {
 		},
 		worldHasPosters() {
 			return this.visibleRooms.some(room => room.modules.length === 1 && room.modules[0].type === 'poster.native')
-		},
-		hasPublishedSchedule() {
-			// Only show schedule-related items if there's a published schedule
-			// The schedule is considered published if it has a version (not WIP)
-			return this.schedule && this.schedule.version
 		},
 	},
 	methods: {


### PR DESCRIPTION
Fix: Hide unpublished sessions from talk component menu

The talk component's left sidebar was displaying **Schedule**, **Sessions**, and **Speakers** menu links even when the schedule had **not been officially published**. This exposed Work-In-Progress (WIP) session information to attendees before organizers were ready to release it.


Added publication status checks to the talk component's sidebar to hide schedule-related menu items and session information when the schedule has not been officially released.




Fixes #1307

## Summary by Sourcery

Hide schedule-related menu items and session details in the talk component until the schedule has been officially published

Bug Fixes:
- Add publication status checks to the room sidebar to hide Schedule, Sessions, and Speakers links and session information when the schedule is not published
- Update server-side talk navigation template to only show the Sessions tab if a published or current schedule exists

Enhancements:
- Introduce hasPublishedSchedule computed property to centralize schedule publication checks