### PR TITLE
fix(ui): Polish navigation, split info and tickets, fixes #1707

### DIFF
--- a/app/eventyay/presale/checkoutflowstep/base_checkout_flow_step.py
+++ b/app/eventyay/presale/checkoutflowstep/base_checkout_flow_step.py
@@ -64,7 +64,7 @@ class BaseCheckoutFlowStep:
             kwargs = {}
             if request.resolver_match and 'cart_namespace' in request.resolver_match.kwargs:
                 kwargs['cart_namespace'] = request.resolver_match.kwargs['cart_namespace']
-            return eventreverse(self.request.event, 'presale:event.index', kwargs=kwargs)
+            return eventreverse(self.request.event, 'presale:event.tickets', kwargs=kwargs)
         else:
             return prev.get_step_url(request)
 

--- a/app/eventyay/presale/templates/pretixpresale/event/base.html
+++ b/app/eventyay/presale/templates/pretixpresale/event/base.html
@@ -10,115 +10,123 @@
 {% block container_width %} presale-container{% endblock %}
 
 {% block title %}
-    {% if messages %}
-        {{ messages|join:" " }} ::
-    {% endif %}
-    {% block pagetitle %}{{ event.name }}{% endblock %}
+{% if messages %}
+{{ messages|join:" " }} ::
+{% endif %}
+{% block pagetitle %}{{ event.name }}{% endblock %}
 {% endblock %}
 
 {% block custom_header %}
-    {% if event.settings.meta_noindex %}
-        <meta name="robots" content="noindex, nofollow">
-    {% endif %}
-    <meta property="og:type" content="website" />
-    {% if social_image %}
-        <meta property="og:image" content="{{ social_image }}" />
-    {% endif %}
-    {{ block.super }}
+{% if event.settings.meta_noindex %}
+<meta name="robots" content="noindex, nofollow">
+{% endif %}
+<meta property="og:type" content="website" />
+{% if social_image %}
+<meta property="og:image" content="{{ social_image }}" />
+{% endif %}
+{{ block.super }}
 {% endblock %}
 
 {% block site_notice %}
-    {{ block.super }}
-    {{ request.organizer.slug|json_script:"organizer_name" }}
-    {% if not event.live %}
-        <div class="offline-banner {% if event.settings.logo_image %}offline-banner-absolute{% endif %}">
-            <div class="container">
-                <span class="fa fa-user-secret" aria-hidden="true"></span>
-                {% trans "This shop is currently only visible to you and your team." %}
-                <a href='{% url "control:event.live" event=event.slug organizer=event.organizer.slug %}'>
-                    {% trans "Take it live now" %}
-                </a>
-            </div>
-        </div>
-    {% endif %}
+{{ block.super }}
+{{ request.organizer.slug|json_script:"organizer_name" }}
+{% if not event.live %}
+<div class="offline-banner {% if event.settings.logo_image %}offline-banner-absolute{% endif %}">
+    <div class="container">
+        <span class="fa fa-user-secret" aria-hidden="true"></span>
+        {% trans "This shop is currently only visible to you and your team." %}
+        <a href='{% url "control:event.live" event=event.slug organizer=event.organizer.slug %}'>
+            {% trans "Take it live now" %}
+        </a>
+    </div>
+</div>
+{% endif %}
 {% endblock %}
 
 {% block header_tabs %}
-    {% if request.event.settings.organizer_link_back %}
-        <a class="header-tab" href="{% eventurl request.organizer "presale:organizer.index" %}">
-            &laquo; {% blocktrans trimmed with name=request.organizer.name %}
-            Show all events of {{ name }}
-        {% endblocktrans %}
-        </a>
-    {% endif %}
-    {% include "common/fragment_nav.html" with nav_context="presale" show_online_video_link=True %}
+{% if request.event.settings.organizer_link_back %}
+<a class="header-tab" href="{% eventurl request.organizer " presale:organizer.index" %}">
+    &laquo; {% blocktrans trimmed with name=request.organizer.name %}
+    Show all events of {{ name }}
+    {% endblocktrans %}
+</a>
+{% endif %}
+{% include "pretixpresale/event/fragment_nav.html" %}
 {% endblock header_tabs %}
 
 
 {% block alerts %}
