### PR TITLE
fix: migrate to uv-only dependency management (#1841)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,10 +1,11 @@
 version: 2
 
 updates:
-  - package-ecosystem: "pip"
-    directory: "/"
+  # Application dependencies - managed by uv
+  - package-ecosystem: "uv"
+    directory: "/app"
     schedule:
-      interval: "daily"
+      interval: "weekly"
     versioning-strategy: increase
 
   - package-ecosystem: "npm"

--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -1,4 +1,4 @@
--e ../
+
 sphinx
 sphinx-rtd-theme
 sphinxcontrib-httpdomain


### PR DESCRIPTION
Hi @mariobehling,

I've done the changes from #1841 for the uv migration.

**What changed:**
- Dependabot now uses `uv` instead of `pip` and points to `/app` directory
- Removed that broken `-e ../` from doc/requirements.txt that was causing errors

**One question though:** The old config had daily updates but your example shows weekly. I changed it to weekly but can switch back to daily if you want?

I tested it locally - uv sync works and CI should be fine since it already uses uv.

After this merges I'll check if Dependabot runs properly and post the screenshot in #1841.

Fixes #1841

## Summary by Sourcery

Migrate automated Python dependency updates to use uv and clean up documentation dependency configuration.

Build:
- Update Dependabot configuration to manage application Python dependencies via uv in the /app directory with a weekly update schedule.

Documentation:
- Remove the broken editable install reference from doc/requirements.txt to simplify documentation dependency installation.