### PR TITLE
Fix reload errors due to overly-broad routing

### DIFF
--- a/app/eventyay/multidomain/maindomain_urlconf.py
+++ b/app/eventyay/multidomain/maindomain_urlconf.py
@@ -143,16 +143,13 @@ unified_event_patterns = [
         include(
             [
                 # Video patterns under {organizer}/{event}/video/
+                # Match static assets with file extensions (js, css, png, etc.)
                 re_path(
                     r'^video/(?P<path>[^?]*\.[a-zA-Z0-9._-]+)$', VideoAssetView.as_view(), name='video.assets.file'
                 ),
-                path(
-                    'video/<path:path>',
-                    VideoAssetView.as_view(),
-                    name='video.assets',
-                ),
                 # The frontend Video SPA app is not served by Nginx so the Django view needs to
                 # serve all paths under /video/ to allow client-side routing.
+                # This catch-all must come after the asset pattern to allow SPA routes like /video/admin/rooms
                 re_path(r'^video(?:/.*)?$', VideoSPAView.as_view(), name='video.spa'),
                 path('talk/', EventStartpage.as_view(), name='event.talk'),
                 path('', include(('eventyay.agenda.urls', 'agenda'))),


### PR DESCRIPTION
What claude changed:
- Removed the middle catch-all pattern that sent everything to VideoAssetView
- Now only files with extensions (like .js, .css, .png) are routed to VideoAssetView for serving static assets
- All other video paths (like video/admin/rooms) fall through to the VideoSPAView, which serves the index.html and allows the Vue.js router to handle client-side routing

How it now works:
1. First pattern: Matches static assets with file extensions → serves via VideoAssetView
2. Second pattern: Catches all remaining /video/* paths → serves index.html via VideoSPAView

This is the standard pattern for SPAs with client-side routing.

## Summary by Sourcery

Bug Fixes:
- Fix incorrect routing where all /video/* paths were handled as static assets, causing page reload failures for SPA routes like /video/admin/rooms.