### PR TITLE
Fix missing celery task registration

### DIFF
--- a/app/eventyay/base/tasks.py
+++ b/app/eventyay/base/tasks.py
@@ -1,0 +1,21 @@
+"""
+Celery task imports for autodiscovery.
+
+This module imports all Celery tasks from the services package so they can be
+registered with the Celery worker via autodiscover_tasks().
+"""
+
+from eventyay.base.services import (  # noqa: F401
+    cancelevent,
+    cart,
+    export,
+    invoices,
+    mail,
+    notifications,
+    orderimport,
+    orders,
+    shredder,
+    tickets,
+    update_check,
+    waitinglist,
+)


### PR DESCRIPTION
Create a tasks.py file at the app level that Celery can autodiscover. This will import all the service modules with Celery tasks.

When e.g. adding a ticket and going to purchase, some celery tasks fail to run with the following backtrace:

```
eventyay-next-worker      | [2026-01-06 21:35:40,148: INFO/MainProcess] Task eventyay.base.services.orders.perform_order[530a944f-a326-492b-996c-88ec4b717aac] received
eventyay-next-worker      | [2026-01-06 21:35:40,231: ERROR/MainProcess] Received unregistered task of type 'eventyay.base.services.notifications.notify'.
eventyay-next-worker      | The message has been ignored and discarded.
eventyay-next-worker      |
eventyay-next-worker      | Did you remember to import the module containing this task?
eventyay-next-worker      | Or maybe you're using relative imports?
eventyay-next-worker      |
eventyay-next-worker      | Please see
eventyay-next-worker      | https://docs.celeryq.dev/en/latest/internals/protocol.html
eventyay-next-worker      | for more information.
eventyay-next-worker      |
eventyay-next-worker      | The full contents of the message body was:
eventyay-next-worker      | b'[[34], {}, {"callbacks": null, "errbacks": null, "chain": null, "chord": null}]' (79b)
eventyay-next-worker      |
eventyay-next-worker      | The full contents of the message headers:
eventyay-next-worker      | {'lang': 'py', 'task': 'eventyay.base.services.notifications.notify', 'id': '076e6f6c-ef22-40e8-9e3d-aa6e1cc421bf', 'shadow': None, 'eta': None,
'expires': None, 'group': None, 'group_index': None, 'retries': 0, 'timelimit': [None, None], 'root_id': '530a944f-a326-492b-996c-88ec4b717aac', 'parent_id':
'530a944f-a326-492b-996c-88ec4b717aac', 'argsrepr': '(34,)', 'kwargsrepr': '{}', 'origin': 'gen42@eefc5a03b289', 'ignore_result': False, 'replaced_task_nesting': 0,
'stamped_headers': None, 'stamps': {}}
eventyay-next-worker      |
eventyay-next-worker      | The delivery info for this task is:
eventyay-next-worker      | {'exchange': '', 'routing_key': 'notifications'}
eventyay-next-worker      | Traceback (most recent call last):
eventyay-next-worker      |   File "/home/app/web/.venv/lib/python3.12/site-packages/celery/worker/consumer/consumer.py", line 662, in on_task_received
eventyay-next-worker      |     strategy = strategies[type_]
eventyay-next-worker      |                ~~~~~~~~~~^^^^^^^
eventyay-next-worker      | KeyError: 'eventyay.base.services.notifications.notify'
eventyay-next-worker      | [2026-01-06 21:35:40,235: INFO/MainProcess] Task eventyay.api.webhooks.notify_webhooks[c110bcc0-93d2-411c-aeb2-8ecf7428511c] received
eventyay-next-worker      | [2026-01-06 21:35:40,257: ERROR/MainProcess] Received unregistered task of type 'eventyay.base.services.notifications.notify'.
eventyay-next-worker      | The message has been ignored and discarded.
eventyay-next-worker      |
eventyay-next-worker      | Did you remember to import the module containing this task?
eventyay-next-worker      | Or maybe you're using relative imports?
eventyay-next-worker      |
eventyay-next-worker      | Please see
eventyay-next-worker      | https://docs.celeryq.dev/en/latest/internals/protocol.html
eventyay-next-worker      | for more information.
eventyay-next-worker      |
eventyay-next-worker      | The full contents of the message body was:
eventyay-next-worker      | b'[[36], {}, {"callbacks": null, "errbacks": null, "chain": null, "chord": null}]' (79b)
eventyay-next-worker      |
eventyay-next-worker      | The full contents of the message headers:
eventyay-next-worker      | {'lang': 'py', 'task': 'eventyay.base.services.notifications.notify', 'id': '49824d15-e35f-425b-8c35-7185ffe4cbd5', 'shadow': None, 'eta': None,
'expires': None, 'group': None, 'group_index': None, 'retries': 0, 'timelimit': [None, None], 'root_id': '530a944f-a326-492b-996c-88ec4b717aac', 'parent_id':
'530a944f-a326-492b-996c-88ec4b717aac', 'argsrepr': '(36,)', 'kwargsrepr': '{}', 'origin': 'gen42@eefc5a03b289', 'ignore_result': False, 'replaced_task_nesting': 0,
'stamped_headers': None, 'stamps': {}}
eventyay-next-worker      |
eventyay-next-worker      | The delivery info for this task is:
eventyay-next-worker      | {'exchange': '', 'routing_key': 'notifications'}
eventyay-next-worker      | Traceback (most recent call last):
eventyay-next-worker      |   File "/home/app/web/.venv/lib/python3.12/site-packages/celery/worker/consumer/consumer.py", line 662, in on_task_received
eventyay-next-worker      |     strategy = strategies[type_]
eventyay-next-worker      |                ~~~~~~~~~~^^^^^^^
eventyay-next-worker      | KeyError: 'eventyay.base.services.notifications.notify'
eventyay-next-worker      | [2026-01-06 21:35:40,259: INFO/MainProcess] Task eventyay.api.webhooks.notify_webhooks[71ae5339-9b0b-4a17-9359-0f60fce4e32a] received
eventyay-next-worker      | [2026-01-06 21:35:40,278: INFO/ForkPoolWorker-15] Task eventyay.api.webhooks.notify_webhooks[c110bcc0-93d2-411c-aeb2-8ecf7428511c] succeeded in
0.04143820000172127s: None
eventyay-next-worker      | [2026-01-06 21:35:40,294: INFO/ForkPoolWorker-16] Task eventyay.api.webhooks.notify_webhooks[71ae5339-9b0b-4a17-9359-0f60fce4e32a] succeeded in
0.03321135199803393s: None
eventyay-next-worker      | INFO 2026-01-06 21:35:40,417 email: Email context: {'event': <LazyI18nString: {'de': 'SuperMeeting', 'en': 'SuperMeeting'}>, 'event_slug': '8suuhk',
'code': 'E0WYA', 'total': <eventyay.base.i18n.LazyNumber object at 0x7f3d70858bc0>, 'currency': 'EUR', 'total_with_currency': <eventyay.base.i18n.LazyCurrencyNumber object at
0x7f3d70858a10>, 'expire_date': <eventyay.base.i18n.LazyExpiresDate object at 0x7f3d708587a0>, 'url': 'https://eventyay.localhost/abcorg/8suuhk/order/E0WYA/193BE5E5/open/f4be447b6/',
 'url_info_change': 'https://eventyay.localhost/abcorg/8suuhk/order/E0WYA/193BE5E5/modify', 'url_products_change':
'https://eventyay.localhost/abcorg/8suuhk/order/E0WYA/193BE5E5/change', 'url_cancel': 'https://eventyay.localhost/abcorg/8suuhk/order/E0WYA/193BE5E5/cancel', 'invoice_name': '',
'invoice_company': '', 'payment_info': '', 'name': 'aaa bbb', 'join_online_event': '<a
href="https://next.localhost/abcorg/8suuhk/video/#token=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJhbnkiLCJhdWQiOiJldmVudHlheSIsImV4cCI6MTc3MDMyNzM0MCwiaWF0IjoxNzY3NzM1MzQwLCJ1a
WQiOiJHU0FMSjc4RlJFIiwicHJvZmlsZSI6eyJmaWVsZHMiOnt9LCJkaXNwbGF5X25hbWUiOiJhYWEgYmJiIn0sInRyYWl0cyI6WyJldmVudHlheS12aWRlby1ldmVudC04c3V1aGsiLCJldmVudHlheS12aWRlby12YXJpYXRpb24tTm9uZSI
sImV2ZW50eWF5LXZpZGVvLWNhdGVnb3J5LU5vbmUiLCJldmVudHlheS12aWRlby1zdWJldmVudC1Ob25lIiwiZXZlbnR5YXktdmlkZW8tcHJvZHVjdC0xIl19.Q2lWB5wTTLtgBtxoNYjYKxm-IDa2L8CI6pVTBdr6P4M"
class="button">Join online event</a>', 'name_given_name': 'aaa', 'name_family_name': 'bbb'}
eventyay-next-worker      | [2026-01-06 21:35:40,471: INFO/MainProcess] Task eventyay.base.services.mail.mail_send_task[80bb33a8-c5d5-4a7e-a0cd-0350ca875331] received
eventyay-next-worker      | [2026-01-06 21:35:40,472: INFO/ForkPoolWorker-14] Task eventyay.base.services.orders.perform_order[530a944f-a326-492b-996c-88ec4b717aac] succeeded in
0.3232372290076455s: 1
eventyay-next-web         | WARNING 2026-01-06 21:35:40,766 log: Not Found: /.well-known/appspecific/com.chrome.devtools.json
eventyay-next-worker      | [2026-01-06 21:35:41,797: INFO/ForkPoolWorker-15] Task eventyay.base.services.mail.mail_send_task[80bb33a8-c5d5-4a7e-a0cd-0350ca875331] succeeded in
1.3256132139940746s: None
```

The reason is that the Celery task notify is defined in eventyay/base/services/notifications.py, but this module is never imported at startup. The imports in the model files are all inside functions (lazy imports), so they don't execute until those functions are called.

## Summary by Sourcery

Bug Fixes:
- Fix unregistered Celery task errors (e.g. notifications.notify) by importing the corresponding service modules at startup so their tasks are registered.