### PR TITLE
Let Celery run in "development" environment by default

### DIFF
--- a/app/eventyay/__main__.py
+++ b/app/eventyay/__main__.py
@@ -2,7 +2,7 @@ import os
 import sys
 
 if __name__ == '__main__':
-    os.environ.setdefault('EVY_RUNNING_ENVIRONMENT', 'production')
+    os.environ.setdefault('EVY_RUNNING_ENVIRONMENT', 'development')
     os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'eventyay.config.next_settings')
 
     from django.core.management import execute_from_command_line

--- a/app/eventyay/celery.py
+++ b/app/eventyay/celery.py
@@ -2,7 +2,7 @@ import os
 
 from celery import Celery
 
-os.environ.setdefault('EVY_RUNNING_ENVIRONMENT', 'production')
+os.environ.setdefault('EVY_RUNNING_ENVIRONMENT', 'development')
 os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'eventyay.config.next_settings')
 
 from django.conf import settings

--- a/app/eventyay/celery_app.py
+++ b/app/eventyay/celery_app.py
@@ -2,7 +2,7 @@ import os
 
 from celery import Celery
 
-os.environ.setdefault('EVY_RUNNING_ENVIRONMENT', 'production')
+os.environ.setdefault('EVY_RUNNING_ENVIRONMENT', 'development')
 os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'eventyay.config.next_settings')
 
 from django.conf import settings


### PR DESCRIPTION
Currently, in development, our developers have to use long command like this to run Celery:

```sh
EVY_RUNNING_ENVIRONMENT=development celery -A eventyay worker -l info
```

It is not convenient, let set "development" as default, so that we only need to run:

```sh
celery -A eventyay worker -l info
```

## Summary by Sourcery

Enhancements:
- Change the EVY_RUNNING_ENVIRONMENT default from production to development to simplify local Celery and app execution.