-    {% if request.event.testmode %}
-        {% if request.sales_channel.testmode_supported %}
-            <div class="alert alert-warning alert-margin">
-                <strong>
-                    {% trans "This ticket shop is currently in test mode. Please do not perform any real purchases as your order might be deleted without notice." %}
-                </strong>
-            </div>
-        {% else %}
-            <div class="alert alert-danger">
-                <strong>
-                    {% trans "Orders made through this sales channel cannot be deleted - even if the ticket shop is in test mode!" %}
-                </strong>
-            </div>
-        {% endif %}
-    {% endif %}
-    {% if messages %}
-        {% for message in messages %}
-            <div class="alert {{ message.tags }}">
-                {{ message }}
-            </div>
-        {% endfor %}
-    {% endif %}
-    {% if request.event.settings.banner_text %}
-        <div class="site-notice-top">
-            {{ request.event.settings.banner_text|rich_text }}
-        </div>
-    {% endif %}
+{% if request.event.testmode %}
+{% if request.sales_channel.testmode_supported %}
+<div class="alert alert-warning alert-margin">
+    <strong>
+        {% blocktrans trimmed %}
+        This ticket shop is currently in test mode. Please do not perform any real purchases as your order might be deleted without notice.
+        {% endblocktrans %}
+    </strong>
+</div>
+{% else %}
+<div class="alert alert-danger">
+    <strong>
+        {% blocktrans trimmed %}
+        Orders made through this sales channel cannot be deleted - even if the ticket shop is in test mode!
+        {% endblocktrans %}
+    </strong>
+</div>
+{% endif %}
+{% endif %}
+{% if messages %}
+{% for message in messages %}
+<div class="alert {{ message.tags }}">
+    {{ message }}
+</div>
+{% endfor %}
+{% endif %}
+{% if request.event.settings.banner_text %}
+<div class="site-notice-top">
+    {{ request.event.settings.banner_text|rich_text }}
+</div>
+{% endif %}
 {% endblock %}
 
 {% block content %}
-    {% block page_content %}{{ block.super }}{% endblock %}
+{% block page_content %}{{ block.super }}{% endblock %}
 {% endblock %}
 
 {% block footer %}
-    {% if request.event.settings.banner_text_bottom %}
-        <div class="site-notice-bottom">
-            {{ request.event.settings.banner_text_bottom|rich_text }}
-        </div>
-    {% endif %}
-    {% if request.event.testmode %}
-        {% if request.sales_channel.testmode_supported %}
-            <div class="alert alert-testmode alert-warning">
-                <strong>
-                    {% trans "This ticket shop is currently in test mode. Please do not perform any real purchases as your order might be deleted without notice." %}
-                </strong>
-            </div>
-        {% else %}
-            <div class="alert alert-testmode alert-danger">
-                <strong>
-                    {% trans "Orders made through this sales channel cannot be deleted - even if the ticket shop is in test mode!" %}
-                </strong>
-            </div>
-        {% endif %}
-    {% endif %}
-    {{ block.super }}
+{% if request.event.settings.banner_text_bottom %}
+<div class="site-notice-bottom">
+    {{ request.event.settings.banner_text_bottom|rich_text }}
+</div>
+{% endif %}
+{% if request.event.testmode %}
+{% if request.sales_channel.testmode_supported %}
+<div class="alert alert-testmode alert-warning">
+    <strong>
+        {% blocktrans trimmed %}
+        This ticket shop is currently in test mode. Please do not perform any real purchases as your order might be deleted without notice.
+        {% endblocktrans %}
+    </strong>
+</div>
+{% else %}
+<div class="alert alert-testmode alert-danger">
+    <strong>
+        {% blocktrans trimmed %}
+        Orders made through this sales channel cannot be deleted - even if the ticket shop is in test mode!
+        {% endblocktrans %}
+    </strong>
+</div>
+{% endif %}
+{% endif %}
+{{ block.super }}
 {% endblock %}
 
 {% block footernav %}
-    {% if request.event.settings.contact_mail %}
-        <a href="mailto:{{ request.event.settings.contact_mail }}">{% trans "Contact event organizer" %}</a> &middot;
-    {% endif %}
-    {% if request.event.settings.imprint_url %}
-        <a href="{% safelink request.event.settings.imprint_url %}" target="_blank" rel="noopener">{% trans "Imprint" %}</a>
-        &middot;
-    {% endif %}
+{% if request.event.settings.contact_mail %}
+<a href="mailto:{{ request.event.settings.contact_mail }}">{% trans "Contact event organizer" %}</a> &middot;
+{% endif %}
+{% if request.event.settings.imprint_url %}
+<a href="{% safelink request.event.settings.imprint_url %}" target="_blank" rel="noopener">{% trans "Imprint" %}</a>
+&middot;
+{% endif %}
 {% endblock %}

--- a/app/eventyay/presale/templates/pretixpresale/event/fragment_nav.html
+++ b/app/eventyay/presale/templates/pretixpresale/event/fragment_nav.html
@@ -5,42 +5,51 @@
 
 <nav id='header-nav-bar'>
     <div class="navigation">
-        <a href="{% eventurl request.event 'presale:event.index' %}" class="header-tab underline">
+        <a href="{% eventurl request.event 'presale:event.index' %}"
+            class="header-tab {% if request.resolver_match.url_name == 'event.index' %}active{% endif %}">
+            <i class="fa fa-info-circle"></i> {% translate "Info" %}
+        </a>
+
+        <a href="{% if subevent %}{% eventurl request.event 'presale:event.tickets' subevent=subevent.pk %}{% else %}{% eventurl request.event 'presale:event.tickets' %}{% endif %}"
+            class="header-tab {% if request.resolver_match.url_name == 'event.tickets' %}active{% endif %}">
             <i class="fa fa-ticket"></i> {% translate "Tickets" %}
         </a>
 
         {% if schedule or request.event.has_schedule_content %}
-            <a href="{{ request.event.talk_schedule_url }}" class="header-tab ">
-                <i class="fa fa-calendar"></i> {% translate "Schedule" %}
-            </a>
+        <a href="{{ request.event.talk_schedule_url }}" class="header-tab ">
+            <i class="fa fa-calendar"></i> {% translate "Schedule" %}
+        </a>
 
