### PR TITLE
Fix Tickets menu link on order page to redirect to event shop

### DIFF
--- a/app/eventyay/presale/templates/pretixpresale/event/fragment_nav.html
+++ b/app/eventyay/presale/templates/pretixpresale/event/fragment_nav.html
@@ -5,7 +5,7 @@
 
 <nav id='header-nav-bar'>
     <div class="navigation">
-        <a href="#" class="header-tab underline">
+        <a href="{% eventurl request.event 'presale:event.index' %}" class="header-tab underline">
             <i class="fa fa-ticket"></i> {% translate "Tickets" %}
         </a>
 


### PR DESCRIPTION
fixes #1447 

Fix the "Tickets" menu link on order/thank-you pages to properly redirect users back 
to the event's main tickets overview page.
Previously pointed to "#" anchor.

https://github.com/user-attachments/assets/99c17e7c-f9cb-4cca-943d-1f674e96429a

## Summary by Sourcery

Bug Fixes:
- Fix the Tickets menu link on order/thank-you pages so it correctly routes to the event’s ticket overview page.