### PR TITLE
Remove legacy pretalx version display and GitHub link from talk base …

### DIFF
--- a/app/eventyay/orga/templates/orga/base.html
+++ b/app/eventyay/orga/templates/orga/base.html
@@ -489,12 +489,6 @@
                     {% if development_mode %}
                         <span class="text-warning">· {% translate "running in development mode" %}</span>
                     {% endif %}
-                    {% if pretalx_version %}
-                        <span>·
-                            {% if development_mode %}<a href="https://github.com/fossasia/eventyay-talk/tree/development/"> development<!--{{ pretalx_version }}--></a>
-                            {% else %}v{{ pretalx_version }}{% endif %}
-                        </span>
-                    {% endif %}
                 </footer>
             </div>
         </div>


### PR DESCRIPTION

## Summary by Sourcery

Enhancements:
- Clean up the organiser footer by dropping the obsolete pretalx version and repository link display.