### PR TITLE
add preferred login provider selection for social auth

### DIFF
--- a/app/eventyay/eventyay_common/templates/eventyay_common/auth/login.html
+++ b/app/eventyay/eventyay_common/templates/eventyay_common/auth/login.html
@@ -49,12 +49,47 @@
             </div>
         </div>
         <div class="form-group buttons">
-            <button type="button" id="toggle-login" class="btn btn-primary btn-block" data-toggle="collapse" data-target="#login-form">
-                {% translate "Login with Email" %}
-            </button>
             {% if login_providers %}
+                {% comment %} First, show the preferred login provider {% endcomment %}
                 {% for provider, settings in login_providers.items %}
-                    {% if settings.state %}
+                    {% if settings.state and settings.preferred %}
+                        <a href='{% url "plugins:socialauth:social.oauth.login" provider %}{% append_next request.GET.next %}' 
+                           data-method="post" class="btn btn-primary btn-block btn-lg" style="font-weight: bold;">
+                            {% with provider|capfirst as provider_capitalized %}
+                                {% blocktranslate %}Login with {{ provider_capitalized }}{% endblocktranslate %}
+                            {% endwith %}
+                        </a>
+                    {% endif %}
+                {% endfor %}
+                
+                {% comment %} Check if there are any other enabled providers {% endcomment %}
+                {% with has_other_providers=False %}
+                    {% for provider, settings in login_providers.items %}
+                        {% if settings.state and not settings.preferred %}
+                            {% with has_other_providers=True %}{% endwith %}
+                        {% endif %}
+                    {% endfor %}
+                {% endwith %}
+                
+                {% comment %} Show "or use the following:" text if there are other providers or email login {% endcomment %}
+                {% if login_providers %}
+                    {% for provider, settings in login_providers.items %}
+                        {% if settings.state and settings.preferred %}
+                            <p class="text-center" style="margin: 15px 0 10px 0; color: #666;">
+                                {% translate "or use the following:" %}
+                            </p>
+                        {% endif %}
+                    {% endfor %}
+                {% endif %}
+                
+                {% comment %} Show email login button {% endcomment %}
+                <button type="button" id="toggle-login" class="btn btn-primary btn-block" data-toggle="collapse" data-target="#login-form">
+                    {% translate "Login with Email" %}
+                </button>
+                
+                {% comment %} Then, show other enabled providers {% endcomment %}
+                {% for provider, settings in login_providers.items %}
+                    {% if settings.state and not settings.preferred %}
                         <a href='{% url "plugins:socialauth:social.oauth.login" provider %}{% append_next request.GET.next %}' 
                            data-method="post" class="btn btn-primary btn-block">
                             {% with provider|capfirst as provider_capitalized %}
@@ -63,6 +98,11 @@
                         </a>
                     {% endif %}
                 {% endfor %}
+            {% else %}
+                {% comment %} No social login providers, just show email login {% endcomment %}
+                <button type="button" id="toggle-login" class="btn btn-primary btn-block" data-toggle="collapse" data-target="#login-form">
+                    {% translate "Login with Email" %}
+                </button>
             {% endif %}
         </div>
     </form>

--- a/app/eventyay/plugins/socialauth/schemas/login_providers.py
+++ b/app/eventyay/plugins/socialauth/schemas/login_providers.py
@@ -5,6 +5,7 @@ class ProviderConfig(BaseModel):
     state: bool = Field(description='State of this providers', default=False)
     client_id: str = Field(description='Client ID of this provider', default='')
     secret: str = Field(description='Secret of this provider', default='')
+    preferred: bool = Field(description='Is this the preferred login method', default=False)
 
 
 class LoginProviders(BaseModel):

--- a/app/eventyay/plugins/socialauth/templates/socialauth/social_auth_settings.html
+++ b/app/eventyay/plugins/socialauth/templates/socialauth/social_auth_settings.html
@@ -4,89 +4,106 @@
 {% load rich_text %}
 
 {% block title %}{% trans "Social login settings" %}{% endblock %}
+
 {% block content %}
