### PR TITLE
Preselect custom field target based on entry point in speaker forms

### DIFF
--- a/app/eventyay/orga/views/cfp.py
+++ b/app/eventyay/orga/views/cfp.py
@@ -266,20 +266,10 @@ class QuestionView(OrderActionMixin, OrgaCRUDView):
     context_object_name = 'question'
     detail_is_update = False
 
-    def get_initial(self):
-        try:
-            initial = super().get_initial()
-        except AttributeError:
-            initial = {}
-        if 'target' in self.request.GET:
-            initial['target'] = self.request.GET['target']
-        return initial
-
     def get_form_kwargs(self):
         kwargs = super().get_form_kwargs()
-        initial = kwargs.get("initial", {}) or {}
-        initial.update(self.get_initial())
-        kwargs["initial"] = initial
+        if target := self.request.GET.get('target'):
+            kwargs.setdefault('initial', {})['target'] = target
         return kwargs
 
     def get_queryset(self):
@@ -684,8 +674,7 @@ class AccessCodeView(OrderActionMixin, OrgaCRUDView):
         kwargs = super().get_form_kwargs()
         if track := self.request.GET.get('track'):
             if track := self.request.event.tracks.filter(pk=track).first():
-                kwargs['initial'] = kwargs.get('initial', {})
-                kwargs['initial']['track'] = track
+                kwargs.setdefault('initial', {})['track'] = track
         return kwargs
 
     def delete_handler(self, request, *args, **kwargs):


### PR DESCRIPTION
Fixed custom field target preselection in the CfP form configuration. The buttons for creating new custom fields under "Speaker Information", "Proposal Information", and "Reviewer Information" now properly preselect the corresponding target dropdown value.

### Changes
- Modified `QuestionView.get_form_kwargs()` to pass initial values (including target parameter) to the form
- Fixed `get_initial()` to extract target from URL query parameters

### Before
- Organizers had to manually select the target dropdown when creating custom fields
- No indication of which section's button was clicked

### After
- Target field is automatically preselected based on the entry point:
  - Speaker Information button → "per speaker" preselected
  - Proposal Information button → "per proposal" preselected  
  - Reviewer Information button → "for reviewers" preselected
- Dropdown remains editable if organizer needs to change it
- Direct form access without target parameter still works


Fixes **#2042**

## Summary by Sourcery

Bug Fixes:
- Ensure the CfP custom question form receives the correct initial target value from URL query parameters so the appropriate target option is preselected.