### PR TITLE
docs: add GitHub badges to README (fixes #2587)

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,6 +1,18 @@
 eventyay-tickets (ENext)
 ========================
 
+.. image:: https://img.shields.io/github/stars/fossasia/eventyay?style=social
+   :target: https://github.com/fossasia/eventyay
+
+.. image:: https://img.shields.io/github/forks/fossasia/eventyay
+   :target: https://github.com/fossasia/eventyay/network
+
+.. image:: https://img.shields.io/github/issues/fossasia/eventyay
+   :target: https://github.com/fossasia/eventyay/issues
+
+.. image:: https://img.shields.io/github/license/fossasia/eventyay
+   :target: https://github.com/fossasia/eventyay/blob/dev/LICENSE
+   
 Project status & release cycle
 ------------------------------
 


### PR DESCRIPTION
Fixes #2587

This PR adds relevant GitHub badges (stars, forks, issues, license)
to improve repository visibility and documentation clarity.

## Summary by Sourcery

Documentation:
- Update README with GitHub badges for stars, forks, issues, and license information.