### PR TITLE
Revert "Fix: missing room config fields required by frontend"

### DIFF
--- a/app/eventyay/base/services/event.py
+++ b/app/eventyay/base/services/event.py
@@ -174,12 +174,7 @@ def get_room_config(room, permissions):
         "force_join": room.force_join,
         "modules": [],
         "schedule_data": room.schedule_data or None,
-        # Frontend expects these fields for visibleRooms filtering
-        "setup_complete": True,  # All rooms with config are complete
-        "hidden": False,
-        "sidebar_hidden": False,
     }
-
 
     if hasattr(room, "current_roomviews"):
         # set actual viewer count instead of approximate text


### PR DESCRIPTION
Reverts fossasia/eventyay#1501

## Summary by Sourcery

Bug Fixes:
- Remove always-true/false room configuration flags that were added solely for frontend filtering and are no longer desired in the API response.