### PR TITLE
fix(deployment): mount media/data volume in worker so regenerated CSS becomes visible to web server

### DIFF
--- a/deployment/docker-compose.yml
+++ b/deployment/docker-compose.yml
@@ -24,7 +24,7 @@ services:
     container_name: eventyay-next-websocket
     entrypoint: daphne -b 0.0.0.0 -p 8001 eventyay.config.asgi:application
     volumes:
-      - ./data/data:/data
+      - ./data/data:/home/app/web/eventyay/data
       - ./eventyay.cfg:/etc/eventyay.cfg:ro
     ports:
       - 8001:8001


### PR DESCRIPTION
This PR fixes (#1175) a deployment issue where regenerated presale CSS files returned **404 Not Found** in production.

the celery worker runs `regenerate_css` and writes files like:

```
eventyay/data/media/pub/<org>/<event>/presale.<hash>.css
```

but, unlike the `web` container, the `worker` container did **not** mount the shared `./data/data -> /home/app/web/eventyay/data` volume. This meant the worker generated CSS only inside its own container filesystem, and the web server never saw those files resulting in

```
404: presale.<hash>.css not found
```

Now both containers share the same media directory and the web server can correctly serve the regenerated CSS.

## Summary by Sourcery

Deployment:
- Update docker-compose worker service to mount the shared data volume used by the web container.