### PR TITLE
fix(badge): add missing item to product rename in badge view

### DIFF
--- a/app/eventyay/plugins/badges/views.py
+++ b/app/eventyay/plugins/badges/views.py
@@ -46,7 +46,7 @@ class LayoutListView(BadgePluginEnabledMixin, EventPermissionRequiredMixin, List
     context_object_name = 'layouts'
 
     def get_queryset(self):
-        return self.request.event.badge_layouts.prefetch_related('item_assignments')
+        return self.request.event.badge_layouts.prefetch_related('product_assignments')
 
 
 class LayoutCreate(BadgePluginEnabledMixin, EventPermissionRequiredMixin, CreateView):


### PR DESCRIPTION
## Summary by Sourcery

Bug Fixes:
- Fix badge layout queryset to prefetch the correct product assignment relation after a product rename.