### PR TITLE
Stay on team members page after adding a team member

### DIFF
--- a/app/eventyay/eventyay_common/views/team.py
+++ b/app/eventyay/eventyay_common/views/team.py
@@ -29,7 +29,8 @@ class UnifiedTeamManagementRedirectMixin:
 
     def dispatch(self, request, *args, **kwargs):
         team_id = kwargs.get('team')
-        query_params = {'section': 'permissions'}
+        section = request.GET.get('section', 'permissions')
+        query_params = {'section': section}
         if team_id:
             query_params['team'] = team_id
         target = reverse(
@@ -274,9 +275,14 @@ class TeamMemberView(
             return self.get(request, *args, **kwargs)
 
     def get_success_url(self) -> str:
-        return reverse(
-            'eventyay_common:organizer.team',
-            kwargs={'organizer': self.request.organizer.slug, 'team': self.object.pk},
+        section = self.request.GET.get('section', 'members')
+    
+        return (
+            reverse(
+                'eventyay_common:organizer.teams',
+                kwargs={'organizer': self.request.organizer.slug},
+            )
+            + f'?section={section}&team={self.object.pk}'
         )
 
 


### PR DESCRIPTION
Fixes #2678

Problem

Currently, when an organizer adds a new member from the Members & API section of the team management interface, the application redirects the user to the Team Permissions section instead of remaining on the Members & API section.

This behavior disrupts the user workflow and forces organizers to manually navigate back to the Members & API tab to continue managing team members.

Cause

The redirect after form submission does not preserve the active section of the team management page.

When a member is added, the backend redirects using:

redirect(self.get_success_url())

However, the success URL does not include the section query parameter that determines which tab should be active.

Since the section parameter is missing, the page defaults to:

section=permissions

which opens the Team Permissions tab instead of Members & API.

Solution

This PR updates the redirect logic in TeamMemberView.get_success_url() to preserve the currently active section of the team management interface.

The implementation retrieves the section parameter from the request and includes it in the redirect URL. If no section parameter is present, it defaults to "members" to ensure the user remains on the Members & API tab after adding a member.

Updated logic:

section = self.request.GET.get('section', 'members')

return (
    reverse(
        'eventyay_common:organizer.teams',
        kwargs={'organizer': self.request.organizer.slug},
    )
    + f'?section={section}&team={self.object.pk}'
)

This ensures the application returns to the correct tab after a successful operation.

Result

After this change:

The organizer remains on the Members & API tab after adding a team member.

The newly added member appears immediately in the list.

The workflow for managing team members becomes smoother.

Existing functionality related to team permissions and invitations remains unchanged.

Testing
Steps to reproduce before fix

Navigate to Teams → Members & API

Add a new team member

Observe that the interface redirects to the Team Permissions tab.

Steps after fix

Navigate to Teams → Members & API

Add a new team member

The page remains on the Members & API tab.

The newly added member appears in the members list.

Impact

Improves usability of the team management interface.

Prevents unnecessary navigation for organizers managing multiple team members.

No impact on invitation logic, permissions handling, or API token functionality.


<img width="904" height="899" alt="image" src="https://github.com/user-attachments/assets/ce2ffad2-7fe6-4552-821e-ca1f946c91f3" />

<img width="904" height="899" alt="image" src="https://github.com/user-attachments/assets/737630c5-0d5b-4773-8180-42a3d862e444" />

## Summary by Sourcery

Preserve the active team management section when redirecting after team-related actions so organizers remain on the intended tab.

Bug Fixes:
- Keep the current team management section (tab) selected when dispatching team views by carrying through the section query parameter instead of always defaulting to permissions.
- Ensure that after adding a team member the user is redirected back to the organizer teams view with the appropriate section (defaulting to members) and selected team in the query string.