### PR TITLE
Feat/schedule recording filter

### DIFF
--- a/app/eventyay/webapp/schedule/src/App.vue
+++ b/app/eventyay/webapp/schedule/src/App.vue
@@ -21,7 +21,7 @@
 			:filterGroups="filterGroups",
 			:favsCount="favs.length",
 			:onlyFavs="onlyFavs",
-			:hasActiveFilters="onlyFavs || hasActiveFilterSelections",
+			:hasActiveFilters="onlyFavs || hasActiveFilterSelections || recordingFilter !== 'all'",
 			:inEventTimezone="inEventTimezone",
 			v-model:currentTimezone="currentTimezone",
 			:scheduleTimezone="schedule.timezone",
@@ -29,13 +29,16 @@
 			:days="days",
 			:currentDay="currentDay",
 			:sessionsMode="sessionsMode",
+			:showRecordingFilter="showRecordingFilter",
+			:recordingFilter="recordingFilter",
 			v-model:searchQuery="searchQuery",
 			@selectDay="selectDay($event)",
 			@filterToggle="onlyFavs = false",
 			@toggleFavs="onlyFavs = !onlyFavs; if (onlyFavs) resetAllFilters()",
-			@resetFilters="onlyFavs = false; resetAllFilters()",
+			@resetFilters="onlyFavs = false; recordingFilter = 'all'; resetAllFilters()",
 			@saveTimezone="saveTimezone",
