### PR TITLE
fix: ensure Links button text is white (#1779)

### DIFF
--- a/app/eventyay/static/common/css/_dropdown.css
+++ b/app/eventyay/static/common/css/_dropdown.css
@@ -13,6 +13,11 @@ details.dropdown summary {
   color: inherit;
 }
 
+details.dropdown summary.color-primary,
+details.dropdown summary.btn-primary {
+  color: white;
+}
+
 details.dropdown summary::before,
 details.dropdown summary::marker {
   display: none;


### PR DESCRIPTION
Fixes #1779

This PR resolves a UI visibility issue on the review page where the "Links" button displayed blue text on a blue background, making it unreadable.

Root Cause: A CSS specificity conflict caused details.dropdown summary to inherit the link color (blue), overriding the button's intended white text.

Changes:

Updated _dropdown.css to explicitly enforce color: white for .color-primary dropdown summaries, ensuring proper contrast and readability.
<img width="1469" height="882" alt="image" src="https://github.com/user-attachments/assets/28392412-b1b3-47bd-9b49-53efac557a40" />

## Summary by Sourcery

Bug Fixes:
- Fix unreadable blue-on-blue text for the Links dropdown button by explicitly forcing white text on primary-styled dropdown summaries in the shared dropdown CSS.