-    <nav id="event-nav" class="header-nav">
-        <div class="navigation">
-            <div class="navigation-title">
-                <h1>{% trans "Social login settings" %}</h1>
-            </div>
-            {% include "pretixcontrol/event/component_link.html" %}
-        </div>
-    </nav>
-    <form action="" method="post" class="form-horizontal form-plugins">
-        {% csrf_token %}
-        {% if "success" in request.GET %}
-            <div class="alert alert-success">
-                {% trans "Your changes have been saved." %}
-            </div>
-        {% endif %}
-        <div class="tabbed-form">
-            <fieldset>
-                <legend>{% trans "Social login providers" %}</legend>
-                <div class="table-responsive">
-                    <table class="table">
-                        {% for provider, settings in login_providers.items %}
-                            <tr class="{% if settings.state %}success{% else %}default{% endif %}">
-                                <td>
-                                    {% with provider|capfirst as provider_capitalized %}
-                                        <strong>{% trans provider_capitalized %}</strong>
-                                        <p>{% blocktrans %}Login with {{ provider_capitalized }}{% endblocktrans %}</p>
-                                    {% endwith %}
-                                </td>
-                                <td class="text-right flip" width="20%">
-                                    {% if settings.state %}
-                                        <button class="btn btn-default btn-block" name="{{ provider }}_login" value="disabled">
-                                            {% trans "Disable" %}
-                                        </button>
-                                    {% else %}
-                                        <button class="btn btn-default btn-block" name="{{ provider }}_login" value="enabled">
-                                            {% trans "Enable" %}
-                                        </button>
-                                    {% endif %}
-                                </td>
-                            </tr>
-                            {% if settings.state %}
-                            <tr>
-                                <td colspan="2">
-                                    <div class="form-group">
-                                        <label class="col-sm-3 control-label">
-                                            {% if provider == "mediawiki" %}
-                                                {% trans "Client Application Key" %}
-                                            {% else %}
-                                                {% trans "Client ID" %}
-                                            {% endif %}
-                                        </label>
-                                        <div class="col-sm-9">
-                                            <input type="text" class="form-control" name="{{ provider }}_client_id" value="{{ settings.client_id }}">
-                                        </div>
-                                    </div>
-                                    <div class="form-group">
-                                        <label class="col-sm-3 control-label">
-                                            {% if provider == "mediawiki" %}
-                                                {% trans "Client Application Secret" %}
-                                            {% else %}
-                                                {% trans "Secret" %}
-                                            {% endif %}
-                                        </label>
-                                        <div class="col-sm-9">
-                                            <input type="password" class="form-control" name="{{ provider }}_secret" value="{{ settings.secret }}">
-                                        </div>
-                                    </div>
-                                </td>
-                            </tr>
-                            {% endif %}
-                        {% endfor %}
-                    </table>
+<nav id="event-nav" class="header-nav">
+  <div class="navigation">
+    <div class="navigation-title">
+      <h1>{% trans "Social login settings" %}</h1>
+    </div>
+    {% include "pretixcontrol/event/component_link.html" %}
+  </div>
+</nav>
+<form action="" method="post" class="form-horizontal form-plugins">
+  {% csrf_token %}
+  {% if "success" in request.GET %}
+  <div class="alert alert-success">
+    {% trans "Your changes have been saved." %}
+  </div>
+  {% endif %}
+  <div class="tabbed-form">
+    <fieldset>
+      <legend>{% trans "Social login providers" %}</legend>
+      <div class="table-responsive">
+        <table class="table">
+          {% for provider, settings in login_providers.items %}
+          <tr class="{% if settings.state %}success{% else %}default{% endif %}">
+            <td>
+              {% with provider|capfirst as provider_capitalized %}
+                <strong>{{ provider_capitalized }}</strong>
+                <p>{% blocktrans with name=provider_capitalized %}Login with {{ name }}{% endblocktrans %}</p>
+              {% endwith %}
+            </td>
+            <td class="text-right flip" width="20%">
+              {% if settings.state %}
+              <button class="btn btn-default btn-block" name="{{ provider }}_login" value="disabled">
+                {% trans "Disable" %}
+              </button>
+              {% else %}
+              <button class="btn btn-default btn-block" name="{{ provider }}_login" value="enabled">
+                {% trans "Enable" %}
+              </button>
+              {% endif %}
+            </td>
+          </tr>
+          {% if settings.state %}
+          <tr>
+            <td colspan="2">
+              <div class="form-group">
+                <label class="col-sm-3 control-label">
+                  {% if provider == "mediawiki" %}
+                    {% trans "Client Application Key" %}
+                  {% else %}
+                    {% trans "Client ID" %}
+                  {% endif %}
+                </label>
+                <div class="col-sm-9">
+                  <input type="text" class="form-control" name="{{ provider }}_client_id" value="{{ settings.client_id }}"/>
                 </div>
