### PR TITLE
fix: correct radio button layout in CfP submission area (#1780)

### DIFF
--- a/app/eventyay/presale/forms/renderers.py
+++ b/app/eventyay/presale/forms/renderers.py
@@ -186,7 +186,12 @@ class CheckoutFieldRenderer(FieldRenderer):
             )
             parts = []
             for subwidget in choices:
-               
+                if subwidget.attrs is None:
+                    subwidget.attrs = {}
+                existing_class = subwidget.attrs.get('class', '')
+                subwidget.attrs['class'] = add_css_class(existing_class, 'form-check-input')
+                input_html = subwidget.tag()
+                
                 label_html = (
                     '<label class="form-check-label" for="{for_id}">{label}</label>'.format(
                         for_id=subwidget.id_for_label,


### PR DESCRIPTION
This PR fixes the layout inconsistency of radio buttons in the CfP submission form.



In the current implementation, the radio button label text appears below the input and is rendered in bold, which differs from the layout used in the Talks organiser area and other form components. This change updates the CfP templates to match the established radio button styling used across the system.



The following updates were made:-

             Display radio button labels inline to the right of each input

             Remove bold styling from the labels

             Adjust spacing to match the existing form pattern

              Ensure label associations remain intact for accessibility



I tested the CfP submission flow locally to confirm:-

             Layout is consistent with the Talks organiser area

             Form validation works as expected

             Submission flow remains unaffected

             No visual regressions in related form components



Please let me know if any adjustments are needed.

Closes #1780

## Summary by Sourcery

Bug Fixes:
- Correct radio button layout in the CfP submission form so labels render inline to the right of inputs with consistent styling.