### PR TITLE
Make navbar sticky in events public page

### DIFF
--- a/app/eventyay/common/templates/common/base_public.html
+++ b/app/eventyay/common/templates/common/base_public.html
@@ -130,8 +130,6 @@
                         </div>
                     </div>
                 </div>
-            </header>
-            <nav class="header-navbar">
                 <div class="header-wrapper">
                     <div id="header-tabs">
                         {% block header_tabs %}{% endblock header_tabs %}
@@ -142,7 +140,7 @@
                         </div>
                     </div>
                 </div>
-            </nav>
+            </header>
             <div class="card" id="main-card">
                 {% block alerts %}
                     {% if messages %}

--- a/app/eventyay/static/cfp/css/_layout.css
+++ b/app/eventyay/static/cfp/css/_layout.css
@@ -28,6 +28,9 @@ h1 a {
 }
 
 header {
+  position: sticky;
+  top: -180px;
+
   z-index: 1000;
   height: 220px;
   display: flex;
@@ -39,12 +42,6 @@ header {
     max-height: 140px;
     width: auto;
   }
-}
-
-nav.header-navbar {
-  position: sticky;
-  top: 0;
-  z-index: 1000;
 
   .header-wrapper {
     width: 100%;
@@ -332,6 +329,7 @@ footer {
     }
 
     header {
+      top: -124px;
       padding: 0;
       #event-logo {
         max-height: 120px;

--- a/app/eventyay/static/pretixpresale/scss/custom.css
+++ b/app/eventyay/static/pretixpresale/scss/custom.css
@@ -28,6 +28,16 @@ header {
     word-break: normal;
 }
 
+header .header-wrapper {
+    width: 100%;
+    max-width: calc(100vw - 8px);
+    word-break: keep-all;
+    flex-wrap: nowrap;
+    background: var(--color-bg);
+    border-radius: var(--size-border-radius) var(--size-border-radius) 0 0;
+    margin-bottom: 0;
+}
+
 header .header-row-right {
     padding-bottom: 4px;
 	color: var(--color-primary);
@@ -37,16 +47,6 @@ header .header-row-right {
     flex-shrink: 0;
     align-items: center;
     font-size: 1rem;
-}
-
-nav .header-wrapper {
-    width: 100%;
-    max-width: calc(100vw - 8px);
-    word-break: keep-all;
-    flex-wrap: nowrap;
-    background: var(--color-bg);
-    border-radius: var(--size-border-radius) var(--size-border-radius) 0 0;
-    margin-bottom: 0;
 }
 
 .alert::before {


### PR DESCRIPTION
Fixes #1706 

# Preview

Demo shows Tickets page and Call for Speakers page with sticky navbar tabs implemented. The dropdown menu stays in place, has no jitter, and is responsive.

Note: Video has been updated as per today's commit:

https://github.com/user-attachments/assets/66065d3c-09df-443d-b5d7-5ab0afe29c5e

## Summary by Sourcery

Make the event public page navbar a separate sticky element at the top of the page for improved navigation on tickets and call-for-speakers views.

Enhancements:
- Move header navigation markup into a dedicated <nav> element with its own wrapper to separate it from the main header content.
- Apply sticky positioning and layering styles to the header navbar so tabs and user menu remain visible while scrolling on public pages.