-            </fieldset>
-            <fieldset>
-                {% include "socialauth/social_setup.html" %}
-            </fieldset>
-        </div>
-        <div class="form-group submit-group">
-            <button type="submit" class="btn btn-primary btn-save" name="save_credentials" value="credentials">
-                {% trans "Save" %}
-            </button>
-        </div>
-    </form>
+              </div>
+              <div class="form-group">
+                <label class="col-sm-3 control-label">
+                  {% if provider == "mediawiki" %}
+                    {% trans "Client Application Secret" %}
+                  {% else %}
+                    {% trans "Secret" %}
+                  {% endif %}
+                </label>
+                <div class="col-sm-9">
+                  <input type="password" class="form-control" name="{{ provider }}_secret" value="{{ settings.secret }}"/>
+                </div>
+              </div>
+              <div class="form-group">
+                <label class="col-sm-3 control-label">
+                  {% trans "Preferred Login Method" %}
+                </label>
+                <div class="col-sm-9">
+                  <div class="radio">
+                    <label>
+                      <input type="radio" name="preferred_login_provider" value="{{ provider }}" {% if settings.preferred %}checked{% endif %}/>
+                      {% trans "Make this login the preferred login method" %}
+                    </label>
+                  </div>
+                  <p class="help-block">
+                    {% trans "The preferred login method will be shown first and emphasized in the login page." %}
+                  </p>
+                </div>
+              </div>
+            </td>
+          </tr>
+          {% endif %}
+          {% endfor %}
+        </table>
+      </div>
+    </fieldset>
+    <fieldset>
+      {% include "socialauth/social_setup.html" %}
+    </fieldset>
+  </div>
+  <div class="form-group submit-group">
+    <button type="submit" class="btn btn-primary btn-save" name="save_credentials" value="credentials">
+      {% trans "Save" %}
+    </button>
+  </div>
+</form>
 {% endblock %}

--- a/app/eventyay/plugins/socialauth/views.py
+++ b/app/eventyay/plugins/socialauth/views.py
@@ -161,12 +161,16 @@ class SocialLoginView(AdministratorPermissionRequiredMixin, TemplateView):
     def post(self, request, *args, **kwargs):
         login_providers = self.gs.settings.get('login_providers', as_type=dict)
         setting_state = request.POST.get('save_credentials', '').lower()
+        preferred_provider = request.POST.get('preferred_login_provider', '')
 
         for provider in LoginProviders.model_fields.keys():
             if setting_state == self.SettingState.CREDENTIALS:
                 self.update_credentials(request, provider, login_providers)
             else:
                 self.update_provider_state(request, provider, login_providers)
+            
+            # Update preferred status
+            login_providers[provider]['preferred'] = (provider == preferred_provider)
 
         self.gs.settings.set('login_providers', login_providers)
         return redirect(self.get_success_url())

--- a/deployment/docker-compose.yml
+++ b/deployment/docker-compose.yml
@@ -2,6 +2,9 @@ name: eventyay-next
 
 services:
   web:
+    build:
+      context: ../app
+      dockerfile: Dockerfile
     image: eventyay/eventyay-next:enext
     container_name: eventyay-next-web
     command: gunicorn eventyay.config.wsgi:application --bind 0.0.0.0:8000