-            <a href="{{ request.event.talk_session_url }}" class="header-tab {% if '/sessions/' in request.path_info %}active{% endif %}">
-                <i class="fa fa-comments-o"></i> {% translate "Sessions" %}
-            </a>
+        <a href="{{ request.event.talk_session_url }}"
+            class="header-tab {% if '/sessions/' in request.path_info %}active{% endif %}">
+            <i class="fa fa-comments-o"></i> {% translate "Sessions" %}
+        </a>
 
-            {% if request.event.speakers.exists %}
-                <a href="{{ request.event.talk_speaker_url }}" class="header-tab {% if '/speakers/' in request.path_info %}active{% endif %}">
-                    <i class="fa fa-group"></i> {% translate "Speakers" %}
-                </a>
-            {% endif %}
+        {% if request.event.speakers.exists %}
+        <a href="{{ request.event.talk_speaker_url }}"
+            class="header-tab {% if '/speakers/' in request.path_info %}active{% endif %}">
+            <i class="fa fa-group"></i> {% translate "Speakers" %}
+        </a>
+        {% endif %}
         {% endif %}
 
         {% with cfp=request.event.cfp %}
-            {% if cfp.is_open or access_code.is_valid %}
-                <a class="header-tab"
-                    href="{% url 'cfp:event.start' event=request.event.slug organizer=request.event.organizer.slug %}">
-                    <i class="fa fa-bullhorn"></i> {% translate "Call for Speakers" %}
-                </a>
-            {% elif not cfp.settings.hide_after_deadline %}
-                <a class="header-tab"
-                    href="{% url 'cfp:event.start' event=request.event.slug organizer=request.event.organizer.slug %}">
-                    <i class="fa fa-bullhorn"></i> {% translate "Call for Speakers (Closed)" %}
-                </a>
-            {% endif %}
+        {% if cfp.is_open or access_code.is_valid %}
+        <a class="header-tab"
+            href="{% url 'cfp:event.start' event=request.event.slug organizer=request.event.organizer.slug %}">
+            <i class="fa fa-bullhorn"></i> {% translate "Call for Speakers" %}
+        </a>
+        {% elif not cfp.settings.hide_after_deadline %}
+        <a class="header-tab"
+            href="{% url 'cfp:event.start' event=request.event.slug organizer=request.event.organizer.slug %}">
+            <i class="fa fa-bullhorn"></i> {% translate "Call for Speakers (Closed)" %}
+        </a>
+        {% endif %}
         {% endwith %}
 
         <div class="video-link">
-            <a id="join-event-link" class="header-tab join-event {% if request.path_info == '/onlinevideo' %}underline{% endif %}"
+            <a id="join-event-link"
+                class="header-tab join-event {% if request.path_info == '/onlinevideo' %}underline{% endif %}"
                 href="{% eventurl request.event 'presale:event.onlinevideo.join' %}">
                 <i class="fa fa-video-camera"></i> {% translate "Join online video" %}
             </a>

--- a/app/eventyay/presale/templates/pretixpresale/event/fragment_subevent_calendar.html
+++ b/app/eventyay/presale/templates/pretixpresale/event/fragment_subevent_calendar.html
@@ -1,16 +1,16 @@
 {% load i18n %}
 {% load eventurl %}
 {% load urlreplace %}
-<form class="form-inline" method="get" id="monthselform" action="{% eventurl event "presale:event.index" cart_namespace=cart_namespace %}">
+<form class="form-inline" method="get" id="monthselform" action="{% eventurl event " presale:event.tickets"
+    cart_namespace=cart_namespace %}">
     {% for f, v in request.GET.items %}
-        {% if f != "month" and f != "year" %}
-            <input type="hidden" name="{{ f }}" value="{{ v }}">
-        {% endif %}
+    {% if f != "month" and f != "year" %}
+    <input type="hidden" name="{{ f }}" value="{{ v }}">
+    {% endif %}
     {% endfor %}
     <div class="row">
         <div class="col-sm-4 hidden-xs text-left flip">
-            <a href="?{% url_replace request "year" before.year "month" before.month %}"
-                    class="btn btn-default">
+            <a href="?{% url_replace request " year" before.year "month" before.month %}" class="btn btn-default">
                 <span class="fa fa-arrow-left" aria-hidden="true"></span>
                 {{ before|date:"F Y" }}
             </a>
@@ -18,12 +18,12 @@
         <div class="col-sm-4 col-xs-12 text-center">
             <select name="month" class="form-control">
                 {% for m in months %}
-                    <option value="{{ m|date:"m" }}" {% if m == date %}selected{% endif %}>{{ m|date:"F" }}</option>
+                <option value="{{ m|date:" m" }}" {% if m==date %}selected{% endif %}>{{ m|date:"F" }}</option>
                 {% endfor %}
             </select>
             <select name="year" class="form-control">
                 {% for y in years %}
