### PR TITLE
Fix/review comments

### DIFF
--- a/app/eventyay/cfp/flow.py
+++ b/app/eventyay/cfp/flow.py
@@ -647,14 +647,8 @@ class ProfileStep(GenericFlowStep, FormFlowStep):
             messages.error(self.request, error_message)
             return self.get(request)
         
-        # Manually extract and save user fields from POST data
-        # This bypasses the unreliable cleaned_data mechanism for dynamic fields
+        # Use only validated and cleaned form data
         saved_data = form.cleaned_data.copy()
-        from eventyay.person.forms import SpeakerProfileForm
-        if isinstance(form, SpeakerProfileForm):
-            for field_name in form.user_fields:
-                if field_name in request.POST:
-                    saved_data[field_name] = request.POST.get(field_name)
         
         self.set_data(saved_data)
         self.set_files(form.files)

--- a/app/tests/conftest.py
+++ b/app/tests/conftest.py
@@ -1,0 +1,7 @@
+import os
+import pytest
+from django.conf import settings
+
+@pytest.fixture(autouse=True)
+def enable_db_access_for_all_tests(db):
+    pass

--- a/app/tests/test_cfp_submission.py
+++ b/app/tests/test_cfp_submission.py
@@ -1,0 +1,57 @@
+import pytest
+from django.utils.timezone import now
+from eventyay.base.models import Event, Organizer, User, Team
+from eventyay.cfp.flow import ProfileStep
+from eventyay.person.forms import SpeakerProfileForm
+
+@pytest.mark.django_db
+def test_cfs_profile_step_execution_with_invalid_data():
+    """
+    Test that ProfileStep.done() raises an error or handles invalid data gracefully.
+    Currently, it might crash with 500 if form is invalid.
+    """
+    # Setup
+    organizer = Organizer.objects.create(name='Org', slug='org')
+    event = Event.objects.create(
+        organizer=organizer, name='Event', slug='event',
+        date_from=now(), date_to=now()
+    )
+    user = User.objects.create_user(email='test@example.com', password='password')
+    
+    # Create request mock
+    from django.test import RequestFactory
+    factory = RequestFactory()
+    request = factory.post('/submit/profile/')
+    request.user = user
+    request.event = event
+    
+    class MockResolverMatch:
+        kwargs = {'tmpid': 'testtmpid'}
+    request.resolver_match = MockResolverMatch()
+
+    class MockSession(dict):
+        modified = False
+    
+    request.session = MockSession({'cfp': {}})
+
+    # Initialize Step
+    step = ProfileStep(event=event)
+    step.request = request
+    
+    # Simulate invalid form data (empty required fields if any, or just empty POST)
+    # Profile form usually requires fullname if it's in the form
+    # Let's say we pass empty data
+    request.POST = {} 
+
+    # Execute done()
+    from django_scopes import scope
+    try:
+        with scope(event=event):
+            step.done(request)
+    except Exception as e:
+        import traceback
+        traceback.print_exc()
+        pytest.fail(f"ProfileStep.done raised exception: {e}")
+
+    # If it didn't fail, check if it saved invalid data? 
+    # But the bug report says it returns HTTP 500, which usually implies an unhandled exception.

--- a/app/tests/test_cfp_valid_submission.py
+++ b/app/tests/test_cfp_valid_submission.py
@@ -1,0 +1,83 @@
+import pytest
+from django.utils.timezone import now
+from eventyay.base.models import Event, Organizer, User, SpeakerProfile
+from eventyay.cfp.flow import ProfileStep
+from django_scopes import scope
+
+@pytest.fixture(autouse=True)
+def enable_db_access_for_all_tests(db):
+    pass
+
+@pytest.mark.django_db
+def test_cfs_profile_step_valid_submission_loop():
+    """
+    Test that a valid submission passes is_completed() check.
+    """
+    # Setup
+    organizer = Organizer.objects.create(name='Org', slug='org')
+    event = Event.objects.create(
+        organizer=organizer, name='Event', slug='event',
+        date_from=now(), date_to=now()
+    )
+    user = User.objects.create_user(email='test@example.com', password='password', fullname='Test User')
+    
+    # Create request mock
+    from django.test import RequestFactory
+    factory = RequestFactory()
+    request = factory.post('/submit/profile/')
+    request.user = user
+    request.event = event
+    
+    class MockResolverMatch:
+        kwargs = {'tmpid': 'testtmpid'}
+    request.resolver_match = MockResolverMatch()
+
+    class MockSession(dict):
+        modified = False
+    
+    request.session = MockSession({'cfp': {}})
+
+    # Initialize Step
+    step = ProfileStep(event=event)
+    step.request = request
+    
+    # Simulate VALID form data
+    data = {
+        'fullname': 'Test User',
+        'email': 'test@example.com',
+        'biography': 'My Bio',
+        'availabilities': '[]', # JSON string for availabilities
+        'action': 'submit'
+    }
+    # Re-create request with data
+    request = factory.post('/submit/profile/', data=data)
+    request.user = user
+    request.event = event
+    request.resolver_match = MockResolverMatch()
+    request.session = MockSession({'cfp': {}})
+    step.request = request
+
+    from django_scopes import scope
+    try:
+        with scope(event=event):
+             # 1. Simulate the POST logic manually to check internal state
+            form = step.get_form()
+            
+            assert form.is_valid(), f"Form should be valid but has errors: {form.errors}"
+            
+            step.set_data(form.cleaned_data)
+            
+            # 2. Key Check: is_completed()
+            # This reconstructs form from session data
+            is_complete = step.is_completed(request)
+            
+            if not is_complete:
+                bound_form = step.get_form(from_storage=True)
+                bound_form.is_valid()
+                
+            assert is_complete, "Profile step should be completed after valid submission"
+
+    except Exception as e:
+        import traceback
+        traceback.print_exc()
+        pytest.fail(f"Test failed with exception: {e}")


### PR DESCRIPTION
Fixes validation loop in CFP Profile step and addresses code review comments.

Changes:

ProfileStep: Switched to form.cleaned_data to ensure validated data is used, fixing the is_completed validation loop.
SpeakerProfileForm: Refactored init for cleaner fullname/email
field creation and improved exception handling to log errors instead of swallowing them.
Tests: Added test_cfp_valid_submission.py to verify the full submission flow.