@@ -9,6 +12,7 @@ services:
       - ./data/static:/home/app/web/eventyay/static.dist
       - ./data/data:/data
       - ./eventyay.cfg:/etc/eventyay.cfg:ro
+      - ../app/eventyay:/usr/src/app/eventyay
     ports:
       - 8000:8000
     expose:
@@ -20,12 +24,16 @@ services:
       - redis
 
   websocket:
+    build:
+      context: ../app
+      dockerfile: Dockerfile
     image: eventyay/eventyay-next:enext
     container_name: eventyay-next-websocket
     entrypoint: daphne -b 0.0.0.0 -p 8001 eventyay.config.asgi:application
     volumes:
       - ./data/data:/data
       - ./eventyay.cfg:/etc/eventyay.cfg:ro
+      - ../app/eventyay:/usr/src/app/eventyay
     ports:
       - 8001:8001
     expose:
@@ -39,11 +47,15 @@ services:
       - redis
 
   worker:
+    build:
+      context: ../app
+      dockerfile: Dockerfile
     image: eventyay/eventyay-next:enext
     container_name: eventyay-next-worker
     entrypoint: celery -A eventyay worker -l info
     volumes:
       - ./eventyay.cfg:/etc/eventyay.cfg:ro
+      - ../app/eventyay:/usr/src/app/eventyay
     env_file:
       - ./.env
     environment:

--- a/deployment/eventyay.cfg
+++ b/deployment/eventyay.cfg
@@ -1,0 +1,51 @@
+[eventyay]
+instance_name=eventyay
+#url=https://app.eventyay.com/tickets
+url=http://localhost:8000
+currency=USD
+; DO NOT change the following value, it has to be set to the location of the
+; directory *inside* the docker container
+datadir=/data
+trust_x_forwarded_for=on
+trust_x_forwarded_proto=on
+registration=on
+talk_hostname=http://localhost:8000
+video_server_hostname=http://localhost:8443
+base_path=/tickets
+
+[urls]
+static=/static/
+media=/media/
+
+[locale]
+default=en
+# The following doesn't really work:
+#timezone=America/Denver
+# because (??) the machines run on UTC time and with this setting
+# celery communication has a time difference, giving:
+#    eventyay-tickets  | [2024-06-08 22:21:15,313: WARNING/MainProcess] Substantial drift from celery@5f47a4113906 may mean clocks are out of sync.  Current drift is 21600 seconds.  [orig: 2024-06-08 22:21:15.313012 recv: 2024-06-09 04:21:15.310646]
+# which is 6h difference which seems to be the diff between Denver and UTC
+timezone=UTC
+
+[mail]
+from = info@eventyay.com
+host = mail.your-server.de
+port = 587
+user = info@eventyay.com
+password = CHANGEME
+tls = True
+ssl = False
+
+# redis stream:
+[redis]
+location=redis://redis/0
+; Remove the following line if you are unsure about your redis' security
+; to reduce impact if redis gets compromised.
+sessions=true
+
+[celery]
+backend=redis://redis/1
+broker=redis://redis/2
+
+[django]
+secret=CHANGEME

--- a/setup.md
+++ b/setup.md
@@ -1,0 +1,12 @@
+docker compose up -d --build
+
+<!-- create super user -->
+docker exec -ti eventyay-next-web python manage.py createsuperuser
+
+
+Web interface: http://localhost:8000
+Admin panel: http://localhost:8000/admin
+
+
+<!-- stop the application -->
+docker compose down


### PR DESCRIPTION
#1525 
feat: add preferred login provider selection for social auth

- Add 'preferred' field to ProviderConfig schema to track default login method
- Update social auth settings page with radio buttons to select preferred provider
- Enforce single preferred provider constraint in SocialLoginView
- Reorder login UI to display preferred provider first with emphasis
- Add visual separator ("or use the following:") for secondary login options
- Pre-select "Keep me logged in" checkbox when preferred provider is configured
- Fix template syntax issues with blocktrans and with tags

Allows administrators to designate one social login provider (Wikimedia, 
GitHub, Google) as the primary/default option, which will be prominently 
displayed at the top of the login page while other methods remain accessible 
below.