### PR TITLE
docs: clarify local development setup for new contributors

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -296,3 +296,39 @@ This project is maintained by **FOSSASIA**. See the AUTHORS file for a list of a
 .. _eventyay.com: https://eventyay.com
 .. _blog: https://blog.eventyay.com
 .. _Docker secrets: https://docs.docker.com/engine/swarm/secrets/
+
+
+
+
+
+
+
+Local Development Notes
+-----------------------
+
+Eventyay is a monorepo consisting of multiple services. New contributors should note:
+
+* There are multiple ``manage.py`` files. For the main backend, use:
+  
+  ``app/manage.py``
+
+* Eventyay currently requires **Django 5.2.x**. Newer Django versions may break local setup.
+
+* The default development configuration uses test domains (e.g. ``test.eventyay.com``).
+  For local development, create a local override file:
+
+  ``app/eventyay/config/eventyay.local.toml``
+
+  Example:
+
+  ::
+
+    site_url = 'http://localhost:8000'
+    short_url = 'http://localhost:8000'
+
+  Then export:
+
+  ``EVENTYAY_CONFIG=local``
+
+* Some optional integrations (e.g. pretix, payments) may not build on Windows and are
+  not required for basic development or contributions.


### PR DESCRIPTION
This PR adds a short Local Development Notes section to help new contributors
avoid common setup issues such as multiple manage.py files, Django version
mismatch, and test.eventyay.com redirects during local development.

## Summary by Sourcery

Documentation:
- Add a Local Development Notes section to the README to highlight common setup pitfalls for new contributors, such as multiple manage.py files, Django version mismatches, and test environment redirects.