### PR TITLE
fix(docker): mount static.dist in worker container to enable SCSS compilation

### DIFF
--- a/deployment/docker-compose.yml
+++ b/deployment/docker-compose.yml
@@ -43,6 +43,7 @@ services:
     container_name: eventyay-next-worker
     entrypoint: celery -A eventyay worker -l info
     volumes:
+      - ./data/static:/home/app/web/eventyay/static.dist
       - ./eventyay.cfg:/etc/eventyay.cfg:ro
     env_file:
       - ./.env


### PR DESCRIPTION
This PR fixes (#1175) a production issue where the Celery worker failed to regenerate event CSS because it did not have access to the compiled static files under `STATIC_ROOT` (`eventyay/static.dist`). As a result, libsass raised the following error:

```
Error: File to import not found or unreadable: main.scss.
        on line 6:1 of stdin
>> @import "main.scss";
   ^
```

from inside the task:

```
eventyay-next-worker | [2025-12-08 06:57:48,885: INFO/MainProcess] Task eventyay.base.services.tickets.invalidate_cache[7650ee32-e7bd-4610-82ea-3cdbd82b1ca9] received 
eventyay-next-worker | [2025-12-08 06:57:48,914: INFO/MainProcess] Task eventyay.presale.style.regenerate_css[5b24b613-a5fa-4ad4-aff8-18993d5b3340] received 
eventyay-next-worker | [2025-12-08 06:57:49,040: INFO/ForkPoolWorker-2] Task eventyay.base.services.tickets.invalidate_cache[7650ee32-e7bd-4610-82ea-3cdbd82b1ca9] succeeded in 0.1489226371049881s: None 
eventyay-next-worker | [2025-12-08 06:57:49,100: ERROR/ForkPoolWorker-1] Task eventyay.presale.style.regenerate_css[5b24b613-a5fa-4ad4-aff8-18993d5b3340] raised unexpected: CompileError('Error: File to import not found or unreadable: main.scss.\n on line 6:1 of stdin\n>> @import "main.scss";\n ^\n')
```

The web container mounts `./data/static` into `/home/app/web/eventyay/static.dist`, but the worker did not. Adding the same volume mount to the worker should ensure `main.scss` and other SCSS sources are available, allowing `compile_scss()` to run successfully.

## Summary by Sourcery

Deployment:
- Mount the shared static.dist volume into the Celery worker container so SCSS compilation can read the necessary static files.