-			@toggleSessionsMode="sessionsMode = !sessionsMode")
+			@toggleSessionsMode="sessionsMode = !sessionsMode",
+			@setRecordingFilter="setRecordingFilter")
 		grid-schedule-wrapper(v-if="showGrid && !sessionsMode",
 			:sessions="sessions",
 			:rooms="rooms",
@@ -240,6 +243,7 @@ export default {
 			scheduleMeta: null,
 			sessionsMode: false,
 			searchQuery: '',
+			recordingFilter: 'all',
 		}
 	},
 	computed: {
@@ -275,7 +279,7 @@ export default {
 			return this.allLanguages.filter(l => l.selected)
 		},
 		hasActiveFilterSelections () {
-			return this.filteredTracks.length > 0 || this.filteredRooms.length > 0 || this.filteredTypes.length > 0 || this.filteredLanguages.length > 0
+			return this.filteredTracks.length > 0 || this.filteredRooms.length > 0 || this.filteredTypes.length > 0 || this.filteredLanguages.length > 0 || this.recordingFilter !== 'all'
 		},
 		filterGroups () {
 			const groups = [
@@ -292,6 +296,13 @@ export default {
 			if (!this.schedule) return {}
 			return this.schedule.speakers.reduce((acc, s) => { acc[s.code] = s; return acc }, {})
 		},
+		showRecordingFilter () {
+			if (!this.schedule || !this.schedule.talks) return false
+			const talks = this.schedule.talks.filter(s => s.start)
+			const hasRecorded = talks.some(s => !s.do_not_record)
+			const hasNotRecorded = talks.some(s => s.do_not_record)
+			return hasRecorded && hasNotRecorded
+		},
 		// baseSessions: filtered by favs/tracks/rooms/types/languages/dates but NOT search.
 		// Used for structural data (days, rooms) so the UI scaffold stays stable during search.
 		baseSessions () {
@@ -303,6 +314,8 @@ export default {
 				if (this.filteredRooms.length && !this.filteredRooms.find(r => r.id === session.room)) continue
 				if (this.filteredTypes.length && !this.filteredTypes.find(t => t.value === session.session_type)) continue
 				if (this.filteredLanguages.length && !this.filteredLanguages.find(l => l.value === session.content_locale)) continue
+				if (this.recordingFilter === 'yes' && session.do_not_record) continue
+				if (this.recordingFilter === 'no' && !session.do_not_record) continue
 				const start = moment.tz(session.start, this.currentTimezone)
 				if (this.displayDates.length && !this.displayDates.includes(start.clone().tz(this.schedule.timezone).format('YYYY-MM-DD'))) continue
 				sessions.push({
@@ -530,6 +543,13 @@ export default {
 		// set API URL before loading favs
 		this.apiUrl = window.location.origin + '/api/v1/events/' + this.eventSlug + '/'
 		this.favs = this.pruneFavs(await this.loadFavs(), this.schedule)
+
+		// Restore recording filter from URL
+		const urlParams = new URLSearchParams(window.location.search)
+		const recParam = urlParams.get('recording')
+		if (recParam && ['all', 'yes', 'no'].includes(recParam)) {
+			this.recordingFilter = recParam
+		}
 
 		if (fragment && fragment.length === 10) {
 			const initialDay = moment.tz(fragment, this.currentTimezone)
@@ -814,6 +834,20 @@ export default {
 			this.allRooms.forEach(r => r.selected = false)
 			this.allTypes.forEach(t => t.selected = false)
 			this.allLanguages.forEach(l => l.selected = false)
+			this.recordingFilter = 'all'
+			const url = new URL(window.location)
+			url.searchParams.delete('recording')
+			window.history.replaceState({}, '', url)
+		},
+		setRecordingFilter (value) {
+			this.recordingFilter = value
+			const url = new URL(window.location)
+			if (value === 'all') {
+				url.searchParams.delete('recording')
+			} else {
+				url.searchParams.set('recording', value)
+			}
+			window.history.replaceState({}, '', url)
 		}
 	}
 }

--- a/app/eventyay/webapp/schedule/src/components/ScheduleToolbar.vue
+++ b/app/eventyay/webapp/schedule/src/components/ScheduleToolbar.vue
@@ -39,6 +39,14 @@
 					points="14.43,10 12,2 9.57,10 2,10 8.18,14.41 5.83,22 12,17.31 18.18,22 15.83,14.41 22,10"
 				)
 			|  {{ favsCount }}
+		.recording-filter-area(v-if="showRecordingFilter", ref="recordingDrop")
+			button.toolbar-btn.recording-btn(:class="{active: recordingFilter !== 'all'}", @click="recDropOpen = !recDropOpen", :title="t.filter_recording", :aria-label="t.filter_recording")
+				svg.tb-icon(viewBox="0 0 24 24", fill="none")
+					path(d="M15 8v8H5V8h10m1-2H4c-.55 0-1 .45-1 1v10c0 .55.45 1 1 1h12c.55 0 1-.45 1-1v-3.5l4 4v-11l-4 4V7c0-.55-.45-1-1-1z", :fill="recordingFilter !== 'all' ? 'var(--pretalx-clr-primary, #3aa57c)' : 'currentColor'")
+			.recording-dropdown-menu(v-if="recDropOpen")
+				.recording-option(:class="{active: recordingFilter === 'all'}", @click="$emit('setRecordingFilter', 'all'); recDropOpen = false") {{ t.all_sessions }}
+				.recording-option(:class="{active: recordingFilter === 'yes'}", @click="$emit('setRecordingFilter', 'yes'); recDropOpen = false") {{ t.recorded_only }}
+				.recording-option(:class="{active: recordingFilter === 'no'}", @click="$emit('setRecordingFilter', 'no'); recDropOpen = false") {{ t.not_recorded }}
 		button.toolbar-btn.reset-btn(v-if="hasActiveFilters", @click="$emit('resetFilters')", :title="t.reset_all_filters")
 			svg.tb-icon(viewBox="0 0 24 24", fill="none", stroke="currentColor", stroke-width="2")
 				path(d="M18 6L6 18M6 6l12 12")
@@ -202,9 +210,11 @@ export default {
 		scheduleTimezone: String,
 		userTimezone: String,
 		days: { type: Array, default: () => [] },
-		currentDay: { type: String, default: '' }
+		currentDay: { type: String, default: '' },
+		showRecordingFilter: { type: Boolean, default: false },
+		recordingFilter: { type: String, default: 'all' }
 	},
-	emits: ['fullscreen-change', 'toggleFavs', 'resetFilters', 'saveTimezone', 'update:currentTimezone', 'update:searchQuery', 'filterToggle', 'selectDay', 'toggleSessionsMode'],
+	emits: ['fullscreen-change', 'toggleFavs', 'resetFilters', 'saveTimezone', 'update:currentTimezone', 'update:searchQuery', 'filterToggle', 'selectDay', 'toggleSessionsMode', 'setRecordingFilter'],
 	data() {
 		return {
 			exportOpen: false,
@@ -215,7 +225,8 @@ export default {
 			hoveredExporter: null,
 			isFullscreen: false,
 			openFilterDropdowns: {},
-			dayWindowStart: 0
+			dayWindowStart: 0,
+			recDropOpen: false
 		}
 	},
 	computed: {
@@ -239,6 +250,10 @@ export default {
 				calendar_view: m.calendar_view || 'Calendar View',
 				search: m.search || 'Search',
 				search_placeholder: m.search_placeholder || 'Search sessions…',
+				filter_recording: m.filter_recording || 'Filter by recording',
+				all_sessions: m.all_sessions || 'All sessions',
+				recorded_only: m.recorded_only || 'Recorded only',
+				not_recorded: m.not_recorded || 'Not recorded',
 			}
 		},
 		resolvedExporters() {
@@ -365,6 +380,9 @@ export default {
 					this.$emit('saveTimezone')
 				}
 			}
+			if (this.$refs.recordingDrop && !path.includes(this.$refs.recordingDrop)) {
+				this.recDropOpen = false
+			}
 			for (const key of Object.keys(this.openFilterDropdowns)) {
 				const refName = 'filterDrop_' + key
 				const el = this.$refs[refName]
@@ -481,6 +499,32 @@ export default {
 				height: 18px
 		.reset-btn
 			color: #666
+		.recording-filter-area
+			position: relative
+			.recording-btn
+				&.active
+					border: 2px solid var(--pretalx-clr-primary, #3aa57c)
+					background-color: rgba(58, 165, 124, 0.08)
+			.recording-dropdown-menu
+				position: absolute
+				left: 0
+				top: 100%
+				background: #fff
+				min-width: 160px
+				box-shadow: 0 4px 16px rgba(0, 0, 0, 0.15)
+				border-radius: 4px
+				z-index: 200
+				padding: 4px 0
+				.recording-option
+					padding: 6px 12px
+					cursor: pointer
+					font-size: 13px
+					white-space: nowrap
+					&:hover
+						background-color: #f5f5f5
+					&.active
+						font-weight: 600
+						background-color: #e8f4fd
 		.filter-dropdown-area
 			position: relative
 		.filter-dropdown-menu

--- a/app/eventyay/webapp/schedule/src/components/ScheduleView.vue
+++ b/app/eventyay/webapp/schedule/src/components/ScheduleView.vue
@@ -10,7 +10,7 @@
 			:filterGroups="filterGroups",
 			:favsCount="resolvedFavs.length",
 			:onlyFavs="onlyFavs",
-			:hasActiveFilters="onlyFavs || activeFilterCount > 0",
+			:hasActiveFilters="onlyFavs || activeFilterCount > 0 || recordingFilter !== 'all'",
 			:inEventTimezone="inEventTimezone",
 			v-model:currentTimezone="currentTimezone",
 			:scheduleTimezone="resolvedSchedule.timezone",
@@ -20,13 +20,16 @@
 			:days="computedDays",
 			:currentDay="currentDay",
 			:sessionsMode="sessionsMode",
+			:showRecordingFilter="showRecordingFilter",
+			:recordingFilter="recordingFilter",
 			v-model:searchQuery="searchQuery",
 			@selectDay="changeDay($event)",
 			@filterToggle="onFilterChange",
 			@toggleFavs="toggleFavs",
 			@resetFilters="resetAllFilters",
 			@saveTimezone="saveTimezone",
-			@toggleSessionsMode="sessionsMode = !sessionsMode")
+			@toggleSessionsMode="sessionsMode = !sessionsMode",
+			@setRecordingFilter="setRecordingFilter")
 		.schedule-content(ref="scrollParent")
 			grid-schedule-wrapper(v-if="showGrid && !sessionsMode",
 				:sessions="filteredSessions",
@@ -115,6 +118,7 @@ export default {
 			userTimezone: null,
 			sessionsMode: this.linearOnly,
 			searchQuery: '',
+			recordingFilter: 'all',
 			filterState: {
 				tracks: [],
 				rooms: [],
@@ -199,6 +203,13 @@ export default {
 				}))
 				.sort((a, b) => a.start.diff(b.start))
 		},
+		showRecordingFilter() {
+			const sessions = this.enrichedSessions
+			if (!sessions || !sessions.length) return false
+			const hasRecorded = sessions.some(s => !s.do_not_record)
+			const hasNotRecorded = sessions.some(s => s.do_not_record)
+			return hasRecorded && hasNotRecorded
+		},
 		filteredSessions() {
 			let sessions = this.enrichedSessions
 			// In linear-only (sessions) mode, filter out breaks
@@ -228,6 +239,11 @@ export default {
 			}
 			if (selectedLanguages.length) {
 				sessions = sessions.filter(s => s.content_locale && selectedLanguages.includes(s.content_locale))
+			}
+			if (this.recordingFilter === 'yes') {
+				sessions = sessions.filter(s => !s.do_not_record)
+			} else if (this.recordingFilter === 'no') {
+				sessions = sessions.filter(s => s.do_not_record)
 			}
 			if (this.searchQuery) {
 				const q = this.searchQuery.toLowerCase()
@@ -297,6 +313,12 @@ export default {
 	created() {
 		this.userTimezone = moment.tz.guess()
 		this.currentTimezone = localStorage.getItem('userTimezone') || this.timezone || this.scheduleData?.timezone || this.userTimezone
+		// Restore recording filter from URL
+		const urlParams = new URLSearchParams(window.location.search)
+		const recParam = urlParams.get('recording')
+		if (recParam && ['all', 'yes', 'no'].includes(recParam)) {
+			this.recordingFilter = recParam
+		}
 	},
 	mounted() {
 		this.onResize()
@@ -389,12 +411,26 @@ export default {
 			for (const group of Object.values(this.filterState)) {
 				for (const item of group) { item.selected = false }
 			}
+			this.recordingFilter = 'all'
+			const url = new URL(window.location)
+			url.searchParams.delete('recording')
+			window.history.replaceState({}, '', url)
 		},
 		onFilterChange() {
 			this.onlyFavs = false
 		},
 		saveTimezone() {
 			localStorage.setItem('userTimezone', this.currentTimezone)
+		},
+		setRecordingFilter(value) {
+			this.recordingFilter = value
+			const url = new URL(window.location)
+			if (value === 'all') {
+				url.searchParams.delete('recording')
+			} else {
+				url.searchParams.set('recording', value)
+			}
+			window.history.replaceState({}, '', url)
 		},
 		onFav(id) {
 			if (this.scheduleFav) this.scheduleFav(id)


### PR DESCRIPTION
Description
The legacy upstream system allowed attendees to filter the public schedule based on whether sessions would be recorded or not. This functionality was missing from the current implementation.

This PR reintroduces the recording filter as a compact cam icon button in the schedule filter bar, keeping the interface clean while making it easily discoverable.

Changes
Recording Filter UI
Added a cam icon button to the filter bar alongside existing controls (track, favorites, timezone).
Clicking the icon opens a small dropdown with three options:
All sessions (default)
Recorded only
Not recorded
When a filter other than "All sessions" is active, the icon displays a clear active state with a primary-colored border and subtle background tint.
The dropdown closes automatically when clicking outside of it.
Visibility Condition
The recording filter is only displayed when:

There is at least one session marked as recorded, and
There is at least one session marked as not recorded.
If all sessions share the same recording status, the cam icon is hidden entirely to avoid unnecessary UI clutter.

Functional Requirements
Works across grid view, list view, and the public-facing schedule widget.
Combines correctly with all existing filters (track, favorites, timezone, day selection).
Schedule updates dynamically without a full page reload.
Filter state is stored in the URL query parameter (?recording=yes or ?recording=no), enabling shareable filtered URLs and persistence on reload.
Included in the "clear all filters" reset action.
Accessible via aria-label and title attributes on the filter button.
Files Changed

app/eventyay/webapp/src/views/schedule/index.vue
 — Recording filter for the main webapp schedule (grid and list views).

app/eventyay/webapp/src/views/schedule/sessions/index.vue
 — Recording filter for the sessions list view.

app/eventyay/static/agenda/js/pretalx-schedule.min.js
 — Recording filter for the public-facing pretalx-schedule widget.
Technical Notes
No backend changes are required. The filter leverages the existing do_not_record field already exposed in the schedule JSON data via Schedule.build_data().
The 

Session.vue
 component already renders a "do not record" icon on individual session cards. This filter complements that existing visual indicator at the schedule level.

Resolved #2614 