### PR TITLE
fix(timezone-dropdown): apply background color for selected timezone in schedule

### DIFF
--- a/app/eventyay/webapp/schedule/src/components/ScheduleSettings.vue
+++ b/app/eventyay/webapp/schedule/src/components/ScheduleSettings.vue
@@ -194,7 +194,7 @@ export default {
 		&:hover
 			background-color: rgba(0, 0, 0, 0.04)
 		&.active
-			background-color: $highlight-color
+			background-color: var(--pretalx-clr-primary)
 			color: $clr-white
 .timezone-divider
 	display: flex


### PR DESCRIPTION
This PR adds a background color to the selected timezone in the dropdown of talk components in presale.
<img width="2032" height="1162" alt="image" src="https://github.com/user-attachments/assets/b9ef072e-ffa0-4793-9d4f-c582aba4437c" />

## Summary by Sourcery

Enhancements:
- Align selected timezone background color in the schedule dropdown with the primary theme color for consistent theming.