### PR TITLE
fix: enable real-time live preview for color settings (#1175)

### DIFF
--- a/app/eventyay/webapp/src/components/ColorPicker.vue
+++ b/app/eventyay/webapp/src/components/ColorPicker.vue
@@ -2,7 +2,7 @@
 .c-color-picker
 	.color(:style="{'--color': modelValue}")
 	bunt-input(v-bind="$attrs", :modelValue="modelValue", @update:modelValue="$emit('update:modelValue', $event)")
-	input.color-picker(type="color", :value="modelValue", @change="$emit('update:modelValue', $event.target.value)")
+	input.color-picker(type="color", :value="modelValue", @input="$emit('update:modelValue', $event.target.value)")
 </template>
 <script>
 export default {


### PR DESCRIPTION
### Description
Fixed the issue where live preview of color settings was not working. Previously, the preview only updated after saving.

### Issues
Closes #1175

### Fix
1. **ColorPicker.vue**: Changed the input event from `@change` to `@input`. This ensures the parent component receives color updates continuously while dragging the color picker, not just when the picker is closed.
2. **theme.vue**: Added a deep watcher on `config.theme.colors`. This triggers `applyThemeConfig` immediately whenever colors change, updating the CSS variables in real-time for an instant preview.

### Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

## Summary by Sourcery

Enable real-time theme color preview while editing admin configuration

Bug Fixes:
- Update the color picker to emit changes continuously so theme colors update while dragging the selector instead of only on change commit

Enhancements:
- Add a deep watcher on theme color configuration to immediately apply theme updates for live preview in the admin UI