### PR TITLE
Fix the width of proposal, speaker and review info tables

### DIFF
--- a/app/eventyay/orga/templates/orga/cfp/forms.html
+++ b/app/eventyay/orga/templates/orga/cfp/forms.html
@@ -91,7 +91,7 @@
                         <a href="{{ request.event.cfp.urls.editor }}">{% translate "Click here to view the proposal form." %}</a>
                     </span></div>
                 </dialog>
-                <div class="table-responsive-sm">
+                <div class="table-responsive-always">
                     <table class="table table-sm table-flip table-sticky cfp-option-table">
                     <thead>
                         <tr>
@@ -495,7 +495,7 @@
                     </table>
                 </div>
                 <div class="row">
-                    <div class="col-md-9 offset-md-3 d-flex justify-content-end">
+                    <div class="col-md-12 d-flex justify-content-end">
                         <a href="{{ create_url }}?target=submission" class="btn btn-success btn-sm">
                             <i class="fa fa-plus"></i> {% translate "New custom field" %}
                         </a>
@@ -516,7 +516,7 @@
                         {% translate "Select which information should be requested and/or required from speakers." %}
                     </span></div>
                 </dialog>
-                <div class="table-responsive-sm">
+                <div class="table-responsive-always">
                     <table class="table table-sm table-flip table-sticky cfp-option-table">
                     <thead>
                         <tr>
@@ -847,7 +847,7 @@
                     </table>
                 </div>
                 <div class="row">
-                    <div class="col-md-9 offset-md-3 d-flex justify-content-end">
+                    <div class="col-md-12 d-flex justify-content-end">
                         <a href="{{ create_url }}?target=speaker" class="btn btn-success btn-sm">
                             <i class="fa fa-plus"></i> {% translate "New custom field" %}
                         </a>
@@ -859,7 +859,7 @@
                     {% translate "Reviewer Information" %}
                 </div></legend>
                 {% if custom_reviewer_fields %}
-                <div class="table-responsive-sm">
+                <div class="table-responsive-always">
                     <table class="table table-sm table-flip table-sticky cfp-option-table">
                     <thead>
                         <tr>
@@ -937,7 +937,7 @@
                 </div>
                 {% endif %}
                 <div class="row mb-3">
-                    <div class="col-md-9 offset-md-3 d-flex justify-content-end">
+                    <div class="col-md-12 d-flex justify-content-end">
                         <a href="{{ create_url }}?target=reviewer" class="btn btn-success btn-sm">
                             <i class="fa fa-plus"></i> {% translate "New custom field" %}
                         </a>

--- a/app/eventyay/static/orga/css/_layout.css
+++ b/app/eventyay/static/orga/css/_layout.css
@@ -802,23 +802,25 @@ details.submission-state-dropdown {
     width: auto;
   }
 
-  thead th:nth-child(2),
-  thead th:nth-child(3),
-  thead th:nth-child(6) {
-    width: 90px;
-  }
+  @media (min-width: 768px) {
+    thead th:nth-child(2),
+    thead th:nth-child(3),
+    thead th:nth-child(6) {
+      width: 90px;
+    }
 
-  thead th:nth-child(4),
-  thead th:nth-child(5) {
-    width: 130px;
-  }
+    thead th:nth-child(4),
+    thead th:nth-child(5) {
+      width: 130px;
+    }
 
-  thead th:nth-child(7) {
-    width: 80px;
-  }
+    thead th:nth-child(7) {
+      width: 80px;
+    }
 
-  thead th:last-child {
-    width: 110px;
+    thead th:last-child {
+      width: 110px;
+    }
   }
 
   tbody th {


### PR DESCRIPTION
fixes #2523 

removed the offset-md-3 from table container div elements

<img width="799" height="401" alt="image" src="https://github.com/user-attachments/assets/40dd4b54-73c8-4ba0-aeb9-6ffeea92178d" />

## Summary by Sourcery

Enhancements:
- Standardize CFP table container layout by dropping the offset-md-3 class from table-responsive wrappers.