### PR TITLE
fix(presale) restore login popup on checkout for unauthenticated users

### DIFF
--- a/app/eventyay/presale/templates/pretixpresale/event/index.html
+++ b/app/eventyay/presale/templates/pretixpresale/event/index.html
@@ -383,4 +383,5 @@
             {% eventsignal event "eventyay.presale.signals.front_page_bottom_widget" subevent=subevent request=request %}
         {% endif %}
     {% endif %}
+    {% include "pretixpresale/fragment_modals.html" %}
 {% endblock %}


### PR DESCRIPTION
Fixes #2519


https://github.com/user-attachments/assets/8e0e9884-ac07-48a2-b34b-cb525fb6df2d


## Summary by Sourcery

Bug Fixes:
- Re-add the shared modal fragment to the presale event index template so login and related dialogs are available again during checkout.