### PR TITLE
Delete the demo showing that Django-Compressor can work with JS modules

### DIFF
--- a/app/eventyay/config/next_settings.py
+++ b/app/eventyay/config/next_settings.py
@@ -995,11 +995,11 @@ COMPRESS_PRECOMPILERS = (
     ('text/x-scss', 'django_libsass.SassCompiler'),
     ('text/vue', 'eventyay.helpers.compressor.VueCompiler'),
     # This is to help Django-Compressor minify 'module' type JS files.
-    # The actual job is done by esbuild. Note that due to the limitation of
-    # Django-Compressor + esbuild integration, we cannot use "import" syntax in the JS code
-    # (esbuild cannot resolve the import path).
-    # We don't need to specify {infile} {outfile} because both esbuild and Django-Compressor support stdin/stdout.
-    ('module', 'npx esbuild --minify --loader=js --platform=browser'),
+    # The actual job is done by esbuild. In the JS code, we can use "import" statements,
+    # but only with relative import paths (like `import Alpine from '../alpinejs.mjs'`).
+    # We don't need to specify {outfile} because both esbuild and Django-Compressor support stdin/stdout.
+    # We still specify {infile} to enable resolving "import" paths.
+    ('module', 'npx esbuild {infile} --bundle --minify --platform=browser'),
 )
 # We have one Vue 2 app to be built by Django-Compressor, so we need to enable compression.
 COMPRESS_ENABLED = True

--- a/app/eventyay/presale/templates/pretixpresale/index.html
+++ b/app/eventyay/presale/templates/pretixpresale/index.html
@@ -29,9 +29,4 @@
         </p>
         <p>{% trans "Enjoy!" %}</p>
     </div>
-
-    {# This is just for demo. Should be deleted later. #}
-    {% compress js %}
-    <script defer type='module' src="{% static 'demo/sample-module.js' %}"></script>
-    {% endcompress %}
 {% endblock %}

--- a/app/eventyay/static/demo/sample-module.js
+++ b/app/eventyay/static/demo/sample-module.js
@@ -1,5 +1,0 @@
-/* This file is just to demonstrate how to let Django-Compressor minify 'module' type JS files.
-* It should be deleted after the PR is merged.
-*/
-
-console.log('Hello from sample-module.js');


### PR DESCRIPTION
We no longer need it.

## Summary by Sourcery

Remove the obsolete Django-Compressor JS module demo and update JS module compression settings to use esbuild bundling with import support.

Enhancements:
- Adjust Django-Compressor configuration to run esbuild with bundling and minification for module-type JS, supporting relative import paths.

Chores:
- Remove the sample JS module demo from the presale template and delete the associated demo static file.