### PR TITLE
fix(agenda): Fix scroll behaviour in sessions

### DIFF
--- a/app/eventyay/agenda/templates/agenda/schedule.html
+++ b/app/eventyay/agenda/templates/agenda/schedule.html
@@ -13,7 +13,6 @@
 <script>
     (function () {
         // Prevent auto-scroll on schedule pages (both grid and list views)
-        console.log("Schedule page scroll blocker loaded");
 
         const originalScrollIntoView = Element.prototype.scrollIntoView;
         const originalScrollTo = window.scrollTo;
@@ -24,14 +23,12 @@
         let scrollDisabled = true;
         setTimeout(() => {
             scrollDisabled = false;
-            console.log("Scroll blocker disabled");
         }, 2000);
 
         const shouldBlock = () => scrollDisabled;
 
         Element.prototype.scrollIntoView = function (...args) {
             if (shouldBlock()) {
-                console.log("Blocked scrollIntoView on", this);
                 return;
             }
             return originalScrollIntoView.apply(this, args);
@@ -39,7 +36,6 @@
 
         window.scrollTo = function (...args) {
             if (shouldBlock()) {
-                console.log("Blocked window.scrollTo", args);
                 return;
             }
             return originalScrollTo.apply(this, args);
@@ -47,7 +43,6 @@
 
         window.scroll = function (...args) {
             if (shouldBlock()) {
-                console.log("Blocked window.scroll", args);
                 return;
             }
             return originalScroll.apply(this, args);
@@ -55,7 +50,6 @@
 
         window.scrollBy = function (...args) {
             if (shouldBlock()) {
-                console.log("Blocked window.scrollBy", args);
                 return;
             }
             return originalScrollBy.apply(this, args);


### PR DESCRIPTION
# Fix Temporary Scroll Workaround for Schedule Page

This PR prevents the jarring upward scroll caused by the third-party `<pretalx-schedule>` widget during initial load.

**Fixes #1430**

---

The schedule page embeds the external Pretalx schedule widget:

```html
<pretalx-schedule …></pretalx-schedule>
```

This widget is **not part of the Eventyay codebase**. Its script (`pretalx-schedule.min.js`) is sourced from the upstream Pretalx project and contains internal logic that:

* Automatically scrolls the page to the current day/time
* Uses `window.scroll({ top: … })` in the minified bundle
* Triggers immediately on load, causing an unexpected jump when navigating from Speakers → Schedule, Sessions → Schedule, etc.

The `speaker.html` template does not include this JS widget, so it never exhibits this behavior.

---

## Temporary Workaround Implemented

Because the widget is external and cannot be modified directly within this repository, a short-term fix is applied:

* Override programmatic scroll APIs (`scroll`, `scrollTo`, `scrollBy`, `scrollIntoView`)
* Block their behavior for the first **2 seconds**, covering the widget initialization window
* Restore the original functions after 2 seconds
* User scrolling remains completely unaffected

This prevents the auto-scroll while keeping native scrolling intact after load.



https://github.com/user-attachments/assets/63c32c2a-0259-4c38-9b10-800c19f09540

## Summary by Sourcery

Improve agenda schedule page behaviour and layout.

Bug Fixes:
- Prevent unwanted automatic scrolling on schedule pages by temporarily blocking scroll APIs during initial load.

Enhancements:
- Add inline script to control scroll behaviour on schedule views while keeping existing schedule widgets and layout intact.