### PR TITLE
Centralize file upload size limits in configuration

### DIFF
--- a/app/eventyay/api/serializers/order.py
+++ b/app/eventyay/api/serializers/order.py
@@ -198,7 +198,7 @@ class AnswerSerializer(I18nAwareModelSerializer):
             raise ValidationError(
                 'The submitted file "{fid}" has a file type that is not allowed in this field.'.format(fid=data)
             )
-        if cf.file.size > settings.MAX_SIZE_CONFIG[SizeKey.OTHER]:
+        if cf.file.size > settings.MAX_SIZE_CONFIG[SizeKey.UPLOAD_SIZE_OTHER]:
             raise ValidationError('The submitted file "{fid}" is too large to be used in this field.'.format(fid=data))
 
         data['options'] = []

--- a/app/eventyay/api/serializers/product.py
+++ b/app/eventyay/api/serializers/product.py
@@ -157,7 +157,7 @@ class ProductSerializer(I18nAwareModelSerializer):
         required=False,
         allow_null=True,
         allowed_types=('image/png', 'image/jpeg', 'image/gif'),
-        max_size=settings.MAX_SIZE_CONFIG[SizeKey.IMAGE],
+        max_size=settings.MAX_SIZE_CONFIG[SizeKey.UPLOAD_SIZE_IMAGE],
     )
 
     class Meta:

--- a/app/eventyay/api/views/checkin.py
+++ b/app/eventyay/api/views/checkin.py
@@ -1036,7 +1036,7 @@ class CheckinListPositionViewSet(viewsets.ReadOnlyModelViewSet):
             raise BaseValidationError(
                 'The submitted file "{fid}" has a file type that is not allowed in this field.'.format(fid=data)
             )
-        if cf.file.size > settings.MAX_SIZE_CONFIG[SizeKey.OTHER]:
+        if cf.file.size > settings.MAX_SIZE_CONFIG[SizeKey.UPLOAD_SIZE_OTHER]:
             raise BaseValidationError(
                 'The submitted file "{fid}" is too large to be used in this field.'.format(fid=data)
             )

--- a/app/eventyay/api/webhooks.py
+++ b/app/eventyay/api/webhooks.py
@@ -322,7 +322,7 @@ def send_webhook(self, logentry_id: int, action_type: str, webhook_id: int):
                     execution_time=time.time() - t,
                     return_code=resp.status_code,
                     payload=json.dumps(payload),
-                    response_body=resp.text[: settings.MAX_SIZE_CONFIG[SizeKey.WEBHOOK]],
+                    response_body=resp.text[: settings.MAX_SIZE_CONFIG[SizeKey.RESPONSE_SIZE_WEBHOOK]],
                     success=200 <= resp.status_code <= 299,
                 )
                 if resp.status_code == 410:
@@ -341,7 +341,7 @@ def send_webhook(self, logentry_id: int, action_type: str, webhook_id: int):
                     execution_time=time.time() - t,
                     return_code=0,
                     payload=json.dumps(payload),
