### PR TITLE
removed your account section from view or edit speaker

### DIFF
--- a/app/eventyay/cfp/templates/cfp/event/user_profile.html
+++ b/app/eventyay/cfp/templates/cfp/event/user_profile.html
@@ -9,8 +9,6 @@
 {% block cfp_header %}
     {% include "cfp/includes/forms_header.html" %}
     {% compress js %}
-        <script defer src="{% static 'vendored/zxcvbn.js' %}"></script>
-        <script defer src="{% static 'common/js/password_strength.js' %}"></script>
     {% endcompress %}
 {% endblock cfp_header %}
 
@@ -63,25 +61,6 @@
             </div>
         </form>
     {% endif %}
-
-    <h2>{% translate "Your Account" %}</h2>
-    <p>{% translate "You can change your log in data here." %}</p>
-    <form method="post" class="form password-input-form">
-        {% csrf_token %}
-        {{ login_form.media }}
-        {{ login_form.old_password.as_field_group }}
-        {{ login_form.email.as_field_group }}
-        {{ login_form.password.as_field_group }}
-        {{ login_form.password_repeat.as_field_group }}
-        <div class="row">
-            <div class="col-md-4 flip ml-auto">
-                <input type="hidden" name="form" value="login">
-                <button type="submit" class="btn btn-block btn-success btn-lg">
-                    {{ phrases.base.save }}
-                </button>
-            </div>
-        </div>
-    </form>
 
     {% html_signal "eventyay.common.signals.profile_bottom_html" sender=request.event user=user %}
 

--- a/app/eventyay/cfp/views/user.py
+++ b/app/eventyay/cfp/views/user.py
@@ -31,7 +31,7 @@ from eventyay.common.image import gravatar_csp
 from eventyay.common.middleware.event import get_login_redirect
 from eventyay.common.text.phrases import phrases
 from eventyay.common.views import is_form_bound
-from eventyay.person.forms import LoginInfoForm, SpeakerProfileForm
+from eventyay.person.forms import SpeakerProfileForm
 from eventyay.talk_rules.person import can_view_information
 from eventyay.schedule.forms import AvailabilitiesFormMixin
 from eventyay.submission.forms import InfoForm, TalkQuestionsForm, ResourceForm
@@ -43,14 +43,6 @@ logger = logging.getLogger(__name__)
 @method_decorator(gravatar_csp(), name='dispatch')
 class ProfileView(LoggedInEventPageMixin, TemplateView):
     template_name = 'cfp/event/user_profile.html'
-
-    @context
-    @cached_property
-    def login_form(self):
-        return LoginInfoForm(
-            user=self.request.user,
-            data=self.request.POST if is_form_bound(self.request, 'login') else None,
-        )
 
     @context
     @cached_property
@@ -91,10 +83,7 @@ class ProfileView(LoggedInEventPageMixin, TemplateView):
         return self.request.event.talkquestions.filter(target='speaker').exists()
 
     def post(self, request, *args, **kwargs):
-        if self.login_form.is_bound and self.login_form.is_valid():
-            self.login_form.save()
-            request.user.log_action('eventyay.user.password.update')
-        elif self.profile_form.is_bound and self.profile_form.is_valid():
+        if self.profile_form.is_bound and self.profile_form.is_valid():
             self.profile_form.save()
             profile = self.request.user.profiles.get_or_create(event=self.request.event)[0]
             profile.log_action('eventyay.user.profile.update', person=request.user)


### PR DESCRIPTION
Fixes #1785 

Removes the "Your Account" section (password change and email update functionality) from the Speaker Profile page. These actions are already available via the main account settings, and their presence on the speaker profile page was redundant

<img width="806" height="737" alt="Screenshot 2026-01-14 at 4 00 42 PM" src="https://github.com/user-attachments/assets/0c699215-f96a-4a30-a24a-3e846a563ca1" />

## Summary by Sourcery

Enhancements:
- Simplify the speaker profile view by removing redundant account (email/password) update functionality and its associated form handling.