### PR TITLE
fix(links): move header and footer links from talk to common settings

### DIFF
--- a/app/eventyay/eventyay_common/templates/eventyay_common/event/settings.html
+++ b/app/eventyay/eventyay_common/templates/eventyay_common/event/settings.html
@@ -58,6 +58,37 @@
             {% include "pretixcontrol/event/fragment_geodata.html" %}
             {% bootstrap_field sform.contact_mail layout="control" %}
             {% bootstrap_field sform.imprint_url layout="control" %}
+            <div class="form-group">
+                <label class="col-md-3 control-label">
+                    {% translate "Header links" %}
+                </label>
+                <div class="col-md-9">
+                    <div class="help-block text-muted">
+                        {% blocktranslate trimmed %}
+                            These links will be shown at the top of all your schedule-related pages, e.g.
+                            the schedule itself, speaker pages, session pages, etc.
+                            You could for example link to your home page, your registration page, or your
+                            livestream here.
+                        {% endblocktranslate %}
+                    </div>
+                    {% include "orga/includes/event_links_formset.html" with formset=header_links_formset %}
+                </div>
+            </div>
+
+            <div class="form-group">
+                <label class="col-md-3 control-label">
+                    {% translate "Footer links" %}
+                </label>
+                <div class="col-md-9">
+                    <div class="help-block text-muted">
+                        {% blocktranslate trimmed %}
+                            These links will be shown in the footer of all your public pages. You could
+                            for example link your terms of service, imprint, or privacy policy here.
+                        {% endblocktranslate %}
+                    </div>
+                    {% include "orga/includes/event_links_formset.html" with formset=footer_links_formset %}
+                </div>
+            </div>
             {% bootstrap_field form.is_public layout="control" %}
             {% comment %}
             <div class="setting-part">

--- a/app/eventyay/orga/forms/event.py
+++ b/app/eventyay/orga/forms/event.py
@@ -516,6 +516,18 @@ class ReviewScoreCategoryForm(I18nHelpText, I18nModelForm):
 class EventExtraLinkForm(I18nModelForm):
     default_renderer = InlineFormLabelRenderer
 
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        for fname in ('label', 'url'):
+            if fname in self.fields:
+                widget = self.fields[fname].widget
+                if hasattr(widget, 'widgets'):
+                    for subwidget in widget.widgets:
+                        css = subwidget.attrs.get('class', '')
+                        subwidget.attrs['class'] = (css + ' form-control').strip()
+                css = widget.attrs.get('class', '')
+                widget.attrs['class'] = (css + ' form-control').strip()
+
     class Meta:
         model = EventExtraLink
         fields = ['label', 'url']

--- a/app/eventyay/orga/templates/orga/settings/form.html
+++ b/app/eventyay/orga/templates/orga/settings/form.html
@@ -65,40 +65,6 @@
             <fieldset>
                 <legend id="other-settings">{% translate "Other settings" %}</legend>
                 {{ form.meta_noindex.as_field_group }}
-
-                <div class="form-group hide-optional">
-                    <label class="col-md-3 control-label">
-                        {% translate "Header links" %}<br>
-                        <span class="optional">{% translate "Optional" %}</span>
-                    </label>
-                    <div class="col-md-9">
-                        <p class="mt-1 mb-2 text-muted">
-                            {% blocktranslate trimmed %}
-                                These links will be shown at the top of all your schedule-related pages, e.g.
-                                the schedule itself, speaker pages, session pages, etc.
-                                You could for example link to your home page, your registration page, or your
-                                livestream here.
-                            {% endblocktranslate %}
-                        </p>
-                        {% include "orga/includes/event_links_formset.html" with formset=header_links_formset %}
-                    </div>
-                </div>
-
-                <div class="form-group hide-optional">
-                    <label class="col-md-3 control-label">
-                        {% translate "Footer links" %}<br>
-                        <span class="optional">{% translate "Optional" %}</span>
-                    </label>
-                    <div class="col-md-9">
-                        <p class="mt-1 mb-2 text-muted">
-                            {% blocktranslate trimmed %}
-                                These links will be shown in the footer of all your public pages. You could
-                                for example link your terms of service, imprint, or privacy policy here.
-                            {% endblocktranslate %}
-                        </p>
-                        {% include "orga/includes/event_links_formset.html" with formset=footer_links_formset %}
-                    </div>
-                </div>
             </fieldset>
         </section>
         <section role="tabpanel" id="tabpanel-texts" aria-labelledby="tab-texts" tabindex="0" aria-hidden="true">

