### PR TITLE
Fix enforce UI language toggle to avoid silent desynchronization

### DIFF
--- a/app/eventyay/presale/views/locale.py
+++ b/app/eventyay/presale/views/locale.py
@@ -17,6 +17,9 @@ from eventyay.helpers.cookies import set_cookie_without_samesite
 from .robots import NoSearchIndexViewMixin
 
 
+VALID_UI_LOCALES = {code.lower() for code, __ in settings.LANGUAGES}
+
+
 def _cookie_expires(max_age: int) -> str:
     expires_at = datetime.now(timezone.utc) + timedelta(seconds=max_age)
     return f"{expires_at:%a, %d %b %Y %H:%M:%S GMT}"
@@ -120,7 +123,7 @@ class EventLocaleSet(NoSearchIndexViewMixin, View):
                     else request.COOKIES.get(enforce_cookie_name, '0') == '1'
                 )
                 if enforce_active and locale.lower() != ui_language.lower():
-                    if locale in [lc for lc, ll in settings.LANGUAGES]:
+                    if locale.lower() in VALID_UI_LOCALES:
                         if request.user.is_authenticated and request.user.locale != locale:
                             request.user.locale = locale
                             request.user.save(update_fields=['locale'])


### PR DESCRIPTION
Fixes #2438 

## What this PR does

Fixes inconsistent synchronization between **UI Language** and **Event Language** when the **“Link Languages”** toggle is enabled.

## Behavior after this change

- When **Link Languages** is ON:
  - Changing the language via either selector results in a consistent, predictable state.
  - The UI language is treated as authoritative for synchronization.
  - The toggle state always reflects whether synchronization is actually active.

- When **Link Languages** is OFF:
  - UI language and Event language remain independent (unchanged behavior).


https://github.com/user-attachments/assets/6ef06c2a-9d91-45e2-a110-abd1a308169c

## Summary by Sourcery

Ensure UI and event language stay synchronized when language linking is enforced, avoiding silent desynchronization.

Bug Fixes:
- Fix desynchronization between UI language and event language when the language linking toggle is enabled by keeping UI language authoritative and aligned with the event language.

Enhancements:
- Update user locale and language cookie when a valid event language is selected while language enforcement is active, falling back to disabling enforcement only for invalid locales.