### PR TITLE
fix(exhibitor): add isort to project

### DIFF
--- a/app/pyproject.toml
+++ b/app/pyproject.toml
@@ -111,6 +111,7 @@ dependencies = [
     "idna>=3.11",
     "importlib-metadata>=8.7.1",
     "incremental>=24.11.0",
+    "isort>=7.0.0",
     "isoweek>=1.3.3",
     "jinja2>=3.1.6",
     "jsonschema>=4.26.0",

--- a/app/uv.lock
+++ b/app/uv.lock
@@ -1340,6 +1340,7 @@ dependencies = [
     { name = "idna" },
     { name = "importlib-metadata" },
     { name = "incremental" },
+    { name = "isort" },
     { name = "isoweek" },
     { name = "jinja2" },
     { name = "jsonschema" },
@@ -1576,6 +1577,7 @@ requires-dist = [
     { name = "idna", specifier = ">=3.11" },
     { name = "importlib-metadata", specifier = ">=8.7.1" },
     { name = "incremental", specifier = ">=24.11.0" },
+    { name = "isort", specifier = ">=7.0.0" },
     { name = "isoweek", specifier = ">=1.3.3" },
     { name = "jinja2", specifier = ">=3.1.6" },
     { name = "jsonschema", specifier = ">=4.26.0" },
@@ -1949,6 +1951,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/f2/97/ebf4da567aa6827c909642694d71c9fcf53e5b504f2d96afea02718862f3/iniconfig-2.1.0.tar.gz", hash = "sha256:3abbd2e30b36733fee78f9c7f7308f2d0050e88f0087fd25c2645f63c773e1c7", size = 4793, upload-time = "2025-03-19T20:09:59.721Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/2c/e1/e6716421ea10d38022b952c159d5161ca1193197fb744506875fbb87ea7b/iniconfig-2.1.0-py3-none-any.whl", hash = "sha256:9deba5723312380e77435581c6bf4935c94cbfab9b1ed33ef8d238ea168eb760", size = 6050, upload-time = "2025-03-19T20:10:01.071Z" },
+]
+
+[[package]]
+name = "isort"
+version = "7.0.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/63/53/4f3c058e3bace40282876f9b553343376ee687f3c35a525dc79dbd450f88/isort-7.0.0.tar.gz", hash = "sha256:5513527951aadb3ac4292a41a16cbc50dd1642432f5e8c20057d414bdafb4187", size = 805049, upload-time = "2025-10-11T13:30:59.107Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7f/ed/e3705d6d02b4f7aea715a353c8ce193efd0b5db13e204df895d38734c244/isort-7.0.0-py3-none-any.whl", hash = "sha256:1bcabac8bc3c36c7fb7b98a76c8abb18e0f841a3ba81decac7691008592499c1", size = 94672, upload-time = "2025-10-11T13:30:57.665Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
This PR adds isort to the project as it is required for the workflow in exhibitors-plugin

## Summary by Sourcery

Build:
- Declare isort>=7.0.0 as a project dependency in pyproject.toml to support formatting-related tooling.