### PR TITLE
Fix: Return 400 error for duplicate check-ins (Fixes #809)

### DIFF
--- a/app/eventyay/api/views/checkin.py
+++ b/app/eventyay/api/views/checkin.py
@@ -688,10 +688,6 @@ def _redeem_process(
                     user=user,
                     auth=auth,
                 )
-                # Checkin.objects.create(    # commented out to avoid double logging
-                #     position=op,
-                #     **common_checkin_args,
-                # )
 
             serializer_context = _setup_context(request, expand, op.order.event, pdf_data, user, auth)
             position_data = CheckinListOrderPositionSerializer(op, context=serializer_context).data
@@ -700,13 +696,13 @@ def _redeem_process(
 
             return Response(
                 {
-                    'status': 'error', # Correct: 'error'
-                    'reason': e.code,  # Correct: dynamic code
+                    'status': 'error', 
+                    'reason': e.code,  
                     'require_attention': op.require_checkin_attention,
                     'position': position_data,
                     'list': MiniCheckinListSerializer(list_by_event[op.order.event_id]).data,
                 },
-                status=400,   # Correct: 400 Bad Request
+                status=400,   
             )
         else:
             serializer_context = _setup_context(request, expand, op.order.event, pdf_data, user, auth)


### PR DESCRIPTION
**Fixes:** #809

**Summary:**
This PR fixes a bug in the `_redeem_process` function where the API was returning a **201 Created (Success)** status even when a check-in failed (e.g., "User already checked in").

**Changes Made:**
* **Modified `app/eventyay/api/views/checkin.py`**:
    * Updated the `except CheckInError` block in `_redeem_process`.
    * **Commented** `Checkin.objects.create(...)` so invalid check-ins are not recorded as valid.
    * Changed the response status code from `201` to `400 Bad Request`.
    * Changed the response body status from `'redeemed'` to `'error'`.
    * Replaced the hardcoded string `'Already checked in'` with the dynamic error code `e.code`.

## Summary by Sourcery

Handle duplicate check-in attempts as client errors and avoid logging them as successful check-ins.

Bug Fixes:
- Return HTTP 400 with an error status and dynamic error code when a duplicate or invalid check-in is attempted instead of incorrectly returning 201 created.
- Prevent duplicate check-in attempts from being recorded as successful check-ins in the database.

Note: This is my second contribution, so I don't have much experience yet. If I made a mistake or have done something wrong, please feel free to correct me—I am eager to learn!