### PR TITLE
chore: fix docker vue build collection

### DIFF
--- a/app/Dockerfile
+++ b/app/Dockerfile
@@ -38,6 +38,9 @@ RUN --mount=type=cache,target=/root/.cache/uv \
 # Run npm stuff (needs nodejs)
 RUN make npminstall
 
+# Pre-build static.dist so the image ships with the Vite manifest
+RUN uv run python manage.py collectstatic --noinput
+
 
 ###########
 # RUNTIME #

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,6 +8,7 @@ services:
     command: python manage.py runserver 0.0.0.0:8000
     volumes:
       - ./app/eventyay:/usr/src/app/eventyay
+      - /usr/src/app/eventyay/static.dist
       - /usr/src/app/eventyay/static/video
       - /usr/src/app/eventyay/static/schedule-editor
       - /usr/src/app/eventyay/webapp/video/node_modules
@@ -29,6 +30,7 @@ services:
     entrypoint: celery -A eventyay worker -l info
     volumes:
       - ./app/eventyay:/usr/src/app/eventyay
+      - /usr/src/app/eventyay/static.dist
       - /usr/src/app/eventyay/static/video
       - /usr/src/app/eventyay/static/schedule-editor
       - /usr/src/app/eventyay/webapp/video/node_modules


### PR DESCRIPTION
Follow up on #2307

## Summary by Sourcery

Prebuild Django static assets in the Docker image and mount the generated static.dist directory into runtime containers to ensure the Vite manifest is available.

Enhancements:
- Run Django collectstatic during the Docker build so the image includes prebuilt static assets and the Vite manifest.
- Mount the static.dist directory into the web and worker services in docker-compose to use the prebuilt static files at runtime.