### PR TITLE
Fix PermissionError when generating submission cards on Windows

### DIFF
--- a/app/eventyay/orga/views/cards.py
+++ b/app/eventyay/orga/views/cards.py
@@ -168,11 +168,11 @@ class SubmissionCards(EventPermissionRequired, View):
         )
         doc.build(self.get_story(doc))
         buffer.seek(0)
-        timestamp = now().strftime('%Y-%m-%d-%H%M')
+        timestamp = now()
         return FileResponse(
             buffer,
             as_attachment=True,
-            filename=f'{request.event.slug}_submission_cards_{timestamp}.pdf',
+            filename=f'{request.event.slug}_submission_cards_{timestamp:%Y-%m-%d-%H%M}.pdf',
             content_type='application/pdf',
         )
 


### PR DESCRIPTION
Use ` io.BytesIO` instead of `tempfile.NamedTemporaryFile` for PDF generation
to avoid Windows file-locking issues.

fixes #2664 
## Summary by Sourcery

Bug Fixes:
- Fix PermissionError on Windows when generating submission cards by replacing temporary file-based PDF creation with an in-memory buffer.