### PR TITLE
Fix: Wikimedia login redirect to return user to last visited page 

### DIFF
--- a/app/eventyay/eventyay_common/views/auth.py
+++ b/app/eventyay/eventyay_common/views/auth.py
@@ -67,7 +67,7 @@ def process_login(request, user, keep_logged_in):
     request.session['eventyay_auth_long_session'] = settings.EVENTYAY_LONG_SESSIONS and keep_logged_in
     
     # Check for socialauth_next_url (from OAuth flows) first, then fall back to backend's get_next_url
-    next_url = getattr(request, 'socialauth_next_url', None)
+    next_url = request.session.pop('socialauth_next_url', None)
     if not next_url:
         next_url = get_auth_backends()[user.auth_backend].get_next_url(request)
     


### PR DESCRIPTION
https://github.com/user-attachments/assets/a904b442-a75f-4fc3-bb9c-f324b349b79f

Fixes #1473

## Summary by Sourcery

Bug Fixes:
- Store the 'next' URL in session during OAuth login and reapply it on OAuth return so users are redirected back to their last visited page after login, while restricting redirects to safe relative URLs.