### PR TITLE
Rename "next" branch to "dev" and update deployment mappings (main → next.eventyay.com, dev → dev.eventyay.com)

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -3,7 +3,7 @@ name: Deploy Documentation
 on:
   push:
     branches:
-      - enext
+      - dev
       - main
     paths:
       - 'doc/**'

--- a/.github/workflows/enext-docker-pr.yml
+++ b/.github/workflows/enext-docker-pr.yml
@@ -1,12 +1,12 @@
-name: Docker PR Build (enext)
+name: Docker PR Build (dev)
 
 on:
   pull_request:
-    branches: [ enext, main ]
+    branches: [ dev, main ]
 
 jobs:
   build_docker_image:
-    name: Build Docker image for enext PR
+  name: Build Docker image for dev PR
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/enext-docker.yml
+++ b/.github/workflows/enext-docker.yml
@@ -2,7 +2,7 @@ name: Docker
 on:
   workflow_dispatch:
   push:
-    branches: [ enext, main ]
+    branches: [ dev, main ]
 
 jobs:
   push_to_registry:
@@ -22,7 +22,7 @@ jobs:
         id: meta
         uses: docker/metadata-action@98669ae865ea3cffbcbaa878cf57c20bbf1c6c38
         with:
-          images: eventyay/eventyay-next
+          images: eventyay/eventyay
       
       - name: Build and push Docker image
         uses: docker/build-push-action@ad44023a93711e3deb337508980b4b5e9bcdc5dc

--- a/README.rst
+++ b/README.rst
@@ -49,11 +49,11 @@ Getting Started
 
   cd eventyay/app
 
-3. **Switch to the `enext` branch**:
+3. **Switch to the `dev` branch (was "next")**:
 
 .. code-block:: bash
 
-  git switch enext
+  git switch dev
 
 
 4. **Install Python packages**
@@ -197,7 +197,7 @@ The directory `app/eventyay` is mounted into the docker, thus live editing is su
 Configuration
 -------------
 
-Our configuration are based on TOML files. First of all, check the ``BaseSettings`` class in *app/eventyay/config/next_settings.py* for possible keys and original values.
+Our configuration are based on TOML files. First of all, check the ``BaseSettings`` class in *app/eventyay/config/next_settings.py* (or *dev_settings.py* for the dev branch) for possible keys and original values.
 Other than that, the configuration is divided to three running environments:
 
 * ``development``: With default values in *eventyay.development.toml*.
@@ -251,18 +251,18 @@ Due to this reason, overriding configuration via environment variables are not e
 Deployment
 ----------
 
-* copy all of the `deployment` directory onto the server (eg. as `/home/fossasia/enext`)
+* copy all of the `deployment` directory onto the server (eg. as `/home/fossasia/dev`)
 * prepare the used volumes in docker-compose: one for static files and one for
   the postgres database. Create on the server:
         /home/fossasia/enext/data/static
         /home/fossasia/enext/data/postgres
   and
         chown 100:101 /home/fossasia/enext/data/static
-* copy `env.prod-sample` to `.env` in `/home/fossasia/enext`, and edit it to your
+* copy `env.prod-sample` to `.env` in `/home/fossasia/dev`, and edit it to your
   liking
-* copy `nginx/enext-direct` to your system `/etc/nginx/sites-available`
-  The file needs to be adjusted if the `enext` dir is NOT in `/home/fossasia`!
-* Link the `enext-direct` file into `/etc/nginx/sites-enabled`
+* copy `nginx/enext-direct` (or the `edev-direct` variant for dev) to your system `/etc/nginx/sites-available`
+  The file needs to be adjusted if the `dev` dir is NOT in `/home/fossasia`!
+* Link the `enext-direct` (production/next) or `edev-direct` (dev) file into `/etc/nginx/sites-enabled`
 * Restart nginx
 * Run
         docker compose up -d

--- a/app/eventyay.cfg.dev
+++ b/app/eventyay.cfg.dev
@@ -1,0 +1,40 @@
+[eventyay]
+instance_name=eventyay
+#url=https://app.eventyay.com/tickets
+url=https://dev.eventyay.com
+currency=USD
+; DO NOT change the following value, it has to be set to the location of the
+; directory *inside* the docker container
+trust_x_forwarded_for=on
+trust_x_forwarded_proto=on
+registration=on
+talk_hostname=https://dev.eventyay.com
+video_server_hostname=https://dev.eventyay.com:8443
+
+[urls]
+static=/static/
+media=/media/
+
+[locale]
+default=en
+timezone=UTC
+
+[mail]
+from = info@eventyay.com
+host = mail.your-server.de
+port = 587
+user = info@eventyay.com
+password = CHANGEME
+tls = True
+ssl = False
+
+[redis]
+location=redis://eventyay-dev-redis/0
+sessions=true
+
+[celery]
+backend=redis://eventyay-dev-redis/1
+broker=redis://eventyay-dev-redis/2
+
+[django]
+secret=CHANGEME

