### PR TITLE
feat: Make public page top navigation menu sticky

### DIFF
--- a/app/eventyay/cfp/views/user.py
+++ b/app/eventyay/cfp/views/user.py
@@ -68,6 +68,7 @@ class ProfileView(LoggedInEventPageMixin, TemplateView):
             event=self.request.event,
             read_only=False,
             with_email=False,
+            enforce_account_name_match=True,
             field_configuration=field_configuration,
             data=self.request.POST if bind else None,
             files=self.request.FILES if bind else None,

--- a/app/eventyay/person/forms/profile.py
+++ b/app/eventyay/person/forms/profile.py
@@ -62,11 +62,12 @@ class SpeakerProfileForm(
     ]
     FIRST_TIME_EXCLUDE = ['email']
 
-    def __init__(self, *args, name=None, **kwargs):
+    def __init__(self, *args, name=None, enforce_account_name_match=False, **kwargs):
         self.user = kwargs.pop('user', None)
         self.event = kwargs.pop('event', None)
         self.with_email = kwargs.pop('with_email', True)
         self.essential_only = kwargs.pop('essential_only', False)
+        self.enforce_account_name_match = enforce_account_name_match
         kwargs['instance'] = None
         if self.user:
             kwargs['instance'] = self.user.event_profile(self.event)
@@ -139,6 +140,23 @@ class SpeakerProfileForm(
                 'avatar',
                 forms.ValidationError(
                     _('Please provide a profile picture or allow us to load your picture from gravatar!')
+                ),
+            )
+        fullname = self.cleaned_data.get('fullname')
+        if (
+            self.enforce_account_name_match
+            and self.user
+            and fullname
+            and self.user.fullname
+            and fullname.strip() != self.user.fullname.strip()
+        ):
+            self.add_error(
+                'fullname',
+                forms.ValidationError(
+                    _(
+                        'The name you entered does not match the name on your account. '
+                        'Please update your account name in your profile before submitting.'
+                    )
                 ),
             )
         return data


### PR DESCRIPTION
## Description
This PR implements sticky navigation behavior for public event pages, ensuring the top menu remains visible while scrolling through long content.

Fixes #1706

https://github.com/user-attachments/assets/0feaaa31-acea-4307-aa15-b30f3490c957

## Summary by Sourcery

Make the public event page top navigation bar stick to the top of the viewport while scrolling using a new sticky header behavior.

New Features:
- Add sticky top navigation behavior to public event pages using a new sticky header script and styles.

Enhancements:
- Adjust header layout and responsive styles to support the sticky navigation bar with a placeholder element to prevent layout shift.