### PR TITLE
Add type hints to functions with obvious signatures

### DIFF
--- a/app/eventyay/config/settings.py
+++ b/app/eventyay/config/settings.py
@@ -31,11 +31,13 @@ if _PLUGIN_LOCAL.is_dir():
 
 import django.conf.locale
 from django.contrib.messages import constants as messages
+from django.http import HttpRequest
 from django.utils.translation import gettext_lazy as _
 from kombu import Queue
 from pycountry import currencies
 from redis.asyncio.retry import Retry
 from redis.backoff import ExponentialBackoff
+from typing import Dict
 
 from eventyay import __version__
 from eventyay.common.settings.config import build_config
@@ -63,7 +65,7 @@ talk_config, TALK_CONFIG_FILES = build_config()
 TALK_CONFIG = talk_config
 
 
-def instance_name(request):
+def instance_name(request: HttpRequest) -> Dict[str, str]:
     from django.conf import settings
 
     return {'INSTANCE_NAME': getattr(settings, 'INSTANCE_NAME', 'eventyay')}

--- a/video/server/tests/utils.py
+++ b/video/server/tests/utils.py
@@ -4,9 +4,10 @@ import random
 import jwt
 from channels.testing import WebsocketCommunicator
 from django.utils.crypto import get_random_string
+from typing import List, Optional
 
 
-def get_token(world, traits, uid=None):
+def get_token(world, traits: List[str], uid: Optional[int] = None) -> str:
     config = world.config["JWT_secrets"][0]
 
     iat = dt.datetime.utcnow()

--- a/video/server/venueless/api/views.py
+++ b/video/server/venueless/api/views.py
@@ -19,6 +19,7 @@ from rest_framework.authentication import get_authorization_header
 from rest_framework.decorators import api_view, permission_classes
 from rest_framework.response import Response
 from rest_framework.views import APIView
+from typing import Any, Dict
 
 from eventyay.base.api.auth import (
     ApiAccessRequiredPermission,
@@ -334,7 +335,7 @@ class ExportView(APIView):
         return Response(response.content.decode("utf-8"))
 
 
-def get_domain(path):
+def get_domain(path: str) -> str:
     if not path:
         return ""
     domain = urlparse(path).netloc

--- a/video/server/venueless/core/models/room.py
+++ b/video/server/venueless/core/models/room.py
@@ -9,13 +9,14 @@ from rest_framework import serializers
 from eventyay.base.models.auth import User
 from eventyay.base.models.cache import VersionedModel
 from eventyay.core.permissions import SYSTEM_ROLES, Permission
+from typing import Dict, List, Optional
 
 
-def empty_module_config():
+def empty_module_config() -> List[dict]:
     return []
 
 
-def default_grants():
+def default_grants() -> Dict[str, List[str]]:
     return {
         "viewer": [],
     }
@@ -204,7 +205,7 @@ class RoomConfigSerializer(serializers.ModelSerializer):
         )
 
 
-def approximate_view_number(actual_number):
+def approximate_view_number(actual_number: Optional[int]) -> str:
     if actual_number is None or actual_number < 1:
         return "none"
     elif actual_number > 10:
@@ -213,7 +214,7 @@ def approximate_view_number(actual_number):
         return "few"
 
 
-def generate_short_token():
+def generate_short_token() -> str:
     chars = "abcdefghijklmnpqrstuvwxyzABCDEFGHJKLMNPQRSTUVWXYZ123456789"
     return get_random_string(6, chars)
 


### PR DESCRIPTION
fixes #1637

**Description**
This PR adds Python type annotations to a small set of functions with clear and unambiguous parameter and return types.

The changes are purely annotational and do not affect runtime behavior. They improve IDE support, readability, and long-term maintainability.

**Files updated:**
- settings.py
- room.py
- views.py
- utils.py

**Screenshots**
<img width="385" height="48" alt="image" src="https://github.com/user-attachments/assets/84d820ea-5ec9-41f0-8cbf-9013acc624df" />
<img width="442" height="97" alt="image" src="https://github.com/user-attachments/assets/2ab78387-48ff-4df5-81aa-bb16824bdc7f" />

## Summary by Sourcery

Add static type annotations to selected utility and view-related functions across the codebase to clarify parameter and return types without changing runtime behavior.

Enhancements:
- Annotate room helper functions with precise list, dict, and optional integer types for configuration and view-count utilities.
- Add type hints to JWT test token helper for traits and optional user identifier, standardizing its return as a string.
- Specify request and path argument and return types in settings and API view helpers to improve IDE support and readability.