### PR TITLE
fix: do not enforce billing validation in test mode

### DIFF
--- a/app/eventyay/base/models/event.py
+++ b/app/eventyay/base/models/event.py
@@ -1926,13 +1926,10 @@ class Event(
                 )
 
         gs = GlobalSettingsObject()
-        billing_validation_setting = gs.settings.get('billing_validation', True)
-        if isinstance(billing_validation_setting, str):
-            billing_validation_enabled = billing_validation_setting.lower() == 'true'
-        else:
-            billing_validation_enabled = bool(billing_validation_setting)
+        billing_validation_setting = gs.settings.get('billing_validation', as_type=bool, default=True)
+        billing_validation_enabled = bool(billing_validation_setting)
 
-        if billing_validation_enabled:
+        if billing_validation_enabled and not self.testmode:
             billing_obj = OrganizerBillingModel.objects.filter(organizer=self.organizer).first()
             if not billing_obj or not billing_obj.stripe_payment_method_id:
                 url = reverse(


### PR DESCRIPTION
Fixes #1689 

### Context
Billing validation is enforced even when an event is in `testmode`.

This causes test events to fail `live_issues()` checks unless a billing method is configured, which is a regression from previous behavior.

### What this PR fixes
- Uses the GlobalSettings API (`as_type=bool`) to read `billing_validation`
- Skips billing validation when `event.testmode` is enabled
- Restores expected behavior for test events without affecting production logic

## Summary by Sourcery

Bug Fixes:
- Prevent test mode events from failing live issue checks due to enforced billing validation settings.