### PR TITLE
Fix user dropdown redirect on Talks page

### DIFF
--- a/app/eventyay/orga/templates/orga/base.html
+++ b/app/eventyay/orga/templates/orga/base.html
@@ -155,9 +155,14 @@ endblocktranslate %}
             {% endif %}
             {% block navbar_right %}{% endblock navbar_right %}
             <li class="nav-item d-none d-md-block">
-                <button type="button" class="nav-link active">
-                    <i class="fa fa-user"></i>
-                    {{ request.user.get_display_name }}
+                <button type="button"
+                    class="nav-link active"
+                    aria-label="{% translate 'User menu' %}"
+                    aria-haspopup="true"
+                    aria-controls="global-nav-menu"
+                    aria-expanded="false">
+                 <i class="fa fa-user"></i>
+                 {{ request.user.get_display_name }}
                 </button>
 
                 {# The menu built by Vue 3 app will be mounted here. The ID must match. #}


### PR DESCRIPTION
Issue : 
On the Talks page, clicking the logged-in user name in the top navigation redirected directly to Account Settings instead of opening the user dropdown. This behavior was inconsistent with the Tickets page, where clicking the user name correctly opens the dropdown menu.

Root Cause : 
In the Talks navbar, the user name was rendered as an anchor (<a>) element with an href pointing to the Account Settings page. Because of this, the browser navigated immediately on click, preventing the dropdown from opening.

Fix : 
The anchor element was replaced with a semantic button element to remove the unintended navigation behavior. The existing dropdown implementation remains unchanged and continues to be handled by the existing Vue component.

Result : 
Clicking the user name on the Talks page now opens the user dropdown instead of redirecting. The navigation behavior is consistent across both the Tickets and Talks pages.

How to Test :
- Log in as any user
- Open an event
- Navigate to the Talks page
- Click the user name in the top-right navigation
- Confirm that the dropdown opens and no redirect occurs

Scope :
This change is intentionally minimal and limited to the Talks navbar template. No Vue, JavaScript, backend, or Tickets page logic was modified.