### PR TITLE
Fix : Hides tickets tab when in private test mode

### DIFF
--- a/app/eventyay/agenda/templates/agenda/fragment_nav.html
+++ b/app/eventyay/agenda/templates/agenda/fragment_nav.html
@@ -4,9 +4,11 @@
 {% load eventurl %}
 
 {% load presale_locale %}
-<a href="{% url 'presale:event.index' event=request.event.slug organizer=request.event.organizer.slug %}" class="header-tab">
-    <i class="fa fa-ticket"></i> {% translate "Tickets" %}
-</a>
+{% if request.event.live or show_organizer_area or request.user.is_staff %}
+    <a href="{% url 'presale:event.index' event=request.event.slug organizer=request.event.organizer.slug %}" class="header-tab">
+        <i class="fa fa-ticket"></i> {% translate "Tickets" %}
+    </a>
+{% endif %}
 {% if schedule or request.event.has_schedule_content %}
     <a href="{{ request.event.urls.schedule }}" class="header-tab {% if '/schedule/' in request.path_info %}active{% endif %}">
         <i class="fa fa-calendar"></i> {{ phrases.schedule.schedule }}

--- a/app/eventyay/common/templates/common/fragment_nav.html
+++ b/app/eventyay/common/templates/common/fragment_nav.html
@@ -4,9 +4,11 @@
 {% load eventurl %}
 
 {% with current_event=request.event path=request.path_info schedule_label=phrases.schedule.schedule|default:_("Schedule") sessions_label=phrases.schedule.sessions|default:_("Sessions") speakers_label=phrases.schedule.speakers|default:_("Speakers") %}
-    <a href="{% url 'presale:event.index' event=current_event.slug organizer=current_event.organizer.slug %}" class="header-tab {% if '/schedule/' not in path and '/sessions/' not in path and '/speakers/' not in path and '/cfp' not in path %}active{% endif %}">
-        <i class="fa fa-ticket"></i> {% translate "Tickets" %}
-    </a>
+    {% if current_event.live or show_organizer_area or request.user.is_staff %}
+        <a href="{% url 'presale:event.index' event=current_event.slug organizer=current_event.organizer.slug %}" class="header-tab {% if '/schedule/' not in path and '/sessions/' not in path and '/speakers/' not in path and '/cfp' not in path %}active{% endif %}">
+            <i class="fa fa-ticket"></i> {% translate "Tickets" %}
+        </a>
+    {% endif %}
     {% if schedule or current_event.has_schedule_content %}
         {% with schedule_url=current_event.talk_schedule_url|default:current_event.urls.schedule %}
             <a href="{{ schedule_url }}" class="header-tab {% if '/schedule/' in path %}active{% endif %}">

--- a/app/eventyay/presale/templates/pretixpresale/event/fragment_nav.html
+++ b/app/eventyay/presale/templates/pretixpresale/event/fragment_nav.html
@@ -5,9 +5,11 @@
 
 <nav id='header-nav-bar'>
     <div class="navigation">
-        <a href="{% eventurl request.event 'presale:event.index' %}" class="header-tab underline">
-            <i class="fa fa-ticket"></i> {% translate "Tickets" %}
-        </a>
+        {% if request.event.live or show_organizer_area or request.user.is_staff %}
+            <a href="{% eventurl request.event 'presale:event.index' %}" class="header-tab underline">
+                <i class="fa fa-ticket"></i> {% translate "Tickets" %}
+            </a>
+        {% endif %}
 
         {% if schedule or request.event.has_schedule_content %}
             <a href="{{ request.event.talk_schedule_url }}" class="header-tab ">


### PR DESCRIPTION
Closes #2102

- [x] The Tickets tab is hidden from the public menu when the tickets component is set to private test mode
- [x] Navigation only shows Tickets once tickets are publicly available

Screenshots : 
User view when tickets not live :
<img width="507" height="593" alt="Screenshot 2026-01-26 at 5 56 45 AM" src="https://github.com/user-attachments/assets/474df14c-34a1-40ec-8076-d7435d4c4228" />

Organizer/admin view not live / user view when tickets live :
<img width="557" height="563" alt="Screenshot 2026-01-26 at 5 56 31 AM" src="https://github.com/user-attachments/assets/587d5314-1bfc-44ec-81a6-f1dad58aa02c" />

## Summary by Sourcery

Bug Fixes:
- Prevent the Tickets tab from appearing in the public navigation when an event is not live.