### PR TITLE
#1367 Fix: Override navbar icon color in popover menu

### DIFF
--- a/app/eventyay/static/pretixcontrol/scss/main.scss
+++ b/app/eventyay/static/pretixcontrol/scss/main.scss
@@ -849,6 +849,9 @@ h1 .label {
         cursor: pointer;
         a {
             color: darken($btn-primary-bg, 10%) !important;
+            i {
+                color: rgb(26, 105, 164) !important;
+            }
         }
         .dashboard-item {
             color: darken($btn-primary-bg, 10%);
@@ -870,6 +873,9 @@ h1 .label {
         background-color: darken($btn-primary-bg, 10%) !important;
         a {
             color: #fff !important;
+            i {
+                color: #fff !important;
+            }
         }
     }
     .dashboard-item {


### PR DESCRIPTION
## Description
Fixes icon color issue in the popover menu where navbar-inverse CSS rule was overriding the popover icon colors, causing icons (like fa-shopping-cart) to display in white instead of the intended blue color.

## Changes Made
- Added specific CSS rule `.popover-content .profile-menu a i` to set icon color to `rgb(26, 105, 164)` 
- Added hover state for icons to turn white on hover
- Uses `!important` flag to ensure proper specificity override

## Screenshot
<img width="312" height="549" alt="Screenshot (213)" src="https://github.com/user-attachments/assets/48205904-9d91-4390-85b4-41fd9eb920f0" />

## Related Issue
#1367 

## Testing
- [ ] Tested that icons in popover menu display in correct blue color
- [ ] Tested hover state shows white icons
- [ ] Verified no other UI elements are affected

## Checklist
- [x] Code follows the project's style guidelines
- [x] Self-review completed
- [x] Comments added for complex code
- [x] Documentation updated (if needed)
- [x] No new warnings generated