### PR TITLE
Fix: Add main navigation menu to CfP pages for consistent user experience

### DIFF
--- a/app/eventyay/cfp/templates/cfp/event/base.html
+++ b/app/eventyay/cfp/templates/cfp/event/base.html
@@ -7,5 +7,6 @@
 {% block nav_link %}{{ request.event.urls.base }}{% endblock nav_link %}
 
 {% block header_tabs %}
+    {{ block.super }}
     {% include 'agenda/fragment_nav.html' %}
 {% endblock header_tabs %}


### PR DESCRIPTION
## Description

Fixes: #1786

Fixes navigation inconsistency on CfP pages by adding the standard main navigation menu.

## Problem

CfP pages were missing the top navigation menu (Tickets, Orders, etc.), causing inconsistent UX and navigation difficulties.

## Solution

Added `{% block header_tabs %}` with `agenda/fragment_nav.html` include to `cfp/event/base.html`.

## Changes

- **Modified:** `app/eventyay/cfp/templates/cfp/event/base.html`
  - Added header_tabs block with navigation include

## Testing

- [ ] Navigation appears on CfP pages (proposals, profile, submissions)
- [ ] Menu items are functional
- [ ] Tested with authenticated and unauthenticated users
- [ ] Responsive layout verified


<img width="1919" height="871" alt="top_navigation" src="https://github.com/user-attachments/assets/6bb904fc-ba85-4d34-8224-454b8eda6839" />


<img width="1919" height="869" alt="topnav2" src="https://github.com/user-attachments/assets/091b638b-e0e7-4bac-8a55-7be7a6221776" />

## Summary by Sourcery

Bug Fixes:
- Restore missing top navigation menu on CfP pages so users can access primary sections like tickets and orders from these views.