### PR TITLE
Restore Talks Forms edit/delete button colors 

### DIFF
--- a/app/eventyay/static/orga/css/question-toggles.css
+++ b/app/eventyay/static/orga/css/question-toggles.css
@@ -222,3 +222,41 @@ select.required-status-dropdown[data-current="after_deadline"] {
 .cfp-option-table tbody td {
     vertical-align: middle;
 }
+
+.cfp-option-table .btn-info {
+    --highlight-color: #2a8fd7;
+    border-color: #2a8fd7;
+    background-color: #2a8fd7;
+}
+
+.cfp-option-table .btn-info:hover,
+.cfp-option-table .btn-info:focus-visible {
+    --highlight-color: #2178b5;
+    border-color: #2178b5;
+    background-color: #2178b5;
+}
+
+.cfp-option-table .btn-info:active {
+    --highlight-color: #1b6599;
+    border-color: #1b6599;
+    background-color: #1b6599;
+}
+
+.cfp-option-table .btn-danger {
+    --highlight-color: #b6373f;
+    border-color: #b6373f;
+    background-color: #b6373f;
+}
+
+.cfp-option-table .btn-danger:hover,
+.cfp-option-table .btn-danger:focus-visible {
+    --highlight-color: #9e2f36;
+    border-color: #9e2f36;
+    background-color: #9e2f36;
+}
+
+.cfp-option-table .btn-danger:active {
+    --highlight-color: #88282e;
+    border-color: #88282e;
+    background-color: #88282e;
+}


### PR DESCRIPTION
## Fix: Restore Talks Forms Action Button Colors

Restores the Talks Forms action-button color regression by scoping button color overrides to the CFP forms table.

- **Edit** is returned to the intended lighter blue  
- **Delete** is restored to a clearer destructive red (including proper hover/active states)  
- No changes to layout, spacing, or behavior  


<img width="516" height="133" alt="260225_04h09m54s_screenshot" src="https://github.com/user-attachments/assets/452e474f-2b45-41ad-b8cc-6d2246f12e83" />

- Closes : #2557

## Summary by Sourcery

Bug Fixes:
- Fix regression where Talks Forms edit and delete action buttons lost their intended informational and destructive color schemes.