### PR TITLE
Make sendgrid token optional when smtp email is selected

### DIFF
--- a/app/eventyay/control/forms/event.py
+++ b/app/eventyay/control/forms/event.py
@@ -1075,7 +1075,7 @@ class MailSettingsForm(SettingsForm):
     )
     send_grid_api_key = forms.CharField(
         label=_('Sendgrid Token'),
-        required=True,
+        required=False,
         widget=forms.TextInput(attrs={'placeholder': 'SG.xxxxxxxx'}),
     )
 
@@ -1172,6 +1172,13 @@ class MailSettingsForm(SettingsForm):
             data['smtp_password'] = self.initial.get('smtp_password')
         if data.get('smtp_use_tls') and data.get('smtp_use_ssl'):
             raise ValidationError(_('You can activate either SSL or STARTTLS security, but not both at the same time.'))
+
+        # Validate SendGrid token is provided when SendGrid is selected
+        if data.get('smtp_use_custom') and data.get('email_vendor') == 'sendgrid':
+            if not data.get('send_grid_api_key'):
+                raise ValidationError({'send_grid_api_key': _('This field is required when using SendGrid as email vendor.')})
+
+        return data
 
 
 class TicketSettingsForm(SettingsForm):

--- a/app/eventyay/control/forms/global_settings.py
+++ b/app/eventyay/control/forms/global_settings.py
@@ -323,6 +323,16 @@ class GlobalSettingsForm(SettingsForm):
             ]),
         ]
 
+    def clean(self):
+        data = super().clean()
+
+        # Validate SendGrid token is provided when SendGrid is selected
+        if data.get('email_vendor') == 'sendgrid':
+            if not data.get('send_grid_api_key'):
+                raise forms.ValidationError({'send_grid_api_key': _('This field is required when using SendGrid as email vendor.')})
+
+        return data
+
 
 class UpdateSettingsForm(SettingsForm):
     update_check_perform = forms.BooleanField(


### PR DESCRIPTION
## Summary by Sourcery

Bug Fixes:
- Prevent configurations where SendGrid is selected as the email vendor without providing a SendGrid API key.