### PR TITLE
Improve empty state UI when no upcoming events are available

### DIFF
--- a/app/eventyay/presale/templates/pretixpresale/startpage.html
+++ b/app/eventyay/presale/templates/pretixpresale/startpage.html
@@ -204,8 +204,15 @@
                             <div class="startpage-event-list">
                                 {% for event in upcoming_events %}
                                     {% include "pretixpresale/includes/startpage_event_card.html" with event=event %}
-                                {% empty %}
-                                    <p class="startpage-empty">{% trans "No upcoming events available yet." %}</p>
+                                    {% empty %}
+                                    <div class="startpage-empty text-center">
+                                        <p>{% trans "No upcoming events available yet." %}</p>
+                                    
+                                        <a href="{% url 'eventyay_common:events.add' %}" class="btn btn-primary">
+                                            <span class="fa fa-plus"></span>
+                                            {% trans "Create your first event" %}
+                                        </a>
+                                    </div>
                                 {% endfor %}
                             </div>
                         </section>


### PR DESCRIPTION
Fixes #2688

Currently, when no upcoming events are available on the homepage,
the interface only displays the message:

"No upcoming events available yet."

This provides limited guidance for new users and may cause confusion
about what actions they should take next.

This PR improves the empty state by adding a call-to-action button
that encourages users to create their first event.

Changes made:
- Added a "Create your first event" button below the empty state message
- The button redirects users to the event creation page (/control/events/create)
- Maintains existing styling and translation support using Django's {% trans %}

Benefits:
- Improves onboarding experience for new users
- Provides clear next steps when no events exist
- Enhances the overall user experience of the homepage

Testing:
1. Start the development server
2. Visit the homepage when no events exist
3. Confirm the "Create your first event" button appears
4. Verify that clicking the button redirects to the event creation page


<img width="924" height="516" alt="Screenshot from 2026-03-06 18-44-25" src="https://github.com/user-attachments/assets/a6ef1048-e664-4ff3-9373-e8ea67843f53" />

## Summary by Sourcery

Improve the homepage upcoming-events empty state with a clearer call to action when no events are available.

New Features:
- Add a call-to-action flow from the empty upcoming-events state to the event creation page.

Enhancements:
- Refine the empty upcoming-events message layout to be centered and more visually prominent.