### PR TITLE
fix(api): update api's to include job title

### DIFF
--- a/app/eventyay/api/serializers/order.py
+++ b/app/eventyay/api/serializers/order.py
@@ -481,6 +481,7 @@ class OrderPositionSerializer(I18nAwareModelSerializer):
         # (hopefully), we'll be extra careful here and be explicit about the model fields we update.
         update_fields = [
             'attendee_name_parts',
+            'job_title',
             'company',
             'street',
             'zipcode',
@@ -587,6 +588,7 @@ class CheckinListOrderPositionSerializer(OrderPositionSerializer):
             'price',
             'attendee_name',
             'attendee_name_parts',
+            'job_title',
             'company',
             'street',
             'zipcode',
@@ -930,6 +932,7 @@ class OrderPositionCreateSerializer(I18nAwareModelSerializer):
             'attendee_name_parts',
             'attendee_email',
             'company',
+            'job_title',
             'street',
             'zipcode',
             'city',

--- a/app/eventyay/eventyay_common/views/organizer.py
+++ b/app/eventyay/eventyay_common/views/organizer.py
@@ -559,9 +559,11 @@ class OrganizerTeamsView(UpdateView, OrganizerPermissionRequiredMixin):
     def _handle_team_tokens(self):
         team = self._get_team_from_post()
         self._forced_section = 'permissions'
+        token_form_prefix = self._token_form_prefix(team)
+        prefixed_name_field = f'{token_form_prefix}-name'
         token_form = TokenForm(
-            data=(self.request.POST if 'name' in self.request.POST else None),
-            prefix=self._token_form_prefix(team),
+            data=(self.request.POST if prefixed_name_field in self.request.POST else None),
+            prefix=token_form_prefix,
         )
 
         post = self.request.POST
@@ -569,7 +571,7 @@ class OrganizerTeamsView(UpdateView, OrganizerPermissionRequiredMixin):
         with transaction.atomic():
             if 'remove-token' in post:
                 return self._handle_remove_token(team, post)
-            if 'name' in post and token_form.is_valid() and token_form.has_changed():
+            if prefixed_name_field in post and token_form.is_valid() and token_form.has_changed():
                 return self._handle_create_token(team, token_form)
 
         messages.error(self.request, _('Your changes could not be saved.'))


### PR DESCRIPTION
This PR adds fixes to serializers to handle job title and fixes api token creation for teams.

## Summary by Sourcery

Ensure team token creation uses the correct prefixed form field and expose attendee job title in order-related API serializers.

Bug Fixes:
- Fix team API token handling by checking for the correctly prefixed token name field before validating and creating tokens.

Enhancements:
- Include attendee job title in order update handling and expose it in order and order-position related API serializer fields.