### PR TITLE
fix: add Jinja template for change password view

### DIFF
--- a/app/eventyay/eventyay_common/templates/account/password_change.jinja
+++ b/app/eventyay/eventyay_common/templates/account/password_change.jinja
@@ -1,0 +1,22 @@
+{% extends "eventyay_common/base.html" %}
+{% load i18n %}
+{% load bootstrap3 %}
+
+{% block title %}{% trans "Change password" %}{% endblock %}
+
+{% block content %}
+  <h1>{% trans "Change password" %}</h1>
+
+  <form method="post" class="form-horizontal">
+    {% csrf_token %}
+    {% bootstrap_form_errors form %}
+    {% bootstrap_form form layout="horizontal" %}
+
+    <div class="form-group submit-group">
+      <button type="submit" class="btn btn-primary btn-save">
+        {% trans "Change password" %}
+      </button>
+    </div>
+  </form>
+{% endblock %}
+

--- a/app/eventyay/eventyay_common/templates/account/password_change_done.jinja
+++ b/app/eventyay/eventyay_common/templates/account/password_change_done.jinja
@@ -1,0 +1,10 @@
+{% extends "eventyay_common/base.html" %}
+{% load i18n %}
+
+{% block title %}{% trans "Change password" %}{% endblock %}
+
+{% block content %}
+  <h1>{% trans "Change password" %}</h1>
+  <p>{% trans "Your password has been changed." %}</p>
+{% endblock %}
+


### PR DESCRIPTION
Closes #1953


## Summary
Adds a missing Jinja template for the Change Password view after the project
switched `ACCOUNT_TEMPLATE_EXTENSION` to `jinja`.

## Background
django-allauth provides default templates in `.html` format. After switching to
Jinja templates, allauth can no longer find its default Change Password template.

## Changes
- Ensures Change Password view renders correctly with Jinja templates

## Testing
- Template follows existing account template structure
- No backend logic changes

## Summary by Sourcery

Add Jinja-based templates so the account password change flow renders correctly with the new template engine.

New Features:
- Provide a Jinja template for the account password change form view.
- Provide a Jinja template for the password change confirmation page.