### PR TITLE
fix(plugins): remove explicit registration for external plugins and add auto registration

### DIFF
--- a/app/eventyay/multidomain/maindomain_urlconf.py
+++ b/app/eventyay/multidomain/maindomain_urlconf.py
@@ -46,15 +46,13 @@ presale_patterns_main = [
 ]
 
 # Plugin URL registration strategy:
-# - Local plugins (in eventyay.plugins.*): Dynamic discovery is safe because they're greppable
-#   in the local codebase (eventyay/plugins/ directory).
-# - External plugins (installed packages): Explicit registration for easier debugging and tracing.
+# - Auto-discover any installed plugin that provides EventyayPluginMeta and URLs.
 
 raw_plugin_patterns = []
 
-# Auto-register local plugins from eventyay.plugins.*
+# Auto-register installed plugins with EventyayPluginMeta
 for app in apps.get_app_configs():
-    if hasattr(app, 'EventyayPluginMeta') and app.name.startswith('eventyay.plugins.'):
+    if hasattr(app, 'EventyayPluginMeta'):
         if importlib.util.find_spec(f'{app.name}.urls'):
             try:
                 urlmod = importlib.import_module(f'{app.name}.urls')
@@ -71,45 +69,6 @@ for app in apps.get_app_configs():
                 logger.debug('Registered URLs under "%s" namespace:\n%s', app.label, single_plugin_patterns)
             except (ImportError, AttributeError, TypeError):
                 logger.exception('Error loading plugin URLs for %s', app.name)
-
-# Explicit registration for external plugins (installed packages)
-# Add external plugins here as they are installed and tested
-
-# eventyay-paypal (always installed via pyproject.toml)
-try:
-    if importlib.util.find_spec('eventyay_paypal.urls'):
-        urlmod = importlib.import_module('eventyay_paypal.urls')
-        single_plugin_patterns = []
-        if hasattr(urlmod, 'urlpatterns'):
-            single_plugin_patterns += urlmod.urlpatterns
-        if hasattr(urlmod, 'event_patterns'):
-            patterns = plugin_event_urls(urlmod.event_patterns, plugin='eventyay_paypal')
-            single_plugin_patterns.append(path('<orgslug:organizer>/<slug:event>/', include(patterns)))
-        if hasattr(urlmod, 'organizer_patterns'):
-            patterns = urlmod.organizer_patterns
-            single_plugin_patterns.append(path('<orgslug:organizer>/', include(patterns)))
-        raw_plugin_patterns.append(path('', include((single_plugin_patterns, 'eventyay_paypal'))))
-        logger.debug('Registered URLs under "eventyay_paypal" namespace:\n%s', single_plugin_patterns)
-except (ImportError, AttributeError, TypeError):
-    logger.exception('Error loading plugin URLs for eventyay_paypal')
-
-# eventyay-stripe (always installed via pyproject.toml)
-try:
-    if importlib.util.find_spec('eventyay_stripe.urls'):
-        urlmod = importlib.import_module('eventyay_stripe.urls')
-        single_plugin_patterns = []
-        if hasattr(urlmod, 'urlpatterns'):
-            single_plugin_patterns += urlmod.urlpatterns
-        if hasattr(urlmod, 'event_patterns'):
-            patterns = plugin_event_urls(urlmod.event_patterns, plugin='eventyay_stripe')
-            single_plugin_patterns.append(path('<orgslug:organizer>/<slug:event>/', include(patterns)))
-        if hasattr(urlmod, 'organizer_patterns'):
-            patterns = urlmod.organizer_patterns
-            single_plugin_patterns.append(path('<orgslug:organizer>/', include(patterns)))
-        raw_plugin_patterns.append(path('', include((single_plugin_patterns, 'eventyay_stripe'))))
-        logger.debug('Registered URLs under "eventyay_stripe" namespace:\n%s', single_plugin_patterns)
-except (ImportError, AttributeError, TypeError):
-    logger.exception('Error loading plugin URLs for eventyay_stripe')
 
 
 plugin_patterns = [path('', include((raw_plugin_patterns, 'plugins')))]


### PR DESCRIPTION
This PR introduces auto registration of all plugins including external plugins, this can be useful when creating new external plugins or adding plugins like the exhibitor plugin while not affecting the local plugins.

## Summary by Sourcery

Auto-register all installed plugins exposing EventyayPluginMeta URLs instead of maintaining explicit URL configuration for specific external plugins.

New Features:
- Enable automatic URL discovery and registration for any installed plugin that defines EventyayPluginMeta.

Enhancements:
- Remove hard-coded URL registration for specific external payment plugins in favor of generic plugin auto-discovery.