-                    <option value="{{ y }}" {% if y == date.year %}selected{% endif %}>{{ y }}</option>
+                <option value="{{ y }}" {% if y==date.year %}selected{% endif %}>{{ y }}</option>
                 {% endfor %}
             </select>
             <button type="submit" class="js-hidden btn btn-default">
@@ -31,7 +31,7 @@
             </button>
         </div>
         <div class="col-sm-4 hidden-xs text-right flip">
-            <a href="?{% url_replace request "year" after.year "month" after.month %}" class="btn btn-default">
+            <a href="?{% url_replace request " year" after.year "month" after.month %}" class="btn btn-default">
                 {{ after|date:"F Y" }}
                 <span class="fa fa-arrow-right" aria-hidden="true"></span>
             </a>

--- a/app/eventyay/presale/templates/pretixpresale/event/fragment_subevent_calendar_week.html
+++ b/app/eventyay/presale/templates/pretixpresale/event/fragment_subevent_calendar_week.html
@@ -1,16 +1,17 @@
 {% load i18n %}
 {% load eventurl %}
 {% load urlreplace %}
-<form class="form-inline" method="get" id="monthselform" action="{% eventurl event "presale:event.index" cart_namespace=cart_namespace %}">
+<form class="form-inline" method="get" id="monthselform" action="{% eventurl event " presale:event.tickets"
+    cart_namespace=cart_namespace %}">
     {% for f, v in request.GET.items %}
-        {% if f != "week" and f != "year" %}
-            <input type="hidden" name="{{ f }}" value="{{ v }}">
-        {% endif %}
+    {% if f != "week" and f != "year" %}
+    <input type="hidden" name="{{ f }}" value="{{ v }}">
+    {% endif %}
     {% endfor %}
     <div class="row">
         <div class="col-sm-4 hidden-xs text-left flip">
-            <a href="?{% url_replace request "year" before.isocalendar.0 "week" before.isocalendar.1 %}"
-                    class="btn btn-default">
+            <a href="?{% url_replace request " year" before.isocalendar.0 "week" before.isocalendar.1 %}"
+                class="btn btn-default">
                 <span class="fa fa-arrow-left" aria-hidden="true"></span>
                 {{ before|date:week_format }}
             </a>
@@ -18,12 +19,14 @@
         <div class="col-sm-4 col-xs-12 text-center">
             <select name="week" class="form-control select-calendar-week-short">
                 {% for w in weeks %}
-                    <option value="{{ w.0.isocalendar.1 }}" {% if w.0.isocalendar.1 == date.isocalendar.1 %}selected{% endif %}>{% trans "W" %} {{ w.0.isocalendar.1 }} ({{ w.0|date:"SHORT_DATE_FORMAT" }} – {{ w.1|date:"SHORT_DATE_FORMAT" }})</option>
+                <option value="{{ w.0.isocalendar.1 }}" {% if w.0.isocalendar.1==date.isocalendar.1 %}selected{% endif
+                    %}>{% trans "W" %} {{ w.0.isocalendar.1 }} ({{ w.0|date:"SHORT_DATE_FORMAT" }} – {{
+                    w.1|date:"SHORT_DATE_FORMAT" }})</option>
                 {% endfor %}
             </select>
             <select name="year" class="form-control">
                 {% for y in years %}
-                    <option value="{{ y }}" {% if y == date.isocalendar.0 %}selected{% endif %}>{{ y }}</option>
+                <option value="{{ y }}" {% if y==date.isocalendar.0 %}selected{% endif %}>{{ y }}</option>
                 {% endfor %}
             </select>
             <button type="submit" class="js-hidden btn btn-default">
@@ -31,8 +34,8 @@
             </button>
         </div>
         <div class="col-sm-4 hidden-xs text-right flip">
-            <a href="?{% url_replace request "year" after.isocalendar.0 "week" after.isocalendar.1 %}"
-                    class="btn btn-default">
+            <a href="?{% url_replace request " year" after.isocalendar.0 "week" after.isocalendar.1 %}"
+                class="btn btn-default">
                 {{ after|date:week_format }}
                 <span class="fa fa-arrow-right" aria-hidden="true"></span>
             </a>
@@ -41,13 +44,12 @@
 </form>
 {% include "pretixpresale/fragment_week_calendar.html" with show_avail=event.settings.event_list_availability %}
 <div class="col-sm-4 visible-xs text-center">
-    <a href="?{% url_replace request "year" before.isocalendar.0 "week" before.isocalendar.1 %}"
-            class="btn btn-default">
+    <a href="?{% url_replace request " year" before.isocalendar.0 "week" before.isocalendar.1 %}"
+        class="btn btn-default">
         <span class="fa fa-arrow-left" aria-hidden="true"></span>
         {{ before|date:week_format }}
     </a>
-    <a href="?{% url_replace request "year" after.isocalendar.0 "week" after.isocalendar.1 %}"
-            class="btn btn-default">
+    <a href="?{% url_replace request " year" after.isocalendar.0 "week" after.isocalendar.1 %}" class="btn btn-default">
         {{ after|date:week_format }}
         <span class="fa fa-arrow-right" aria-hidden="true"></span>
     </a>

