### PR TITLE
Add missing VIDEO_SERVER_HOSTNAME setting to prevent runtime error

### DIFF
--- a/app/eventyay/config/settings.py
+++ b/app/eventyay/config/settings.py
@@ -570,6 +570,9 @@ TALK_HOSTNAME = (
     if not DEBUG
     else 'http://localhost:8000/'
 )
+VIDEO_SERVER_HOSTNAME = config.get(
+    'eventyay', 'video_server_hostname', fallback='https://app.eventyay.com/video'
+)
 # Internationalization
 # https://docs.djangoproject.com/en/5.1/topics/i18n/
 


### PR DESCRIPTION
## What does this PR do?

This PR addresses a runtime error that occurs when users enable video creation for events. The error manifests as:

AttributeError("'Settings' object has no attribute 'VIDEO_SERVER_HOSTNAME'")

The issue occurs in the `create_world` Celery task when the video creation feature is enabled and the user has the required permissions. The task attempts to access `settings.VIDEO_SERVER_HOSTNAME` to construct the video server API endpoint, but this setting was not defined in the application configuration.

## What changed?

- Added the missing `VIDEO_SERVER_HOSTNAME` setting to `app/eventyay/config/settings.py`
- The setting reads from the `[eventyay]` section of the configuration file under the key `video_server_hostname`
- Provides a safe default value (`https://app.eventyay.com/video`) for deployments that do not explicitly configure this setting
- Placed alongside related hostname settings for consistency

## Why this approach?

- Minimal scope — only adds the missing setting
- Safe for existing deployments
- No behavior changes beyond preventing the runtime error

## How can this be verified?

```python
from django.conf import settings
assert hasattr(settings, "VIDEO_SERVER_HOSTNAME")

## Summary by Sourcery

Add configuration for the video server hostname to prevent runtime errors when accessing video features.

New Features:
- Introduce VIDEO_SERVER_HOSTNAME Django setting sourced from the eventyay configuration.

Bug Fixes:
- Prevent AttributeError caused by missing VIDEO_SERVER_HOSTNAME when running the video creation Celery task.

Enhancements:
- Provide a sensible default video server URL for deployments that do not configure VIDEO_SERVER_HOSTNAME explicitly.