### PR TITLE
Consolidate order forms settings and remove redundant options

### DIFF
--- a/app/eventyay/control/templates/pretixcontrol/items/orderforms.html
+++ b/app/eventyay/control/templates/pretixcontrol/items/orderforms.html
@@ -25,9 +25,7 @@
                 {% bootstrap_field sform.order_email_asked layout="control" %}
                 {% bootstrap_field sform.order_email_required layout="control" %}
             {% endif %}
-            {% bootstrap_field sform.require_registered_account_for_tickets layout="control" %}
             {% bootstrap_field sform.order_email_asked_twice layout="control" %}
-            {% bootstrap_field sform.include_wikimedia_username layout="control" %}
             {% bootstrap_field sform.order_phone_asked_required layout="control" %}
             <div class="form-group">
                 <label class="control-label col-md-3">
@@ -49,24 +47,13 @@
             {% bootstrap_field sform.attendee_emails_asked_required layout="control" %}
             {% bootstrap_field sform.attendee_company_asked_required layout="control" %}
             {% bootstrap_field sform.attendee_addresses_asked_required layout="control" %}
-
-            <div class="form-group">
-                <label class="control-label col-md-3">
-                    {% trans "Custom fields" %}
-                </label>
-                <div class="col-md-9 static-form-row">
-                    <p>
-                        <a href="{% url "control:event.products.questions" event=request.event.slug organizer=request.organizer.slug %}" target="_blank">
-                            {% trans "Manage custom fields" %}
-                        </a>
-                    </p>
-                </div>
-            </div>
             {% bootstrap_field sform.attendee_data_explanation_text layout="control" %}
         </fieldset>
 
         <fieldset>
             <legend>{% trans "Form settings" %}</legend>
+            {% bootstrap_field sform.require_registered_account_for_tickets layout="control" %}
+            {% bootstrap_field sform.include_wikimedia_username layout="control" %}
             {% bootstrap_field sform.name_scheme layout="control" %}
             {% bootstrap_field sform.name_scheme_titles layout="control" %}
             {% bootstrap_field sform.checkout_show_copy_answers_button layout="control" %}


### PR DESCRIPTION
Fixes: #1798 
**Changes**

1. **Removed redundant "Custom fields" link** from Attendee data section (already accessible via dedicated page)

2. Moved form behavior settings to "Form settings" section:


- "Require user to be logged in to place an order"

- "Add Wikimedia ID for authenticated users"

These are form behavior options, not data collection fields, so they belong with other form configuration settings.

**Benefits**

- Better information architecture with logically grouped settings
- Eliminates duplicate navigation
- Makes form configuration easier for organizers

**Testing**

- Template syntax validated
- No functional changes, pure UI reorganization
