### PR TITLE
Fix mobile navbar overlap on Talk tab

### DIFF
--- a/app/eventyay/orga/templates/orga/base.html
+++ b/app/eventyay/orga/templates/orga/base.html
@@ -110,19 +110,13 @@
                 {% endif %}
             </ul>
             <ul class="nav navbar-nav navbar-top-links navbar-right flip">
-                {% if request.user.is_staff and not request.user|has_active_staff_session:request.session.session_key %}
+{% if request.user.is_staff and not request.user|has_active_staff_session:request.session.session_key %}
                     <li>
                         <form action="{% url 'control:user.sudo' %}?next={{ request.path|add:"?"|add:request.GET.urlencode|urlencode }}" method="post">
                             {% csrf_token %}
-                            {% if not request.event and not request.organizer %}
-                                <button type="submit" class="btn btn-link" id="button-sudo">
-                                    <i class="fa fa-id-card"></i>
-                                </button>
-                            {% else %}
-                                <button type="submit" class="btn btn-link" id="button-sudo">
-                                    <i class="fa fa-id-card"></i> {% translate "Admin mode" %}
-                                </button>
-                            {% endif %}
+                            <button type="submit" class="btn btn-link" id="button-sudo">
+                                <i class="fa fa-id-card"></i> {% translate "Admin mode" %}
+                            </button>
                         </form>
                     </li>
                 {% elif request.user.is_staff and request.user|has_active_staff_session:request.session.session_key %}

--- a/app/eventyay/static/cfp/css/_layout.css
+++ b/app/eventyay/static/cfp/css/_layout.css
@@ -74,90 +74,88 @@ header {
     padding-bottom: 4px;
     color: var(--color-primary);
     margin-left: auto;
-	margin-right: 10px;
+    margin-right: 10px;
     display: flex;
     flex-wrap: nowrap;
     flex-shrink: 0;
     align-items: center;
     font-size: 1rem;
+  }
 
-    .header-nav {
-      color: var(--color-primary);
-      border-color: var(--color-primary);
-      background: transparent;
-    }
+  .header-row-right .header-nav {
+    color: var(--color-primary);
+    border-color: var(--color-primary);
+    background: transparent;
+  }
 
-    .header-nav:hover,
-    .header-nav:focus {
-      color: white;
-      background: var(--color-primary);
-      border-color: var(--color-primary);
-      text-decoration: none;
-    }
+  .header-row-right .header-nav:hover,
+  .header-row-right .header-nav:focus {
+    color: white;
+    background: var(--color-primary);
+    border-color: var(--color-primary);
+    text-decoration: none;
+  }
 
-    /* Inline locale links */
-    .locales-inline {
-      display: inline-block;
-      margin-right: 0.8rem;
-    }
+  /* Inline locale links */
+  .header-row-right .locales-inline {
+    display: inline-block;
+    margin-right: 0.8rem;
+  }
 
-    .locale-link {
-      color: var(--color-primary);
-      text-decoration: none;
-      font-size: 0.9rem;
-      opacity: 0.85;
-      transition: opacity 0.2s, color 0.2s;
-      margin-left: 0.65rem;
-    }
+  .header-row-right .locale-link {
+    color: var(--color-primary);
+    text-decoration: none;
+    font-size: 0.9rem;
+    opacity: 0.85;
+    transition: opacity 0.2s, color 0.2s;
+    margin-left: 0.65rem;
+  }
 
-    .locale-link:hover {
-      opacity: 1;
-      text-decoration: underline;
-    }
+  .header-row-right .locale-link:hover {
+    opacity: 1;
+    text-decoration: underline;
+  }
 
-    .locale-link.active {
-      font-weight: bold;
-      opacity: 1;
-    }
+  .header-row-right .locale-link.active {
+    font-weight: bold;
+    opacity: 1;
+  }
 
