### PR TITLE
chore: fix graph permissions

### DIFF
--- a/app/eventyay/base/models/world.py
+++ b/app/eventyay/base/models/world.py
@@ -96,7 +96,7 @@ def default_roles():
     video_user_moderator = [Permission.EVENT_USERS_MANAGE]
     video_room_manager = [Permission.ROOM_UPDATE, Permission.ROOM_DELETE]
     video_kiosk_manager = [Permission.EVENT_KIOSKS_MANAGE]
-    video_config_manager = [Permission.EVENT_UPDATE]
+    video_config_manager = [Permission.EVENT_UPDATE, Permission.EVENT_GRAPHS]
     return {
         "attendee": attendee,
         "viewer": viewer,

--- a/app/eventyay/core/permissions.py
+++ b/app/eventyay/core/permissions.py
@@ -105,6 +105,7 @@ SYSTEM_ROLES = {
     ],
     "video_config_manager": [
         Permission.EVENT_UPDATE.value,
+        Permission.EVENT_GRAPHS.value,
     ],
 }
 


### PR DESCRIPTION
Fixes #1289

## Summary by Sourcery

Bug Fixes:
- Allow video configuration managers to access event graphs by adding the required permission.