### PR TITLE
Fix: Add missing whitenoise dependency

### DIFF
--- a/app/pyproject.toml
+++ b/app/pyproject.toml
@@ -210,6 +210,7 @@ dependencies = [
     "webauthn>=2.2.0",
     "webencodings>=0.5.1",
     "websockets>=15.0.1",
+    "whitenoise>=6.11.0",
     "xmlschema>=3.4.3",
     "yarl>=1.22.0",
     "zipp>=3.21.0",

--- a/app/uv.lock
+++ b/app/uv.lock
@@ -1438,6 +1438,7 @@ dependencies = [
     { name = "webauthn" },
     { name = "webencodings" },
     { name = "websockets" },
+    { name = "whitenoise" },
     { name = "xmlschema" },
     { name = "yarl" },
     { name = "zipp" },
@@ -1673,6 +1674,7 @@ requires-dist = [
     { name = "webauthn", specifier = ">=2.2.0" },
     { name = "webencodings", specifier = ">=0.5.1" },
     { name = "websockets", specifier = ">=15.0.1" },
+    { name = "whitenoise", specifier = ">=6.11.0" },
     { name = "xmlschema", specifier = ">=3.4.3" },
     { name = "yarl", specifier = ">=1.22.0" },
     { name = "zipp", specifier = ">=3.21.0" },
@@ -4275,6 +4277,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/9f/69/83029f1f6300c5fb2471d621ab06f6ec6b3324685a2ce0f9777fd4a8b71e/werkzeug-3.1.3.tar.gz", hash = "sha256:60723ce945c19328679790e3282cc758aa4a6040e4bb330f53d30fa546d44746", size = 806925, upload-time = "2024-11-08T15:52:18.093Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/52/24/ab44c871b0f07f491e5d2ad12c9bd7358e527510618cb1b803a88e986db1/werkzeug-3.1.3-py3-none-any.whl", hash = "sha256:54b78bf3716d19a65be4fceccc0d1d7b89e608834989dfae50ea87564639213e", size = 224498, upload-time = "2024-11-08T15:52:16.132Z" },
+]
+
+[[package]]
+name = "whitenoise"
+version = "6.11.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/15/95/8c81ec6b6ebcbf8aca2de7603070ccf37dbb873b03f20708e0f7c1664bc6/whitenoise-6.11.0.tar.gz", hash = "sha256:0f5bfce6061ae6611cd9396a8231e088722e4fc67bc13a111be74c738d99375f", size = 26432, upload-time = "2025-09-18T09:16:10.995Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/6c/e9/4366332f9295fe0647d7d3251ce18f5615fbcb12d02c79a26f8dba9221b3/whitenoise-6.11.0-py3-none-any.whl", hash = "sha256:b2aeb45950597236f53b5342b3121c5de69c8da0109362aee506ce88e022d258", size = 20197, upload-time = "2025-09-18T09:16:09.754Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
**Description**
Adds `whitenoise` to [pyproject.toml](cci:7://file:///Users/abhijeet/Documents/project3/eventyay/app/pyproject.toml:0:0-0:0) and updates `uv.lock`. 

**Relation to #1200**
This fixes the CI build failure blocking the deployment work for #1200. Without this dependency, collectstatic fails, preventing any production Docker image from building.

**Changes**
- Added `whitenoise>=6.6.0` to [app/pyproject.toml](cci:7://file:///Users/abhijeet/Documents/project3/eventyay/app/pyproject.toml:0:0-0:0)
- Updated [app/uv.lock](cci:7://file:///Users/abhijeet/Documents/project3/eventyay/app/uv.lock:0:0-0:0) via uv lock

## Summary by Sourcery

Build:
- Add whitenoise>=6.11.0 to the application dependencies and update uv.lock accordingly.