### PR TITLE
fix: revert 'Avatar' terminology to 'Profile picture' for speaker context

### DIFF
--- a/app/eventyay/orga/templates/orga/cfp/text.html
+++ b/app/eventyay/orga/templates/orga/cfp/text.html
@@ -457,12 +457,12 @@
                         {# Avatar #}
                         {% with field=sform.cfp_ask_avatar %}
                         <tr>
-                            <th>{% translate "Avatar" %}</th>
+                            <th>{% translate "Profile picture" %}</th>
                             <td class="text-center">
                                 <label class="toggle-switch" data-field-id="{{ field.auto_id }}"
-                                    aria-label="Toggle active state for Avatar">
+                                    aria-label="Toggle active state for Profile picture">
                                     <input type="checkbox" {% if field.value != 'do_not_ask' %}checked{% endif %}
-                                        aria-label="Active toggle for Avatar">
+                                        aria-label="Active toggle for Profile picture">
                                     <span class="toggle-slider"></span>
                                 </label>
                                 <input type="hidden" name="{{ field.html_name }}" value="{{ field.value }}"
@@ -472,7 +472,7 @@
                                 <div class="required-status-wrapper" data-current="{% if field.value == 'required' %}required{% else %}optional{% endif %}">
                                     <select class="required-status-dropdown" data-field-id="{{ field.auto_id }}"
                                         data-current="{% if field.value == 'required' %}required{% else %}optional{% endif %}"
-                                        aria-label="Required status for Avatar">
+                                        aria-label="Required status for Profile picture">
                                         <option value="optional" {% if field.value == 'optional' or field.value == 'do_not_ask' %}selected{% endif %}>Optional</option>
                                         <option value="required" {% if field.value == 'required' %}selected{% endif %}>
                                             Required</option>
@@ -487,12 +487,12 @@
                         {# Avatar Source #}
                         {% with field=sform.cfp_ask_avatar_source %}
                         <tr>
-                            <th>{% translate "Avatar source" %}</th>
+                            <th>{% translate "Profile picture source" %}</th>
                             <td class="text-center">
                                 <label class="toggle-switch" data-field-id="{{ field.auto_id }}"
-                                    aria-label="Toggle active state for Avatar source">
+                                    aria-label="Toggle active state for Profile picture source">
                                     <input type="checkbox" {% if field.value != 'do_not_ask' %}checked{% endif %}
-                                        aria-label="Active toggle for Avatar source">
+                                        aria-label="Active toggle for Profile picture source">
                                     <span class="toggle-slider"></span>
                                 </label>
                                 <input type="hidden" name="{{ field.html_name }}" value="{{ field.value }}"
@@ -502,7 +502,7 @@
                                 <div class="required-status-wrapper" data-current="{% if field.value == 'required' %}required{% else %}optional{% endif %}">
                                     <select class="required-status-dropdown" data-field-id="{{ field.auto_id }}"
                                         data-current="{% if field.value == 'required' %}required{% else %}optional{% endif %}"
-                                        aria-label="Required status for Avatar source">
+                                        aria-label="Required status for Profile picture source">
                                         <option value="optional" {% if field.value == 'optional' or field.value == 'do_not_ask' %}selected{% endif %}>Optional</option>
                                         <option value="required" {% if field.value == 'required' %}selected{% endif %}>
                                             Required</option>
@@ -517,12 +517,12 @@
                         {# Avatar License #}
                         {% with field=sform.cfp_ask_avatar_license %}
                         <tr>
-                            <th>{% translate "Avatar license" %}</th>
+                            <th>{% translate "Profile picture license" %}</th>
                             <td class="text-center">
                                 <label class="toggle-switch" data-field-id="{{ field.auto_id }}"
-                                    aria-label="Toggle active state for Avatar license">
+                                    aria-label="Toggle active state for Profile picture license">
                                     <input type="checkbox" {% if field.value != 'do_not_ask' %}checked{% endif %}
-                                        aria-label="Active toggle for Avatar license">
+                                        aria-label="Active toggle for Profile picture license">
                                     <span class="toggle-slider"></span>
                                 </label>
                                 <input type="hidden" name="{{ field.html_name }}" value="{{ field.value }}"
@@ -532,7 +532,7 @@
                                 <div class="required-status-wrapper" data-current="{% if field.value == 'required' %}required{% else %}optional{% endif %}">
                                     <select class="required-status-dropdown" data-field-id="{{ field.auto_id }}"
                                         data-current="{% if field.value == 'required' %}required{% else %}optional{% endif %}"
-                                        aria-label="Required status for Avatar license">
+                                        aria-label="Required status for Profile picture license">
                                         <option value="optional" {% if field.value == 'optional' or field.value == 'do_not_ask' %}selected{% endif %}>Optional</option>
                                         <option value="required" {% if field.value == 'required' %}selected{% endif %}>
                                             Required</option>


### PR DESCRIPTION
This reverts terminology changes introduced in PR #1784 to align with the original intent .