### PR TITLE
Consolidate form settings on Order Forms page

### DIFF
--- a/app/eventyay/control/templates/pretixcontrol/items/orderforms.html
+++ b/app/eventyay/control/templates/pretixcontrol/items/orderforms.html
@@ -25,9 +25,7 @@
                 {% bootstrap_field sform.order_email_asked layout="control" %}
                 {% bootstrap_field sform.order_email_required layout="control" %}
             {% endif %}
-            {% bootstrap_field sform.require_registered_account_for_tickets layout="control" %}
             {% bootstrap_field sform.order_email_asked_twice layout="control" %}
-            {% bootstrap_field sform.include_wikimedia_username layout="control" %}
             {% bootstrap_field sform.order_phone_asked_required layout="control" %}
             <div class="form-group">
                 <label class="control-label col-md-3">
@@ -49,19 +47,6 @@
             {% bootstrap_field sform.attendee_emails_asked_required layout="control" %}
             {% bootstrap_field sform.attendee_company_asked_required layout="control" %}
             {% bootstrap_field sform.attendee_addresses_asked_required layout="control" %}
-
-            <div class="form-group">
-                <label class="control-label col-md-3">
-                    {% trans "Custom fields" %}
-                </label>
-                <div class="col-md-9 static-form-row">
-                    <p>
-                        <a href="{% url "control:event.products.questions" event=request.event.slug organizer=request.organizer.slug %}" target="_blank">
-                            {% trans "Manage custom fields" %}
-                        </a>
-                    </p>
-                </div>
-            </div>
             {% bootstrap_field sform.attendee_data_explanation_text layout="control" %}
         </fieldset>
 
@@ -70,6 +55,8 @@
             {% bootstrap_field sform.name_scheme layout="control" %}
             {% bootstrap_field sform.name_scheme_titles layout="control" %}
             {% bootstrap_field sform.checkout_show_copy_answers_button layout="control" %}
+            {% bootstrap_field sform.require_registered_account_for_tickets layout="control" %}
+            {% bootstrap_field sform.include_wikimedia_username layout="control" %}
         </fieldset>
         
         <div class="form-group submit-group">


### PR DESCRIPTION
Fixes: https://github.com/fossasia/eventyay/issues/1798

This PR enhances the Order Forms page in the ticket component by consolidating form-related settings and removing redundant UI elements.

### Changes Made
- **Removed** redundant "Custom Field – Manage custom fields" link from Attendee data section (custom fields are already managed from their dedicated page)
- **Moved** "Require user to be logged in to place an order" setting to Form settings section
- **Moved** "Add Wikimedia ID for users authenticated via Wikimedia" setting to Form settings section

### Result
- All form behavior options are now grouped together in a single, clearly defined **Form settings** section
- Improved information architecture and UX clarity
- No duplicated configuration options

## Summary by Sourcery

Consolidate order form behavior controls into a single Form settings section on the Order Forms page to streamline configuration and remove redundant UI.

Enhancements:
- Relocate login requirement and Wikimedia ID options from the main order form section into the Form settings section for clearer grouping of form behavior settings.
- Remove the separate Custom fields management link from the attendee data section to avoid redundant navigation and simplify the page layout.