### PR TITLE
fix: correct Hindi and Marathi flag mapping

### DIFF
--- a/app/eventyay/static/pretixcontrol/scss/_flags.scss
+++ b/app/eventyay/static/pretixcontrol/scss/_flags.scss
@@ -122,6 +122,7 @@ pre[lang=gt], input[lang=gt], textarea[lang=gt], div[lang=gt] { background-image
 pre[lang=gu], input[lang=gu], textarea[lang=gu], div[lang=gu] { background-image: url(static('pretixbase/img/flags/gu.png')); }
 pre[lang=gw], input[lang=gw], textarea[lang=gw], div[lang=gw] { background-image: url(static('pretixbase/img/flags/gw.png')); }
 pre[lang=gy], input[lang=gy], textarea[lang=gy], div[lang=gy] { background-image: url(static('pretixbase/img/flags/gy.png')); }
+pre[lang=hi], input[lang=hi], textarea[lang=hi], div[lang=hi] { background-image: url(static('pretixbase/img/flags/in.png')); }
 pre[lang=hk], input[lang=hk], textarea[lang=hk], div[lang=hk] { background-image: url(static('pretixbase/img/flags/hk.png')); }
 pre[lang=hm], input[lang=hm], textarea[lang=hm], div[lang=hm] { background-image: url(static('pretixbase/img/flags/hm.png')); }
 pre[lang=hn], input[lang=hn], textarea[lang=hn], div[lang=hn] { background-image: url(static('pretixbase/img/flags/hn.png')); }
@@ -175,7 +176,7 @@ pre[lang=mn], input[lang=mn], textarea[lang=mn], div[lang=mn] { background-image
 pre[lang=mo], input[lang=mo], textarea[lang=mo], div[lang=mo] { background-image: url(static('pretixbase/img/flags/mo.png')); }
 pre[lang=mp], input[lang=mp], textarea[lang=mp], div[lang=mp] { background-image: url(static('pretixbase/img/flags/mp.png')); }
 pre[lang=mq], input[lang=mq], textarea[lang=mq], div[lang=mq] { background-image: url(static('pretixbase/img/flags/mq.png')); }
-pre[lang=mr], input[lang=mr], textarea[lang=mr], div[lang=mr] { background-image: url(static('pretixbase/img/flags/mr.png')); }
+pre[lang=mr], input[lang=mr], textarea[lang=mr], div[lang=mr] { background-image: url(static('pretixbase/img/flags/in.png')); }
 pre[lang=ms], input[lang=ms], textarea[lang=ms], div[lang=ms] { background-image: url(static('pretixbase/img/flags/ms.png')); }
 pre[lang=mt], input[lang=mt], textarea[lang=mt], div[lang=mt] { background-image: url(static('pretixbase/img/flags/mt.png')); }
 pre[lang=mu], input[lang=mu], textarea[lang=mu], div[lang=mu] { background-image: url(static('pretixbase/img/flags/mu.png')); }


### PR DESCRIPTION
Fixes #2589

- Added a mapping for Hindi (hi) → in.png
- Updated Marathi (mr) → in.png

<img width="1919" height="876" alt="image" src="https://github.com/user-attachments/assets/25517b31-87c2-4b17-bd5c-8234194910aa" />

## Summary by Sourcery

Update language-to-flag mappings for Indian languages in the flags stylesheet.

Bug Fixes:
- Map Hindi (hi) language code to the Indian flag asset.
- Correct Marathi (mr) language code to use the Indian flag asset instead of a dedicated mr.png flag.