### PR TITLE
fix: handle empty/None URL schemes in get_protocol and add type hints

### DIFF
--- a/app/eventyay/api/utils.py
+++ b/app/eventyay/api/utils.py
@@ -1,24 +1,30 @@
+from typing import Optional
+
 from urllib.parse import urlparse
 
 
-def get_protocol(url: str) -> str:
+def get_protocol(url: Optional[str]) -> str:
     """Return the URL scheme (protocol) for *url*, lower-cased.
 
-    If *url* is ``None``, empty, or has no explicit scheme (e.g. a
-    schemeless URL like ``//example.com/path``), the function returns
+    If *url* is ``None``, empty, whitespace-only, or has no explicit
+    scheme (e.g. a schemeless URL like ``//example.com/path`` or a
+    bare hostname like ``example.com``), the function returns
     ``'https'`` as a safe default so callers never receive an empty
     string that would produce a malformed domain such as
     ``://example.com``.
 
     Args:
-        url: The URL string to inspect.
+        url: The URL string to inspect. ``None`` is accepted and treated
+            as empty.
 
     Returns:
         The scheme component of *url* in lower-case, or ``'https'`` when
         no scheme can be determined.
     """
-    if not url:
+    # Normalize/strip whitespace so that raw user input like '   '
+    # is treated as empty rather than passed directly to urlparse.
+    if not url or not url.strip():
         return 'https'
-    parsed = urlparse(url)
+    parsed = urlparse(url.strip())
     scheme = parsed.scheme.lower()
     return scheme if scheme else 'https'

--- a/app/tests/talk/api/test_get_protocol.py
+++ b/app/tests/talk/api/test_get_protocol.py
@@ -2,10 +2,12 @@
 
 Covers:
 - Normal https / http URLs
-- Schemeless URLs (//host/path)  → should fall back to 'https'
-- None input                      → should fall back to 'https'
-- Empty string input              → should fall back to 'https'
-- Mixed-case scheme               → always returned in lower-case
+- Schemeless URLs (//host/path)     → should fall back to 'https'
+- None input                        → should fall back to 'https'
+- Empty / whitespace-only strings   → should fall back to 'https'
+- Bare hostname (no scheme or //)   → should fall back to 'https'
+- Relative paths                    → should fall back to 'https'
+- Mixed-case scheme                 → always returned in lower-case
 """
 
 import pytest
@@ -20,11 +22,18 @@ from eventyay.api.utils import get_protocol
         ("https://example.com", "https"),
         ("http://example.com/path", "http"),
         ("https://example.com:8080/api/v1/", "https"),
-        # Edge cases – schemeless URLs
+        # Edge cases – schemeless URLs with authority
         ("//example.com/path", "https"),
+        # Edge cases – bare hostname (no scheme, no //)
+        ("example.com", "https"),
+        ("example.com/some/path", "https"),
+        # Edge cases – relative paths (no scheme, no host)
+        ("/relative/path", "https"),
         # Edge cases – no URL at all
         (None, "https"),
         ("", "https"),
+        # Edge cases – whitespace-only strings
+        ("   ", "https"),
         # Mixed-case scheme must be normalised to lower-case
         ("HTTPS://example.com", "https"),
         ("HTTP://example.com", "http"),


### PR DESCRIPTION
Fixes #2616

## Problem
`get_protocol()` in `app/eventyay/api/utils.py` silently returned an empty string when passed:
- A schemeless URL like `//example.com/path` (`urlparse` returns `''` for `.scheme`)
- `None`
- An empty string `""`

This caused callers (e.g. `CreateEventView`) to build malformed domain strings like `://example.com` and save them to the database, with no error raised.

## Changes

### `app/eventyay/api/utils.py`
- Added `str` type hints to the function signature and return type.
- Added an early-return guard for falsy input (`None` / `""`).
- Added a safe fallback: when `urlparse` produces an empty scheme (schemeless URLs), returns `'https'` instead of `""`.
- Renamed the intermediate variable from `protocol` to `scheme` for clarity.
- Added a comprehensive docstring.

### `app/tests/talk/api/test_get_protocol.py` *(new file)*
Added parametrized tests covering:
- Normal `https` / `http` URLs ✅
- Schemeless URL `//example.com/path` → `'https'` ✅
- `None` input → `'https'` ✅
- Empty string `""` → `'https'` ✅
- Mixed-case scheme normalisation (e.g. `HTTPS://` → `'https'`) ✅
- Unusual valid scheme (e.g. `ftp://`) ✅

## Before / After

```python
# Before
def get_protocol(url):
    parsed = urlparse(url)
    protocol = parsed.scheme
    return protocol.lower()  # returns "" for schemeless URLs → ://example.com

# After
def get_protocol(url: str) -> str:
    if not url:
        return 'https'
    parsed = urlparse(url)
    scheme = parsed.scheme.lower()
    return scheme if scheme else 'https'
```

## Summary by Sourcery

Ensure get_protocol always returns a valid, lower-cased scheme with a safe default and add tests for edge cases.

Bug Fixes:
- Prevent get_protocol from returning an empty string for schemeless, empty, or None URLs by defaulting to 'https'.

Enhancements:
- Add type hints and a detailed docstring to get_protocol for clearer behavior and usage.

Tests:
- Introduce parametrized tests for get_protocol covering normal URLs, schemeless URLs, bare hostnames, relative paths, None, empty/whitespace input, mixed-case schemes, and unusual schemes.