### PR TITLE
chore: hide custom domain feature

### DIFF
--- a/app/eventyay/control/forms/organizer_forms/organizer_update_form.py
+++ b/app/eventyay/control/forms/organizer_forms/organizer_update_form.py
@@ -24,13 +24,15 @@ class OrganizerUpdateForm(OrganizerForm):
         super().__init__(*args, **kwargs)
         if not self.change_slug:
             self.fields['slug'].widget.attrs['readonly'] = 'readonly'
-        if self.domain:
-            self.fields['domain'] = forms.CharField(
-                max_length=255,
-                label=_('Custom domain'),
-                required=False,
-                help_text=_('You need to configure the custom domain in the webserver beforehand.'),
-            )
+        # Custom domain feature is temporarily disabled.
+        # Uncomment when the feature is ready for re-enablement.
+        # if self.domain:
+        #     self.fields['domain'] = forms.CharField(
+        #         max_length=255,
+        #         label=_('Custom domain'),
+        #         required=False,
+        #         help_text=_('You need to configure the custom domain in the webserver beforehand.'),
+        #     )
 
     def clean_domain(self):
         d = self.cleaned_data['domain']

--- a/app/eventyay/control/templates/pretixcontrol/organizers/edit.html
+++ b/app/eventyay/control/templates/pretixcontrol/organizers/edit.html
@@ -29,9 +29,11 @@
                         <legend>{% trans "General" %}</legend>
                         {% bootstrap_field form.name layout="control" %}
                         {% bootstrap_field form.slug layout="control" %}
+                        {% comment 'Custom domain feature is temporarily disabled. Uncomment when ready for re-enablement.' %}
                         {% if form.domain %}
                             {% bootstrap_field form.domain layout="control" %}
                         {% endif %}
+                        {% endcomment %}
                         {% bootstrap_field sform.imprint_url layout="control" %}
                         {% bootstrap_field sform.contact_mail layout="control" %}
                         {% bootstrap_field sform.organizer_info_text layout="control" %}

--- a/app/eventyay/control/views/organizer_views/organizer_view.py
+++ b/app/eventyay/control/views/organizer_views/organizer_view.py
@@ -179,7 +179,9 @@ class OrganizerUpdate(OrganizerPermissionRequiredMixin, UpdateView):
     def get_form_kwargs(self):
         kwargs = super().get_form_kwargs()
         if self.request.user.has_active_staff_session(self.request.session.session_key):
-            kwargs['domain'] = True
+            # Custom domain feature is temporarily disabled.
+            # Uncomment when the feature is ready for re-enablement.
+            # kwargs['domain'] = True
             kwargs['change_slug'] = True
         return kwargs
 


### PR DESCRIPTION
Fixes #2464

## Summary by Sourcery

Temporarily disable the organizer custom domain feature in the control panel while keeping the underlying code paths easily re-enablable.

Enhancements:
- Remove the custom domain field from the organizer update form and edit view by commenting out its initialization and template rendering.

Chores:
- Disable passing the custom domain flag to the organizer form for staff sessions, effectively hiding the feature from the UI.