### PR TITLE
fix: Consolidate Speaker Profile forms and remove duplicate Save button

### DIFF
--- a/app/eventyay/cfp/templates/cfp/event/user_profile.html
+++ b/app/eventyay/cfp/templates/cfp/event/user_profile.html
@@ -32,12 +32,10 @@
             {% include "common/availabilities.html" %}
             {{ profile_form.availabilities.as_field_group }}
         {% endif %}
-        {% if questions_exist %}
+        {% if profile_question_fields %}
             <h2>{% translate "We have some questions" %}</h2>
-            {% for field in profile_form %}
-                {% if field.name|slice:":9" == "question_" %}
-                    {{ field.as_field_group }}
-                {% endif %}
+            {% for field in profile_question_fields %}
+                {{ field.as_field_group }}
             {% endfor %}
         {% endif %}
 

--- a/app/eventyay/cfp/views/user.py
+++ b/app/eventyay/cfp/views/user.py
@@ -45,7 +45,6 @@ class ProfileView(LoggedInEventPageMixin, TemplateView):
     template_name = 'cfp/event/user_profile.html'
 
     @context
-    @context
     @cached_property
     def profile_form(self):
         bind = is_form_bound(self.request, 'profile')
@@ -81,8 +80,8 @@ class ProfileView(LoggedInEventPageMixin, TemplateView):
         )
 
     @context
-    def questions_exist(self):
-        return self.request.event.talkquestions.filter(target='speaker').exists()
+    def profile_question_fields(self):
+        return [field for field in self.profile_form if field.name.startswith('question_')]
 
     def post(self, request, *args, **kwargs):
         if self.profile_form.is_bound and self.profile_form.is_valid():


### PR DESCRIPTION
fixes #2310 
<img width="1920" height="1088" alt="Screenshot From 2026-02-09 06-38-34" src="https://github.com/user-attachments/assets/6084ae64-c851-4791-9dda-f3a11e015f60" />

## Summary by Sourcery

Consolidate the speaker profile and questions into a single form submission and remove the redundant second questions form and save button.

Bug Fixes:
- Ensure speaker profile questions are submitted together with the main profile form instead of via a separate questions form that had its own submit button.

Enhancements:
- Render speaker questions as part of the existing profile form when present, simplifying the profile editing UI.
- Remove now-unused questions_form handling logic and related form-binding checks from the profile view.