### PR TITLE
Drop world-create celery task and calls to it, it does nothing

### DIFF
--- a/app/eventyay/eventyay_common/tasks.py
+++ b/app/eventyay/eventyay_common/tasks.py
@@ -69,83 +69,6 @@ def send_team_webhook(self, user_id, team):
             logger.error('Max retries exceeded for sending organizer webhook.')
 
 
-@shared_task(
-    bind=True, max_retries=5, default_retry_delay=60, base=CreateWorldTask
-)  # Retries up to 5 times with a 60-second delay
-def create_world(self, is_video_creation: bool, event_data: dict) -> Optional[dict]:
-    """
-    Create a video system for the specified event.
-
-    :param self: Task instance
-    :param is_video_creation: A boolean indicating whether the user has chosen to add a video.
-    :param event_data: A dictionary containing the following event details:
-        - id (str): The unique identifier for the event.
-        - title (str): The title of the event.
-        - timezone (str): The timezone in which the event takes place.
-        - locale (str): The locale for the event.
-        - token (str): Authorization token for making the request.
-        - has_permission (bool): Indicates if the user has 'can_create_events' permission or is in admin session mode.
-
-    To successfully create a world, both conditions must be satisfied:
-    - The user must have the necessary permission.
-    - The user must choose to create a video.
-    """
-
-    def _create_world(payload: dict, headers: dict) -> Optional[dict]:
-        try:
-            response = requests.post(
-                urljoin(settings.VIDEO_SERVER_HOSTNAME, 'api/v1/create-world/'),
-                json=payload,
-                headers=headers,
-            )
-            response.raise_for_status()
-            return response.json()
-        except (
-            requests.exceptions.JSONDecodeError,
-            requests.exceptions.ConnectionError,
-            requests.exceptions.Timeout,
-            requests.exceptions.RequestException,
-        ) as e:
-            error_type = type(e).__name__
-            logger.error('%s during video world creation: %s', error_type, e)
-            raise
-
-    has_permission = event_data.get('has_permission', False)
-    if not (is_video_creation and has_permission):
-        logger.info(
-            'Skipping video world creation - Video enabled: %s, Has permission: %s',
-            is_video_creation,
-            has_permission,
-        )
-        return None
-
-    event_slug = event_data.get('id', '')
-    payload = {
-        'id': event_slug,
-        'title': event_data.get('title', ''),
-        'timezone': event_data.get('timezone', ''),
-        'locale': event_data.get('locale', ''),
-        'traits': {
-            'attendee': 'eventyay-video-event-{}'.format(event_slug),
-        },
-    }
-
-    try:
-        return _create_world(
-            payload=payload,
-            headers={'Authorization': 'Bearer ' + event_data.get('token', '')},
-        )
-    except requests.RequestException as e:
-        try:
-            self.retry(exc=e)
-        except self.MaxRetriesExceededError:
-            logger.error(
-                'Max retries exceeded for video world creation. Event: %s, Error: %s',
-                event_slug,
-                e,
-            )
-
-
 def get_header_token(user_id):
     # Fetch the user and organizer instances
     user_model = get_user_model()
@@ -169,7 +92,7 @@ def collect_billing_invoice(
 ) -> CollectBillingResponse:
     """
     Collect billing data for an event on a monthly basis.
-    
+
     This function checks if a billing invoice already exists for the given event and
     month. If not, it checks if there were any paid orders in the last
     month, and if there were, it calculates the total amount and ticket

--- a/app/eventyay/eventyay_common/views/event.py
+++ b/app/eventyay/eventyay_common/views/event.py
@@ -38,7 +38,6 @@ from eventyay.control.views import PaginationMixin, UpdateView
 from eventyay.control.views.event import DecoupleMixin, EventSettingsViewMixin
 from eventyay.control.views.product import MetaDataEditorMixin
 from eventyay.eventyay_common.forms.event import EventCommonSettingsForm
-from eventyay.eventyay_common.tasks import create_world
 from eventyay.eventyay_common.utils import (
     EventCreatedFor,
     check_create_permission,
@@ -291,16 +290,6 @@ class EventCreateView(SafeSessionWizardView):
                     action='eventyay.event.added',
                     user=self.request.user,
                 )
-        # The user automatically creates a world when selecting the add video option in the create ticket form.
-        event_data = dict(
-            id=basics_data.get('slug'),
-            title=basics_data.get('name').data,
-            timezone=basics_data.get('timezone'),
-            locale=basics_data.get('locale'),
-            has_permission=has_permission,
-            token=generate_token(self.request),
-        )
-        create_world.delay(is_video_creation=final_is_video_creation, event_data=event_data)
 
         return redirect(
             reverse(
@@ -423,17 +412,6 @@ class EventUpdate(
             messages.error(self.request, _('You do not have permission to perform this action.'))
             return False
 
-        create_world.delay(
-            is_video_creation=True,
-            event_data={
-                'id': self.request.event.slug,
-                'title': self.request.event.name.data,
-                'timezone': self.request.event.settings.timezone,
-                'locale': self.request.event.settings.locale,
-                'has_permission': True,
-                'token': generate_token(self.request),
-            },
-        )
         return True
 
     def post(self, request, *args, **kwargs):

--- a/doc/video/admin/management.rst
+++ b/doc/video/admin/management.rst
@@ -43,30 +43,6 @@ migrations. It may be useful debug output to include in bug reports about databa
 World management
 ----------------
 
-``create_world``
-""""""""""""""""
-
-The interactive ``create_world`` command allows you to create an empty eventyay world from scratch::
-
-    > create_world
-    Enter the internal ID for the new world (alphanumeric): myevent2020
-    Enter the title for the new world: My Event 2020
-    Enter the domain of the new world (e.g. myevent.example.org): eventyay.mydomain.com
-    World created.
-    Default API keys: [{'issuer': 'any', 'audience': 'Eventyay', 'secret': 'zvB7hI28vbrI7KtsRnJ1TZBSN3DvYdoy9VoJGLI1ouHQP5VtRG3U6AgKJ9YOqKNU'}]
-
-``clone_world``
-"""""""""""""""
-
-The interactive ``clone_world`` command allows you to create a eventyay world while copying all settings and rooms
-(but not users and user-generated content) from an existing one::
-
-    > clone_world myevent2019
-    Enter the internal ID for the new world (alphanumeric): myevent2020
-    Enter the title for the new world: My Event 2020
-    Enter the domain of the new world (e.g. myevent.example.org): eventyay.mydomain.com
-    World cloned.
-
 ``generate_token``
 """"""""""""""""""
 
@@ -74,16 +50,6 @@ The ``generate_token`` command allows you to create a valid access token to a ev
 
     > generate_token myevent2019 --trait moderator --trait speaker --days 90
     https://eventyay.mydomain.com/#token=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9…
-
-``list_worlds``
-"""""""""""""""
-
-The ``list_worlds`` command allows you to list all worlds in the database::
-
-    > list_worlds
-    ID                  Title                             URL
-    myevent2019         My Event 2019                     https://2019.myevent.com
-    myevent2020         My Event 2020                     https://2020.myevent.com
 
 ``import_config``
 """""""""""""""""


### PR DESCRIPTION
## Summary by Sourcery

Remove the unused Celery task for video world creation and its invocations from the event workflow.

Enhancements:
- Delete the obsolete create_world Celery task responsible for video world provisioning.
- Remove automatic video world creation triggers from event creation and video enablement flows.