### PR TITLE
fix: prevent user dropdown redirect on Talks page

### DIFF
--- a/app/eventyay/orga/templates/orga/base.html
+++ b/app/eventyay/orga/templates/orga/base.html
@@ -65,8 +65,8 @@
             <script defer src="{% static "common/js/formTools.js" %}"></script>
             <script defer src="{% static "common/js/lightbox.js" %}"></script>
             <script defer src="{% static "orga/js/sidebar.js" %}"></script>
-            <script defer src="{% static 'jquery/js/jquery-3.7.1.min.js' %}"></script>
-            <script defer src="{% static 'bootstrap/js/bootstrap.js' %}"></script>
+            <script src="{% static 'jquery/js/jquery-3.7.1.min.js' %}"></script>
+            <script src="{% static 'bootstrap/js/bootstrap.js' %}"></script>
             <script defer src="{% static 'utils/js/utils.js' %}"></script>
             <script defer src="{% static 'pretixcontrol/js/ui/popover.js' %}"></script>
         {% endcompress %}
@@ -135,7 +135,7 @@
                 {% endif %}
                 {{ staff_session|json_script:"is_admin_mode" }}
                 {{ 'popover-profile'|json_script:"popover_toggle" }}
-                {{ ''|json_script:"base_path" }}
+                {{ base_path|json_script:"base_path" }}
 
                 {% if warning_update_available %}
                     <li class="nav-item">
@@ -146,7 +146,7 @@
                 {% endif %}
                 {% block navbar_right %}{% endblock navbar_right %}
                 <li class="nav-item d-none d-md-block">
-                    <a class="nav-link active" data-toggle="popover-profile" style="cursor: pointer;">
+                    <a class="nav-link" data-toggle="popover-profile" style="cursor: pointer;">
                         <i class="fa fa-user"></i>
                         {{ request.user.get_display_name }}
                         <i class="fa fa-caret-down"></i>

--- a/app/eventyay/static/orga/css/_popover.css
+++ b/app/eventyay/static/orga/css/_popover.css
@@ -7,8 +7,7 @@
     box-shadow: 0 5px 10px rgba(0, 0, 0, 0.2);
     z-index: 1060;
     background: white;
-    position: absolute !important;
-    top: 50px !important;
+    position: absolute;
 }
 
 .popover-content {


### PR DESCRIPTION
Fixes #1568

## Overview
On the Talks page, clicking the logged-in user in the top navigation redirected to Account Settings instead of opening the user dropdown. This behavior was inconsistent with the Tickets page.

## Solution
- Reused the existing `popover.js` implementation from the Tickets page
- Ensured required data attributes and dependencies are present
- Prevented navigation redirect and restored dropdown behavior

## Result
Clicking the user name on the Talks page now correctly opens the user dropdown, consistent with the Tickets page behavior.