### PR TITLE
fix: handle OSError on Windows when accessing file field paths in Fil…

### DIFF
--- a/app/eventyay/base/models/mixins.py
+++ b/app/eventyay/base/models/mixins.py
@@ -159,7 +159,17 @@ class FileCleanupMixin:
             old_value = getattr(pre_save_instance, field)
             if old_value:
                 new_value = getattr(self, field)
-                if new_value and old_value.path != new_value.path:
+                try:
+                    old_path = old_value.path
+                    new_path = new_value.path if new_value else None
+                except (OSError, NotImplementedError):
+                    # On Windows, accessing .path can raise OSError (Errno 22)
+                    # if the stored filename contains characters invalid on
+                    # that OS (e.g. colons). NotImplementedError is raised by
+                    # some storage backends that do not support absolute paths.
+                    # In either case we skip the cleanup for this field.
+                    continue
+                if new_value and old_path != new_path:
                     # We don't want to delete the file immediately, as the save action
                     # that triggered this task might still fail, so we schedule the
                     # deletion for 10 seconds in the future, and pass the file field
@@ -171,7 +181,7 @@ class FileCleanupMixin:
                             'model': str(self._meta.model_name.capitalize()),
                             'pk': self.pk,
                             'field': field,
-                            'path': old_value.path,
+                            'path': old_path,
                         },
                         countdown=10,
                     )


### PR DESCRIPTION
Fix: OSError [Errno 22] on Windows when saving Review Settings
Problem
Saving review settings on Windows raises OSError [Errno 22] Invalid argument, preventing organizers from updating score categories, review phases, or any review configuration.

Root Cause
When saving review settings, the following call chain is triggered:

ReviewSettingsForm.save()
  → JsonSubfieldMixin.save()
    → Event.save()
      → FileCleanupMixin.save()  ← Error occurs here
FileCleanupMixin.save() iterates over all file fields on the 
Event
 model (
logo
, header_image, 
custom_css
) and accesses the .path property on FieldFile objects to compare old and new file paths:

python
if new_value and old_value.path != new_value.path:
On Windows, FieldFile.path internally calls self.storage.path(self.name), which can raise OSError [Errno 22] Invalid argument if the stored filename contains characters that are invalid on Windows (e.g., colons), or if the OS-level path resolution fails.

This error is triggered even though the review settings page does not involve any file uploads — it happens because Event.save() always passes through FileCleanupMixin.save(), which checks all file fields regardless of what was actually modified.

Fix
Wrapped the .path access in a try-except block that catches OSError and NotImplementedError. When path resolution fails, the file cleanup for that specific field is skipped via continue, allowing the save operation to complete successfully.

python
try:
    old_path = old_value.path
    new_path = new_value.path if new_value else None
except (OSError, NotImplementedError):
    continue
This is a safe approach because:

File cleanup is a best-effort operation — skipping it only means stale files may not be automatically deleted
The existing 
_delete_files()
 method already uses suppress(Exception) for the same reason
Normal behavior on Linux/macOS and valid Windows paths is completely unchanged
Files Changed
app/eventyay/base/models/mixins.py
 — FileCleanupMixin.save()

## Summary by Sourcery

Bug Fixes:
- Prevent OSError and NotImplementedError when resolving file paths during file cleanup, allowing saves to succeed even with invalid or unsupported storage paths.

solve #2541 