### PR TITLE
Fix speaker profile 404 error by auto-creating missing profiles

### DIFF
--- a/app/eventyay/agenda/views/speaker.py
+++ b/app/eventyay/agenda/views/speaker.py
@@ -32,6 +32,28 @@ from eventyay.base.models import SpeakerProfile, User
 from eventyay.base.models import TalkQuestionTarget
 
 
+def get_or_create_speaker_profile(event, speaker_code):
+    """Get a speaker profile by code, creating one if needed.
+
+    This handles cases where a speaker was added to talks but doesn't have
+    an explicit profile record for the event.
+    """
+    profile = SpeakerProfile.objects.filter(
+        event=event, user__code__iexact=speaker_code
+    ).first()
+
+    if not profile:
+        try:
+            user = User.objects.get(code__iexact=speaker_code)
+            profile = SpeakerProfile.objects.get_or_create(
+                user=user, event=event
+            )[0]
+        except User.DoesNotExist:
+            pass
+
+    return profile
+
+
 class ScheduleDataMixin:
     """Provide schedule_json context for pages that embed the schedule widget."""
 
@@ -89,11 +111,7 @@ class SpeakerView(ScheduleDataMixin, PermissionRequired, TemplateView):
     @context
     @cached_property
     def profile(self):
-        return (
-            SpeakerProfile.objects.filter(event=self.request.event, user__code__iexact=self.kwargs['code'])
-            .select_related('user', 'event', 'event__organizer')
-            .first()
-        )
+        return get_or_create_speaker_profile(self.request.event, self.kwargs['code'])
 
     @context
     @cached_property
@@ -137,7 +155,7 @@ class SpeakerTalksIcalView(PermissionRequired, DetailView):
     slug_field = 'code'
 
     def get_object(self, queryset=None):
-        return SpeakerProfile.objects.filter(event=self.request.event, user__code__iexact=self.kwargs['code']).first()
+        return get_or_create_speaker_profile(self.request.event, self.kwargs['code'])
 
     def get(self, request, event, *args, **kwargs):
         if not self.request.event.current_schedule:
@@ -173,9 +191,7 @@ class SpeakerTalksExportView(EventPermissionRequired, View):
     permission_required = 'base.list_schedule'
 
     def get_speaker_and_slots(self, request):
-        speaker = SpeakerProfile.objects.filter(
-            event=request.event, user__code__iexact=self.kwargs['code']
-        ).select_related('user').first()
+        speaker = get_or_create_speaker_profile(request.event, self.kwargs['code'])
         if not speaker:
             raise Http404()
         schedule = request.event.current_schedule
@@ -276,9 +292,7 @@ class SpeakerTalksCalendarRedirectView(EventPermissionRequired, View):
 
     def get(self, request, event, **kwargs):
         provider = kwargs.get('provider', '')
-        speaker = SpeakerProfile.objects.filter(
-            event=request.event, user__code__iexact=self.kwargs['code']
-        ).select_related('user').first()
+        speaker = get_or_create_speaker_profile(request.event, self.kwargs['code'])
         if not speaker:
             raise Http404()
         schedule = request.event.current_schedule