--- a/app/eventyay/presale/templates/pretixpresale/event/fragment_subevent_list.html
+++ b/app/eventyay/presale/templates/pretixpresale/event/fragment_subevent_list.html
@@ -1,51 +1,51 @@
 {% load i18n %}
 {% load eventurl %}
 {% for subev in subevent_list %}
-    <a href="{% if request.GET.voucher %}{% eventurl event "presale:event.redeem" cart_namespace=cart_namespace %}?voucher={{ request.GET.voucher|urlencode }}&subevent={{ subev.pk }}{% else %}{% eventurl event "presale:event.index" subevent=subev.id cart_namespace=cart_namespace %}{% endif %}"
-            class="subevent-row">
-        <div class="row">
-            <div class="col-md-6">
-                <strong>{{ subev.name }}</strong>
-            </div>
-            <div class="col-md-4">
-                <span class="fa fa-calendar" aria-hidden="true"></span>
-                {{ subev.get_date_range_display }}
-                {% if event.settings.show_times %}
-                    <span data-time="{{ subev.date_from.isoformat }}" data-timezone="{{ event.timezone }}" data-time-short>
-                        <span class="fa fa-clock-o" aria-hidden="true"></span>
-                        {{ subev.date_from|date:"TIME_FORMAT" }}
-                    </span>
-                {% endif %}
-            </div>
-            <div class="col-md-2 text-right flip">
-                {% if subev.presale_is_running and event.settings.event_list_availability %}
-                    {% if subev.best_availability_state == 100 %}
-                        <span class="label label-success">{% trans "Book now" %}</span>
-                    {% elif event.settings.waiting_list_enabled and subev.best_availability_state >= 0 %}
-                        <span class="label label-warning">{% trans "Waiting list" %}</span>
-                    {% elif subev.best_availability_state == 20 %}
-                        <span class="label label-warning">{% trans "Reserved" %}</span>
-                    {% elif subev.best_availability_state < 20 %}
-                        {% if subev.has_paid_item %}
-                            <span class="label label-danger">{% trans "Sold out" %}</span>
-                        {% else %}
-                            <span class="label label-danger">{% trans "Fully booked" %}</span>
-                        {% endif %}
-                    {% endif %}
-                {% elif subev.presale_is_running %}
-                    <span class="label label-success">{% trans "Book now" %}</span>
-                {% elif subev.presale_has_ended %}
-                    <span class="label label-danger">{% trans "Sale over" %}</span>
-                {% elif event.settings.presale_start_show_date %}
-                    <span class="label label-warning">
-                                    {% blocktrans trimmed with date=subev.effective_presale_start|date:"SHORT_DATE_FORMAT" %}
-                                        Sale starts {{ date }}
-                                    {% endblocktrans %}
-                                </span>
-                {% else %}
-                    <span class="label label-warning">{% trans "Not yet on sale" %}</span>
-                {% endif %}
-            </div>
+<a href="{% if request.GET.voucher %}{% eventurl event " presale:event.redeem" cart_namespace=cart_namespace
+    %}?voucher={{ request.GET.voucher|urlencode }}&subevent={{ subev.pk }}{% else %}{% eventurl
+    event "presale:event.tickets" subevent=subev.id cart_namespace=cart_namespace %}{% endif %}" class="subevent-row">
+    <div class="row">
+        <div class="col-md-6">
+            <strong>{{ subev.name }}</strong>
         </div>
-    </a>
+        <div class="col-md-4">
+            <span class="fa fa-calendar" aria-hidden="true"></span>
+            {{ subev.get_date_range_display }}
+            {% if event.settings.show_times %}
+            <span data-time="{{ subev.date_from.isoformat }}" data-timezone="{{ event.timezone }}" data-time-short>
+                <span class="fa fa-clock-o" aria-hidden="true"></span>
+                {{ subev.date_from|date:"TIME_FORMAT" }}
+            </span>
+            {% endif %}
+        </div>
+        <div class="col-md-2 text-right flip">
+            {% if subev.presale_is_running and event.settings.event_list_availability %}
+            {% if subev.best_availability_state == 100 %}
+            <span class="label label-success">{% trans "Book now" %}</span>
+            {% elif event.settings.waiting_list_enabled and subev.best_availability_state >= 0 %}
+            <span class="label label-warning">{% trans "Waiting list" %}</span>
+            {% elif subev.best_availability_state == 20 %}
+            <span class="label label-warning">{% trans "Reserved" %}</span>
+            {% elif subev.best_availability_state < 20 %} {% if subev.has_paid_item %} <span class="label label-danger">
+                {% trans "Sold out" %}</span>
+                {% else %}
+                <span class="label label-danger">{% trans "Fully booked" %}</span>
+                {% endif %}
+                {% endif %}
+                {% elif subev.presale_is_running %}
+                <span class="label label-success">{% trans "Book now" %}</span>
+                {% elif subev.presale_has_ended %}
+                <span class="label label-danger">{% trans "Sale over" %}</span>
+                {% elif event.settings.presale_start_show_date %}
+                <span class="label label-warning">
+                    {% blocktrans trimmed with date=subev.effective_presale_start|date:"SHORT_DATE_FORMAT" %}
+                    Sale starts {{ date }}
+                    {% endblocktrans %}
+                </span>
+                {% else %}
+                <span class="label label-warning">{% trans "Not yet on sale" %}</span>
+                {% endif %}
+        </div>
+    </div>
+</a>
 {% endfor %}

