### PR TITLE
fix(video): Revert Changes from frontend Webapp

### DIFF
--- a/app/eventyay/webapp/src/App.vue
+++ b/app/eventyay/webapp/src/App.vue
@@ -43,7 +43,7 @@
 	.fatal-error(v-if="currentFatalError") {{ currentFatalError.message || currentFatalError.code }}
 </template>
 <script>
-import { mapState, mapGetters } from 'vuex'
+import { mapState } from 'vuex'
 import AppBar from 'components/AppBar'
 import RoomsSidebar from 'components/RoomsSidebar'
 import MediaSource from 'components/MediaSource'
@@ -67,7 +67,6 @@ export default {
 		...mapState(['fatalConnectionError', 'fatalError', 'connected', 'socketCloseCode', 'world', 'rooms', 'user', 'mediaSourcePlaceholderRect', 'userLocale', 'userTimezone', 'roomFatalErrors']),
 		...mapState('notifications', ['askingPermission']),
 		...mapState('chat', ['call']),
-		...mapGetters(['visibleRooms']),
 		currentFatalError() {
 			if (this.room && this.roomFatalErrors?.[this.room.id]) {
 				return this.roomFatalErrors[this.room.id]
@@ -82,8 +81,8 @@ export default {
 			const routeName = this.$route?.name
 			if (!routeName) return
 			if (routeName.startsWith && routeName.startsWith('admin')) return
-			if (routeName === 'home') return this.visibleRooms?.[0]
-			return this.visibleRooms?.find(room => room.id === this.$route.params.roomId)
+			if (routeName === 'home') return this.rooms?.[0]
+			return this.rooms?.find(room => room.id === this.$route.params.roomId)
 		},
 		// TODO since this is used EVERYWHERE, use provide/inject?
 		modules() {
@@ -255,7 +254,7 @@ export default {
 				primaryWasPlaying &&
 				// don't background bbb room when switching to new bbb room
 				!(newRoom?.modules.some(isExclusive) && oldRoom?.modules.some(isExclusive)) &&
-				!newRoomHasMedia 
+				!newRoomHasMedia
 			) {
 				this.backgroundRoom = oldRoom
 			} else if (newRoomHasMedia) {
@@ -271,10 +270,10 @@ export default {
 			}
 		},
 		roomListChange() {
-			if (this.room && !this.visibleRooms.includes(this.room)) {
+			if (this.room && !this.rooms.includes(this.room)) {
 				this.$router.push('/').catch(() => {})
 			}
-			if (this.backgroundRoom && !this.visibleRooms.includes(this.backgroundRoom)) {
+			if (!this.backgroundRoom && !this.rooms.includes(this.backgroundRoom)) {
 				this.backgroundRoom = null
 			}
 		}

--- a/app/eventyay/webapp/src/components/RoomsSidebar.vue
+++ b/app/eventyay/webapp/src/components/RoomsSidebar.vue
@@ -3,17 +3,17 @@ transition(name="sidebar")
 	.c-rooms-sidebar(v-show="show && !snapBack", :style="style", role="navigation", @pointerdown="onPointerdown", @pointermove="onPointermove", @pointerup="onPointerup", @pointercancel="onPointercancel")
 		scrollbars(y)
 			.global-links(role="group", aria-label="pages")
-				router-link.room(v-if="homeRoom && roomsByType.page.includes(homeRoom)", :to="{name: 'home'}", v-html="$emojify(homeRoom.name)")
+				router-link.room(v-if="roomsByType.page.includes(rooms[0])", :to="{name: 'home'}", v-html="$emojify(rooms[0].name)")
 				router-link.room(:to="{name: 'schedule'}") {{ $t('RoomsSidebar:schedule:label') }}
 				router-link.room(:to="{name: 'schedule:sessions'}") {{ $t('RoomsSidebar:session:label') }}
 				router-link.room(:to="{name: 'schedule:speakers'}") {{ $t('RoomsSidebar:speaker:label') }}
 				template(v-for="page of roomsByType.page", :key="page.id")
-					router-link.room(v-if="page !== homeRoom", :to="{name: 'room', params: {roomId: page.id}}", v-html="$emojify(page.name)")
+					router-link.room(v-if="page !== rooms[0]", :to="{name: 'room', params: {roomId: page.id}}", v-html="$emojify(page.name)")
 			.group-title#stages-title(v-if="roomsByType.stage.length || hasPermission('world:rooms.create.stage')")
 				span {{ $t('RoomsSidebar:stages-headline:text') }}
-				bunt-icon-button(v-if="hasPermission('world:rooms.create.stage')", :tooltip="$t('RoomsSidebar:create-stage:tooltip')", :tooltip-fixed="true", @click="showStageCreationPrompt = true") plus
+				bunt-icon-button(v-if="hasPermission('world:rooms.create.stage')", @click="showStageCreationPrompt = true") plus
 			.stages(role="group", aria-describedby="stages-title")
-				router-link.stage(v-for="stage of roomsByType.stage", :to="stage.room === homeRoom ? {name: 'home'} : {name: 'room', params: {roomId: stage.room.id}}", :class="{active: stage.room.id === $route.params.roomId, session: stage.session, live: stage.session && stage.room.schedule_data, 'has-image': stage.image, 'starts-with-emoji': startsWithEmoji(stage.room.name)}")
+				router-link.stage(v-for="stage of roomsByType.stage", :to="stage.room === rooms[0] ? {name: 'home'} : {name: 'room', params: {roomId: stage.room.id}}", :class="{active: stage.room.id === $route.params.roomId, session: stage.session, live: stage.session && stage.room.schedule_data, 'has-image': stage.image, 'starts-with-emoji': startsWithEmoji(stage.room.name)}")
 					template(v-if="stage.session")
 						img.preview(v-if="stage.image", :src="stage.image")
 						.info
@@ -38,11 +38,11 @@ transition(name="sidebar")
 				bunt-icon-button(v-if="hasPermission('world:rooms.create.chat') || hasPermission('world:rooms.create.bbb')", tooltip="Create Channel", :tooltip-fixed="true", @click="showChatCreationPrompt = true") plus
 				bunt-icon-button(v-if="worldHasTextChannels", tooltip="Browse all channels", :tooltip-fixed="true", @click="showChannelBrowser = true") compass-outline
 			.chats(role="group", aria-describedby="chats-title")
-				router-link.video-chat(v-for="chat of roomsByType.videoChat", :to="chat === homeRoom ? {name: 'home'} : {name: 'room', params: {roomId: chat.id}}", :class="{active: chat.id === $route.params.roomId, 'starts-with-emoji': startsWithEmoji(chat.name)}")
+				router-link.video-chat(v-for="chat of roomsByType.videoChat", :to="chat === rooms[0] ? {name: 'home'} : {name: 'room', params: {roomId: chat.id}}", :class="{active: chat.id === $route.params.roomId, 'starts-with-emoji': startsWithEmoji(chat.name)}")
 					.room-icon(aria-hidden="true")
 					.name(v-html="$emojify(chat.name)")
 					i.bunt-icon.activity-icon.mdi(v-if="chat.users === 'many' || chat.users === 'few'", :class="{'mdi-account-group': (chat.users === 'many'), 'mdi-account-multiple': (chat.users === 'few')}", v-tooltip.bottom.fixed="{text: $t('RoomsSidebar:users-tooltip:' + chat.users)}", :aria-label="$t('RoomsSidebar:users-tooltip:' + chat.users)")
-				router-link.text-chat(v-for="chat of roomsByType.textChat", :to="chat.room === homeRoom ? {name: 'home'} : {name: 'room', params: {roomId: chat.room.id}}", :class="{unread: hasUnreadMessages(chat.room.modules[0].channel_id), 'starts-with-emoji': startsWithEmoji(chat.room.name)}")
+				router-link.text-chat(v-for="chat of roomsByType.textChat", :to="chat.room === rooms[0] ? {name: 'home'} : {name: 'room', params: {roomId: chat.room.id}}", :class="{unread: hasUnreadMessages(chat.room.modules[0].channel_id), 'starts-with-emoji': startsWithEmoji(chat.room.name)}")
 					.room-icon(aria-hidden="true")
 					.name(v-html="$emojify(chat.room.name)")
 					.notifications(v-if="chat.notifications") {{ chat.notifications }}
@@ -114,7 +114,7 @@ export default {
 		...mapState('schedule', ['schedule']),
 		...mapState('chat', ['joinedChannels', 'call']),
 		...mapState('exhibition', ['staffedExhibitions']),
-		...mapGetters(['hasPermission', 'visibleRooms']),
+		...mapGetters(['hasPermission']),
 		...mapGetters('chat', ['hasUnreadMessages', 'notificationCount']),
 		...mapGetters('schedule', ['sessions', 'currentSessionPerRoom']),
 		// showAdminConfigLink no longer needed; link is always visible and backend will enforce access
@@ -124,9 +124,6 @@ export default {
 				transform: `translateX(${this.pointerMovementX}px)`
 			}
 		},
-		homeRoom() {
-			return this.visibleRooms[0] || null
-		},
 		roomsByType() {
 			const rooms = {
 				page: [],
@@ -134,7 +131,7 @@ export default {
 				textChat: [],
 				videoChat: []
 			}
-			for (const room of this.visibleRooms) {
+			for (const room of this.rooms) {
 				if (room.modules.length === 1 && room.modules[0].type === 'chat.native') {
 					if (!this.joinedChannels.some(channel => channel.id === room.modules[0].channel_id)) continue
 					const notifications = this.notificationCount(room.modules[0].channel_id)
@@ -178,13 +175,13 @@ export default {
 				.sort((a, b) => (this.hasUnreadMessages(b.id) - this.hasUnreadMessages(a.id)) || this.getDMChannelName(a).localeCompare(this.getDMChannelName(b)))
 		},
 		worldHasTextChannels() {
-			return this.visibleRooms.some(room => room.modules.length === 1 && room.modules[0].type === 'chat.native')
+			return this.rooms.some(room => room.modules.length === 1 && room.modules[0].type === 'chat.native')
 		},
 		worldHasExhibition() {
-			return this.visibleRooms.some(room => room.modules.length === 1 && room.modules[0].type === 'exhibition.native')
+			return this.rooms.some(room => room.modules.length === 1 && room.modules[0].type === 'exhibition.native')
 		},
 		worldHasPosters() {
-			return this.visibleRooms.some(room => room.modules.length === 1 && room.modules[0].type === 'poster.native')
+			return this.rooms.some(room => room.modules.length === 1 && room.modules[0].type === 'poster.native')
 		},
 	},
 	methods: {

--- a/app/eventyay/webapp/src/store/index.js
+++ b/app/eventyay/webapp/src/store/index.js
@@ -55,10 +55,6 @@ export default new Vuex.Store({
 				lookup[room.id] = room
 				return lookup
 			}, {})
-		},
-		visibleRooms(state) {
-			if (!state.rooms) return []
-			return state.rooms.filter(room => !room.hidden && !room.sidebar_hidden && room.setup_complete)
 		}
 	},
 	mutations: {

--- a/app/eventyay/webapp/src/views/admin/rooms/RoomListItem.vue
+++ b/app/eventyay/webapp/src/views/admin/rooms/RoomListItem.vue
@@ -1,11 +1,7 @@
 <template lang="pug">
-.c-room-list-item.table-row
-	.handle.mdi.mdi-drag-vertical(:class="{disabled}", v-handle, v-tooltip="disabled ? 'sorting is disabled while searching' : ''")
-	router-link.name(:to="{name: 'admin:rooms:item', params: {roomId: room.id}}", v-html="$emojify($localize(room.name))")
-	.visibility
-		i.fa(:class="visibilityIconClass")
-	.actions
-		bunt-button(size="small", @click.stop="openRoomConfig") {{ actionLabel }}
+router-link.c-room-list-item.table-row(:to="{name: 'admin:rooms:item', params: {roomId: room.id}}")
+	.handle.mdi.mdi-drag-vertical(class="{disabled}", v-handle, v-tooltip="disabled ? 'sorting is disabled while searching' : ''")
+	.name(v-html="$emojify($localize(room.name))")
 </template>
 <script>
 import { ElementMixin, HandleDirective } from 'vue-slicksort'
@@ -13,27 +9,7 @@ export default {
 	directives: { handle: HandleDirective },
 	mixins: [ElementMixin],
 	props: {
-		room: Object,
-		disabled: Boolean
-	},
-	computed: {
-		isConfigured() {
-			return !!this.room.setup_complete
-		},
-		actionLabel() {
-			return this.isConfigured ? 'Configure' : 'Complete Setup'
-		},
-		visibilityIconClass() {
-			if (this.room.hidden) return 'fa-eye-slash hidden-room'
-			if (!this.room.setup_complete) return 'fa-eye-slash setup-incomplete'
-			if (this.room.sidebar_hidden) return 'fa-eye-slash sidebar-hidden'
-			return 'fa-eye visible-room'
-		}
-	},
-	methods: {
-		openRoomConfig() {
-			this.$router.push({name: 'admin:rooms:item', params: {roomId: this.room.id}})
-		}
+		room: Object
 	}
 }
 </script>
@@ -42,8 +18,6 @@ export default {
 	display: flex
 	align-items: center
 	color: $clr-primary-text-light
-	width: 100%
-	box-sizing: border-box
 	.handle
 		user-select: none
 		cursor: row-resize
@@ -51,21 +25,4 @@ export default {
 		&.disabled
 			cursor: auto
 			color: $clr-grey-300
-	.visibility
-		width: 80px
-		text-align: center
-		font-size: 18px
-		.fa
-			font-size: 20px
-			color: $clr-primary-text-light
-	.actions
-		width: 160px
-		display: flex
-		justify-content: flex-end
-
-.c-room-list-item.slick-sortable-helper
-	width: 100%
-	box-sizing: border-box
-	background-color: $clr-grey-50
-	box-shadow: 0 2px 8px rgba(0, 0, 0, 0.08)
 </style>

--- a/app/eventyay/webapp/src/views/admin/rooms/index.vue
+++ b/app/eventyay/webapp/src/views/admin/rooms/index.vue
@@ -13,21 +13,8 @@
 		.header
 			.drag
 			.name Name
-			.visibility Visibility
-			.actions Actions
-		template(v-if="rooms")
-			SlickList.tbody(
-				v-if="!search",
-				v-model:list="rooms",
-				lockAxis="y",
-				:valueKey="'id'",
-				:useDragHandle="true",
-				v-scrollbar.y="",
-				@update:list="onListSort"
-			)
-				RoomListItem(v-for="(room, index) of rooms" :index="index", :key="room.id", :room="room", :disabled="rooms.length < 2")
-			.table-body(v-else, v-scrollbar.y="")
-				RoomListItem(v-for="room of filteredRooms", :key="room.id", :room="room", :disabled="filteredRooms.length < 2")
+		SlickList.tbody(v-if="filteredRooms", v-model:list="rooms", lockAxis="y", :useDragHandle="true", v-scrollbar.y="", @update:list="onListSort")
+			RoomListItem(v-for="(room, index) of filteredRooms" :index="index", :key="index", :room="room", :disabled="filteredRooms !== rooms")
 		bunt-progress-circular(v-else, size="huge", :page="true")
 </template>
 <script>
@@ -88,16 +75,12 @@ export default {
 			}
 		},
 		async onListSort() {
-			const idList = this.rooms.map(room => String(room.id))
-			const previousOrder = [...this.rooms]
 			try {
-				this.rooms = await api.call('room.config.reorder', idList)
+				this.rooms = await api.call('room.config.reorder', this.rooms.map(room => room.id))
 			} catch (e) {
 				console.error(e)
-				// Rollback to previous order on error
-				this.rooms = previousOrder
-				await this.fetchRooms()
 			}
+			// TODO error handling
 		}
 	}
 }
@@ -119,8 +102,6 @@ export default {
 			align-items: center
 			.bunt-button:not(:last-child)
 				margin-right: 16px
-			h2
-				margin: 16px
 			.btn-create
 				themed-button-primary()
 	h2
@@ -133,19 +114,6 @@ export default {
 		background-color: $clr-white
 	.rooms-list
 		flex-table()
-		.header
-			margin-bottom: 0
-			padding-bottom: 8px
-			border-bottom: border-separator()
-		.slick-list
-			margin-top: 0
-		.table-row
-			width: 100%
-			box-sizing: border-box
-		.table-body
-			display: block
-			max-height: calc(100vh - 260px)
-			overflow: auto
 		.room
 			display: flex
 			align-items: center
@@ -155,10 +123,4 @@ export default {
 		.name
 			flex: auto
 			ellipsis()
-		.visibility
-			width: 80px
-			text-align: center
-		.actions
-			width: 160px
-			text-align: right
 </style>


### PR DESCRIPTION
This PR revert's changes from the frontend video Webapp that got accidentally added in #1151 and reverts the `hidden room` and `complete setup` references.

Screenshots:
<img width="2032" height="1161" alt="image" src="https://github.com/user-attachments/assets/6b08da0d-ccae-42ee-af2b-bc9d201bd84b" />
<img width="2032" height="1161" alt="image" src="https://github.com/user-attachments/assets/420331bb-451c-4f2b-86bf-9aaea8b725df" />
<img width="2032" height="1161" alt="image" src="https://github.com/user-attachments/assets/63dd4dc1-6ff8-4c6e-9b00-c869b04c8502" />

## Summary by Sourcery

Revert recently introduced room setup and visibility handling in the video frontend and restore the previous rooms sidebar and admin room list behavior.

Bug Fixes:
- Remove accidental room setup and visibility flags (hidden, sidebar_hidden, setup_complete) from room edit and save flow to avoid inconsistent UI state.
- Restore sidebar and routing logic to use the full rooms list rather than filtered visibleRooms so navigation matches backend behavior.

Enhancements:
- Simplify admin room list and room edit views by removing the temporary type-selection UI, visibility controls, and action column.
- Streamline room reordering to operate directly on the current rooms list without extra rollback logic.