--- a/app/eventyay/config/dev_settings.py
+++ b/app/eventyay/config/dev_settings.py
@@ -1,0 +1,34 @@
+"""
+Dev-specific settings wrapper.
+
+This file imports the main `next_settings` and applies a small set of overrides
+so the same codebase can be deployed for the `dev` branch without duplicating
+the full settings file.
+
+Note: The canonical settings for the next (production preview) remain in
+`next_settings.py`. The `dev` branch should include this file and set
+`DJANGO_SETTINGS_MODULE=eventyay.config.dev_settings` in the deployment
+environment, or the deployment tooling should set
+`EVY_RUNNING_ENVIRONMENT` and provide `eventyay.dev.toml`.
+"""
+
+from eventyay.config.next_settings import *  # noqa: F401,F403
+
+# Override host/CSRF trusted origins for the dev environment.
+CSRF_TRUSTED_ORIGINS = [
+    'http://localhost:1337',
+    'http://dev.eventyay.com:1337',
+    'https://dev.eventyay.com',
+]
+
+# If the `conf` object exists and has site_url configured from TOML, the
+# deployed environment will normally set that via `eventyay.dev.toml`. However
+# set a sensible default here, so running the code locally still works.
+try:
+    # If conf.site_url is present, respect it. Otherwise, set SITE_URL to dev.
+    SITE_URL = str(conf.site_url) if hasattr(conf, 'site_url') else 'https://dev.eventyay.com'
+except Exception:
+    SITE_URL = 'https://dev.eventyay.com'
+
+from urllib.parse import urlparse
+SITE_NETLOC = urlparse(SITE_URL).netloc

--- a/app/eventyay/config/eventyay.dev.toml
+++ b/app/eventyay/config/eventyay.dev.toml
@@ -1,0 +1,20 @@
+postgres_db = 'eventyay_dev'
+postgres_host = 'eventyay-dev-db'
+postgres_port = 5432
+postgres_user = 'eventyay-dev-user'
+# Please provide postgres_password via secret file or Docker secret.
+
+email_backend = 'django.core.mail.backends.smtp.EmailBackend'
+email_host = 'mail.your-server.de'
+# Please provide email_host_password via secret file or Docker secret.
+
+allowed_hosts = [
+    'dev.eventyay.com',
+    'eventyay.com',
+]
+
+site_url = 'https://dev.eventyay.com'
+
+talk_hostname = 'https://dev.eventyay.com/'
+
+redis_url = 'redis://eventyay-dev-redis/0'

--- a/deployment/env.dev-sample
+++ b/deployment/env.dev-sample
@@ -1,4 +1,4 @@
-TAG=enext
+TAG=dev
 DEBUG=1
 SECRET_KEY=foo
 DATABASE=postgres

--- a/deployment/nginx/edev-direct
+++ b/deployment/nginx/edev-direct
@@ -1,0 +1,59 @@
+server {
+    server_name dev.eventyay.com;
+
+    access_log /var/log/nginx/edev-access.log;
+        error_log /var/log/nginx/edev-error.log;
+
+    # WebSocket connections - route to daphne
+    location /ws/ {
+        proxy_pass http://127.0.0.1:8001;
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection "upgrade";
+        proxy_set_header Host $http_host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_redirect off;
+        proxy_buffering off;
+        proxy_read_timeout 86400;
+    }
+
+    # Regular HTTP requests - route to gunicorn
+    location / {
+        proxy_pass http://127.0.0.1:8000;
+        proxy_set_header Host $http_host;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_redirect off;
+    }
+
+    location /static/ {
+        alias /home/fossasia/dev/data/static/;
+    }
+
+    location /media/ {
+        alias /home/fossasia/dev/data/data/media/;
+        access_log off;
+        expires 30d;
+    }
+
+
+    listen 443 ssl; # managed by Certbot
+    ssl_certificate /etc/letsencrypt/live/dev.eventyay.com/fullchain.pem; # managed by Certbot
+    ssl_certificate_key /etc/letsencrypt/live/dev.eventyay.com/privkey.pem; # managed by Certbot
+    include /etc/letsencrypt/options-ssl-nginx.conf; # managed by Certbot
+    ssl_dhparam /etc/letsencrypt/ssl-dhparams.pem; # managed by Certbot
+
+}
+
+server {
+    if ($host = dev.eventyay.com) {
+        return 301 https://$host$request_uri;
+    } # managed by Certbot
+
+    listen 80;
+    server_name dev.eventyay.com;
+    return 404; # managed by Certbot
+
+}

--- a/doc/README.md
+++ b/doc/README.md
@@ -146,7 +146,7 @@ All suppressions are for **expected** warnings that don't affect documentation q
 
 ## Automated Deployment
 
-Documentation auto-deploys to **docs.eventyay.com** via GitHub Actions when you push to `enext` or `main` branches.
+Documentation auto-deploys to **docs.eventyay.com** via GitHub Actions when you push to `dev` or `main` branches.
 
 **Workflow**: `.github/workflows/deploy-docs.yml`
 
@@ -250,7 +250,7 @@ grep html_theme conf.py          # Check setting
 ## Support
 
 - **Issues**: https://github.com/fossasia/eventyay/issues
-- **Docs Source**: https://github.com/fossasia/eventyay/tree/enext/doc
+- **Docs Source**: https://github.com/fossasia/eventyay/tree/dev/doc
 
 ## License
 


### PR DESCRIPTION
## Summary by Sourcery

Align branch and deployment configuration around the new `dev` branch and set up environment-specific settings for the dev deployment.

New Features:
- Introduce dedicated dev Django settings module that wraps `next_settings` with dev-specific host and URL overrides.
- Add dev-specific TOML configuration and app config files for database, Redis, email, and site URL settings.
- Add dev-specific Nginx deployment configuration stub.

Enhancements:
- Retarget documentation deployment workflows and docs references from the deprecated `enext` branch to the `dev` branch.
- Update Docker build workflows to trigger on `dev` instead of `enext` and to publish images under the unified `eventyay/eventyay` repository.

CI:
- Adjust GitHub Actions workflows to build and deploy Docker images and docs when changes are pushed to the `dev` or `main` branches instead of `enext`.

Deployment:
- Configure dev environment settings and infrastructure mappings so the `dev` branch deploys to dev.eventyay.com while main deploys to next.eventyay.com.

Documentation:
- Update documentation to reference the `dev` branch for docs source and automated deployment triggers.