--- a/app/eventyay/orga/views/event.py
+++ b/app/eventyay/orga/views/event.py
@@ -41,8 +41,6 @@ from eventyay.event.forms import (
 from eventyay.base.models import Event, Team, TeamInvite
 from eventyay.orga.forms import EventForm
 from eventyay.orga.forms.event import (
-    EventFooterLinkFormset,
-    EventHeaderLinkFormset,
     MailSettingsForm,
     ReviewPhaseForm,
     ReviewScoreCategoryForm,
@@ -84,26 +82,6 @@ class EventDetail(EventSettingsPermission, ActionFromUrl, UpdateView):
         return response
 
     @context
-    @cached_property
-    def header_links_formset(self):
-        return EventHeaderLinkFormset(
-            self.request.POST if self.request.method == 'POST' else None,
-            event=self.object,
-            prefix='header-links',
-            instance=self.object,
-        )
-
-    @context
-    @cached_property
-    def footer_links_formset(self):
-        return EventFooterLinkFormset(
-            self.request.POST if self.request.method == 'POST' else None,
-            event=self.object,
-            prefix='footer-links',
-            instance=self.object,
-        )
-
-    @context
     def tablist(self):
         return {
             'display': _('Display settings'),
@@ -115,13 +93,7 @@ class EventDetail(EventSettingsPermission, ActionFromUrl, UpdateView):
 
     @transaction.atomic
     def form_valid(self, form):
-        if not self.footer_links_formset.is_valid() or not self.header_links_formset.is_valid():
-            messages.error(self.request, phrases.base.error_saving_changes)
-            return self.form_invalid(form)
-
         result = super().form_valid(form)
-        self.footer_links_formset.save()
-        self.header_links_formset.save()
 
         form.instance.log_action('eventyay.event.update', person=self.request.user, orga=True)
         messages.success(self.request, phrases.base.saved)

--- a/app/eventyay/static/pretixcontrol/js/ui/tabs.js
+++ b/app/eventyay/static/pretixcontrol/js/ui/tabs.js
@@ -10,7 +10,7 @@ $(function () {
         var i = 0;
         var preselect = null;
         var validity_error = false;
-        $form.find("fieldset").each(function () {
+        $form.children("fieldset").each(function () {
             var $fieldset = $(this);
             var tid = $fieldset.attr("id");
             if (!tid) tid = "tab-" + j + "-" + i;


### PR DESCRIPTION
This PR moves the header and footer links to the common settings page.

Screenshots:
<img width="1582" height="1034" alt="image" src="https://github.com/user-attachments/assets/a4d2b909-37ef-4eac-9b2b-10be35028b60" />
<img width="1582" height="1034" alt="image" src="https://github.com/user-attachments/assets/3aab2458-9812-46f3-91b9-ea24a75b53dd" />
<img width="1582" height="1034" alt="image" src="https://github.com/user-attachments/assets/dd7d2a75-dec5-47e0-96cf-b8f48b909d52" />

## Summary by Sourcery

Move configuration of public header and footer links from the event’s talk-specific settings to the shared/common event settings page.

New Features:
- Allow managing header links for schedule-related pages from the common event settings.
- Allow managing footer links for all public pages from the common event settings.

Enhancements:
- Ensure header and footer link formsets are validated and saved as part of the common event settings workflow.
- Improve styling of extra link form fields by applying consistent form-control classes to label and URL widgets.
- Adjust tab JavaScript to only treat top-level fieldsets as tabs, avoiding nested fieldset issues.