### PR TITLE
Replace weak crypto algs with sha256

### DIFF
--- a/app/eventyay/base/models/orders.py
+++ b/app/eventyay/base/models/orders.py
@@ -96,10 +96,7 @@ class SecureOrderQuerySet(models.QuerySet):
             raise
 
         order_secret = order.tagged_secret(tag, secret_length) if tag else order.secret
-        valid_digest = hash_compare(order_secret, received_secret)
-        valid_sha1 = tag and hash_compare(hashlib.sha1(order.secret.encode()).hexdigest(), received_secret)
-
-        if not valid_digest and not valid_sha1:
+        if not hash_compare(order_secret, received_secret):
             raise Order.DoesNotExist
 
         return order

--- a/app/eventyay/base/models/turn.py
+++ b/app/eventyay/base/models/turn.py
@@ -22,7 +22,7 @@ class TurnServer(models.Model):
         expire = int(time.time()) + (24 * 3600)
         username = f"{expire}:{username}"
         hmacv = hmac.new(
-            self.auth_secret.encode(), username.encode(), hashlib.sha1
+            self.auth_secret.encode(), username.encode(), hashlib.sha256
         ).digest()
         password = base64.b64encode(hmacv).decode()
         return username, password

--- a/app/eventyay/base/services/bbb.py
+++ b/app/eventyay/base/services/bbb.py
@@ -24,7 +24,7 @@ logger = logging.getLogger(__name__)
 def get_url(operation, params, base_url, secret):
     encoded = urlencode(params)
     payload = operation + encoded + secret
-    checksum = hashlib.sha1(payload.encode()).hexdigest()
+    checksum = hashlib.sha256(payload.encode()).hexdigest()
     return urljoin(
         base_url, "api/" + operation + "?" + encoded + "&checksum=" + checksum
     )

--- a/app/eventyay/helpers/safedownload.py
+++ b/app/eventyay/helpers/safedownload.py
@@ -8,11 +8,11 @@ def get_token(request, answer):
         request.session.create()
     payload = '{}:{}'.format(request.session.session_key, answer.pk)
     signer = TimestampSigner()
-    return signer.sign(hashlib.sha1(payload.encode()).hexdigest())
+    return signer.sign(hashlib.sha256(payload.encode()).hexdigest())
 
 
 def check_token(request, answer, token):
-    payload = hashlib.sha1('{}:{}'.format(request.session.session_key, answer.pk).encode()).hexdigest()
+    payload = hashlib.sha256('{}:{}'.format(request.session.session_key, answer.pk).encode()).hexdigest()
     signer = TimestampSigner()
     try:
         return payload == signer.unsign(token, max_age=3600 * 24)


### PR DESCRIPTION
- orders.py: remove legacy valid_sha1 backward-compatibility fallback
- safedownload.py: replaced hashlib.sha1 with hashlib.sha256, used only for internal tokens
- turn.py: replaced hashlib.sha1 with hashlib.sha256, coturn server needs to be configured for sha256
- bbb.py: replaced hashlib.sha1 with hashlib.sha256 in the BBB API checksum, bbb server must be configured for sha256 (supported since bbb 2.5)

## Summary by Sourcery

Replace legacy SHA-1 usage with SHA-256 and drop backward-compatibility fallbacks for stronger crypto defaults.

Enhancements:
- Update internal download token generation and validation to use SHA-256 instead of SHA-1.
- Switch TURN credential HMAC generation to use SHA-256, requiring matching coturn configuration.
- Update BigBlueButton API checksum generation to use SHA-256, requiring servers configured with SHA-256 support.
- Remove legacy SHA-1-based order secret fallback, relying solely on the primary digest.