### PR TITLE
fix: add exception handling for missing user in update_user

### DIFF
--- a/app/eventyay/base/services/user.py
+++ b/app/eventyay/base/services/user.py
@@ -243,12 +243,15 @@ def create_user(
 def update_user(
     event_id, id, *, traits=None, data=None, is_admin=False, serialize=True
 ):
-    # TODO: Exception handling
-    user = (
-        User.objects.select_related("event")
-        .select_for_update()
-        .get(id=id, event_id=event_id)
-    )
+    try:
+        user = (
+            User.objects.select_related("event")
+            .select_for_update()
+            .get(id=id, event_id=event_id)
+        )
+    except User.DoesNotExist:
+        logger.warning("update_user called with non-existent user id=%s event_id=%s", id, event_id)
+        return None
 
     if traits is not None:
         if user.traits != traits:


### PR DESCRIPTION
## Problem
In `update_user()` in `services/user.py`, the `.get()` call had 
a TODO comment noting missing exception handling. If a user ID 
does not exist, it raises an unhandled `User.DoesNotExist` error.

## Fix
Wrapped the `.get()` call in a try/except block. Returns `None` 
with a warning log when the user is not found, instead of crashing.

## Changes
- `app/eventyay/base/services/user.py`: Added try/except around 
  User.objects.get() in update_user()

## Summary by Sourcery

Bug Fixes:
- Return None and log a warning when update_user is called with a non-existent user instead of raising User.DoesNotExist.