--- a/app/eventyay/presale/templates/pretixpresale/event/info.html
+++ b/app/eventyay/presale/templates/pretixpresale/event/info.html
@@ -1,0 +1,170 @@
+{% extends "pretixpresale/event/base.html" %}
+{% load i18n %}
+{% load l10n %}
+{% load eventurl %}
+{% load money %}
+{% load thumb %}
+{% load eventsignal %}
+{% load rich_text %}
+{% load compress %}
+{% load static %}
+
+{% block custom_header %}
+    {{ block.super }}
+    <meta property="og:title" content="{{ ev.name }}" />
+    <meta property="og:description" content="{{ ev.get_date_range_display }}" />
+    {% if subevent %}
+        <meta property="og:url" content="{% abseventurl request.event "presale:event.index" subevent=subevent.pk %}" />
+    {% else %}
+        <meta property="og:url" content="{% abseventurl request.event "presale:event.index" %}" />
+    {% endif %}
+{% endblock %}
+{% block content %}
+
+    {% autoescape off %}
+        <script type="application/ld+json">
+            {{ ev.event_microdata }}
+        </script>
+    {% endautoescape %}
+    <main aria-label="{% trans "General information" %}">
+        {% if request.event.has_subevents %}
+            {% if not subevent %}
+                {% if event_logo_image and request.event.settings.logo_show_title %}
+                    <h2 class="content-header">
+                        {{ event.name }}
+                    </h2>
+                {% endif %}
+                {% if frontpage_text and not cart_namespace %}
+                    <div>
+                        {{ frontpage_text|rich_text }}
+                    </div>
+                {% endif %}
+            {% endif %}
+
+            {% if subevent %}
+                <h2 class="subevent-head">{{ subevent.name }}</h2>
+                {% if frontpage_text and not cart_namespace %}
+                    <div>
+                        {{ frontpage_text|rich_text }}
+                    </div>
+                {% endif %}
+            {% endif %}
+        {% else %}
+            {% if event_logo_image and request.event.settings.logo_show_title %}
+                <h2 class="content-header">
+                    {{ event.name }}
+                    {% if request.event.settings.show_dates_on_frontpage %}
+                        <small>{{ event.get_date_range_display }}</small>
+                    {% endif %}
+                </h2>
+            {% endif %}
+            {% if not event_logo_image %}
+                <h2 class="content-header">
+                    {{ event.name }}
+                    {% if request.event.settings.show_dates_on_frontpage %}
+                        <small>{{ event.get_date_range_display }}</small>
+                    {% endif %}
+                </h2>
+            {% endif %}
+            {% if frontpage_text and not cart_namespace %}
+                <div>
+                    {{ frontpage_text|rich_text }}
+                </div>
+            {% endif %}
+        {% endif %}
+
+        {% if subevent or not event.has_subevents %}
+            {% if not cart_namespace or subevent %}
+                <div>
+                    {% if ev.location %}
+                        <div class="info-row">
+                            <span class="fa fa-map-marker fa-fw" aria-hidden="true"></span>
+                            <p><span class="sr-only">{% trans "Location" %}:</span>
+                                {{ ev.location|linebreaksbr }}
+                            </p>
+                        </div>
+                    {% endif %}
+                    {% if ev.settings.show_dates_on_frontpage %}
+                        <div class="info-row">
+                            <span class="fa fa-clock-o fa-fw" aria-hidden="true"></span>
+                            <p>
+                                {{ ev.get_date_range_display }}
+                                {% if event.settings.show_times %}
+                                    <br>
+                                    <span data-time="{{ ev.date_from.isoformat }}" data-timezone="{{ request.event.settings.timezone }}">
+                                        {% blocktrans trimmed with time=ev.date_from|date:"TIME_FORMAT" %}
+                                            Begin: {{ time }}
+                                        {% endblocktrans %}
+                                    </span>
+                                    {% if event.settings.show_date_to and ev.date_to %}
+                                        <br>
+                                        <span data-time="{{ ev.date_to.isoformat }}" data-timezone="{{ request.event.settings.timezone }}">
+                                            {% blocktrans trimmed with time=ev.date_to|date:"TIME_FORMAT" %}
+                                                End: {{ time }}
+                                            {% endblocktrans %}
+                                       </span>
+                                    {% endif %}
+                                {% endif %}
+                                {% if ev.date_admission %}
+                                    <br>
+                                    {% if ev.date_admission|date:"SHORT_DATE_FORMAT" == ev.date_from|date:"SHORT_DATE_FORMAT" %}
+                                        <span data-time="{{ ev.date_admission.isoformat }}" data-timezone="{{ request.event.settings.timezone }}">
+                                            {% blocktrans trimmed with time=ev.date_admission|date:"TIME_FORMAT" %}
+                                                Admission: {{ time }}
+                                            {% endblocktrans %}
+                                        </span>
+                                    {% else %}
+                                        <span data-time="{{ ev.date_admission.isoformat }}" data-timezone="{{ request.event.settings.timezone }}">
+                                            {% blocktrans trimmed with datetime=ev.date_admission|date:"SHORT_DATETIME_FORMAT" %}
+                                                Admission: {{ datetime }}
+                                            {% endblocktrans %}
+                                        </span>
+                                    {% endif %}
+                                {% endif %}
+                                <br>
+                                {% if subevent %}
+                                    <a href="{% eventurl event "presale:event.ical.download" subevent=subevent.pk %}">
+                                {% else %}
+                                    <a href="{% eventurl event "presale:event.ical.download" %}">
+                                {% endif %}
+                                    {% trans "Add to Calendar" %}
+                                </a>
+                            </p>
+                        </div>
+                    {% endif %}
+
+                </div>
+
+                {% eventsignal event "eventyay.presale.signals.front_page_top" request=request subevent=subevent %}
+            {% endif %}
+        {% endif %}
+    </main>
+    {% if guest_checkout_allowed %}
+        {% if not cart_namespace %}
+            {% eventsignal event "eventyay.presale.signals.front_page_bottom" subevent=subevent request=request %}
+            <aside class="front-page" aria-labelledby="if-you-already-ordered-a-ticket">
+                <h3 id="if-you-already-ordered-a-ticket">{% trans "If you already ordered a ticket" %}</h3>
+                <div>
+                    <div class="col-md-8 col-xs-12">
+                        <p>
+                            {% blocktrans trimmed %}
+                                If you want to see or change the status and details of your order, click on the link in
+                                one of the
+                                emails we sent you during the order process. If you cannot find the link, click on the
+                                following button to request the link to your order to be sent to you again.
+                            {% endblocktrans %}
+                        </p>
+                    </div>
+                    <div class="col-md-4 col-xs-12">
+                        <a class="btn btn-block btn-default" href="{% eventurl event "presale:event.resend_link" %}">
+                            {% trans "Resend order links" %}
+                        </a>
+                    </div>
+                    <div class="clearfix"></div>
+                </div>
+            </aside>
+        {% else %}
+            {% eventsignal event "eventyay.presale.signals.front_page_bottom_widget" subevent=subevent request=request %}
+        {% endif %}
+    {% endif %}
+{% endblock %}

