### PR TITLE
fix: remove incorrect 'Optional' label from Room name field (#2666)

### DIFF
--- a/app/eventyay/schedule/forms.py
+++ b/app/eventyay/schedule/forms.py
@@ -192,6 +192,7 @@ class RoomForm(AvailabilitiesFormMixin, ReadOnlyFlag, I18nModelForm):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.resolution = '00:15:00'
+        self.fields['name'].required = True
         self.fields['name'].widget.attrs['placeholder'] = _('Room I')
         self.fields['description'].widget.attrs['placeholder'] = _(
             'Description, e.g.: Our main meeting place, Room I, enter from the right.'


### PR DESCRIPTION
Fixes #2666

The Room "name" field was marked as "Optional" in the frontend,
while it is required at the backend level.

This PR explicitly sets `self.fields['name'].required = True`
in RoomForm to ensure consistency between UI rendering and backend validation.

## Summary by Sourcery

Bug Fixes:
- Remove the incorrect optional status of the Room name field so it is consistently required across the UI and backend.