### PR TITLE
fix(nginx): add proxy_hide_header directives before proxy_pass

### DIFF
--- a/deployment/nginx/enext-direct
+++ b/deployment/nginx/enext-direct
@@ -69,6 +69,11 @@ server {
             add_header Vary Origin always;
         }
 
+		proxy_hide_header Access-Control-Allow-Origin;
+		proxy_hide_header Access-Control-Allow-Credentials;
+		proxy_hide_header Access-Control-Allow-Headers;
+		proxy_hide_header Access-Control-Allow-Methods;
+		proxy_hide_header Access-Control-Expose-Headers;
 		proxy_pass http://127.0.0.1:8000;
 		proxy_set_header Host $http_host;
 		proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;


### PR DESCRIPTION
Update Nginx file with proxy_hide

## Summary by Sourcery

Enhancements:
- Update enext-direct Nginx configuration to hide specific proxy headers prior to proxying requests upstream.