-    .locales {
-      margin-right: 20px;
-      
-      summary {
-        cursor: pointer;
-        color: var(--color-primary);
-      }
-      
-      summary:focus-visible {
-        outline: 2px solid var(--color-primary);
-        border-radius: var(--size-border-radius);
-      }
-      
-      .dropdown-content {
-        border: 1px solid var(--color-grey-lighter);
-        border-radius: 4px;
-        right: 0;
-        left: auto;
-        min-width: 100px;
-        
-        .dropdown-item {
-          &:hover {
-            background-color: var(--color-primary-lighter);
-            color: var(--color-grey-dark);
-            text-decoration: none;
-          }
-          
-          &.active {
-            background-color: var(--color-primary);
-            color: white;
-            
-            &:hover {
-              background-color: var(--color-primary-dark, var(--color-primary));
-            }
-          }
-        }
-      }
-    }
+  .header-row-right .locales {
+    margin-right: 20px;
+  }
+
+  .header-row-right .locales summary {
+    cursor: pointer;
+    color: var(--color-primary);
+  }
+
+  .header-row-right .locales summary:focus-visible {
+    outline: 2px solid var(--color-primary);
+    border-radius: var(--size-border-radius);
+  }
+
+  .header-row-right .locales .dropdown-content {
+    border: 1px solid var(--color-grey-lighter);
+    border-radius: 4px;
+    right: 0;
+    left: auto;
+    min-width: 100px;
+  }
+
+  .header-row-right .locales .dropdown-item:hover {
+    background-color: var(--color-primary-lighter);
+    color: var(--color-grey-dark);
+    text-decoration: none;
+  }
+
+  .header-row-right .locales .dropdown-item.active {
+    background-color: var(--color-primary);
+    color: white;
+  }
+
+  .header-row-right .locales .dropdown-item.active:hover {
+    background-color: var(--color-primary-dark, var(--color-primary));
   }
 }
 

--- a/app/eventyay/static/common/css/_navbar.css
+++ b/app/eventyay/static/common/css/_navbar.css
@@ -642,8 +642,6 @@ nav.navbar.navbar-inverse #button-sudo:focus i,
     justify-content: flex-end;
   }
 
-  /* Override justify-content for flipped navbar-right (RTL support) */
-  nav.navbar .event-dashboard-wrapper .nav.navbar-nav.navbar-top-links.navbar-right.flip,
   nav.navbar .nav.navbar-nav.navbar-top-links.navbar-right.flip {
     justify-content: flex-end;
   }
@@ -660,7 +658,6 @@ nav.navbar.navbar-inverse #button-sudo:focus i,
     gap: 4px;
   }
 
-  /* Hide user name in profile dropdown for talk dashboard, show only icon */
   .event-dashboard-wrapper nav.navbar .nav.navbar-nav.navbar-top-links.navbar-right.flip #profile-dropdown summary .fa-user + .fa-caret-down {
     margin-left: 4px;
   }
@@ -669,62 +666,46 @@ nav.navbar.navbar-inverse #button-sudo:focus i,
     display: none;
   }
 
-  /* Extra high-specificity rule to ensure blue background on the exact selector requested */
-  @media (max-width: 767px) {
-    .nav.navbar-nav.navbar-top-links.navbar-right.flip {
-      background-color: #2185d0 !important;
-      padding: 6px 10px !important;
-      display: flex !important;
-      flex-wrap: nowrap !important;
-      align-items: center !important;
-      overflow: visible !important;
-      justify-content: flex-end !important;
-    }
-    .nav.navbar-nav.navbar-top-links.navbar-right.flip > li > a,
-    .nav.navbar-nav.navbar-top-links.navbar-right.flip > li > form > .btn-link {
-      color: #ffffff !important;
-    }
+  .nav.navbar-nav.navbar-top-links.navbar-right.flip {
+    background-color: #2185d0 !important;
+    padding: 6px 10px !important;
+    display: flex !important;
+    flex-wrap: nowrap !important;
+    align-items: center !important;
+    overflow: visible !important;
+    justify-content: flex-end !important;
+  }
+  .nav.navbar-nav.navbar-top-links.navbar-right.flip > li > a,
+  .nav.navbar-nav.navbar-top-links.navbar-right.flip > li > form > .btn-link {
+    color: #f8f9fa !important;
+  }
 
-    /* Also ensure flip class takes precedence for justify-content */
-    nav.navbar .event-dashboard-wrapper .nav.navbar-nav.navbar-top-links.navbar-right.flip {
-      justify-content: flex-end;
-    }
 
-    /* Hide language label on Talk dashboard mobile: show only globe icon */
-    .event-dashboard-wrapper nav.navbar .nav.navbar-nav.navbar-top-links.navbar-right.flip #language-dropdown summary .current-locale {
-      display: none !important;
-    }
 
