### PR TITLE
fix(bitpay): update bitpay

### DIFF
--- a/app/uv.lock
+++ b/app/uv.lock
@@ -1146,7 +1146,7 @@ wheels = [
 [[package]]
 name = "eventyay-bitpay"
 version = "1.5.2"
-source = { git = "https://github.com/fossasia/eventyay-bitpay.git?rev=main#335d676dae6da8da82ae96812be4876d85b5ab16" }
+source = { git = "https://github.com/fossasia/eventyay-bitpay.git?rev=main#a1f21696546c09cec59287957b719ae37704f16e" }
 dependencies = [
     { name = "btcpay-python" },
 ]


### PR DESCRIPTION
This PR updates bitpay version to the latest head.

## Summary by Sourcery

Build:
- Refresh uv.lock to point to the latest BitPay package revision.