-                    response_body=str(e)[: settings.MAX_SIZE_CONFIG[SizeKey.WEBHOOK]],
+                    response_body=str(e)[: settings.MAX_SIZE_CONFIG[SizeKey.RESPONSE_SIZE_WEBHOOK]],
                 )
                 raise self.retry(
                     countdown=2 ** (self.request.retries * 2)

--- a/app/eventyay/base/configurations/default_setting.py
+++ b/app/eventyay/base/configurations/default_setting.py
@@ -2127,7 +2127,7 @@ Your {event} team"""
         'form_kwargs': dict(
             label=_('Header image'),
             ext_whitelist=('.png', '.jpg', '.gif', '.jpeg'),
-            max_size=settings.MAX_SIZE_CONFIG[SizeKey.IMAGE],
+            max_size=settings.MAX_SIZE_CONFIG[SizeKey.UPLOAD_SIZE_IMAGE],
             help_text=_(
                 'This image appears at the top of all event pages, replacing the default color or pattern. '
                 'It is center-aligned and not stretched, ensuring the middle part remains visible on smaller screens. '
@@ -2137,7 +2137,7 @@ Your {event} team"""
         'serializer_class': UploadedFileField,
         'serializer_kwargs': dict(
             allowed_types=['image/png', 'image/jpeg', 'image/gif'],
-            max_size=settings.MAX_SIZE_CONFIG[SizeKey.IMAGE],
+            max_size=settings.MAX_SIZE_CONFIG[SizeKey.UPLOAD_SIZE_IMAGE],
         ),
     },
     'event_logo_image': {
@@ -2147,7 +2147,7 @@ Your {event} team"""
         'form_kwargs': dict(
             label=_('Logo'),
             ext_whitelist=('.png', '.jpg', '.gif', '.jpeg', '.svg'),
-            max_size=settings.MAX_SIZE_CONFIG[SizeKey.IMAGE],
+            max_size=settings.MAX_SIZE_CONFIG[SizeKey.UPLOAD_SIZE_IMAGE],
             help_text=_(
                 'When you upload a logo, the event name and date will not appear in the header. '
                 'The logo scales to 140 px in height while maintaining aspect ratio. '
@@ -2157,7 +2157,7 @@ Your {event} team"""
         'serializer_class': UploadedFileField,
         'serializer_kwargs': dict(
             allowed_types=['image/png', 'image/jpeg', 'image/gif', 'image/svg+xml'],
-            max_size=settings.MAX_SIZE_CONFIG[SizeKey.IMAGE],
+            max_size=settings.MAX_SIZE_CONFIG[SizeKey.UPLOAD_SIZE_IMAGE],
         ),
     },
     'logo_image_large': {
@@ -2187,7 +2187,7 @@ Your {event} team"""
         'form_kwargs': dict(
             label=_('Header image'),
             ext_whitelist=('.png', '.jpg', '.gif', '.jpeg'),
-            max_size=settings.MAX_SIZE_CONFIG[SizeKey.IMAGE],
+            max_size=settings.MAX_SIZE_CONFIG[SizeKey.UPLOAD_SIZE_IMAGE],
             help_text=_(
                 'This image appears at the top of all organizer pages, replacing the default color or pattern. '
                 'It is center-aligned and not stretched, ensuring the middle part remains visible on smaller screens. '
@@ -2197,7 +2197,7 @@ Your {event} team"""
         'serializer_class': UploadedFileField,
         'serializer_kwargs': dict(
             allowed_types=['image/png', 'image/jpeg', 'image/gif'],
-            max_size=settings.MAX_SIZE_CONFIG[SizeKey.IMAGE],
+            max_size=settings.MAX_SIZE_CONFIG[SizeKey.UPLOAD_SIZE_IMAGE],
         ),
     },
     'organizer_logo_image_large': {
@@ -2217,7 +2217,7 @@ Your {event} team"""
         'form_kwargs': dict(
             label=_('Social media image'),
             ext_whitelist=('.png', '.jpg', '.gif', '.jpeg'),
-            max_size=settings.MAX_SIZE_CONFIG[SizeKey.IMAGE],
+            max_size=settings.MAX_SIZE_CONFIG[SizeKey.UPLOAD_SIZE_IMAGE],
             help_text=_(
                 'This image is used as a preview when sharing your event link on social media. '
                 'Facebook recommends a size of 1200 × 630 px, but some platforms such as WhatsApp and Reddit '
@@ -2228,7 +2228,7 @@ Your {event} team"""
         'serializer_class': UploadedFileField,
         'serializer_kwargs': dict(
             allowed_types=['image/png', 'image/jpeg', 'image/gif'],
-            max_size=settings.MAX_SIZE_CONFIG[SizeKey.IMAGE],
+            max_size=settings.MAX_SIZE_CONFIG[SizeKey.UPLOAD_SIZE_IMAGE],
         ),
     },
     'invoice_logo_image': {
@@ -2239,13 +2239,13 @@ Your {event} team"""
             label=_('Logo image'),
             ext_whitelist=('.png', '.jpg', '.gif', '.jpeg'),
             required=False,
-            max_size=settings.MAX_SIZE_CONFIG[SizeKey.IMAGE],
+            max_size=settings.MAX_SIZE_CONFIG[SizeKey.UPLOAD_SIZE_IMAGE],
             help_text=_('We will show your logo with a maximal height and width of 2.5 cm.'),
         ),
         'serializer_class': UploadedFileField,
         'serializer_kwargs': dict(
             allowed_types=['image/png', 'image/jpeg', 'image/gif'],
-            max_size=settings.MAX_SIZE_CONFIG[SizeKey.IMAGE],
+            max_size=settings.MAX_SIZE_CONFIG[SizeKey.UPLOAD_SIZE_IMAGE],
         ),
     },
     'frontpage_text': {

--- a/app/eventyay/base/forms/questions.py
+++ b/app/eventyay/base/forms/questions.py
@@ -625,7 +625,7 @@ class BaseQuestionsForm(forms.Form):
                         '.tif',
                         '.tiff',
                     ),
-                    max_size=settings.MAX_SIZE_CONFIG[SizeKey.QUESTION],
+                    max_size=settings.MAX_SIZE_CONFIG[SizeKey.UPLOAD_SIZE_QUESTION],
                 )
             elif q.type == Question.TYPE_DATE:
                 attrs = {}

--- a/app/eventyay/base/services/mail.py
+++ b/app/eventyay/base/services/mail.py
@@ -394,9 +394,9 @@ def mail_send_task(
                                 args.append((name, content, ct.type))
                                 attach_size += len(content)
 
-                            if attach_size < settings.MAX_SIZE_CONFIG[SizeKey.MAIL]:
+                            if attach_size < settings.MAX_SIZE_CONFIG[SizeKey.UPLOAD_SIZE_MAIL]:
                                 # The maximum attachment size is configurable by overriding
-                                # the `mail` key in your TOML / size_limit_mb dictionary.
+                                # the `upload_size_mail` key in your TOML / size_limit_mb dictionary.
                                 # Values above ~4MB are not recommended, as larger emails are more likely to bounce.
                                 for a in args:
                                     try:

--- a/app/eventyay/config/eventyay.development.toml
+++ b/app/eventyay/config/eventyay.development.toml
@@ -19,15 +19,15 @@ short_url = 'http://localhost:8000'
 # These override the defaults in `size_limit_mb` dict in Python.
 # Uncomment to override values (in MB):
 # File Size Limits
-# csv = 1                # Max file size for CSVs
-# image = 15             # Max file size for images
-# pdf = 25               # Max file size for PDFs
-# xlsx = 2               # Max file size for XLSX files
-# favicon = 1            # Max file size for favicon
-# attachment = 50        # Max file size for attachments
-# mail = 4               # Max file size for mail attachments
-# question = 20          # Max file size for questions
-# other = 10             # Max file size for other files
+# upload_size_csv = 1                # Max file size for CSVs
+# upload_size_image = 15             # Max file size for images
+# upload_size_pdf = 25               # Max file size for PDFs
+# upload_size_xlsx = 2               # Max file size for XLSX files
+# upload_size_favicon = 1            # Max file size for favicon
+# upload_size_attachment = 50        # Max file size for attachments
+# upload_size_mail = 4               # Max file size for mail attachments
+# upload_size_question = 20          # Max file size for questions
+# upload_size_other = 10             # Max file size for other files
 
 # External Response Size Limits
-# webhook = 1            # Max external response size for questions
+# response_size_webhook = 1            # Max external response size for questions

--- a/app/eventyay/config/next_settings.py
+++ b/app/eventyay/config/next_settings.py
@@ -197,16 +197,17 @@ class BaseSettings(_BaseSettings):
 
     size_limit_mb: dict[str, int] = Field(
         default_factory=lambda: {
-            "csv": 1,
-            "image": 10,
-            "pdf": 10,
-            "xlsx": 2,
-            "favicon": 1,
-            "attachment": 10,
-            "mail": 4,
-            "question": 20,
-            "webhook": 1,
-            "other": 10,
+            "upload_size_csv": 1,
+            "upload_size_image": 10,
+            "upload_size_pdf": 10,
+            "upload_size_xlsx": 2,
+            "upload_size_favicon": 1,
+            "upload_size_attachment": 10,
+            "upload_size_mail": 4,
+            "upload_size_question": 20,
+            "upload_size_other": 10,
+
+            "response_size_webhook": 1,
         }
     )
 
@@ -214,16 +215,17 @@ class BaseSettings(_BaseSettings):
     # These allow simple top-level config entries (e.g. `question = 300` in TOML)
     # to override corresponding entries in `size_limit_mb`.
     # The dictionary remains the canonical source of truth.
-    csv: int | None = None
-    image: int | None = None
-    pdf: int | None = None
-    xlsx: int | None = None
-    favicon: int | None = None
-    attachment: int | None = None
-    mail: int | None = None
-    question: int | None = None
-    webhook: int | None = None
-    other: int | None = None
+    upload_size_csv: int | None = None
+    upload_size_image: int | None = None
+    upload_size_pdf: int | None = None
+    upload_size_xlsx: int | None = None
+    upload_size_favicon: int | None = None
+    upload_size_attachment: int | None = None
+    upload_size_mail: int | None = None
+    upload_size_question: int | None = None
+    upload_size_other: int | None = None
+
+    response_size_webhook: int | None = None
 
     #   Apply top-level single-line size limit overrides to `size_limit_mb`.
     #   Any override field that is set (not None) will replace the corresponding

--- a/app/eventyay/consts.py
+++ b/app/eventyay/consts.py
@@ -13,13 +13,14 @@ TIMEZONE_CHOICES = sorted(
 FRONTEND_DEV_DIR = PROJECT_ROOT / 'eventyay' / 'frontend'
 
 class SizeKey(StrEnum):
-    CSV = "csv"
-    IMAGE = "image"
-    PDF = "pdf"
-    XLSX = "xlsx"
-    FAVICON = "favicon"
-    ATTACHMENT = "attachment"
-    MAIL = "mail"
-    QUESTION = "question"
-    WEBHOOK = "webhook"
-    OTHER = "other"
+    UPLOAD_SIZE_CSV = "upload_size_csv"
+    UPLOAD_SIZE_IMAGE = "upload_size_image"
+    UPLOAD_SIZE_PDF = "upload_size_pdf"
+    UPLOAD_SIZE_XLSX = "upload_size_xlsx"
+    UPLOAD_SIZE_FAVICON = "upload_size_favicon"
+    UPLOAD_SIZE_ATTACHMENT = "upload_size_attachment"
+    UPLOAD_SIZE_MAIL = "upload_size_mail"
+    UPLOAD_SIZE_QUESTION = "upload_size_question"
+    UPLOAD_SIZE_OTHER = "upload_size_other"
+
+    RESPONSE_SIZE_WEBHOOK = "response_size_webhook"

--- a/app/eventyay/control/forms/organizer_forms/organizer_settings_form.py
+++ b/app/eventyay/control/forms/organizer_forms/organizer_settings_form.py
@@ -34,7 +34,7 @@ class OrganizerSettingsForm(SettingsForm):
     organizer_logo_image = ExtFileField(
         label=_('Header image'),
         ext_whitelist=('.png', '.jpg', '.gif', '.jpeg'),
-        max_size=settings.MAX_SIZE_CONFIG[SizeKey.IMAGE],
+        max_size=settings.MAX_SIZE_CONFIG[SizeKey.UPLOAD_SIZE_IMAGE],
         required=False,
         help_text=_(
             'If you provide a logo image, we will by default not show your organization name '
@@ -47,7 +47,7 @@ class OrganizerSettingsForm(SettingsForm):
         label=_('Favicon'),
         ext_whitelist=('.ico', '.png', '.jpg', '.gif', '.jpeg'),
         required=False,
-        max_size=settings.MAX_SIZE_CONFIG[SizeKey.FAVICON],
+        max_size=settings.MAX_SIZE_CONFIG[SizeKey.UPLOAD_SIZE_FAVICON],
         help_text=_(
             'If you provide a favicon, we will show it instead of the default pretix icon. '
             'We recommend a size of at least 200x200px to accommodate most devices.'

--- a/app/eventyay/control/views/orderimport.py
+++ b/app/eventyay/control/views/orderimport.py
@@ -46,7 +46,7 @@ class ImportView(EventPermissionRequiredMixin, TemplateView):
                     },
                 )
             )
-        if request.FILES['file'].size > settings.MAX_SIZE_CONFIG[SizeKey.OTHER]:
+        if request.FILES['file'].size > settings.MAX_SIZE_CONFIG[SizeKey.UPLOAD_SIZE_OTHER]:
             max_size_bytes = settings.MAX_SIZE_CONFIG["other"]
             max_size_mb = max_size_bytes / (1024 * 1024)
             messages.error(
@@ -118,7 +118,7 @@ class ProcessView(EventPermissionRequiredMixin, AsyncAction, FormView):
 
     @cached_property
     def parsed(self):
-        return parse_csv(self.file.file, settings.MAX_SIZE_CONFIG[SizeKey.CSV])
+        return parse_csv(self.file.file, settings.MAX_SIZE_CONFIG[SizeKey.UPLOAD_SIZE_CSV])
 
     def get(self, request, *args, **kwargs):
         if 'async_id' in request.GET and settings.HAS_CELERY:

--- a/app/eventyay/control/views/pdf.py
+++ b/app/eventyay/control/views/pdf.py
@@ -39,7 +39,7 @@ class BaseEditorView(EventPermissionRequiredMixin, TemplateView):
     template_name = 'pretixcontrol/pdf/index.html'
     permission = 'can_change_settings'
     accepted_formats = ('application/pdf',)
-    maxfilesize = settings.MAX_SIZE_CONFIG[SizeKey.PDF]
+    maxfilesize = settings.MAX_SIZE_CONFIG[SizeKey.UPLOAD_SIZE_PDF]
     minfilesize = 10
     title = None
 

--- a/app/eventyay/features/importers/conftool.py
+++ b/app/eventyay/features/importers/conftool.py
@@ -200,7 +200,7 @@ def mirror_conftool_file(event, url, password, nonce, preview=False):
         )
         r.raise_for_status()
 
-        if len(r.content) > settings.MAX_SIZE_CONFIG[SizeKey.OTHER]:
+        if len(r.content) > settings.MAX_SIZE_CONFIG[SizeKey.UPLOAD_SIZE_OTHER]:
             logger.warning(
                 f"Not mirroring conftool file {url} because it is {len(r.content)} byte"
             )

--- a/app/eventyay/plugins/sendmail/forms.py
+++ b/app/eventyay/plugins/sendmail/forms.py
@@ -64,7 +64,7 @@ class MailForm(forms.Form):
             'Sending an attachment increases the chance of your email not arriving or being sorted into spam folders. We recommend only using PDFs '
             'of no more than 2 MB in size.'
         ),
-        max_size=settings.MAX_SIZE_CONFIG[SizeKey.OTHER],
+        max_size=settings.MAX_SIZE_CONFIG[SizeKey.UPLOAD_SIZE_OTHER],
     )  # TODO i18n
     products = forms.ModelMultipleChoiceField(
         widget=forms.CheckboxSelectMultiple(attrs={'class': 'scrolling-multiple-choice'}),
@@ -569,7 +569,7 @@ class TeamMailForm(forms.Form):
             'Sending an attachment increases the chance of your email not arriving or being sorted into spam folders. '
             'We recommend only using PDFs of no more than 2 MB in size.'
         ),
-        max_size=settings.MAX_SIZE_CONFIG[SizeKey.ATTACHMENT],
+        max_size=settings.MAX_SIZE_CONFIG[SizeKey.UPLOAD_SIZE_ATTACHMENT],
     )
 
     def __init__(self, *args, **kwargs):

--- a/app/eventyay/storage/external.py
+++ b/app/eventyay/storage/external.py
@@ -40,7 +40,7 @@ def store_image(response, event):  # TODO deduplicate
     if not extension:
         return
 
-    max_size = settings.MAX_SIZE_CONFIG[SizeKey.OTHER]
+    max_size = settings.MAX_SIZE_CONFIG[SizeKey.UPLOAD_SIZE_OTHER]
     if not len(response.content) < max_size:
         return
 

--- a/app/eventyay/storage/views.py
+++ b/app/eventyay/storage/views.py
@@ -112,7 +112,7 @@ class UploadView(UploadMixin, View):
         ".jpeg",
         ".gif",
     )
-    max_size = settings.MAX_SIZE_CONFIG[SizeKey.OTHER]
+    max_size = settings.MAX_SIZE_CONFIG[SizeKey.UPLOAD_SIZE_OTHER]
 
     def post(self, request, *args, **kwargs):
         if not self.user:
@@ -225,7 +225,7 @@ class UploadView(UploadMixin, View):
 class ScheduleImportView(UploadMixin, View):
     permissions = {Permission.EVENT_UPDATE}
     ext_whitelist = (".xlsx",)
-    max_size = settings.MAX_SIZE_CONFIG[SizeKey.XLSX]
+    max_size = settings.MAX_SIZE_CONFIG[SizeKey.UPLOAD_SIZE_XLSX]
 
     def post(self, request, *args, **kwargs):
         if not self.user:


### PR DESCRIPTION
Fixes #1671 

- Hardcoded upload size limits have been removed
- ~Upload size limits and other limits are now loaded from `eventyay.config.next_settings`.~
- Upload size limits and other limits load from `BaseSettings` with default values overriden by `eventyay.development.toml`

## Preview
**Video Description:** UPDATED to show value overriding from TOML file.

https://github.com/user-attachments/assets/b3d17206-75ec-4a5a-b652-b88e51302112

File restriction violation still works as per the older demo video below.

---

**Video Description:** This demo shows how the configurable `question` upload size limit is updated in `/etc/pretix/pretix.cfg`. The `question` setting controls the maximum file size for attachments uploaded during checkout (e.g., verification documents).

All values are specified in megabytes (MB). The demo tests user-configured limits of 5 MB and 10 MB, followed by the default limit of 20 MB when no value is explicitly set.

After modifying the configuration file, the Eventyay server must be restarted for the changes to take effect.

https://github.com/user-attachments/assets/819fabe5-5167-4d26-8451-b6eaa6fac462

## Summary by Sourcery

Centralize various file upload and external response size limits into configurable settings instead of hardcoded constants.

Enhancements:
- Load file-related size limits from the central configuration (pretix.cfg/env) via EnvOrParserConfig and expose them through MAX_FILE_UPLOAD_SIZE_CONFIG and related constants.
- Apply configurable size limits across uploads, imports, webhooks, serializers, and mail handling to replace previous hardcoded megabyte thresholds.