### PR TITLE
fix: stay on team members page after adding member

### DIFF
--- a/app/eventyay/eventyay_common/views/organizer.py
+++ b/app/eventyay/eventyay_common/views/organizer.py
@@ -528,7 +528,7 @@ class OrganizerTeamsView(UpdateView, OrganizerPermissionRequiredMixin):
         )
 
         messages.success(self.request, _('The new member has been added to the team.'))
-        return self._redirect_to_team_permissions(team.pk)
+        return self._redirect_to_team_members_panel(team.pk)
 
     def _handle_create_invite(self, team, invite_form):
         """Handle creating an invite for a user that doesn't exist yet."""
@@ -554,7 +554,7 @@ class OrganizerTeamsView(UpdateView, OrganizerPermissionRequiredMixin):
             data={'email': invite_form.cleaned_data['user']},
         )
         messages.success(self.request, _('The new member has been invited to the team.'))
-        return self._redirect_to_team_permissions(team.pk)
+        return self._redirect_to_team_members_panel(team.pk)
 
     def _handle_team_tokens(self):
         team = self._get_team_from_post()


### PR DESCRIPTION
Fixes #2678


https://github.com/user-attachments/assets/3f65a4da-1719-4b55-b35a-f73298687778


## Changes
- Updated `OrganizerTeamsView._handle_add_member_or_invite` and `_handle_create_invite` to use `_redirect_to_team_members_panel` instead of `_redirect_to_team_permissions` on successful member add or invite creation.

## Summary by Sourcery

Bug Fixes:
- Redirect back to the team members panel instead of the team permissions page after adding a member or creating an invite.