### PR TITLE
chore: cfp visibility fix

### DIFF
--- a/app/eventyay/common/templates/common/fragment_nav.html
+++ b/app/eventyay/common/templates/common/fragment_nav.html
@@ -41,8 +41,9 @@
                 href="{% url 'cfp:event.start' event=current_event.slug organizer=current_event.organizer.slug %}">
                 <i class="fa fa-bullhorn"></i> {% translate "Call for Speakers" %}
             </a>
-        {% else %}
-            <a class="header-tab disabled" tabindex="-1" aria-disabled="true" href="#">
+        {% elif not cfp.settings.hide_after_deadline %}
+            <a class="header-tab {% if '/cfp' in path %}active{% endif %}"
+                href="{% url 'cfp:event.start' event=current_event.slug organizer=current_event.organizer.slug %}">
                 <i class="fa fa-bullhorn"></i> {% translate "Call for Speakers (Closed)" %}
             </a>
         {% endif %}


### PR DESCRIPTION
Fixes #1469 lost conditionals

## Summary by Sourcery

Adjust call-for-speakers navigation visibility when proposals are closed

Bug Fixes:
- Restore the call-for-speakers navigation tab for closed CFPs when they should remain visible based on configuration

Enhancements:
- Update the call-for-speakers navigation tab to link to the CFP page and indicate an active state when selected instead of showing a disabled placeholder