### PR TITLE
Exclude setuptools from Dependabot uv updates to prevent no-op failures

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,6 +12,8 @@ updates:
         versions: [">=6.0.0"]
       - dependency-name: "stripe"
         versions: [">=11.4.0"]
+      # Ignore all setuptools updates; issue is not version-specific.
+      # Can be removed once Dependabot handles no-op uv updates.
       - dependency-name: "setuptools"
 
   - package-ecosystem: "npm"


### PR DESCRIPTION
Fixes #2398 
### Summary
Dependabot fails when trying to update `setuptools` in the `uv` ecosystem because the update can resolve successfully without producing any file changes. Dependabot treats this valid no-op as an error and aborts the entire run.

### What’s happening
- `setuptools` is a build-system dependency
- In `uv`, updating build-system-only dependencies does not always change `pyproject.toml` or `uv.lock`
- Dependabot expects every update to modify at least one file
- When no diff is produced, it fails with `RuntimeError: No files have changed!`

This causes repeated Dependabot failures even though dependency resolution succeeds.

### Change
Exclude `setuptools` from Dependabot’s `uv` updates.

### Impact
- Other dependencies continue to be updated normally by Dependabot
- `setuptools` updates will have to be handled manually when the build-system constraint changes
- Prevents recurring Dependabot failures caused by valid no-op updates

### Notes
This is a workaround for a limitation in Dependabot’s `uv` updater. Ideally, Dependabot should treat no-op updates as success and continue processing.

## Summary by Sourcery

Build:
- Update Dependabot configuration to ignore setuptools in the uv package ecosystem to prevent no-op update failures.