### PR TITLE
fix(mail): fix timezone mismatch in mail

### DIFF
--- a/app/eventyay/base/email.py
+++ b/app/eventyay/base/email.py
@@ -522,7 +522,7 @@ def base_placeholders(sender: Event, **kwargs):
         SimpleFunctionalMailTextPlaceholder(
             'expire_date',
             ['event', 'order'],
-            lambda event, order: LazyExpiresDate(order.expires.astimezone(ZoneInfo(event.timezone))),
+            lambda event, order: LazyExpiresDate(order.expires.astimezone(ZoneInfo(event.settings.timezone))),
             lambda event: LazyDate(djnow() + timedelta(days=15)),
         ),
         SimpleFunctionalMailTextPlaceholder(
@@ -824,4 +824,3 @@ def base_placeholders(sender: Event, **kwargs):
         )
 
     return ph
-

--- a/app/eventyay/base/services/mail.py
+++ b/app/eventyay/base/services/mail.py
@@ -172,7 +172,7 @@ def mail(
         bcc = []
 
         if event:
-            timezone = event.timezone
+            timezone = event.settings.timezone
             renderer = event.get_html_mail_renderer()
             if not auto_email:
                 if event_bcc:  # Use custom BCC if specified

--- a/app/eventyay/base/templates/pretixbase/email/order_details.html
+++ b/app/eventyay/base/templates/pretixbase/email/order_details.html
@@ -1,5 +1,6 @@
 {% load eventurl %}
 {% load i18n %}
+{% load tz %}
 
 {% if position %}
     <div class="order-info">
@@ -16,7 +17,9 @@
                 {% if event.has_subevents and ev.name|upper != event.name|upper %}{{ ev.name }}<br>{% endif %}
                 {{ ev.get_date_range_display }}
                 {% if event.settings.show_times %}
-                    {{ ev.date_from|date:"TIME_FORMAT" }}
+                    {% with tz=event.settings.timezone %}
+                        {{ ev.date_from|timezone:tz|date:"TIME_FORMAT" }} ({{ tz }})
+                    {% endwith %}
                 {% endif %}
             </td>
         </tr>
@@ -66,7 +69,9 @@
                     <br>
                     {{ event.get_date_range_display }}
                     {% if event.settings.show_times %}
-                        {{ event.date_from|date:"TIME_FORMAT" }}
+                        {% with tz=event.settings.timezone %}
+                            {{ event.date_from|timezone:tz|date:"TIME_FORMAT" }} ({{ tz }})
+                        {% endwith %}
                     {% endif %}
                 {% endif %}
             </td>
@@ -105,7 +110,9 @@
                                         {% endif %}
                                         {{ groupkey.2.get_date_range_display }}
                                         {% if event.settings.show_times %}
-                                            {{ groupkey.2.date_from|date:"TIME_FORMAT" }}
+                                            {% with tz=event.settings.timezone %}
+                                                {{ groupkey.2.date_from|timezone:tz|date:"TIME_FORMAT" }} ({{ tz }})
+                                            {% endwith %}
                                         {% endif %}
                                     {% endif %}
                                     {% if groupkey.3 %} {# attendee name #}


### PR DESCRIPTION
Fixes #1403

Before (standard UTC timezone in mail):
<img width="594" height="230" alt="image" src="https://github.com/user-attachments/assets/32c1977b-dfba-4aee-ae2b-1a859c212ac3" />

After (correct event time with event timezone):
<img width="521" height="231" alt="image" src="https://github.com/user-attachments/assets/a260f987-7cb6-4a35-8426-5de26d0cb7cf" />

## Summary by Sourcery

Align email-rendered event and order times with the event’s configured timezone instead of the default/UTC timezone.

Bug Fixes:
- Display event and subevent times in order-related emails using the event’s configured timezone and label it explicitly in the template.
- Use the event’s configured timezone for order expiration placeholders and mail rendering logic instead of the generic event timezone field.