### PR TITLE
feat: add translation editing support for checkbox fields in CFP flow…

### DIFF
--- a/app/eventyay/static/orga/js/cfp_flow.js
+++ b/app/eventyay/static/orga/js/cfp_flow.js
@@ -131,13 +131,13 @@ function areEqual() {
 
 const FieldComponent = {
     render() {
-    const h = Vue.h;
+        const h = Vue.h;
         const isQuestion = this.field.key.startsWith("question_");
         const questionUrl = window.location.pathname.replace(
             "flow/",
             this.field.key.replace("question_", "questions/")
         ) + "/edit";
-        const displayHelpText = isQuestion ? 
+        const displayHelpText = isQuestion ?
             marked.parse(this.fixed_help_text, markedOptions) :
             marked.parse(
                 this.field.help_text[currentLanguage] + " " + this.fixed_help_text,
@@ -147,8 +147,8 @@ const FieldComponent = {
         if (this.field.widget !== 'CheckboxInput') {
             if (this.isModal) {
                 labelContent.push(
-                    h('div', { class: 'i18n-form-group mb-2 title-input', onClick: (e) => e.stopPropagation() }, 
-                        this.locales.map(locale => 
+                    h('div', { class: 'i18n-form-group mb-2 title-input', onClick: (e) => e.stopPropagation() },
+                        this.locales.map(locale =>
                             h('input', {
                                 type: 'text',
                                 class: 'form-control',
@@ -199,6 +199,45 @@ const FieldComponent = {
                         h('span', { class: 'optional' }, [h('strong', 'Required')])
                 );
             }
+        } else {
+            // CheckboxInput fields: support translation editing in modal
+            if (this.isModal) {
+                labelContent.push(
+                    h('div', { class: 'form-check mb-2' }, [
+                        h('input', { type: 'checkbox', class: 'form-check-input', disabled: true }),
+                        h('label', { class: 'form-check-label' }, this.field.label[this.locales[0]] || this.field.label[this.currentLanguage])
+                    ]),
+                    h('div', { class: 'i18n-form-group mb-2 title-input', onClick: (e) => e.stopPropagation() },
+                        this.locales.map(locale =>
+                            h('input', {
+                                type: 'text',
+                                class: 'form-control',
+                                title: locale,
+                                lang: locale,
+                                value: this.field.label[locale],
+                                onInput: (e) => { this.field.label[locale] = e.target.value; }
+                            })
+                        )
+                    )
+                );
+            } else {
+                labelContent.push(
+                    h('div', {
+                        class: ['form-check', this.editable ? 'editable' : ''],
+                        onClick: (e) => {
+                            e.stopPropagation();
+                            if (this.editable) {
+                                currentModal.data = this.field;
+                                currentModal.type = 'field';
+                                currentModal.show = true;
+                            }
+                        }
+                    }, [
+                        h('input', { type: 'checkbox', class: 'form-check-input', disabled: true }),
+                        h('label', { class: 'form-check-label' }, this.field.label[this.currentLanguage])
+                    ])
+                );
+            }
         }
         const fieldInput = this.getFieldInput(h);
         // Help text content
@@ -243,14 +282,7 @@ const FieldComponent = {
                 this.makeModal(e);
             }
         }, [
-            h('label', { class: 'col-md-3 col-form-label pt-0' }, 
-                this.field.widget === 'CheckboxInput' ? [
-                    h('div', { class: 'form-check' }, [
-                        h('input', { type: 'checkbox', class: 'form-check-input' }),
-                        h('label', { class: 'form-check-label' }, this.field.label[this.currentLanguage])
-                    ])
-                ] : labelContent
-            ),
+            h('label', { class: 'col-md-3 col-form-label pt-0' }, labelContent),
             h('div', { class: 'col-md-9' }, [
                 fieldInput,
                 helpTextContent
@@ -287,8 +319,8 @@ const FieldComponent = {
                 return marked.parse(this.fixed_help_text, markedOptions)
             return marked.parse(
                 this.field.help_text[currentLanguage] +
-                    " " +
-                    this.fixed_help_text,
+                " " +
+                this.fixed_help_text,
                 markedOptions,
             )
         },
@@ -322,26 +354,26 @@ const FieldComponent = {
                 case 'TextInput':
                 case 'NumberInput':
                 case 'EmailInput':
-                    return h('input', { 
-                        class: 'form-control', 
-                        type: 'text', 
+                    return h('input', {
+                        class: 'form-control',
+                        type: 'text',
                         placeholder: this.field.title,
                         readonly: true,
                         disabled: true
                     });
                 case 'Select':
-                    return h('select', { 
-                        class: 'form-control', 
-                        type: 'text', 
+                    return h('select', {
+                        class: 'form-control',
+                        type: 'text',
                         placeholder: this.field.title,
                         readonly: true,
                         disabled: true
                     });
                 case 'Textarea':
                 case 'MarkdownWidget':
-                    return h('textarea', { 
-                        class: 'form-control', 
-                        type: 'text', 
+                    return h('textarea', {
+                        class: 'form-control',
+                        type: 'text',
                         placeholder: this.field.title,
                         readonly: true,
                         disabled: true,
@@ -362,8 +394,8 @@ const FieldComponent = {
         getHelpTextContent(h, displayHelpText) {
             if (this.isModal) {
                 return [
-                    h('div', { class: 'i18n-form-group', onClick: (e) => e.stopPropagation() }, 
-                        this.locales.map(locale => 
+                    h('div', { class: 'i18n-form-group', onClick: (e) => e.stopPropagation() },
+                        this.locales.map(locale =>
                             h('input', {
                                 type: 'text',
                                 class: 'form-control',
@@ -377,7 +409,7 @@ const FieldComponent = {
                     this.fixed_help_text ? h('div', { class: 'text-muted' }, this.fixed_help_text) : null
                 ];
             } else {
-                return h('div', { 
+                return h('div', {
                     class: 'text-muted',
                     innerHTML: this.display_help_text
                 });
@@ -394,14 +426,14 @@ const FieldComponent = {
 
 const StepComponent = {
     render() {
-    const h = Vue.h;
-    const headerSteps = this.headerSteps;
-    const stepPosition = this.stepPosition;
-    const titleContent = this.editingTitle ? 
+        const h = Vue.h;
+        const headerSteps = this.headerSteps;
+        const stepPosition = this.stepPosition;
+        const titleContent = this.editingTitle ?
             h('span', { onClick: (e) => e.stopPropagation() }, [
                 h('div', { class: 'col-md-9' }, [
-                    h('div', { class: 'i18n-form-group', onClick: (e) => e.stopPropagation() }, 
-                        this.locales.map(locale => 
+                    h('div', { class: 'i18n-form-group', onClick: (e) => e.stopPropagation() },
+                        this.locales.map(locale =>
                             h('input', {
                                 type: 'text',
                                 class: 'form-control',
@@ -426,8 +458,8 @@ const StepComponent = {
         const textContent = this.editingText ?
             h('span', { onClick: (e) => e.stopPropagation() }, [
                 h('div', { class: 'col-md-9' }, [
-                    h('div', { class: 'i18n-form-group' }, 
-                        this.locales.map(locale => 
+                    h('div', { class: 'i18n-form-group' },
+                        this.locales.map(locale =>
                             h('textarea', {
                                 class: 'form-control',
                                 title: locale,
@@ -451,10 +483,10 @@ const StepComponent = {
                 innerHTML: this.marked(this.step.text[this.currentLanguage] || '…')
             });
         const fieldComponent = Vue.resolveComponent('field');
-        const formContent = this.step.identifier !== 'user' ? 
-            h('form', 
+        const formContent = this.step.identifier !== 'user' ?
+            h('form',
                 this.step.fields.filter(field => field && field.widget !== 'HiddenInput').map(field => {
-                    return h(fieldComponent, { 
+                    return h(fieldComponent, {
                         field: field,
                         locales: this.locales,
                         key: field.key
@@ -478,22 +510,22 @@ const StepComponent = {
                     h('div', { class: 'overlay' }, 'This form cannot be modified – a page to login or register needs to be in place, but you can change the page title and description.')
                 ])
             ]);
-        const questionAlert = this.step.identifier === 'questions' ? 
-            h('div', { class: 'alert alert-info' }, 'This step will only be shown if you have questions configured.') : 
+        const questionAlert = this.step.identifier === 'questions' ?
+            h('div', { class: 'alert alert-info' }, 'This step will only be shown if you have questions configured.') :
             null;
         return h('div', { class: 'step', onClick: () => { this.editingTitle = false; this.editingText = false; } }, [
-            h('div', { 
+            h('div', {
                 class: ['step-header', 'header', this.eventConfiguration.header_pattern],
                 style: this.headerStyle
-            }, this.eventConfiguration.header_image ? 
-                h('img', { src: this.eventConfiguration.header_image }) : 
+            }, this.eventConfiguration.header_image ?
+                h('img', { src: this.eventConfiguration.header_image }) :
                 null
             ),
             h('div', { class: 'step-main-container' }, [
-                h('div', { class: 'submission-steps stages' }, 
-                    headerSteps.map(stp => 
+                h('div', { class: 'submission-steps stages' },
+                    headerSteps.map(stp =>
                         h('span', { class: ['step', 'step-' + stp.phase] }, [
-                            h('div', { class: 'step-icon' }, 
+                            h('div', { class: 'step-icon' },
                                 h('span', { class: ['fa', 'fa-' + stp.icon] })
                             ),
                             h('div', { class: 'step-label' }, stp.label)
@@ -579,10 +611,10 @@ const app = Vue.createApp({
         const h = Vue.h;
         const stepComponent = Vue.resolveComponent('step');
         const fieldComponent = Vue.resolveComponent('field');
-        const modalContent = currentModal.data ? 
+        const modalContent = currentModal.data ?
             h('div', { id: 'flow-modal' }, [
                 h('form', [
-                    h(fieldComponent, { 
+                    h(fieldComponent, {
                         field: currentModal.data,
                         isModal: true,
                         key: 'modal',
@@ -595,7 +627,7 @@ const app = Vue.createApp({
                 h('i', { class: 'fa fa-spinner fa-pulse fa-4x fa-fw text-primary mb-4 mt-4' }),
                 h('h3', { class: 'mt-2 mb-4' }, 'Loading talks, please wait.')
             ]) :
-            h('div', { id: 'steps' }, 
+            h('div', { id: 'steps' },
                 this.stepsConfiguration.map(step => {
                     return h(stepComponent, {
                         step: step,
@@ -610,7 +642,7 @@ const app = Vue.createApp({
             h('div', { class: 'step-header', ref: 'stepHeader' }),
             h('div', { id: 'unassigned-fields' }, [
                 h('div', { class: 'input-group' }, [
-                    h('div', { class: 'input-group-prepend input-group-text' }, 
+                    h('div', { class: 'input-group-prepend input-group-text' },
                         h('i', { class: 'fa fa-search' })
                     ),
                     h('input', {
@@ -621,7 +653,7 @@ const app = Vue.createApp({
                         onInput: (e) => { this.search = e.target.value; }
                     })
                 ]),
-                h('div', { id: 'unassigned-container', ref: 'unassigned' }, 
+                h('div', { id: 'unassigned-container', ref: 'unassigned' },
                     this.filteredFields.map(field => {
                         return h(fieldComponent, { field: field, key: field.id });
                     })
@@ -635,10 +667,10 @@ const app = Vue.createApp({
                     class: 'btn btn-success',
                     onClick: this.save,
                     disabled: this.saving
-                }, this.saving ? 
+                }, this.saving ?
                     h('span', [
                         h('i', { class: 'fa fa-spinner fa-pulse fa-fw text-success mb-2 mt-2' })
-                    ]) : 
+                    ]) :
                     h('span', 'Save now')
                 )
             ]) : null;


### PR DESCRIPTION
Add Translation Editing Support for Checkbox Fields in CFP Flow Editor
Issue
In the CFP flow editor, fields rendered as checkboxes (e.g., Gravatar, Don't record) cannot have translations added or edited via the standard edit popup. This is inconsistent with other configurable fields such as Track, where the popup allows editing translations for all enabled event languages.

The translation fields already exist in the database — this is a UI-only gap.

Root Cause
In 
cfp_flow.js
, the FieldComponent render method excluded CheckboxInput widgets from the translation editing UI:

javascript
if (this.field.widget !== 'CheckboxInput') {
    // Translation inputs and click-to-edit logic — checkboxes skipped entirely
}
Additionally, the label rendering bypassed labelContent for checkboxes with a static, non-interactive template.

Solution
Updated the FieldComponent in 
cfp_flow.js
 to handle CheckboxInput fields with the same translation editing pattern used for other field types:

Editor view: Checkbox labels are now clickable and open the edit popup
Popup view: Displays the checkbox preview along with translation input fields for all enabled event languages
Label rendering: Unified to always use labelContent, since checkbox handling is now included within it
No backend changes were required — 
_get_step_config_from_data()
 in 
flow.py
 already persists 
label
 as an i18n field for all widget types.

Files Changed
app/eventyay/static/orga/js/cfp_flow.js
Verification
Checkbox fields open the edit popup on click
Translation inputs appear for all enabled event languages
Saved translations persist correctly
No regression for existing translatable fields and non-checkbox field types

## Summary by Sourcery

Enable translation editing for checkbox fields in the CFP flow editor and align their label rendering with other field types.

New Features:
- Allow checkbox fields in the CFP flow editor to be edited via the translation modal for all enabled locales.

Bug Fixes:
- Fix missing UI support for adding and editing translations on checkbox fields while preserving existing i18n persistence.

Enhancements:
- Unify label rendering so all field types, including checkboxes, share the same translation-aware labelContent handling.
- Improve general code formatting and consistency in the CFP flow Vue components without changing behavior.
Fixes #2533