### PR TITLE
fix: Fatal Server Error when creating room in video component

### DIFF
--- a/app/eventyay/features/live/modules/room.py
+++ b/app/eventyay/features/live/modules/room.py
@@ -329,6 +329,9 @@ class RoomModule(BaseModule):
         conf = await get_room_config_for_user(
             body["room"], self.consumer.event.id, self.consumer.user
         )
+        if conf is None:
+            # Room not found or not yet available, skip broadcasting
+            return
         if "room:view" not in conf["permissions"]:
             return
         await self.consumer.send_json(
@@ -434,6 +437,9 @@ class RoomModule(BaseModule):
         config = await get_room_config_for_user(
             body["room"], self.consumer.event.id, self.consumer.user
         )
+        if config is None:
+            # Room not found or not yet available, skip broadcasting
+            return
         if "room:view" not in config["permissions"]:
             return
         await self.consumer.send_json(


### PR DESCRIPTION
**Summary**
Fixes a crash that occurred when creating new rooms (Stage, Chat, or BBB) in the video component, which caused the frontend to remain in a perpetual loading state.

**Root Cause**
Two related issues triggered the failure:

1. **Lazy-loaded channel relationship** during room creation caused a sync/async ORM conflict, leading to a crash during AuditLog serialization.
2. **Missing None handling** in WebSocket broadcast logic caused `AttributeError` if room lookup temporarily returned None due to transaction timing.

**Fixes Implemented**

* Pre-warm `room.channel` after creation to avoid lazy-loading inside async flow.
* Added None checks in:

  * `get_room_config_for_user()` to safely handle transient lookup failures
  * WebSocket handlers (`push_room_info`, `push_schedule_data`) to skip broadcasts when room config is unavailable

**Notes**
Issue was more visible in production due to async behavior, connection pooling, and concurrency patterns different from local environments.

**Related**
Closes #1343
Related: #1339
Includes: #1379

## Summary by Sourcery

Prevent crashes and loading hangs when creating new video rooms by hardening room creation and WebSocket room lookups.

Bug Fixes:
- Avoid ORM lazy-loading issues during audit logging by eagerly associating a newly created room with its channel.
- Prevent AttributeError in WebSocket handlers by safely handling cases where room configuration is temporarily unavailable.

Enhancements:
- Skip broadcasting room info or schedule data over WebSocket when room configuration cannot be resolved instead of failing the consumer.