### PR TITLE
Fix: Hide Tickets tab when event is in private test mode

### DIFF
--- a/app/eventyay/agenda/templates/agenda/fragment_nav.html
+++ b/app/eventyay/agenda/templates/agenda/fragment_nav.html
@@ -4,9 +4,11 @@
 {% load eventurl %}
 
 {% load presale_locale %}
-<a href="{% url 'presale:event.index' event=request.event.slug organizer=request.event.organizer.slug %}" class="header-tab">
-    <i class="fa fa-ticket"></i> {% translate "Tickets" %}
-</a>
+{% if not request.event.testmode %}
+    <a href="{% url 'presale:event.index' event=request.event.slug organizer=request.event.organizer.slug %}" class="header-tab">
+        <i class="fa fa-ticket"></i> {% translate "Tickets" %}
+    </a>
+{% endif %}
 {% if schedule or request.event.has_schedule_content %}
     <a href="{{ request.event.urls.schedule }}" class="header-tab {% if '/schedule/' in request.path_info %}active{% endif %}">
         <i class="fa fa-calendar"></i> {{ phrases.schedule.schedule }}

--- a/app/eventyay/common/templates/common/fragment_nav.html
+++ b/app/eventyay/common/templates/common/fragment_nav.html
@@ -4,9 +4,11 @@
 {% load eventurl %}
 
 {% with current_event=request.event path=request.path_info schedule_label=phrases.schedule.schedule|default:_("Schedule") sessions_label=phrases.schedule.sessions|default:_("Sessions") speakers_label=phrases.schedule.speakers|default:_("Speakers") %}
-    <a href="{% url 'presale:event.index' event=current_event.slug organizer=current_event.organizer.slug %}" class="header-tab {% if '/schedule/' not in path and '/sessions/' not in path and '/speakers/' not in path and '/cfp' not in path %}active{% endif %}">
-        <i class="fa fa-ticket"></i> {% translate "Tickets" %}
-    </a>
+    {% if not current_event.testmode %}
+        <a href="{% url 'presale:event.index' event=current_event.slug organizer=current_event.organizer.slug %}" class="header-tab {% if '/schedule/' not in path and '/sessions/' not in path and '/speakers/' not in path and '/cfp' not in path %}active{% endif %}">
+            <i class="fa fa-ticket"></i> {% translate "Tickets" %}
+        </a>
+    {% endif %}
     {% if schedule or current_event.has_schedule_content %}
         {% with schedule_url=current_event.talk_schedule_url|default:current_event.urls.schedule %}
             <a href="{{ schedule_url }}" class="header-tab {% if '/schedule/' in path %}active{% endif %}">

--- a/app/eventyay/presale/templates/pretixpresale/event/fragment_nav.html
+++ b/app/eventyay/presale/templates/pretixpresale/event/fragment_nav.html
@@ -5,9 +5,11 @@
 
 <nav id='header-nav-bar'>
     <div class="navigation">
-        <a href="{% eventurl request.event 'presale:event.index' %}" class="header-tab underline">
-            <i class="fa fa-ticket"></i> {% translate "Tickets" %}
-        </a>
+        {% if not request.event.testmode %}
+            <a href="{% eventurl request.event 'presale:event.index' %}" class="header-tab underline">
+                <i class="fa fa-ticket"></i> {% translate "Tickets" %}
+            </a>
+        {% endif %}
 
         {% if schedule or request.event.has_schedule_content %}
             <a href="{{ request.event.talk_schedule_url }}" class="header-tab ">


### PR DESCRIPTION
- Add conditional check for event.testmode in navigation templates
- Tickets tab now only appears when testmode is False (publicly available)
- Applied consistently across presale, common, and agenda navigation
- Fixes issue where Tickets tab was always visible even in private test mode

user view when tickets component is set to private mode
<img width="1920" height="1076" alt="Screenshot From 2026-01-26 06-12-11" src="https://github.com/user-attachments/assets/ef09cfa6-5ede-44df-94d8-2007398b698f" />

user view when private mode is disabled
<img width="1920" height="1076" alt="Screenshot From 2026-01-26 06-29-51" src="https://github.com/user-attachments/assets/024eaa19-cafc-462f-84d6-7c2ab47337bc" />

Closes #2102