### PR TITLE
room creation null fix

### DIFF
--- a/app/eventyay/api/serializers/rooms.py
+++ b/app/eventyay/api/serializers/rooms.py
@@ -2,7 +2,7 @@ from rest_framework import serializers
 
 from eventyay.api.serializers.i18n import I18nAwareModelSerializer
 from eventyay.base.models.event import Event
-from eventyay.base.models.room import Room
+from eventyay.base.models.room import Room, NullSafeBooleanField
 
 
 class RoomSerializer(I18nAwareModelSerializer):
@@ -10,6 +10,11 @@ class RoomSerializer(I18nAwareModelSerializer):
         child=serializers.DictField(), required=False, default=[]
     )
     trait_grants = serializers.DictField(required=False, default={})
+    deleted = NullSafeBooleanField(required=False, default=False)
+    force_join = NullSafeBooleanField(required=False, default=False)
+    hidden = NullSafeBooleanField(required=False, default=False)
+    sidebar_hidden = NullSafeBooleanField(required=False, default=True)
+    setup_complete = NullSafeBooleanField(required=False, default=False)
 
     class Meta:
         model = Room
@@ -23,6 +28,7 @@ class RoomSerializer(I18nAwareModelSerializer):
             "sorting_priority",
             "pretalx_id",
             "schedule_data",
+            "force_join",
             "setup_complete",
             "hidden",
             "sidebar_hidden",

--- a/app/eventyay/core/utils/config.py
+++ b/app/eventyay/core/utils/config.py
@@ -24,10 +24,17 @@ def import_config(data):
     event.save()
 
     for i, room_config in enumerate(data.pop("rooms")):
-        room, _ = Room.objects.get_or_create(
+        room, created = Room.objects.get_or_create(
             import_id=room_config.pop("id"),
             event=event,
-            defaults={"name": room_config["name"]},
+            defaults={
+                "name": room_config["name"],
+                "deleted": False,
+                "force_join": False,
+                "hidden": False,
+                "sidebar_hidden": True,
+                "setup_complete": False,
+            },
         )
         room.name = room_config.pop("name")
         room.description = room_config.pop("description")
@@ -36,6 +43,22 @@ def import_config(data):
         room.module_config = room_config.pop("modules")
         room.pretalx_id = room_config.pop("pretalx_id", 0)
         room.sorting_priority = i
+        # Set ALL boolean fields with proper defaults (all have NOT NULL constraints)
+        has_modules = bool(room.module_config)
+        # Handle None values explicitly - pop() returns None if key exists with None value
+        deleted_val = room_config.pop("deleted", False)
+        room.deleted = False if deleted_val is None else deleted_val
+        force_join_val = room_config.pop("force_join", False)
+        room.force_join = False if force_join_val is None else force_join_val
+        setup_complete_val = room_config.pop("setup_complete", has_modules)
+        room.setup_complete = has_modules if setup_complete_val is None else setup_complete_val
+        hidden_val = room_config.pop("hidden", False)
+        room.hidden = False if hidden_val is None else hidden_val
+        sidebar_hidden_val = room_config.pop("sidebar_hidden", None)
+        if sidebar_hidden_val is None:
+            room.sidebar_hidden = room.hidden or not room.setup_complete
+        else:
+            room.sidebar_hidden = sidebar_hidden_val
         room.save()
         assert not room_config, f"Unused config data: {room_config}"
 


### PR DESCRIPTION
fixes null value issue

## Summary by Sourcery

Ensure room boolean flags are consistently non-null and safely handled across model saves, config import, serializers, and room creation, while aligning event permissions with world-level aliases.

Bug Fixes:
- Prevent room boolean fields from being saved as NULL by enforcing explicit default values in model saves, room creation, and config import paths.
- Avoid serializer errors and unintended NULL values for room boolean flags by introducing null-safe boolean serializer fields.
- Ensure event.update permissions correctly map to world:update for consistent permission aliasing.

Enhancements:
- Expose additional room boolean fields (including deleted and force_join) through the relevant serializers to keep API and config representations in sync.