### PR TITLE
﻿fix(rooms): remove incorrect 'Optional' label from required Name field

### DIFF
--- a/app/eventyay/schedule/forms.py
+++ b/app/eventyay/schedule/forms.py
@@ -192,6 +192,7 @@ class RoomForm(AvailabilitiesFormMixin, ReadOnlyFlag, I18nModelForm):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.resolution = '00:15:00'
+        self.fields['name'].required = True
         self.fields['name'].widget.attrs['placeholder'] = _('Room I')
         self.fields['description'].widget.attrs['placeholder'] = _(
             'Description, e.g.: Our main meeting place, Room I, enter from the right.'

--- a/app/tests/talk/schedule/test_room_form.py
+++ b/app/tests/talk/schedule/test_room_form.py
@@ -1,0 +1,39 @@
+import pytest
+from eventyay.schedule.forms import RoomForm
+from eventyay.base.models import Room
+
+@pytest.mark.django_db
+def test_room_form_name_required(event):
+    """
+    Verify that the 'name' field in RoomForm is required.
+    This ensures that the 'Optional' label is not displayed in the UI.
+    """
+    # Test with empty name
+    form = RoomForm(event=event, instance=Room(event=event), data={
+        'name': '',
+        'guid': '',
+        'description': 'Test Room',
+        'speaker_info': 'Test Info',
+        'capacity': 100,
+    })
+    
+    # name is required, so the form should be invalid
+    assert form.is_valid() is False
+    assert 'name' in form.errors
+    assert form.fields['name'].required is True
+
+@pytest.mark.django_db
+def test_room_form_valid_with_name(event):
+    """
+    Verify that the RoomForm is valid when a name is provided.
+    """
+    form = RoomForm(event=event, instance=Room(event=event), data={
+        'name': 'Great Hall',
+        'guid': '',
+        'description': 'Test Room',
+        'speaker_info': 'Test Info',
+        'capacity': 100,
+    })
+    
+    assert form.is_valid() is True
+    assert 'name' not in form.errors


### PR DESCRIPTION
## Description
Removes the incorrect "Optional" label from the Room Name field in the Room create/edit form.

The field is required by backend validation, so the UI now correctly reflects this.

##Checklist
- [x] UI reflects required field correctly
- [x] Validation error works as expected
- [x] No unrelated changes included

Fixes #2666 

<img width="931" height="1005" alt="Screenshot 2026-03-03 023731" src="https://github.com/user-attachments/assets/e6c93691-9e29-4f4e-a043-66566adbd1d2" />

## Summary by Sourcery

Ensure the Room form enforces a required name field to align the UI with backend validation.

Bug Fixes:
- Mark the RoomForm name field as required so the UI no longer treats it as optional.

Tests:
- Add tests verifying that the Room form is invalid without a name and valid when a name is provided.