### PR TITLE
Fix(video): Enable Polls feature by default for new events

### DIFF
--- a/app/eventyay/base/models/event.py
+++ b/app/eventyay/base/models/event.py
@@ -187,6 +187,7 @@ def default_feature_flags():
         "present_multiple_times": False,
         "submission_public_review": True,
         "chat-moderation": True,
+        "polls": True,
     }
 
 def default_display_settings():


### PR DESCRIPTION
This PR ensures the Polls sidebar addon is visible by default when a new event is created.

*   **Change:** Adds `"polls": True` to the `default_feature_flags()`.
*   **Note:** Only affects **newly created events**. Existing events require a separate backfill to gain this default.
*   **Why:** The feature flag was `false` by default, hiding the toggle in the admin UI and preventing users from enabling polls.

Resolves #1076
## Summary by Sourcery

New Features:
- Make the polls sidebar addon enabled by default on new events via the default feature flags configuration.