### PR TITLE
Preselected custom field target based on entry point in speaker forms

### DIFF
--- a/app/eventyay/orga/views/cfp.py
+++ b/app/eventyay/orga/views/cfp.py
@@ -266,11 +266,13 @@ class QuestionView(OrderActionMixin, OrgaCRUDView):
     context_object_name = 'question'
     detail_is_update = False
 
-    def get_initial(self):
-        initial = super().get_initial()
-        if 'target' in self.request.GET:
-            initial['target'] = self.request.GET['target']
-        return initial
+    def get_form_kwargs(self):
+        kwargs = super().get_form_kwargs()
+        if self.request.GET.get('target'):
+            initial = kwargs.get('initial', {})
+            initial['target'] = self.request.GET.get('target')
+            kwargs['initial'] = initial
+        return kwargs
 
     def get_queryset(self):
         return (


### PR DESCRIPTION
Closes #2042

## Summary by Sourcery

Enhancements:
- Switch question form initialization to use get_form_kwargs so that a target passed via query parameters is merged into existing initial form data instead of replacing it.