### PR TITLE
Chore: Cfp flow movement preservation

### DIFF
--- a/app/eventyay/cfp/templates/cfp/event/submission_base.html
+++ b/app/eventyay/cfp/templates/cfp/event/submission_base.html
@@ -14,6 +14,7 @@
     {% include "cfp/includes/forms_header.html" %}
     {% compress js %}
         <script defer src="{% static "cfp/js/proposalTabTitles.js" %}"></script>
+        <script defer src="{% static "common/js/fileInput.js" %}"></script>
     {% endcompress %}
     {% block cfp_submission_header %}{% endblock cfp_submission_header %}
 {% endblock cfp_header %}
@@ -76,7 +77,7 @@
                     </div>
                     <div class="col-md-3">
                         {% if prev_url %}
-                            <button type="submit" class="btn btn-block btn-info btn-lg" name="action" value="back">
+                            <button type="submit" class="btn btn-block btn-info btn-lg" name="action" value="back" formnovalidate>
                                 « {{ phrases.base.back_button }}
                             </button>
                         {% endif %}

--- a/app/eventyay/cfp/templates/cfp/event/user_submission_edit.html
+++ b/app/eventyay/cfp/templates/cfp/event/user_submission_edit.html
@@ -17,6 +17,7 @@
         <script defer src="{% static "js/jquery.js" %}"></script>
         <script defer src="{% static "js/jquery.formset.js" %}"></script>
         <script defer src="{% static "cfp/js/animateFormset.js" %}"></script>
+        <script defer src="{% static "common/js/fileInput.js" %}"></script>
     {% endcompress %}
 {% endblock cfp_header %}
 

