### PR TITLE
fixes the events link so it redirects to the common event dashboard

### DIFF
--- a/app/eventyay/control/templates/pretixcontrol/organizers/detail.html
+++ b/app/eventyay/control/templates/pretixcontrol/organizers/detail.html
@@ -64,7 +64,7 @@
                 <tr>
                     <td>
                         <strong><a
-                                href="{% url "control:event.index" organizer=e.organizer.slug event=e.slug %}">{{ e.name }}</a></strong>
+                                href="{% url "eventyay_common:event.index" organizer=e.organizer.slug event=e.slug %}">{{ e.name }}</a></strong>
                         <br><small>{{ e.slug }}</small>
                         {% for k, v in e.meta_data.items %}
                             {% if v %}
@@ -105,7 +105,7 @@
                         {% endif %}
                     </td>
                     <td class="text-right flip">
-                        <a href="{% url "control:event.index" organizer=e.organizer.slug event=e.slug %}"
+                        <a href="{% url "eventyay_common:event.index" organizer=e.organizer.slug event=e.slug %}"
                                 class="btn btn-sm btn-default" title="{% trans "Open event dashboard" %}"
                                 data-toggle="tooltip">
                             <span class="fa fa-eye"></span>


### PR DESCRIPTION
fixes #1477

the events link now redirects to the comman event specific dashboard instead of the control(tick

https://github.com/user-attachments/assets/89373a69-01e7-4445-bbaa-e134e277cd83

ets) dashboard of the specific event

## Summary by Sourcery

Bug Fixes:
- Correct the event link in the organizer detail template to redirect to the common event-specific dashboard.