### PR TITLE
fix: dropdown should show admin on active admin session

### DIFF
--- a/app/eventyay/orga/context_processors.py
+++ b/app/eventyay/orga/context_processors.py
@@ -51,6 +51,8 @@ def orga_events(request):
     if not getattr(request, 'user', None) or not request.user.is_authenticated:
         return context
 
+    context['staff_session'] = request.user.has_active_staff_session(request.session.session_key)
+
     if not getattr(request, 'event', None):
         context['nav_global'] = [
             entry for entry in collect_signal(nav_global, {'sender': None, 'request': request}) if entry


### PR DESCRIPTION
fixes #2107 
Added staff_session to the orga context processor

<img width="959" height="311" alt="image" src="https://github.com/user-attachments/assets/f8b892e8-c899-40df-8fbf-2df512b7a5e7" />

<img width="959" height="311" alt="image" src="https://github.com/user-attachments/assets/3adaf114-c598-47e6-9b07-2891c60789e8" />

## Summary by Sourcery

Enhancements:
- Add the staff_session flag to the orga context processor based on the user's active staff session status.