--- a/app/eventyay/presale/urls.py
+++ b/app/eventyay/presale/urls.py
@@ -69,15 +69,21 @@ frame_wrapped_urls = [
     ),
     path(
         '<int:subevent>/',
-        eventyay.presale.views.event.EventIndex.as_view(),
+        eventyay.presale.views.event.EventInfo.as_view(),
         name='event.index',
+    ),
+    path(
+        'tickets/<int:subevent>/',
+        eventyay.presale.views.event.EventTickets.as_view(),
+        name='event.tickets',
     ),
     path(
         'waitinglist',
         eventyay.presale.views.waiting.WaitingView.as_view(),
         name='event.waitinglist',
     ),
-    path('', eventyay.presale.views.event.EventIndex.as_view(), name='event.index'),
+    path('', eventyay.presale.views.event.EventInfo.as_view(), name='event.index'),
+    path('tickets/', eventyay.presale.views.event.EventTickets.as_view(), name='event.tickets'),
 ]
 event_patterns = [
     # Cart/checkout patterns are a bit more complicated, as they should have simple URLs like cart/clear in normal

--- a/app/eventyay/presale/views/__init__.py
+++ b/app/eventyay/presale/views/__init__.py
@@ -379,7 +379,7 @@ class EventViewMixin:
         kwargs = {}
         if 'cart_namespace' in self.kwargs:
             kwargs['cart_namespace'] = self.kwargs['cart_namespace']
-        return eventreverse(self.request.event, 'presale:event.index', kwargs=kwargs)
+        return eventreverse(self.request.event, 'presale:event.tickets', kwargs=kwargs)
 
 
 class OrganizerViewMixin:

--- a/app/eventyay/presale/views/cart.py
+++ b/app/eventyay/presale/views/cart.py
@@ -66,7 +66,7 @@ class CartActionMixin:
             kwargs = {}
             if 'cart_namespace' in self.kwargs:
                 kwargs['cart_namespace'] = self.kwargs['cart_namespace']
-            u = eventreverse(self.request.event, 'presale:event.index', kwargs=kwargs)
+            u = eventreverse(self.request.event, 'presale:event.tickets', kwargs=kwargs)
         if '?' in u:
             u += '&require_cookie=true'
         else:
@@ -591,7 +591,7 @@ class RedeemView(NoSearchIndexViewMixin, EventViewMixin, TemplateView):
         else:
             context['cart_redirect'] = eventreverse(
                 self.request.event,
-                'presale:event.index',
+                'presale:event.tickets',
                 kwargs={'cart_namespace': kwargs.get('cart_namespace') or ''},
             )
         if context['cart_redirect'].startswith('https:'):
@@ -655,7 +655,7 @@ class RedeemView(NoSearchIndexViewMixin, EventViewMixin, TemplateView):
                 return redirect(
                     eventreverse(
                         self.request.event,
-                        'presale:event.index',
+                        'presale:event.tickets',
                         kwargs={'cart_namespace': kwargs.get('cart_namespace') or ''},
                     )
                     + '?voucher='

--- a/app/eventyay/static/pretixpresale/scss/_theme.scss
+++ b/app/eventyay/static/pretixpresale/scss/_theme.scss
@@ -8,13 +8,17 @@
   h1 {
     margin: 0;
   }
+
   h1 small {
     white-space: nowrap;
   }
+
   .loginbox {
     padding-top: 15px;
   }
-  .event-logo, .organizer-logo {
+
+  .event-logo,
+  .organizer-logo {
     max-width: 100%;
     height: auto;
   }
@@ -24,18 +28,22 @@
   background: $main-box-bg;
 }
 
-.page-header-links > div.header-part {
+.page-header-links>div.header-part {
   padding-top: 15px;
 
   a {
     color: choose-contrast-color($body-bg, white, $link-color);
   }
-  a.active, .locales a.active {
+
+  a.active,
+  .locales a.active {
     border-bottom-color: choose-contrast-color($body-bg, white, $link-color) !important;
   }
+
+
 }
 
-.page-header-links-outside > div.header-part {
+.page-header-links-outside>div.header-part {
   padding-bottom: 5px;
 }
 
@@ -49,6 +57,7 @@
   .loginbox {
     text-align: right;
     padding: 10px;
+
     html.rtl & {
       text-align: left;
     }
@@ -60,24 +69,28 @@
 h2.content-header {
   margin-top: 0;
 }
+
 @media (max-width: $screen-xs-max) {
   h2.content-header small {
     display: block;
   }
 }
+
 @media (min-width: $screen-sm-min) {
   .main-box {
-    @if ($body-bg != #FFFFFF) {
+    @if ($body-bg !=#FFFFFF) {
       margin: 20px auto;
       border-radius: $border-radius-large;
     }
   }
+
   .page-header-links-outside {
     padding-left: 0;
     padding-right: 0;
   }
-  .page-header-links > div.header-part {
-    @if ($body-bg != #FFFFFF) {
+
+  .page-header-links>div.header-part {
+    @if ($body-bg !=#FFFFFF) {
       padding: 10px 0;
       margin-bottom: -20px;
     }
@@ -85,12 +98,13 @@ h2.content-header {
 
   .page-header.logo-large {
     img {
-      @if ($body-bg != #FFFFFF) {
+      @if ($body-bg !=#FFFFFF) {
         border-top-right-radius: $border-radius-large;
         border-top-left-radius: $border-radius-large;
       }
     }
   }
+
   .page-header .loginbox {
     padding-top: 0;
   }

--- a/app/eventyay/static/pretixpresale/scss/custom.scss
+++ b/app/eventyay/static/pretixpresale/scss/custom.scss
@@ -28,13 +28,13 @@
     margin-top: 10px;
     margin-bottom: 3rem;
     overflow: auto;
-    
+
     div {
         font-size: 1.65rem;
         display: flex;
         gap: 2rem;
     }
-    
+
     a {
         cursor: pointer;
         position: relative;
@@ -60,6 +60,7 @@
 
 #schedule-nav {
     margin: 16px 0px;
+
     .header-nav {
         border-color: darken($btn-primary-bg, 10%) !important;
         border: 1px solid;
@@ -67,22 +68,27 @@
         font-weight: normal;
         border-radius: 0;
     }
+
     .navigation {
         display: flex;
         flex-wrap: wrap;
+
         .navigation-button {
             margin-right: 8px;
             margin-bottom: 8px;
         }
+
         @media (min-width: 800px) {
             .video-link {
                 margin-left: auto;
             }
         }
+
         a:hover {
             color: #fff;
             background-color: $hover-button-color !important;
         }
+
         .popover-content {
             .options {
                 color: darken($btn-primary-bg, 10%);
@@ -92,23 +98,48 @@
                 font-weight: normal;
                 border-radius: 0;
             }
+
             .options:hover {
                 color: #fff;
                 color: darken($btn-primary-bg, 10%) !important;
             }
+
             div:first-child {
                 margin-bottom: 8px;
             }
         }
-        
+
     }
-    
+
 }
 
-.page-header-links{
-    .header-part{
+.page-header-links {
+    .header-part {
         a {
             color: #FFFFFF !important;
+        }
+
+        .header-tab {
+            padding: 5px 10px;
+            margin-right: 5px;
+            border-bottom: 2px solid transparent;
+            opacity: 0.9;
+            transition: all 0.2s ease-in-out;
+
+            &:hover,
+            &:focus {
+                text-decoration: none;
+                background-color: rgba(255, 255, 255, 0.1);
+                border-radius: 4px 4px 0 0;
+            }
+
+            &.active {
+                font-weight: bold;
+                border-bottom-color: currentColor !important;
+                opacity: 1;
+                background-color: rgba(255, 255, 255, 0.15);
+                border-radius: 4px 4px 0 0;
+            }
         }
     }
 }


### PR DESCRIPTION
- Split EventInfo and EventTickets views to separate landing page from ticket list
- Update URLs to redirect cart actions to ticket list
- Add .header-tab styles to custom.scss for transparent menu
- Fix multiline {% trans %} tags in base.html
- Add documentation to EventInfo view

Fixes #1707