### PR TITLE
Fix: Anonymize user and unlink social accounts on deletion

### DIFF
--- a/app/eventyay/base/models/auth.py
+++ b/app/eventyay/base/models/auth.py
@@ -949,17 +949,15 @@ the eventyay team"""
         self.show_publicly = False
         self.profile = {}
 
-        # Anonymize user data to prevent re-login and invalidate session
+        # Anonymize user data to prevent re-login via reused credentials;
+        # session/token invalidation is handled by the authentication/session layer
         self.email = f"deleted_{uuid.uuid4()}@localhost"
-        self.fullname = "Deleted User"
+        self.fullname = str(_("Deleted User"))
         self.wikimedia_username = None
         
         # Delete social accounts to prevent automatic re-association
-        try:
-            from allauth.socialaccount.models import SocialAccount
+        if hasattr(self, "socialaccount_set"):
             self.socialaccount_set.all().delete()
-        except ImportError:
-            pass
 
         self.save()
 

--- a/app/tests/base/test_issue_1393.py
+++ b/app/tests/base/test_issue_1393.py
@@ -29,7 +29,7 @@ def test_soft_delete_anonymization():
     # Verify Anonymization
     assert user.deleted is True
     assert "deleted_" in user.email
-    assert user.fullname == "Deleted User"
+    assert user.fullname == "Deleted User" # This should still pass if locale is EN
     assert user.wikimedia_username is None
     
     # Verify SocialAccount deletion


### PR DESCRIPTION
Fixes #1393

Hi team,

This PR solves the issue where accounts created via MediaWiki SSO were not fully deleting. Currently, when a user requests deletion, the account can be recreated upon the next login because the link to the external provider remains active.

The changes in this PR update the 'soft_delete' method to:

1.  Anonymize User Data: Scrambles the email, full name, and username to ensure the account is truly deactivated.
2.  Unlink Social Accounts: Explicitly deletes the SocialAccount entry so that future logins from MediaWiki are treated as new users rather than resurrecting the old account.

I have added a test case 'app/tests/base/test_issue_1393.py' and verified the fix locally using the Dockerized PostgreSQL database.

Could you please review this? Happy to make any changes if needed.

Thanks!

## Summary by Sourcery

Anonymize user accounts and remove linked social logins when a user is soft-deleted to prevent unintended account resurrection.

Bug Fixes:
- Ensure soft-deleted users have their personal identifiers anonymized to prevent re-login with previous credentials.
- Remove associated social login records on soft delete so external SSO providers no longer resurrect deleted accounts.

Tests:
- Add regression test verifying user anonymization and social account removal when performing a soft delete.