### PR TITLE
chore: close dropdown on outside clicks on public agenda and presale views

### DIFF
--- a/app/eventyay/common/templates/common/base_public.html
+++ b/app/eventyay/common/templates/common/base_public.html
@@ -70,7 +70,7 @@
             <script defer src="{% static 'common/js/base.js' %}"></script>
             <script defer src="{% static 'common/js/lightbox.js' %}"></script>
             <script src="{% static 'agenda/js/join-online-event.js' %}"></script>
-            <script defer src="{% static 'common/js/dropdown.js' %}"></script>
+            <script type="module" src="{% static 'common/js/dropdown.js' %}"></script>
             <script defer src="{% static 'common/js/nav-tabs.js' %}"></script>
         {% endcompress %}
         {% block scripts %}{% endblock scripts %}

--- a/app/eventyay/static/common/js/dropdown.js
+++ b/app/eventyay/static/common/js/dropdown.js
@@ -34,13 +34,14 @@ const ensureGlobalListeners = function() {
     }
     document.documentElement.dataset[GLOBAL_INIT_FLAG] = '1';
 
-    document.addEventListener('click', function(event) {
+    const handlePossibleOutsideInteraction = function(event) {
         getOpenDropdowns().forEach(function(dropdown) {
             if (!dropdown.contains(event.target)) {
                 dropdown.open = false;
             }
         });
-    });
+    };
+    document.addEventListener('pointerdown', handlePossibleOutsideInteraction, true);
 
     document.addEventListener('keydown', function(event) {
         if (event.key !== 'Escape' && event.key !== 'Esc') return;


### PR DESCRIPTION
Fixes #2080

## Summary by Sourcery

Ensure dropdowns on public pages close reliably when interacting outside of them and load the dropdown script as an ES module on public views.

Bug Fixes:
- Close open dropdowns on public views when users interact outside them, even if other handlers stop event propagation.

Enhancements:
- Handle outside interactions using a global pointer-based capture listener to make dropdown closing more robust across input types.