### PR TITLE
fix 500 error when clicking on events

### DIFF
--- a/app/eventyay/control/urls.py
+++ b/app/eventyay/control/urls.py
@@ -64,6 +64,11 @@ urlpatterns = [
     url(r'^organizers/add$', organizer_views.organizer_view.OrganizerCreate.as_view(), name='organizers.add'),
     url(r'^organizers/select2$', typeahead.organizer_select2, name='organizers.select2'),
     url(
+        r'^organizer/(?P<organizer>[^/]+)/$',
+        organizer_views.organizer_view.OrganizerDetail.as_view(),
+        name='organizer',
+    ),
+    url(
         r'^organizer/(?P<organizer>[^/]+)/delete$',
         organizer_views.organizer_view.OrganizerDelete.as_view(),
         name='organizer.delete',


### PR DESCRIPTION
Closes #1877

https://github.com/user-attachments/assets/6ff7d57b-efa6-4c14-8fa9-52d2dc7c6472


## Summary by Sourcery

Bug Fixes:
- Resolve 500 errors when clicking on events by defining the organizer detail URL route.