--- a/app/tests/talk/agenda/views/test_speaker_profile_fix.py
+++ b/app/tests/talk/agenda/views/test_speaker_profile_fix.py
@@ -1,0 +1,100 @@
+"""
+Tests for the speaker profile view fix (issue #2635).
+
+These tests validate that speakers can access their profile pages
+even if they don't have an explicit SpeakerProfile record before the
+fix creates one automatically.
+"""
+import pytest
+from django_scopes import scope
+
+from eventyay.base.models import SpeakerProfile
+
+
+@pytest.mark.django_db
+def test_speaker_profile_page_accessible_without_existing_profile(client, event, slot):
+    """Test that a speaker's profile page is accessible even without a pre-existing SpeakerProfile."""
+    # Setup: Create a speaker in a talk but don't explicitly create their profile
+    speaker = slot.submission.speakers.first()
+
+    with scope(event=event):
+        # Make sure talks are published so speakers are viewable
+        event.talks_published = True
+        event.save(update_fields=['talks_published'])
+
+        # Delete the profile to simulate the issue
+        SpeakerProfile.objects.filter(user=speaker, event=event).delete()
+
+        # Verify profile doesn't exist
+        assert not SpeakerProfile.objects.filter(user=speaker, event=event).exists()
+
+    # Access the speaker profile page
+    speaker_profile_url = f"{event.urls.base}speakers/{speaker.code}/"
+    response = client.get(speaker_profile_url, follow=True)
+
+    # Should succeed with 200 status
+    assert response.status_code == 200
+    assert speaker.fullname in response.text or speaker.code in response.text
+
+    # Verify profile was auto-created
+    with scope(event=event):
+        profile = SpeakerProfile.objects.filter(user=speaker, event=event).first()
+        assert profile is not None
+        assert profile.user == speaker
+        assert profile.event == event
+
+
+@pytest.mark.django_db
+def test_speaker_profile_maintains_existing_profile_data(client, event, slot):
+    """Test that auto-created profiles don't overwrite existing profile data."""
+    speaker = slot.submission.speakers.first()
+
+    with scope(event=event):
+        event.talks_published = True
+        event.save(update_fields=['talks_published'])
+
+        # Create profile with specific data
+        profile = SpeakerProfile.objects.get(user=speaker, event=event)
+        profile.biography = "Test biography"
+        profile.is_featured = True
+        profile.position = 5
+        profile.save()
+
+    # Access the page
+    speaker_profile_url = f"{event.urls.base}speakers/{speaker.code}/"
+    response = client.get(speaker_profile_url, follow=True)
+
+    assert response.status_code == 200
+
+    # Verify profile data is preserved
+    with scope(event=event):
+        profile = SpeakerProfile.objects.get(user=speaker, event=event)
+        assert profile.biography == "Test biography"
+        assert profile.is_featured is True
+        assert profile.position == 5
+
+
+@pytest.mark.django_db
+def test_speaker_ical_export_works_without_existing_profile(client, event, slot):
+    """Test that speaker iCal export works with auto-created profile."""
+    speaker = slot.submission.speakers.first()
+
+    with scope(event=event):
+        event.talks_published = True
+        event.save(update_fields=['talks_published'])
+
+        # Delete profile to simulate the issue
+        SpeakerProfile.objects.filter(user=speaker, event=event).delete()
+
+    # Access the iCal export
+    ical_url = f"{event.urls.base}speakers/{speaker.code}/talks.ics"
+    response = client.get(ical_url, follow=True)
+
+    # Should succeed
+    assert response.status_code == 200
+    assert response['Content-Type'] == 'text/calendar'
+
+    # Verify profile was auto-created
+    with scope(event=event):
+        profile = SpeakerProfile.objects.filter(user=speaker, event=event).first()
+        assert profile is not None


### PR DESCRIPTION
When a speaker is added to a talk but doesn't have an explicit **SpeakerProfile** record for the event, accessing their profile page results in a **404 error**. This fix automatically creates the profile on-demand when accessed.

Changes:
- Add **get_or_create_speaker_profile()** helper function to handle profile creation
- Update **SpeakerView.profile** to use the helper
- Update **SpeakerTalksIcalView.get_object()** to use the helper
- Update **SpeakerTalksExportView.get_speaker_and_slots()** to use the helper
- Update **SpeakerTalksCalendarRedirectView.get()** to use the helper
- Add comprehensive tests for the fix


Fixes #2635

## Summary by Sourcery

Ensure speaker-related views can access and auto-create missing speaker profiles to prevent 404s when speakers are linked to talks but lack explicit profiles.

Bug Fixes:
- Prevent 404 errors on speaker profile pages by auto-creating missing SpeakerProfile records when a valid speaker code is used.
- Ensure speaker iCal export, talks export, and calendar redirect continue to work when a speaker profile does not yet exist for the event.

Enhancements:
- Introduce a shared helper to retrieve or lazily create speaker profiles from event and speaker code, consolidating profile lookup logic.

Tests:
- Add integration tests covering profile page access, data preservation on existing profiles, and iCal export behavior when profiles are auto-created.