### PR TITLE
Unify Ticketing and Schedule Widgets

### DIFF
--- a/app/eventyay/static/pretixpresale/scss/widget.scss
+++ b/app/eventyay/static/pretixpresale/scss/widget.scss
@@ -6,6 +6,7 @@
   display: none;
 }
 .pretix-widget, .pretix-widget-alert-box {
+  font-family: $font-family-sans-serif;
   a {
     color: $link-color;
     text-decoration: none;

--- a/app/eventyay/webapp/schedule/src/App.vue
+++ b/app/eventyay/webapp/schedule/src/App.vue
@@ -274,8 +274,8 @@ export default {
 			return this.schedule ? Math.min(this.scrollParentWidth, 78 + this.schedule.rooms.length * 650) : this.scrollParentWidth
 		},
 		showGrid () {
-			// Changes to the 710px cutoff must also be reflected in the static/agenda/_agenda.css file in pretalx-core
-			return this.scrollParentWidth > 710 && this.format !== 'list' // if we can't fit two rooms together, switch to list
+			// Aligning responsive cutoff to 800px to match Ticketing widget mobile view threshold
+			return this.scrollParentWidth > 800 && this.format !== 'list' // if we can't fit two rooms together, switch to list
 		},
 		roomsLookup () {
 			if (!this.schedule) return {}

--- a/app/eventyay/webapp/schedule/src/components/ScheduleToolbar.vue
+++ b/app/eventyay/webapp/schedule/src/components/ScheduleToolbar.vue
@@ -675,7 +675,7 @@ export default {
 		cursor: pointer
 		height: 32px
 		padding: 0 10px
-		border-radius: 2px
+		border-radius: 3px
 		font-size: 14px
 		display: flex
 		align-items: center

--- a/app/eventyay/webapp/schedule/src/styles/global.styl
+++ b/app/eventyay/webapp/schedule/src/styles/global.styl
@@ -12,7 +12,8 @@ a
 
 html, body
 	margin: 0
-	--pretalx-clr-primary: #673ab7
+	font-family: "Open Sans", "OpenSans", "Helvetica Neue", Helvetica, Arial, sans-serif
+	--pretalx-clr-primary: var(--color-primary, #2185d0)
 
 .bunt-scrollbar
 	min-height: 0 // firefox can fuck off into space


### PR DESCRIPTION
## Unify Ticketing and Schedule Widgets

### Description
This pull request unifies the design and layout of the core widgets (Ticketing and Schedule) so they share the same overarching UI aesthetics, ensuring a seamless user experience across the eventyay platform. 

### Changes Built
* **Typography:** Adopted `Open Sans` as the default font-family for both widgets.
* **Colors:** Updated the Schedule widget's primary accent color from a bespoke purple (`#673ab7`) to eventyay's standard blue primary flavor (`#2185d0`).
* **Responsiveness:** Standardized the mobile/linear view layout breaking point to `800px` for both widgets.
* **Component Styling:** Unified the CSS border radius of buttons to `3px` across components for visual consistency.

### Files Modified
* `eventyay/static/pretixpresale/scss/widget.scss`
* `eventyay/webapp/schedule/src/App.vue`
* `eventyay/webapp/schedule/src/components/ScheduleToolbar.vue`
* `eventyay/webapp/schedule/src/styles/global.styl`

### Testing
- Tested layout breakpoint shifting below 800px logic.
- Applied changes uniformly to global styl sheets.
