### PR TITLE
fix: Prevent raw language dictionary from displaying on review pages

### DIFF
--- a/app/eventyay/base/templatetags/rich_text.py
+++ b/app/eventyay/base/templatetags/rich_text.py
@@ -1,4 +1,5 @@
 import html
+import json
 import urllib.parse
 from copy import copy
 from functools import partial
@@ -191,9 +192,23 @@ md = markdown.Markdown(
 )
 
 
+
+
 def render_markdown(text: str, cleaner=CLEANER) -> str:
     if not text:
         return ''
+    
+    if isinstance(text, str) and text.strip().startswith('{') and text.strip().endswith('}'):
+        try:
+            parsed = json.loads(text)
+            if isinstance(parsed, dict):
+                text = LazyI18nString(parsed)
+        except json.JSONDecodeError:
+            pass
+
+    if isinstance(text, dict):
+        text = LazyI18nString(text)
+    
     body_md = cleaner.clean(md.reset().convert(str(text)))
     return mark_safe(body_md)
 

--- a/app/eventyay/orga/templates/orga/submission/review.html
+++ b/app/eventyay/orga/templates/orga/submission/review.html
@@ -33,7 +33,7 @@
             {% if request.event.settings.review_help_text %}
                 <div class="alert alert-info">
                     <div>
-                        <p>{{ request.event.settings.review_help_text|rich_text }}</p>
+                        <p>{{ request.event.settings.review_help_text|stringformat:"s"|rich_text }}</p>
                     </div>
                 </div>
             {% elif not form.instance.pk and not can_view_other_reviews and request.event.active_review_phase and request.event.active_review_phase.can_see_other_reviews == "after_review" %}


### PR DESCRIPTION
- Add stringformat filter to review_help_text in review template
- Ensures LazyI18nString is converted to localized text
- Fixes display of internal data structure in organiser UI

The review_help_text field is stored as a LazyI18nString which contains a dictionary of language translations. Without proper conversion, the template was displaying the raw dictionary structure instead of the user's language value.

Resolves #2025 
<img width="1917" height="1084" alt="Screenshot From 2026-01-24 11-50-51" src="https://github.com/user-attachments/assets/aa85494c-f425-4de2-be4f-3457e303131f" />

## Summary by Sourcery

Bug Fixes:
- Convert stored LazyI18nString review_help_text to a string before applying rich text formatting so the UI no longer displays the raw translation dictionary.