### PR TITLE
fix(payment): resolve jquery errors and css issues blocking payments

### DIFF
--- a/app/eventyay/common/templates/common/base_public.html
+++ b/app/eventyay/common/templates/common/base_public.html
@@ -19,7 +19,6 @@
         <meta name="application-name" content="{{ site_name }}">
         <meta name="generator" content="{{ site_name }}">
         <meta name="keywords" content="{% if current_event %}{{ current_event.name|event_localize }}, {{ current_event.slug }},{% if current_event.date_from %} {{ current_event.date_from.year }},{% endif %}{% endif %} schedule, talks, cfp, call for papers, conference, submissions, organizer">
-        {{ html_head|safe }}
         {% if current_event and current_event.display_settings.meta_noindex %}
             <meta name="robots" content="noindex, nofollow">
         {% else %}
@@ -41,6 +40,7 @@
         {% endblock %}
 
         <script src="{% static "jquery/js/jquery-3.7.1.min.js" %}"></script>
+        {{ html_head|safe }}
 
         {% block public_head_before_assets %}{% endblock public_head_before_assets %}
 

--- a/app/eventyay/static/common/css/base.css
+++ b/app/eventyay/static/common/css/base.css
@@ -632,6 +632,12 @@ a {
     max-height: 100vh;
     transition: max-height 0.5s ease-in-out;
   }
+  /* Bootstrap 3 compatibility: legacy collapses use .in instead of .show */
+  &.in {
+    max-height: none;
+    overflow: visible;
+    transition: none;
+  }
 }
 
 .d-none {


### PR DESCRIPTION
This PR addresses a issue that was preventing payments.
- Moved the `{{ html_head|safe }}` block in `base_public.html` to ensure proper script execution order.
- Added support for Bootstrap 3’s `.in` class in `base.css` to ensure legacy collapses display correctly.

**Current Behaviour in dev:**
```
output.faf1340da105.js:11 Uncaught ReferenceError: $ is not defined
    at output.faf1340da105.js:11:2421
```
https://github.com/user-attachments/assets/970909d2-6cdb-44aa-83a9-d085fea6745f

**Fixed Behaviour:**

https://github.com/user-attachments/assets/85047157-8d7b-4e19-bb71-f0e069a12170

## Summary by Sourcery

Ensure public pages load jQuery before executing injected head scripts and maintain correct display of legacy Bootstrap 3 collapse components.

Bug Fixes:
- Prevent payment pages from throwing `$ is not defined` errors by loading jQuery before custom head scripts that depend on it.
- Restore proper visibility for legacy Bootstrap 3 collapse elements that rely on the `.in` class instead of `.show`.

Enhancements:
- Add CSS compatibility for both modern and Bootstrap 3 collapse states to keep UI behavior consistent across legacy pages.