### PR TITLE
Remove VIDEO_SERVER_URL need by using organizer/event slug

### DIFF
--- a/app/eventyay/eventyay_common/tasks.py
+++ b/app/eventyay/eventyay_common/tasks.py
@@ -80,6 +80,7 @@ def create_world(self, is_video_creation: bool, event_data: dict) -> Optional[di
     :param is_video_creation: A boolean indicating whether the user has chosen to add a video.
     :param event_data: A dictionary containing the following event details:
         - id (str): The unique identifier for the event.
+        - organizer_slug (str): The slug of the event organizer.
         - title (str): The title of the event.
         - timezone (str): The timezone in which the event takes place.
         - locale (str): The locale for the event.
@@ -91,10 +92,11 @@ def create_world(self, is_video_creation: bool, event_data: dict) -> Optional[di
     - The user must choose to create a video.
     """
 
-    def _create_world(payload: dict, headers: dict) -> Optional[dict]:
+    def _create_world(payload: dict, headers: dict, organizer_slug: str, event_slug: str) -> Optional[dict]:
         try:
+            video_url = f"{settings.SITE_URL}/{organizer_slug}/{event_slug}/video/api/v1/create-world/"
             response = requests.post(
-                urljoin(settings.VIDEO_SERVER_HOSTNAME, 'api/v1/create-world/'),
+                video_url,
                 json=payload,
                 headers=headers,
             )
@@ -120,6 +122,7 @@ def create_world(self, is_video_creation: bool, event_data: dict) -> Optional[di
         return None
 
     event_slug = event_data.get('id', '')
+    organizer_slug = event_data.get('organizer_slug', '')
     payload = {
         'id': event_slug,
         'title': event_data.get('title', ''),
@@ -134,6 +137,8 @@ def create_world(self, is_video_creation: bool, event_data: dict) -> Optional[di
         return _create_world(
             payload=payload,
             headers={'Authorization': 'Bearer ' + event_data.get('token', '')},
+            organizer_slug=organizer_slug,
+            event_slug=event_slug,
         )
     except requests.RequestException as e:
         try:

--- a/app/eventyay/eventyay_common/views/event.py
+++ b/app/eventyay/eventyay_common/views/event.py
@@ -294,6 +294,7 @@ class EventCreateView(SafeSessionWizardView):
         # The user automatically creates a world when selecting the add video option in the create ticket form.
         event_data = dict(
             id=basics_data.get('slug'),
+            organizer_slug=event.organizer.slug,
             title=basics_data.get('name').data,
             timezone=basics_data.get('timezone'),
             locale=basics_data.get('locale'),
@@ -427,6 +428,7 @@ class EventUpdate(
             is_video_creation=True,
             event_data={
                 'id': self.request.event.slug,
+                'organizer_slug': self.request.event.organizer.slug,
                 'title': self.request.event.name.data,
                 'timezone': self.request.event.settings.timezone,
                 'locale': self.request.event.settings.locale,


### PR DESCRIPTION
## Summary by Sourcery

Use event and organizer slugs to construct the video creation endpoint URL instead of relying on a separate video server base URL.

Enhancements:
- Extend event video world creation to include organizer slug in event data and URL construction.
- Refine video world creation requests to target a per-event URL derived from SITE_URL, organizer slug, and event slug rather than a global video server hostname.