### PR TITLE
Change Dependabot update schedule from daily to weekly

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,7 +4,8 @@ updates:
   - package-ecosystem: "uv"
     directory: "/app"
     schedule:
-      interval: "daily"
+      interval: "weekly"
+    open-pull-requests-limit: 10
     versioning-strategy: increase
     ignore:
       - dependency-name: "django"
@@ -15,19 +16,23 @@ updates:
   - package-ecosystem: "npm"
     directory: "/app/eventyay/webapp/video"
     schedule:
-      interval: "daily"
+      interval: "weekly"
+    open-pull-requests-limit: 10
 
   - package-ecosystem: "npm"
     directory: "/app/eventyay/webapp/schedule"
     schedule:
-      interval: "daily"
+      interval: "weekly"
+    open-pull-requests-limit: 10
 
   - package-ecosystem: "npm"
     directory: "/app/eventyay/webapp/schedule-editor"
     schedule:
-      interval: "daily"
+      interval: "weekly"
+    open-pull-requests-limit: 10
 
   - package-ecosystem: "npm"
     directory: "/app/eventyay/webapp/webcheckin"
     schedule:
-      interval: "daily"
+      interval: "weekly"
+    open-pull-requests-limit: 10


### PR DESCRIPTION
## Summary by Sourcery

Adjust Dependabot configuration to reduce update frequency and cap concurrent update PRs.

Build:
- Change Dependabot update interval from daily to weekly across all configured ecosystems and directories.
- Limit the number of simultaneously open Dependabot pull requests to 10 for each configured package ecosystem entry.