### PR TITLE
Hover activated submenu and dashboard link fix

### DIFF
--- a/app/eventyay/common/templates/common/fragment_profile_dropdown.html
+++ b/app/eventyay/common/templates/common/fragment_profile_dropdown.html
@@ -7,11 +7,11 @@
             <i class="fa fa-caret-down"></i>
         </summary>
         <div class="dropdown-content dropdown-content-sw">
-            <details class="dropdown">
-                <summary class="dropdown-item">
+            <div class="dashboard-dropdown">
+                <a class="dropdown-item dashboard-dropdown-toggle" href="{{ base_path }}/common/" role="button" tabindex="0" aria-haspopup="true" aria-expanded="false">
                     <i class="fa fa-tachometer"></i> {% translate "Dashboard" %}
-                </summary>
-                <div class="dropdown-content dropdown-content-w">
+                </a>
+                <div class="dropdown-content dropdown-content-w" role="menu">
                     <a class="dropdown-item" href="{{ base_path }}/common/">
                         <i class="fa fa-tachometer"></i> {% translate "Main dashboard" %}
                     </a>
@@ -22,7 +22,7 @@
                         <i class="fa fa-microphone"></i> {% translate "Talks" %}
                     </a>
                 </div>
-            </details>
+            </div>
 
             <a class="dropdown-item" href="{{ base_path }}/common/orders/">
                 <i class="fa fa-shopping-cart"></i> {% translate "My orders" %}

--- a/app/eventyay/static/common/css/_dropdown.css
+++ b/app/eventyay/static/common/css/_dropdown.css
@@ -696,3 +696,25 @@ nav.navbar details.dropdown .dropdown-content a.dropdown-item:hover i,
 nav.navbar details.dropdown .dropdown-content button.dropdown-item:hover i {
   color: #fff;
 }
+
+.dashboard-dropdown {
+  position: relative;
+}
+
+.dashboard-dropdown > .dropdown-content {
+  display: none;
+}
+
+/* Show submenu on hover for devices that support it */
+@media (hover: hover) {
+  .dashboard-dropdown:hover > .dropdown-content {
+    display: block;
+    animation: dropdown-reveal 120ms ease-out;
+  }
+}
+
+/* Show submenu when active class is added (for touch/keyboard) */
+.dashboard-dropdown.active > .dropdown-content {
+  display: block;
+  animation: dropdown-reveal 120ms ease-out;
+}

--- a/app/eventyay/static/common/js/dropdown.js
+++ b/app/eventyay/static/common/js/dropdown.js
@@ -61,6 +61,50 @@ const initDropdowns = function() {
             closeOtherDropdowns(dropdown);
         });
     });
+
+    // Initialize dashboard dropdown submenu toggle for touch/keyboard devices
+    document.querySelectorAll('.dashboard-dropdown-toggle').forEach(function(toggle) {
+        toggle.addEventListener('click', function(event) {
+            // Only prevent default and toggle on non-hover devices
+            // Check if this is a touch device or doesn't support hover
+            const supportsHover = window.matchMedia('(hover: hover)').matches;
+            if (!supportsHover) {
+                event.preventDefault();
+                const parent = toggle.closest('.dashboard-dropdown');
+                if (parent) {
+                    parent.classList.toggle('active');
+                    const isExpanded = parent.classList.contains('active');
+                    toggle.setAttribute('aria-expanded', isExpanded.toString());
+                }
+            }
+        });
+
+        // Keyboard support (Enter and Space keys)
+        toggle.addEventListener('keydown', function(event) {
+            if (event.key === 'Enter' || event.key === ' ') {
+                event.preventDefault();
+                const parent = toggle.closest('.dashboard-dropdown');
+                if (parent) {
+                    parent.classList.toggle('active');
+                    const isExpanded = parent.classList.contains('active');
+                    toggle.setAttribute('aria-expanded', isExpanded.toString());
+                }
+            }
+        });
+    });
+
+    // Close submenu when clicking outside
+    document.addEventListener('click', function(event) {
+        if (!event.target.closest('.dashboard-dropdown')) {
+            document.querySelectorAll('.dashboard-dropdown.active').forEach(function(dropdown) {
+                dropdown.classList.remove('active');
+                const toggle = dropdown.querySelector('.dashboard-dropdown-toggle');
+                if (toggle) {
+                    toggle.setAttribute('aria-expanded', 'false');
+                }
+            });
+        }
+    });
 };
 
 if (document.readyState === 'loading') {


### PR DESCRIPTION
fixes #2308 

Clicking "Dashboard" navigates to Main dashboard. Hovering reveals the submenu 
with all three dashboard links.

https://github.com/user-attachments/assets/2fa0be97-5b7e-470d-b484-100e76c99dfd

https://github.com/user-attachments/assets/eab076bc-4098-48fe-a85e-4817a138f8c7


