### PR TITLE
Fix sidebar height so all items are accessible 

### DIFF
--- a/app/eventyay/static/orga/css/_layout.css
+++ b/app/eventyay/static/orga/css/_layout.css
@@ -182,7 +182,7 @@ aside.sidebar {
   background-color: var(--color-grey-ultralight);
   box-shadow: var(--shadow-lighter);
   width: 45px;
-  height: calc(100vh - 50px);
+  height: calc(100vh - var(--navbar-height));
   display: flex;
   font-size: 14px;
   flex-grow: 0;
@@ -190,7 +190,7 @@ aside.sidebar {
   flex-wrap: nowrap;
   z-index: 150;
   padding-left: 0;
-  margin-top: 50px;
+  margin-top: var(--navbar-height);
   margin-bottom: 0;
   overflow-y: auto;
 
@@ -384,7 +384,7 @@ aside.sidebar {
     width: 250px;
     transform: unset !important;
     top: 53px !important;
-    max-height: calc(100vh - 53px - 50px);
+    max-height: calc(100vh - 53px - var(--navbar-height));
     margin: 0;
     padding: 0;
 
@@ -1647,11 +1647,14 @@ h2 .user-name-display img {
 @media (max-width: 768px) {
   aside.sidebar {
     position: absolute;
+    top: var(--navbar-height);
+    margin-top: 0;
+    height: calc(100vh - var(--navbar-height));
     display: none;
   }
 
   aside.sidebar-uncollapsed {
-    display: inherit;
+    display: flex;
     z-index: 600;
   }
 

--- a/app/eventyay/static/orga/js/sidebar.js
+++ b/app/eventyay/static/orga/js/sidebar.js
@@ -1,8 +1,29 @@
 onReady(() => {
     const element = document.querySelector("[data-toggle=sidebar]")
     const sidebar = document.querySelector("aside.sidebar")
+    const navbar = document.querySelector("nav.navbar")
     const cls = "sidebar-uncollapsed"
-    const isMobile = () => window.matchMedia("(max-width: 767px)").matches
+    const isMobile = () => window.matchMedia("(max-width: 768px)").matches
+
+    const syncMobileSidebarOffset = () => {
+        if (!sidebar) return
+
+        if (isMobile() && navbar) {
+            const navbarHeight = navbar.getBoundingClientRect().height
+            sidebar.style.top = `${navbarHeight}px`
+            sidebar.style.height = `calc(100vh - ${navbarHeight}px)`
+            return
+        }
+
+        sidebar.style.removeProperty("top")
+        sidebar.style.removeProperty("height")
+    }
+
+    if (sidebar) {
+        syncMobileSidebarOffset()
+        window.addEventListener("resize", syncMobileSidebarOffset)
+        window.addEventListener("orientationchange", syncMobileSidebarOffset)
+    }
 
     if (sidebar && localStorage["sidebarVisible"]) {
         sidebar.classList.add(cls)
@@ -31,5 +52,6 @@ onReady(() => {
                 localStorage["sidebarVisible"] = ""
             }
         })
+
     }
 })


### PR DESCRIPTION
fixes #2539 

<img width="619" height="452" alt="image" src="https://github.com/user-attachments/assets/e48197d8-93b4-4023-9b7e-c1b338a97860" />

## Summary by Sourcery

Adjust sidebar layout to account for a 50px offset from the viewport height so the entire sidebar content remains accessible.