--- a/app/eventyay/cfp/views/user.py
+++ b/app/eventyay/cfp/views/user.py
@@ -361,15 +361,6 @@ class SubmissionsEditView(LoggedInEventPageMixin, SubmissionViewMixin, UpdateVie
         return self.get_object()
 
     def post(self, request, *args, **kwargs):
-        clear_field = request.POST.get('clear_file')
-        if clear_field == 'image':
-            submission = self.object
-            if submission and getattr(submission, 'image', None):
-                submission.image.delete(save=False)
-                submission.image = None
-                submission.save(update_fields=['image'])
-            return redirect(request.path)
-
         form = self.get_form()
         if form.is_valid() and self.qform.is_valid():
             return self.form_valid(form)

--- a/app/eventyay/common/forms/widgets.py
+++ b/app/eventyay/common/forms/widgets.py
@@ -89,8 +89,11 @@ class ClearableBasenameFileInput(ClearableFileInput):
 
     def get_context(self, name, value, attrs):
         ctx = super().get_context(name, value, attrs)
-        if value and not getattr(value, 'is_saved_file', False):
-            ctx['widget']['value'] = self.FakeFile(value)
+        if value:
+            if getattr(value, 'is_saved_file', False):
+                ctx['widget']['value'] = None
+            else:
+                ctx['widget']['value'] = self.FakeFile(value)
         return ctx
 
 
@@ -102,8 +105,13 @@ class ImageInput(ClearableBasenameFileInput):
         if value and getattr(value, 'is_saved_file', False):
             ctx['widget']['is_saved_file'] = True
             ctx['widget']['saved_filename'] = Path(value.name).name if getattr(value, 'name', None) else ''
-        elif value and getattr(value, 'name', None):
-            ctx['widget']['saved_filename'] = Path(value.name).name
+        elif value:
+            if getattr(value, 'name', None):
+                ctx['widget']['saved_filename'] = Path(value.name).name
+            elif getattr(value, 'url', None):
+                ctx['widget']['saved_filename'] = Path(value.url).name
+            else:
+                ctx['widget']['saved_filename'] = str(value)
         return ctx
 
 

--- a/app/eventyay/common/templates/common/avatar.html
+++ b/app/eventyay/common/templates/common/avatar.html
@@ -13,25 +13,25 @@
                     <div class="form-saved-file mb-2" id="avatar-saved-info">
                         <span class="text-muted">{% translate "Currently selected" %}: </span>
                         <strong>{{ saved_avatar_name }}</strong>
-                        <button type="submit" name="clear_file" value="avatar" class="btn btn-sm btn-outline-danger ml-2">{% translate "Clear" %}</button>
+                        <button type="submit" name="clear_file" value="avatar" class="btn btn-sm btn-outline-danger ml-2" formnovalidate>{% translate "Clear" %}</button>
                     </div>
                     {% elif user.avatar and not avatar_cleared %}
                     <div class="form-saved-file mb-2" id="avatar-saved-info">
                         <span class="text-muted">{% translate "Currently selected" %}: </span>
-                        <strong>{{ user.avatar.name|cut:"avatars/" }}</strong>
-                        <button type="submit" name="clear_file" value="avatar" class="btn btn-sm btn-outline-danger ml-2">{% translate "Clear" %}</button>
+                        <strong>{% if avatar_basename %}{{ avatar_basename }}{% else %}{{ user.avatar.name }}{% endif %}</strong>
+                        <button type="submit" name="clear_file" value="avatar" class="btn btn-sm btn-outline-danger ml-2" formnovalidate>{% translate "Clear" %}</button>
                     </div>
                     {% endif %}
                     <div class="form-file-selected mb-2" id="avatar-selected-info" style="display: none;">
                         <span class="text-muted">{% translate "Selected" %}: </span>
                         <strong id="avatar-selected-name"></strong>
-                        <button type="button" class="btn btn-sm btn-outline-danger ml-2" onclick="clearFileInput('avatar')">{% translate "Clear" %}</button>
+                        <button type="button" class="btn btn-sm btn-outline-danger ml-2" data-clear-file="avatar">{% translate "Clear" %}</button>
                     </div>
                     {{ form.avatar.as_field_group }}
                 </div>
                 {{ form.get_gravatar.as_field_group }}
             </div>
-            <div class="form-image-preview {% if not user.avatar or avatar_cleared %}{% if not user.get_gravatar %}d-none{% endif %}{% endif %}">
+            <div class="form-image-preview {% if not user.get_gravatar %}{% if not user.avatar or avatar_cleared %}d-none{% endif %}{% endif %}">
                 <a href="{% if user.avatar and not avatar_cleared %}{{ user.avatar|thumbnail:"default" }}{% endif %}" data-lightbox="{% if user.avatar and not avatar_cleared %}{{ user.avatar.url }}{% endif %}">
                     <img loading="lazy"
                          class="avatar"
@@ -51,4 +51,3 @@
 {% compress js %}
     <script defer src="{% static "cfp/js/profile.js" %}"></script>
 {% endcompress %}
-<script src="{% static 'common/js/fileInput.js' %}"></script>

--- a/app/eventyay/common/templates/common/widgets/image_input.html
+++ b/app/eventyay/common/templates/common/widgets/image_input.html
@@ -3,14 +3,14 @@
 <div class="form-saved-file mb-2" id="{{ widget.name }}-saved-info">
     <span class="text-muted">{% translate "Currently selected" %}: </span>
     <strong>{{ widget.saved_filename }}</strong>
-    <button type="submit" name="clear_file" value="{{ widget.name }}" class="btn btn-sm btn-outline-danger ml-2">{% translate "Clear" %}</button>
+    <button type="submit" name="clear_file" value="{{ widget.name }}" class="btn btn-sm btn-outline-danger ml-2" formnovalidate>{% translate "Clear" %}</button>
 </div>
 {% elif widget.value and widget.value.url %}
     <div class="form-existing-file mb-2" id="{{ widget.name }}-existing-info">
         <span class="text-muted">{% translate "Currently selected" %}: </span>
         <strong>{{ widget.saved_filename }}</strong>
-        <button type="button" class="btn btn-sm btn-outline-danger ml-2" onclick="clearExistingFile('{{ widget.name }}')">{% translate "Clear" %}</button>
-        <input type="checkbox" name="{{ widget.name }}-clear" id="{{ widget.name }}-clear-checkbox" style="display:none;">
+        <button type="button" class="btn btn-sm btn-outline-danger ml-2" data-clear-existing="{{ widget.name }}">{% translate "Clear" %}</button>
+        <input type="checkbox" name="{{ widget.name }}-clear" id="{{ widget.name }}-clear-checkbox" class="sr-only" aria-hidden="true">
     </div>
     <div class="form-image-preview" id="{{ widget.name }}-preview">
         <a href="{{ widget.value.url }}" data-lightbox>
@@ -22,7 +22,6 @@
 <div class="form-file-selected mb-2" id="{{ widget.name }}-selected-info" style="display: none;">
     <span class="text-muted">{% translate "Selected" %}: </span>
     <strong id="{{ widget.name }}-selected-name"></strong>
-    <button type="button" class="btn btn-sm btn-outline-danger ml-2" onclick="clearFileInput('{{ widget.name }}')">{% translate "Clear" %}</button>
+    <button type="button" class="btn btn-sm btn-outline-danger ml-2" data-clear-file="{{ widget.name }}">{% translate "Clear" %}</button>
 </div>
-<input type="{{ widget.type }}" name="{{ widget.name }}"{% include "django/forms/widgets/attrs.html" %} onchange="handleFileSelect(this)">
-<script src="{% static 'common/js/fileInput.js' %}"></script>
+<input type="{{ widget.type }}" name="{{ widget.name }}"{% include "django/forms/widgets/attrs.html" %} data-file-input>

--- a/app/eventyay/person/forms/profile.py
+++ b/app/eventyay/person/forms/profile.py
@@ -78,7 +78,7 @@ class SpeakerProfileForm(
             # Only use user's current values for fields not already in initial
             # This allows session data to take priority (for back navigation)
             for field in self.user_fields:
-                if field not in initial or initial.get(field) in (None, ''):
+                if field not in initial or initial.get(field) is None:
                     initial[field] = getattr(self.user, field)
         for field in self.user_fields:
             field_class = self.Meta.field_classes.get(field, User._meta.get_field(field).formfield)

--- a/app/eventyay/static/common/js/fileInput.js
+++ b/app/eventyay/static/common/js/fileInput.js
@@ -1,51 +1,77 @@
-function handleFileSelect(input) {
-    var name = input.name;
-    var selectedInfo = document.getElementById(name + '-selected-info');
-    var selectedName = document.getElementById(name + '-selected-name');
-    var savedInfo = document.getElementById(name + '-saved-info');
-    var existingInfo = document.getElementById(name + '-existing-info');
-    var preview = document.getElementById(name + '-preview');
-    var clearCheckbox = document.getElementById(name + '-clear-checkbox');
-    if (input.files && input.files[0]) {
-        selectedName.textContent = input.files[0].name;
-        selectedInfo.style.display = 'block';
+function handleFileInputChange(input) {
+    const name = input.name;
+    const selectedInfo = document.getElementById(`${name}-selected-info`);
+    const selectedName = document.getElementById(`${name}-selected-name`);
+    const savedInfo = document.getElementById(`${name}-saved-info`);
+    const existingInfo = document.getElementById(`${name}-existing-info`);
+    const preview = document.getElementById(`${name}-preview`);
+    const clearCheckbox = document.getElementById(`${name}-clear-checkbox`);
+
+    if (input.files?.[0]) {
+        if (selectedName) selectedName.textContent = input.files[0].name;
+        if (selectedInfo) selectedInfo.style.display = 'block';
         if (savedInfo) savedInfo.style.display = 'none';
         if (existingInfo) existingInfo.style.display = 'none';
         if (preview) preview.style.display = 'none';
         if (clearCheckbox) clearCheckbox.checked = false;
     } else {
-        selectedInfo.style.display = 'none';
+        if (selectedInfo) selectedInfo.style.display = 'none';
         if (savedInfo) savedInfo.style.display = 'block';
     }
 }
 
 function clearFileInput(name) {
-    var input = document.querySelector('input[name="' + name + '"]');
-    input.value = '';
-    document.getElementById(name + '-selected-info').style.display = 'none';
-    var savedInfo = document.getElementById(name + '-saved-info');
-    var existingInfo = document.getElementById(name + '-existing-info');
-    var preview = document.getElementById(name + '-preview');
-    if (savedInfo) savedInfo.style.display = 'block';
-    if (existingInfo) existingInfo.style.display = 'block';
+    const input = document.querySelector(`input[name="${name}"]`);
+    if (input) input.value = '';
+    const selectedInfo = document.getElementById(`${name}-selected-info`);
+    if (selectedInfo) selectedInfo.style.display = 'none';
+    const savedInfo = document.getElementById(`${name}-saved-info`);
+    const existingInfo = document.getElementById(`${name}-existing-info`);
+    const preview = document.getElementById(`${name}-preview`);
+    // Only show saved/existing info if they exist in DOM (meaning there was a previous file)
+    // Check if element exists and has meaningful content (not just whitespace)
+    const savedStrong = savedInfo?.querySelector('strong');
+    if (savedInfo && savedStrong?.textContent.trim()) {
+        savedInfo.style.display = 'block';
+    }
+    const existingStrong = existingInfo?.querySelector('strong');
+    if (existingInfo && existingStrong?.textContent.trim()) {
+        existingInfo.style.display = 'block';
+    }
     if (preview) preview.style.display = 'block';
 }
 
 function clearExistingFile(name) {
-    var existingInfo = document.getElementById(name + '-existing-info');
-    var preview = document.getElementById(name + '-preview');
-    var clearCheckbox = document.getElementById(name + '-clear-checkbox');
+    const existingInfo = document.getElementById(`${name}-existing-info`);
+    const preview = document.getElementById(`${name}-preview`);
+    const clearCheckbox = document.getElementById(`${name}-clear-checkbox`);
     if (existingInfo) existingInfo.style.display = 'none';
     if (preview) preview.style.display = 'none';
     if (clearCheckbox) clearCheckbox.checked = true;
 }
 
-document.addEventListener('DOMContentLoaded', function() {
-    document.querySelectorAll('.form-file-selected').forEach(function(el) {
-        var name = el.id.replace('-selected-info', '');
-        var input = document.querySelector('input[name="' + name + '"]');
-        if (input && !input.hasAttribute('onchange')) {
-            input.addEventListener('change', function() { handleFileSelect(this); });
+document.addEventListener('DOMContentLoaded', () => {
+    // Auto-attach change handlers to file inputs
+    document.querySelectorAll('.form-file-selected').forEach((el) => {
+        const name = el.id.replace('-selected-info', '');
+        const input = document.querySelector(`input[name="${name}"]`);
+        if (input && !input.dataset.fileHandlerAttached) {
+            input.dataset.fileHandlerAttached = 'true';
+            input.addEventListener('change', () => handleFileInputChange(input));
+        }
+    });
+
+    // Use event delegation for clear buttons with data attributes
+    document.addEventListener('click', (e) => {
+        const btn = e.target.closest('[data-clear-file]');
+        if (btn) {
+            e.preventDefault();
+            clearFileInput(btn.dataset.clearFile);
+        }
+        const existingBtn = e.target.closest('[data-clear-existing]');
+        if (existingBtn) {
+            e.preventDefault();
+            clearExistingFile(existingBtn.dataset.clearExisting);
         }
     });
 });


### PR DESCRIPTION
Fixes #1391

## Summary by Sourcery

Improve CFP submission flow to preserve user input and file selections across navigation, and enhance file/avatar handling UX.

New Features:
- Allow CFP wizard steps to save partial form data and restore it when navigating back.
- Provide UI controls and backend support for clearing previously uploaded files and avatars during CFP and profile flows.
- Display names of previously uploaded files and currently selected files in file and avatar input widgets.

Bug Fixes:
- Ensure CFP session data and uploaded files are refreshed on each request to avoid stale state when moving between steps.
- Prevent loss of entered profile data when navigating back in the CFP wizard by prioritizing session-stored values over user model defaults.
- Fix CFP event submission image clearing so that removing an image actually deletes it from the submission.

Enhancements:
- Refine file upload widgets and templates to better reflect current, existing, and newly selected files, including improved filename display.
- Simplify and standardize CFP file handling in session storage, including safer session mutation and optional file storage interactions.
- Adjust avatar preview logic to correctly hide the existing avatar when it has been marked for clearing.