### PR TITLE
fix(500): item to product renames

### DIFF
--- a/app/eventyay/base/exporters/json.py
+++ b/app/eventyay/base/exporters/json.py
@@ -31,30 +31,30 @@ class JSONExporter(BaseExporter):
                     }
                     for category in self.event.categories.all()
                 ],
-                'items': [
+                'products': [
                     {
-                        'id': item.id,
-                        'name': str(item.name),
-                        'internal_name': str(item.internal_name),
-                        'category': item.category_id,
-                        'price': item.default_price,
-                        'tax_rate': item.tax_rule.rate if item.tax_rule else Decimal('0.00'),
-                        'tax_name': str(item.tax_rule.name) if item.tax_rule else None,
-                        'admission': item.admission,
-                        'active': item.active,
+                        'id': product.id,
+                        'name': str(product.name),
+                        'internal_name': str(product.internal_name),
+                        'category': product.category_id,
+                        'price': product.default_price,
+                        'tax_rate': product.tax_rule.rate if product.tax_rule else Decimal('0.00'),
+                        'tax_name': str(product.tax_rule.name) if product.tax_rule else None,
+                        'admission': product.admission,
+                        'active': product.active,
                         'variations': [
                             {
                                 'id': variation.id,
                                 'active': variation.active,
                                 'price': variation.default_price
                                 if variation.default_price is not None
-                                else item.default_price,
+                                else product.default_price,
                                 'name': str(variation),
                             }
-                            for variation in item.variations.all()
+                            for variation in product.variations.all()
                         ],
                     }
-                    for item in self.event.items.select_related('tax_rule').prefetch_related('variations')
+                    for product in self.event.products.select_related('tax_rule').prefetch_related('variations')
                 ],
                 'questions': [
                     {
@@ -83,7 +83,7 @@ class JSONExporter(BaseExporter):
                         'positions': [
                             {
                                 'id': position.id,
-                                'item': position.item_id,
+                                'product': position.product_id,
                                 'variation': position.variation_id,
                                 'price': position.price,
                                 'attendee_name': position.attendee_name,
@@ -107,10 +107,10 @@ class JSONExporter(BaseExporter):
                     {
                         'id': quota.id,
                         'size': quota.size,
-                        'items': [item.id for item in quota.items.all()],
+                        'products': [product.id for product in quota.products.all()],
                         'variations': [variation.id for variation in quota.variations.all()],
                     }
-                    for quota in self.event.quotas.all().prefetch_related('items', 'variations')
+                    for quota in self.event.quotas.all().prefetch_related('products', 'variations')
                 ],
             }
         }

--- a/app/eventyay/base/models/tax.py
+++ b/app/eventyay/base/models/tax.py
@@ -173,7 +173,7 @@ class TaxRule(LoggedModel):
         return (
             not OrderFee.objects.filter(tax_rule=self, order__event=self.event).exists()
             and not OrderPosition.all.filter(tax_rule=self, order__event=self.event).exists()
-            and not self.event.items.filter(tax_rule=self).exists()
+            and not self.event.products.filter(tax_rule=self).exists()
             and self.event.settings.tax_rate_default != self
         )
 

--- a/app/eventyay/base/services/cancelevent.py
+++ b/app/eventyay/base/services/cancelevent.py
@@ -210,11 +210,11 @@ def cancel_event(
             user=user,
         )
 
-        for i in event.items.filter(active=True):
+        for i in event.products.filter(active=True):
             i.active = False
             i.save(update_fields=['active'])
             i.log_action(
-                'pretix.event.item.changed',
+                'pretix.event.product.changed',
                 user=user,
                 data={'active': False, '_source': 'cancel_event'},
             )

--- a/app/eventyay/control/forms/checkin.py
+++ b/app/eventyay/control/forms/checkin.py
@@ -44,7 +44,7 @@ class CheckinListForm(forms.ModelForm):
         self.event = kwargs.pop('event')
         kwargs.pop('locales', None)
         super().__init__(**kwargs)
-        self.fields['limit_products'].queryset = self.event.items.all()
+        self.fields['limit_products'].queryset = self.event.products.all()
         self.fields['auto_checkin_sales_channels'] = forms.MultipleChoiceField(
             label=self.fields['auto_checkin_sales_channels'].label,
             help_text=self.fields['auto_checkin_sales_channels'].help_text,
@@ -117,7 +117,7 @@ class SimpleCheckinListForm(forms.ModelForm):
         self.event = kwargs.pop('event')
         kwargs.pop('locales', None)
         super().__init__(**kwargs)
-        self.fields['limit_products'].queryset = self.event.items.all()
+        self.fields['limit_products'].queryset = self.event.products.all()
 
         if not self.event.organizer.gates.exists():
             del self.fields['gates']

--- a/app/eventyay/control/views/pdf.py
+++ b/app/eventyay/control/views/pdf.py
@@ -62,12 +62,12 @@ class BaseEditorView(EventPermissionRequiredMixin, TemplateView):
         return None, f
 
     def _get_preview_position(self):
-        item = self.request.event.items.create(
+        product = self.request.event.products.create(
             name=_('Sample product'),
             default_price=42.23,
             description=_('Sample product description'),
         )
-        item2 = self.request.event.items.create(name=_('Sample workshop'), default_price=23.40)
+        product2 = self.request.event.products.create(name=_('Sample workshop'), default_price=23.40)
 
         from pretix.base.models import Order
 
@@ -83,9 +83,9 @@ class BaseEditorView(EventPermissionRequiredMixin, TemplateView):
 
         scheme = PERSON_NAME_SCHEMES[self.request.event.settings.name_scheme]
         sample = {k: str(v) for k, v in scheme['sample'].items()}
-        p = order.positions.create(item=item, attendee_name_parts=sample, price=item.default_price)
-        order.positions.create(item=item2, attendee_name_parts=sample, price=item.default_price, addon_to=p)
-        order.positions.create(item=item2, attendee_name_parts=sample, price=item.default_price, addon_to=p)
+        p = order.positions.create(product=product, attendee_name_parts=sample, price=product.default_price)
+        order.positions.create(product=product2, attendee_name_parts=sample, price=product.default_price, addon_to=p)
+        order.positions.create(product=product2, attendee_name_parts=sample, price=product.default_price, addon_to=p)
 
         InvoiceAddress.objects.create(order=order, name_parts=sample, company=_('Sample company'))
         return p

--- a/app/eventyay/eventyay_common/templates/eventyay_common/event/settings_base.html
+++ b/app/eventyay/eventyay_common/templates/eventyay_common/event/settings_base.html
@@ -18,7 +18,7 @@
                 {% endblocktrans %}
             </p>
             <p>
-                <a href="{% url "control:event.items.add" organizer=request.organizer.slug event=request.event.slug %}"
+                <a href="{% url "control:event.products.add" organizer=request.organizer.slug event=request.event.slug %}"
                     class="btn btn-default">
                     {% trans "Create a first product" %}
                 </a>

--- a/app/eventyay/eventyay_common/templates/eventyay_common/events/index.html
+++ b/app/eventyay/eventyay_common/templates/eventyay_common/events/index.html
@@ -127,7 +127,7 @@
                             {% include "pretixcontrol/fragment_quota_box_paid.html" with quota=q %}
                         {% endfor %}
                         {% if e.first_quotas|length > 3 %}
-                            <a href="{% url 'control:event.items.quotas' organizer=e.organizer.slug event=e.slug %}"
+                            <a href="{% url 'control:event.products.quotas' organizer=e.organizer.slug event=e.slug %}"
                                class="quotabox-more" data-toggle="tooltip" title="{% trans 'More quotas' %}"
                                aria-label="{% trans 'More quotas' %}" data-placement="top">
                                 &middot;&middot;&middot;


### PR DESCRIPTION
This PR fixes a few 500 errors caused due to `item` -> `product` rename like accessing the "My Events" page

<img width="1582" height="1034" alt="image" src="https://github.com/user-attachments/assets/d2b92c80-ccea-4815-b8c8-42ee56e4b57b" />

## Summary by Sourcery

Align event data and UI flows with the new product naming to prevent runtime errors related to the item→product migration.

Bug Fixes:
- Fix JSON export of events to correctly use products instead of items in products, order positions, and quotas payloads.
- Fix PDF upload preview generation by creating and referencing sample products instead of items in orders.
- Prevent event cancellation from failing by deactivating products and logging product change actions instead of items.
- Ensure tax rule deletion checks correctly validate against products that use the tax rule.
- Fix check-in form configuration by sourcing limitable products from the event’s products queryset.
- Correct event settings and event list templates to link to product creation and quota management routes using the updated product URLs.