### PR TITLE
fix to set development defaults to localhost instead of test.eventyay.com

### DIFF
--- a/app/eventyay/config/eventyay.development.toml
+++ b/app/eventyay/config/eventyay.development.toml
@@ -5,8 +5,12 @@ email_backend = 'eventyay.base.email.FileSavedEmailBackend'
 
 allowed_hosts = ['*']
 
-site_url = 'https://test.eventyay.com'
+# For local development, use localhost
+# Can be overridden with EVY_SITE_URL environment variable
+site_url = 'http://localhost:8000'
 
 redis_url = 'redis://localhost/0'
 
-short_url = 'https://test.eventyay.com'
+# For local development, use localhost
+# Can be overridden with EVY_SHORT_URL environment variable
+short_url = 'http://localhost:8000'


### PR DESCRIPTION
Fixes #1632

## Summary by Sourcery

Enhancements:
- Add localhost defaults for site and short URLs in development config, with support for overriding via EVY_SITE_URL and EVY_SHORT_URL environment variables.