-    /* Reduce spacing between navbar items to prevent overflow on talk tab admin mode */
-    .event-dashboard-wrapper nav.navbar .nav.navbar-nav.navbar-top-links.navbar-right.flip {
-      gap: 2px;
-      padding: 4px 8px;
-    }
+ 
 
-    .event-dashboard-wrapper nav.navbar .nav.navbar-nav.navbar-top-links.navbar-right.flip > li > a,
-    .event-dashboard-wrapper nav.navbar .nav.navbar-nav.navbar-top-links.navbar-right.flip > li > form > .btn-link {
-      padding: 6px 8px;
-      font-size: 13px;
-    }
+  .event-dashboard-wrapper nav.navbar .nav.navbar-nav.navbar-top-links.navbar-right.flip > li > a,
+  .event-dashboard-wrapper nav.navbar .nav.navbar-nav.navbar-top-links.navbar-right.flip > li > form > .btn-link {
+    padding: 6px 8px;
+    font-size: 13px;
+  }
 
-    /* Reduce admin mode button spacing */
-    .event-dashboard-wrapper nav.navbar .nav.navbar-nav.navbar-top-links.navbar-right.flip #button-sudo,
-    .event-dashboard-wrapper nav.navbar .nav.navbar-nav.navbar-top-links.navbar-right.flip #button-shop {
-      padding: 6px 8px;
-      min-height: auto;
-      height: auto;
-      margin-left: 2px;
-    }
+  /* Reduce admin mode button spacing */
+  .event-dashboard-wrapper nav.navbar .nav.navbar-nav.navbar-top-links.navbar-right.flip #button-sudo,
+  .event-dashboard-wrapper nav.navbar .nav.navbar-nav.navbar-top-links.navbar-right.flip #button-shop {
+    padding: 6px 8px;
+    min-height: auto;
+    height: auto;
+    margin-left: 2px;
+  }
 
-    /* Reduce profile and language dropdown spacing */
-    .event-dashboard-wrapper nav.navbar .nav.navbar-nav.navbar-top-links.navbar-right.flip #profile-dropdown summary,
-    .event-dashboard-wrapper nav.navbar .nav.navbar-nav.navbar-top-links.navbar-right.flip #language-dropdown summary {
-      padding: 6px 8px;
-    }
+  /* Reduce profile and language dropdown spacing */
+  .event-dashboard-wrapper nav.navbar .nav.navbar-nav.navbar-top-links.navbar-right.flip #profile-dropdown summary,
+  .event-dashboard-wrapper nav.navbar .nav.navbar-nav.navbar-top-links.navbar-right.flip #language-dropdown summary {
+    padding: 6px 8px;
+  }
 
-    /* Reduce warning bell spacing */
-    .event-dashboard-wrapper nav.navbar .nav.navbar-nav.navbar-top-links.navbar-right.flip > li > a.danger {
-      padding: 6px 8px;
-    }
+  .event-dashboard-wrapper nav.navbar .nav.navbar-nav.navbar-top-links.navbar-right.flip > li > a.danger {
+    padding: 6px 8px;
   }
 }


### PR DESCRIPTION
Fixes #2191 
### Problem
On mobile view, the admin-mode navbar items were overlapping the event header and secondary navigation (Home, Tickets, Talk, etc.) when the Talk tab was active.

### Root Cause

The admin navigation uses `float: left !important`, which breaks the layout on mobile when combined with the Talk tab’s header structure, causing elements to overlap instead of stacking.

### Solution

- Removed the problematic float behavior only on mobile
- Ensured the admin navigation stacks above the event navigation, matching the layout used in other tabs
- Shifted the Talk tab buttons below the admin navigation to restore a clean visual hierarchy

### Testing
Verified on mobile view
<img width="524" height="889" alt="image" src="https://github.com/user-attachments/assets/dc434634-d0a0-40b5-bc52-ce5504b3c8bd" />

## Summary by Sourcery

Adjust mobile navbar and page layout to prevent overlap between admin navigation and event content on small screens.

Bug Fixes:
- Fix overlapping admin navigation and event header/navigation on mobile, especially on the Talk tab.

Enhancements:
- Rework mobile navbar into a static, flex-based layout with stacked content to improve readability on small screens.
- Standardize spacing and stacking of event header, navigation buttons, timeline, and dashboard sections in mobile view.
- Hide redundant mobile navbar view links and desktop-only navbar-left items on small screens.