### PR TITLE
Fix(UI): Align event name display in Talk dashboard with Tickets

### DIFF
--- a/app/eventyay/static/orga/css/_layout.css
+++ b/app/eventyay/static/orga/css/_layout.css
@@ -343,8 +343,8 @@ aside.sidebar {
       display: none;
       flex-direction: column;
       flex-grow: 1;
+      min-width: 0;
       overflow: hidden;
-      text-overflow: ellipsis;
       margin-left: 6px;
 
       .context-name,
@@ -354,6 +354,7 @@ aside.sidebar {
         white-space: nowrap;
         overflow: hidden;
         line-height: 17px;
+        max-width: 170px;
       }
 
       .context-name {


### PR DESCRIPTION
## Summary

The Talk dashboard displays long event names differently from the Tickets dashboard. This PR aligns the Talk event name with Tickets for a consistent UI across dashboards.

### Before
<img width="965" height="287" alt="Screenshot 2026-01-04 170157" src="https://github.com/user-attachments/assets/7ba8286d-bc68-41c2-8f01-0c16ad974558" />
<img width="917" height="266" alt="Screenshot 2026-01-04 170652" src="https://github.com/user-attachments/assets/d8678908-f8e7-46ab-938f-0554da6dc8ca" />

### After
<img width="965" height="287" alt="Screenshot 2026-01-04 170157" src="https://github.com/user-attachments/assets/7ba8286d-bc68-41c2-8f01-0c16ad974558" />
<img width="920" height="279" alt="Screenshot 2026-01-04 170349" src="https://github.com/user-attachments/assets/8ae3ac36-0596-437d-b5de-b03b273b8fc6" />

## Summary by Sourcery

Bug Fixes:
- Fix truncation and overflow behavior of event names in the Talk dashboard so long names are displayed consistently with the Tickets dashboard.