### PR TITLE
Let CELERY_TASK_ALWAYS_EAGER configurable

### DIFF
--- a/app/eventyay/config/eventyay.production.toml
+++ b/app/eventyay/config/eventyay.production.toml
@@ -21,3 +21,5 @@ site_url = 'https://next.eventyay.com'
 talk_hostname = 'https://next.eventyay.com/'
 
 redis_url = 'redis://eventyay-next-redis/0'
+
+celery_always_eager = false

--- a/app/eventyay/config/eventyay.testing.toml
+++ b/app/eventyay/config/eventyay.testing.toml
@@ -1,3 +1,5 @@
 # In testing, we use the in-memory email backend,
 # because we do assertions on sent emails and we want to throw away emails after tests.
 email_backend = 'django.core.mail.backends.locmem.EmailBackend'
+
+celery_always_eager = true

--- a/app/eventyay/config/next_settings.py
+++ b/app/eventyay/config/next_settings.py
@@ -141,6 +141,7 @@ class BaseSettings(_BaseSettings):
     metrics_passphrase: str = ''
     log_csp: bool = True
     csp_additional_header: str = ''
+    celery_always_eager: bool = False
     nanocdn_url: HttpUrl | None = None
     zoom_key: str = ''
     zoom_secret: str = ''
@@ -933,7 +934,7 @@ REDIS_USE_PUBSUB = True
 HAS_CELERY = True
 CELERY_BROKER_URL = increase_redis_db(REDIS_URL, 1)
 CELERY_RESULT_BACKEND = increase_redis_db(REDIS_URL, 2)
-CELERY_TASK_ALWAYS_EAGER = IS_TESTING
+CELERY_TASK_ALWAYS_EAGER = conf.celery_always_eager
 CELERY_TASK_SERIALIZER = 'json'
 CELERY_RESULT_SERIALIZER = 'json'
 CELERY_TASK_DEFAULT_QUEUE = 'default'


### PR DESCRIPTION
## Summary by Sourcery

Make Celery task eager execution configurable via application settings instead of being hardwired to the testing flag.

New Features:
- Introduce a celery_always_eager configuration option in base settings and environment-specific TOML files to control Celery eager execution behavior.

Enhancements:
- Wire Celery's CELERY_TASK_ALWAYS_EAGER setting to the new configuration flag for flexible per-environment control.