### PR TITLE
Added translation for no file chosen

### DIFF
--- a/app/eventyay/locale/de/LC_MESSAGES/django.po
+++ b/app/eventyay/locale/de/LC_MESSAGES/django.po
@@ -37741,10 +37741,10 @@ msgstr "abgelehnt"
 #~ msgid "Already have a %(event_name)s account?"
 #~ msgstr "Haben Sie bereits ein %(event_name)s Konto?"
 
-#: eventyay/cfp/templates/cfp/includes/forms_header.html:6
+#: cfp/templates/cfp/includes/forms_header.html:6
 msgid "Choose file"
 msgstr "Datei auswählen"
 
-#: eventyay/cfp/templates/cfp/includes/forms_header.html:7
+#: cfp/templates/cfp/includes/forms_header.html:7
 msgid "No file chosen"
 msgstr "Keine Datei ausgewählt"

--- a/app/eventyay/locale/fr/LC_MESSAGES/django.po
+++ b/app/eventyay/locale/fr/LC_MESSAGES/django.po
@@ -36955,10 +36955,10 @@ msgstr "rejeté"
 #~ msgid "Already have a %(event_name)s account?"
 #~ msgstr "Avez-vous déjà un compte %(event_name)s?"
 
-#: eventyay/cfp/templates/cfp/includes/forms_header.html:6
+#: cfp/templates/cfp/includes/forms_header.html:6
 msgid "Choose file"
 msgstr "Choisir un fichier"
 
-#: eventyay/cfp/templates/cfp/includes/forms_header.html:7
+#: cfp/templates/cfp/includes/forms_header.html:7
 msgid "No file chosen"
 msgstr "Aucun fichier sélectionné"


### PR DESCRIPTION
<img width="1872" height="1033" alt="Screenshot 2026-02-23 at 8 27 40 PM" src="https://github.com/user-attachments/assets/7315297e-c813-4418-90b4-eb6f4f9f4141" />

## Summary by Sourcery

Add missing locale translations for the file upload "no file chosen" message in German and French.

New Features:
- Provide German translation for the "no file chosen" file upload label.
- Provide French translation for the "no file chosen" file upload label.