### PR TITLE
Fix AttributeError: 'NoneType' object has no attribute 'question' in speaker profile form

### DIFF
--- a/app/eventyay/common/forms/mixins.py
+++ b/app/eventyay/common/forms/mixins.py
@@ -182,7 +182,7 @@ class QuestionFieldsMixin:
         for question in questions.prefetch_related('options'):
             initial_object = None
             initial = question.default_answer
-            
+
             if target_object:
                 answer = answers_by_question.get(question.id)
                 if answer:
@@ -197,6 +197,13 @@ class QuestionFieldsMixin:
                 initial_object=initial_object,
                 readonly=readonly,
             )
+            if field is None:
+                logger.warning(
+                    "Could not create form field for question %s (variant: %s). Skipping.",
+                    question.pk,
+                    question.variant,
+                )
+                continue
             field.question = question
             field.answer = initial_object
             self.fields[f'question_{question.pk}'] = field


### PR DESCRIPTION
Fixes #2260 
### Summary
Fixes an `AttributeError` on the speaker profile submission page caused by missing null handling when creating form fields for questions with unsupported variants.

### Changes Made
**File:** `eventyay/common/forms/mixins.py`

- Added a null check after calling `get_field()` to safely handle unsupported question variants.
  - `get_field()` may return `None` when a question’s variant type is not supported.
  - Previously, the code attempted to access `field.question` on a `None` value, causing a crash.
- Added warning-level logging when a question field is skipped.
  - Logs include the question ID and variant type for easier debugging.
  - Helps identify unsupported variants without interrupting page rendering.

### Root Cause
The `get_field()` method returns `None` (line 444) when a question’s variant does not match any supported types (BOOLEAN, NUMBER, STRING, URL, TEXT, FILE, CHOICES, MULTIPLE, DATE, DATETIME).  
`inject_questions_into_fields()` did not account for this case and attempted to access attributes on a `None` value, resulting in an `AttributeError`.

## Summary by Sourcery

Handle unsupported question variants safely when injecting dynamic question fields into speaker-related forms.

Bug Fixes:
- Prevent AttributeError when creating form fields for questions whose variants are not supported by get_field().

Enhancements:
- Log a warning and skip questions when form field creation fails due to unsupported variants, aiding debugging without breaking form rendering.