### PR TITLE
Fix event emails 404 issue

### DIFF
--- a/app/eventyay/common/middleware/event.py
+++ b/app/eventyay/common/middleware/event.py
@@ -125,7 +125,7 @@ class EventPermissionMiddleware:
             response['Access-Control-Allow-Origin'] = '*'
             return response
         if event and not event.user_can_view_talks(request.user, request=request):
-            if 'agenda' in url.namespaces or 'cfp' in url.namespaces:
+            if 'agenda' in url.namespaces:
                 if url.url_name != 'event.css':
                     raise Http404()
         if event:


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Fix Event Emails 404 Page Not Found error (#2563)

## Description
This Pull Request fixes an issue where clicking on the "Event emails" option from the user profile dropdown redirects to `/org/{org_id}/me/mails/` and shows an HTTP 404 error.

**Updates:**
- Removed the `cfp` namespace from the blocking 404 logic in `app/eventyay/common/middleware/event.py`.
- Previously, if the event schedule was not published, `EventPermissionMiddleware` would block both the `agenda` and `cfp` namespaces and raise an `Http404`.
- Because `me/mails/` relies on the `cfp` namespace, this prevented users from accessing their own event emails unless talks were completely published. The `cfp` namespace also handles user profiles and proposal submissions, which need to remain accessible regardless of the public schedule.
- This ensures users can securely navigate from their profile dropdown to "Event emails" without seeing a broken page.

## Motivation and Context
This fixes issue #2563 where users were faced with a 404 error when attempting to read their event emails, restoring reliable access to their user dashboard.

## How Has This Been Tested?
Manual code verification has mapped out the routing behavior and established that the URL block for users within the `cfp` namespace incorrectly hindered dashboard access. Removing `cfp` rectifies this constraint securely.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code refactor or cleanup (changes to existing code for improved readability or performance)
