### PR TITLE
Remove redundant 'Your Account' section from speaker profile page

### DIFF
--- a/app/eventyay/cfp/templates/cfp/event/user_profile.html
+++ b/app/eventyay/cfp/templates/cfp/event/user_profile.html
@@ -1,17 +1,11 @@
 {% extends "cfp/event/base.html" %}
-{% load compress %}
 {% load html_signal %}
 {% load i18n %}
-{% load static %}
 
 {% block title %}{% translate "Your Profile" %} :: {% endblock title %}
 
 {% block cfp_header %}
     {% include "cfp/includes/forms_header.html" %}
-    {% compress js %}
-        <script defer src="{% static 'vendored/zxcvbn.js' %}"></script>
-        <script defer src="{% static 'common/js/password_strength.js' %}"></script>
-    {% endcompress %}
 {% endblock cfp_header %}
 
 {% block content %}
@@ -63,25 +57,6 @@
             </div>
         </form>
     {% endif %}
-
-    <h2>{% translate "Your Account" %}</h2>
-    <p>{% translate "You can change your log in data here." %}</p>
-    <form method="post" class="form password-input-form">
-        {% csrf_token %}
-        {{ login_form.media }}
-        {{ login_form.old_password.as_field_group }}
-        {{ login_form.email.as_field_group }}
-        {{ login_form.password.as_field_group }}
-        {{ login_form.password_repeat.as_field_group }}
-        <div class="row">
-            <div class="col-md-4 flip ml-auto">
-                <input type="hidden" name="form" value="login">
-                <button type="submit" class="btn btn-block btn-success btn-lg">
-                    {{ phrases.base.save }}
-                </button>
-            </div>
-        </div>
-    </form>
 
     {% html_signal "eventyay.common.signals.profile_bottom_html" sender=request.event user=user %}
 

--- a/app/eventyay/cfp/views/user.py
+++ b/app/eventyay/cfp/views/user.py
@@ -31,7 +31,7 @@ from eventyay.common.image import gravatar_csp
 from eventyay.common.middleware.event import get_login_redirect
 from eventyay.common.text.phrases import phrases
 from eventyay.common.views import is_form_bound
-from eventyay.person.forms import LoginInfoForm, SpeakerProfileForm
+from eventyay.person.forms import SpeakerProfileForm
 from eventyay.talk_rules.person import can_view_information
 from eventyay.schedule.forms import AvailabilitiesFormMixin
 from eventyay.submission.forms import InfoForm, TalkQuestionsForm, ResourceForm
@@ -43,14 +43,6 @@ logger = logging.getLogger(__name__)
 @method_decorator(gravatar_csp(), name='dispatch')
 class ProfileView(LoggedInEventPageMixin, TemplateView):
     template_name = 'cfp/event/user_profile.html'
-
-    @context
-    @cached_property
-    def login_form(self):
-        return LoginInfoForm(
-            user=self.request.user,
-            data=self.request.POST if is_form_bound(self.request, 'login') else None,
-        )
 
     @context
     @cached_property
@@ -91,10 +83,7 @@ class ProfileView(LoggedInEventPageMixin, TemplateView):
         return self.request.event.talkquestions.filter(target='speaker').exists()
 
     def post(self, request, *args, **kwargs):
-        if self.login_form.is_bound and self.login_form.is_valid():
-            self.login_form.save()
-            request.user.log_action('eventyay.user.password.update')
-        elif self.profile_form.is_bound and self.profile_form.is_valid():
+        if self.profile_form.is_bound and self.profile_form.is_valid():
             self.profile_form.save()
             profile = self.request.user.profiles.get_or_create(event=self.request.event)[0]
             profile.log_action('eventyay.user.profile.update', person=request.user)


### PR DESCRIPTION
- Removed duplicate 'Your Account' section from View or edit speaker profile page
- Removed corresponding LoginInfoForm handling from EventProfileView
- Account management is now exclusively accessible via the user dropdown menu
- Improves UI clarity and eliminates functionality duplication

Fixes #1785

## Summary by Sourcery

Remove redundant account-management section from the speaker profile page and simplify the associated view logic.

Bug Fixes:
- Eliminate duplicate account management controls on the speaker profile page to avoid redundant password and email update paths.

Enhancements:
- Streamline the profile view by removing unused login form handling and related client-side password-strength assets from the CFP user profile template.