### PR TITLE
Add Full Name field to Speaker Information table

### DIFF
--- a/app/eventyay/orga/templates/orga/cfp/forms.html
+++ b/app/eventyay/orga/templates/orga/cfp/forms.html
@@ -410,6 +410,28 @@
                         </tr>
                     </thead>
                     <tbody>
+                        {# Full Name #}
+                        <tr>
+                            <th>{% translate "Full name" %}</th>
+                            <td class="text-center">
+                                <label class="toggle-switch always-on" aria-label="{% translate 'Full name is always active' %}">
+                                    <input type="checkbox" checked disabled aria-label="{% translate 'Full name always active' %}">
+                                    <span class="toggle-slider"></span>
+                                </label>
+                            </td>
+                            <td class="text-center">
+                                <div class="required-status-wrapper" data-current="required">
+                                    <select class="required-status-dropdown" disabled aria-readonly="true"
+                                        aria-describedby="fullname-required-help" data-current="required">
+                                        <option value="required" selected>Required</option>
+                                    </select>
+                                </div>
+                                <span id="fullname-required-help" class="sr-only">{% translate "The full name is always required and cannot be changed." %}</span>
+                            </td>
+                            <td></td>
+                            <td></td>
+                        </tr>
+
                         {# Biography #}
                         {% with field=sform.cfp_ask_biography %}
                         <tr>


### PR DESCRIPTION
- Add Full Name as first row in Speaker Information configuration table
- Field is always active and cannot be disabled
- Field is always required and cannot be made optional
- Matches the pattern used for Title field in Proposal Information
- Improves consistency between organiser UI and speaker CFP form

This addresses the inconsistency where Full Name was shown in the speaker CFP form but missing from the organiser configuration UI.
Fixes #2121 


https://github.com/user-attachments/assets/385ed8b2-cdab-438e-9f47-f4ee0e2e8412


## Summary by Sourcery

New Features:
- Introduce a fixed, always-active and required Full Name row in the Speaker Information configuration table.