### PR TITLE
fix(mail): fix mail sending for approval workflow

### DIFF
--- a/app/eventyay/base/services/mail.py
+++ b/app/eventyay/base/services/mail.py
@@ -85,6 +85,7 @@ def mail(
     user=None,
     attach_ical=False,
     attach_cached_files: Sequence = None,
+    sync_send: bool = False,
 ):
     """
     Sends out an email to a user. The mail will be sent synchronously or asynchronously depending on the installation.
@@ -302,7 +303,10 @@ def mail(
 
         task_chain.append(send_task)
 
-        if 'locmem' in settings.EMAIL_BACKEND:
+        if sync_send:
+            # Run synchronously in the current process when callers need an immediate and reliable send result.
+            chain(*task_chain).apply(throw=True)
+        elif 'locmem' in settings.EMAIL_BACKEND:
             # This clause is triggered during unit tests, because transaction.on_commit never fires due to the nature
             # Django's unit tests work
             chain(*task_chain).apply_async()

--- a/app/eventyay/plugins/sendmail/models.py
+++ b/app/eventyay/plugins/sendmail/models.py
@@ -121,7 +121,7 @@ class EmailQueue(models.Model):
         for recipient in recipients:
             if recipient.sent:
                 continue
-            self._send_to_recipient(recipient, subject, message)
+            self._send_to_recipient(recipient, subject, message, async_send=async_send)
 
         self._finalize_send_status()
         return True
@@ -147,7 +147,7 @@ class EmailQueue(models.Model):
         self.sent_at = now() if all(r.sent for r in self.recipients.all()) else None
         self.save(update_fields=["sent_at"])
 
-    def _send_to_recipient(self, recipient, subject, message):
+    def _send_to_recipient(self, recipient, subject, message, async_send=True):
         from eventyay.base.services.mail import SendMailException
         email = recipient.email
         if not email:
@@ -185,6 +185,7 @@ class EmailQueue(models.Model):
                 attach_cached_files=self.attachments,
                 user=self.user,
                 auto_email=False,
+                sync_send=not async_send,
             )
             recipient.sent = True
             recipient.error = None

--- a/app/eventyay/plugins/sendmail/tasks.py
+++ b/app/eventyay/plugins/sendmail/tasks.py
@@ -22,7 +22,8 @@ def send_queued_mail(self, event_id: int, queued_mail_id: int):
 
     try:
         qm = EmailQueue.objects.get(pk=queued_mail_id, event=event)
-        result = qm.send(async_send=True)
+        # Execute the actual mail transport in this task so outbox state reflects real send attempts.
+        result = qm.send(async_send=False)
 
         if not result:
             logger.warning("[SendMail] EmailQueue ID %s: no recipients to send to.", queued_mail_id)


### PR DESCRIPTION
This PR solves issue #2364 

Added synchronous email sending option for immediate delivery and accurate state updates.
Updated `mail.py` to handle synchronous and asynchronous email sending based on the `sync_send` parameter.

## Summary by Sourcery

Ensure queued approval workflow emails are sent synchronously within the Celery task so mail-sending state accurately reflects real delivery attempts.

Bug Fixes:
- Fix approval workflow emails not updating recipient and queue state reliably by executing the actual mail send synchronously within the worker task instead of deferring it to another async job.

Enhancements:
- Add a sync_send flag to the core mail service and plumb async_send through the sendmail plugin so callers can choose between synchronous and asynchronous email delivery behavior.