### PR TITLE
Fix: Schedule-editor Vue app not load in Docker deployment

### DIFF
--- a/app/eventyay/common/templatetags/vite.py
+++ b/app/eventyay/common/templatetags/vite.py
@@ -74,7 +74,7 @@ def vite_asset(path: str) -> str:
         return generate_script_tag(path, {'type': 'module'})
 
     manifest_entry = STATIC_FILES_MAPPING.get(path)
-    if not manifest_entry and MANIFEST_PATH.exists():
+    if not manifest_entry:
         msg = (
             f'Cannot find {path} in Vite manifest at {MANIFEST_PATH}.'
             if MANIFEST_PATH.exists()


### PR DESCRIPTION
Previously we look for the manifest.json file (generated by Vite) in "eventyay/data/compiled-frontend", but in Docker deployment, this folder doesn't exist, due to multi-stage image build method. With this PR, we change to `settings.STATIC_ROOT` to make it work on both scenarios.

This PR also simplifies the code to lookup JS/CSS file from _manifest.json_ file.

## Summary by Sourcery

Ensure schedule-editor assets are resolved from the static files directory and simplify Vite manifest handling for the schedule-editor app.

Bug Fixes:
- Load the Vite manifest for the schedule-editor app from the static files directory so the Vue app works in Docker deployments.

Enhancements:
- Simplify Vite manifest parsing and asset URL generation for schedule-editor scripts and styles, including minor type annotations and logging improvements.