### PR TITLE
Add preferred login provider option to Social Auth settings

### DIFF
--- a/app/eventyay/eventyay_common/templates/eventyay_common/auth/_login_form.html
+++ b/app/eventyay/eventyay_common/templates/eventyay_common/auth/_login_form.html
@@ -1,0 +1,46 @@
+{% load bootstrap3 %}
+{% load i18n %}
+{% load urlreplace %}
+{% load append_next_url %}
+<div id='login-form' class='collapse{% if form.errors %} in{% endif %}'>
+  {% if backends|length > 1 %}
+    <ul class='nav nav-pills'>
+      {% for b in backends %}
+        {% if b.visible %}
+          <li class='{% if backend.identifier == b.identifier %}active{% endif %}'>
+            <a href='{% if b.url %}{{ b.url }}{% else %}?{% url_replace request "backend" b.identifier %}{% endif %}'>
+              {{ b.verbose_name }}
+            </a>
+          </li>
+        {% endif %}
+      {% endfor %}
+    </ul>
+    <br>
+  {% endif %}
+  {% csrf_token %}
+  {% bootstrap_form form %}
+  <div class='form-group buttons'>
+    {% if backend.login_form_fields %}
+      <button type='submit' class='btn btn-primary btn-block'>
+        {% translate 'Log in' %}
+      </button>
+    {% endif %}
+    {% if backend.url %}
+      <a href='{{ backend.url }}' class='btn btn-primary btn-block'>
+        {{ backend.verbose_name }}
+      </a>
+    {% endif %}
+    {% if backend.identifier == 'native' %}
+      {% if can_reset %}
+        <a href='{% url "eventyay_common:auth.forgot" %}' class='btn btn-link btn-block'>
+          {% translate 'Lost password?' %}
+        </a>
+      {% endif %}
+      {% if can_register %}
+        <a href='{% url "eventyay_common:auth.register" %}{% append_next request.GET.next %}' class='btn btn-link btn-block'>
+          {% translate 'Register' %}
+        </a>
+      {% endif %}
+    {% endif %}
+  </div>
+</div>

--- a/app/eventyay/eventyay_common/templates/eventyay_common/auth/_login_options.html
+++ b/app/eventyay/eventyay_common/templates/eventyay_common/auth/_login_options.html
@@ -1,32 +1,36 @@
 {% load i18n %}
 {% load append_next_url %}
-<div class='form-group buttons'>
+<div class='form-group buttons{% if preferred_provider %} login-options-primary-first{% endif %}'>
   {% if preferred_provider %}
     {% for provider, settings in login_providers.items %}
       {% if provider == preferred_provider and settings.state %}
         <a href='{% url "plugins:socialauth:social.oauth.login" provider %}{% append_next request.GET.next %}'
-           data-method='post' class='btn btn-primary btn-block'>
+           data-method='post' class='btn btn-primary btn-block login-option-primary'>
           {% with provider|capfirst as provider_capitalized %}
             {% blocktranslate %}Login with {{ provider_capitalized }}{% endblocktranslate %}
           {% endwith %}
         </a>
-        <p class='login-separator'>{% translate 'or use the following:' %}</p>
+        <p class='login-separator'>
+          <span class='login-separator-label'>{% translate 'or' %}</span>
+        </p>
       {% endif %}
     {% endfor %}
   {% endif %}
-  <button type='button' id='toggle-login' class='btn btn-primary btn-block' data-toggle='collapse' data-target='#login-form'>
-    {% translate 'Login with Email' %}
-  </button>
-  {% if login_providers %}
-    {% for provider, settings in login_providers.items %}
-      {% if settings.state and provider != preferred_provider %}
-        <a href='{% url "plugins:socialauth:social.oauth.login" provider %}{% append_next request.GET.next %}'
-           data-method='post' class='btn btn-primary btn-block'>
-          {% with provider|capfirst as provider_capitalized %}
-            {% blocktranslate %}Login with {{ provider_capitalized }}{% endblocktranslate %}
-          {% endwith %}
-        </a>
-      {% endif %}
-    {% endfor %}
-  {% endif %}
+  <div class='login-options-secondary-group'>
+    <button type='button' id='toggle-login' class='btn btn-primary btn-block login-option-secondary' data-toggle='collapse' data-target='#login-form'>
+      {% translate 'Login with Email' %}
+    </button>
+    {% if login_providers %}
+      {% for provider, settings in login_providers.items %}
+        {% if settings.state and provider != preferred_provider %}
+          <a href='{% url "plugins:socialauth:social.oauth.login" provider %}{% append_next request.GET.next %}'
+             data-method='post' class='btn btn-primary btn-block login-option-secondary'>
+            {% with provider|capfirst as provider_capitalized %}
+              {% blocktranslate %}Login with {{ provider_capitalized }}{% endblocktranslate %}
+            {% endwith %}
+          </a>
+        {% endif %}
+      {% endfor %}
+    {% endif %}
+  </div>
 </div>

--- a/app/eventyay/eventyay_common/templates/eventyay_common/auth/_login_options.html
+++ b/app/eventyay/eventyay_common/templates/eventyay_common/auth/_login_options.html
@@ -1,0 +1,32 @@
+{% load i18n %}
+{% load append_next_url %}
+<div class='form-group buttons'>
+  {% if preferred_provider %}
+    {% for provider, settings in login_providers.items %}
+      {% if provider == preferred_provider and settings.state %}
+        <a href='{% url "plugins:socialauth:social.oauth.login" provider %}{% append_next request.GET.next %}'
+           data-method='post' class='btn btn-primary btn-block'>
+          {% with provider|capfirst as provider_capitalized %}
+            {% blocktranslate %}Login with {{ provider_capitalized }}{% endblocktranslate %}
+          {% endwith %}
+        </a>
+        <p class='login-separator'>{% translate 'or use the following:' %}</p>
+      {% endif %}
+    {% endfor %}
+  {% endif %}
+  <button type='button' id='toggle-login' class='btn btn-primary btn-block' data-toggle='collapse' data-target='#login-form'>
+    {% translate 'Login with Email' %}
+  </button>
+  {% if login_providers %}
+    {% for provider, settings in login_providers.items %}
+      {% if settings.state and provider != preferred_provider %}
+        <a href='{% url "plugins:socialauth:social.oauth.login" provider %}{% append_next request.GET.next %}'
+           data-method='post' class='btn btn-primary btn-block'>
+          {% with provider|capfirst as provider_capitalized %}
+            {% blocktranslate %}Login with {{ provider_capitalized }}{% endblocktranslate %}
+          {% endwith %}
+        </a>
+      {% endif %}
+    {% endfor %}
+  {% endif %}
+</div>

--- a/app/eventyay/eventyay_common/templates/eventyay_common/auth/login.html
+++ b/app/eventyay/eventyay_common/templates/eventyay_common/auth/login.html
@@ -49,13 +49,26 @@
             </div>
         </div>
         <div class="form-group buttons">
+            {% if preferred_provider %}
+                {% for provider, settings in login_providers.items %}
+                    {% if provider == preferred_provider and settings.state %}
+                        <a href='{% url "plugins:socialauth:social.oauth.login" provider %}{% append_next request.GET.next %}'
+                           data-method="post" class="btn btn-primary btn-block">
+                            {% with provider|capfirst as provider_capitalized %}
+                                {% blocktranslate %}Login with {{ provider_capitalized }}{% endblocktranslate %}
+                            {% endwith %}
+                        </a>
+                        <p class="login-separator">{% translate "or use the following:" %}</p>
+                    {% endif %}
+                {% endfor %}
+            {% endif %}
             <button type="button" id="toggle-login" class="btn btn-primary btn-block" data-toggle="collapse" data-target="#login-form">
                 {% translate "Login with Email" %}
             </button>
             {% if login_providers %}
                 {% for provider, settings in login_providers.items %}
-                    {% if settings.state %}
-                        <a href='{% url "plugins:socialauth:social.oauth.login" provider %}{% append_next request.GET.next %}' 
+                    {% if settings.state and provider != preferred_provider %}
+                        <a href='{% url "plugins:socialauth:social.oauth.login" provider %}{% append_next request.GET.next %}'
                            data-method="post" class="btn btn-primary btn-block">
                             {% with provider|capfirst as provider_capitalized %}
                                 {% blocktranslate %}Login with {{ provider_capitalized }}{% endblocktranslate %}

--- a/app/eventyay/eventyay_common/templates/eventyay_common/auth/login.html
+++ b/app/eventyay/eventyay_common/templates/eventyay_common/auth/login.html
@@ -6,77 +6,12 @@
 {% load append_next_url %}
 {% block content %}
     <form class="form-signin" action="" method="post">
-        <div id="login-form" class="collapse">
-            {% if backends|length > 1 %}
-                <ul class="nav nav-pills">
-                    {% for b in backends %}
-                        {% if b.visible %}
-                            <li class="{% if backend.identifier == b.identifier %}active{% endif %}">
-                                <a href="{% if b.url %}{{ b.url }}{% else %}?{% url_replace request "backend" b.identifier %}{% endif %}">
-                                    {{ b.verbose_name }}
-                                </a>
-                            </li>
-                        {% endif %}
-                    {% endfor %}
-                </ul>
-                <br>
-            {% endif %}
-            {% csrf_token %}
-            {% bootstrap_form form %}
-            <div class="form-group buttons">
-                {% if backend.login_form_fields %}
-                <button type="submit" class="btn btn-primary btn-block">
-                    {% translate "Log in" %}
-                </button>
-                {% endif %}
-                {% if backend.url %}
-                    <a href="{{ backend.url }}" class="btn btn-primary btn-block">
-                        {{ backend.verbose_name }}
-                    </a>
-                {% endif %}
-                {% if backend.identifier == "native" %}
-                    {% if can_reset %}
-                        <a href="{% url "eventyay_common:auth.forgot" %}" class="btn btn-link btn-block">
-                            {% translate "Lost password?" %}
-                        </a>
-                    {% endif %}
-                    {% if can_register %}
-                        <a href='{% url "eventyay_common:auth.register" %}{% append_next request.GET.next %}' class="btn btn-link btn-block">
-                            {% translate "Register" %}
-                        </a>
-                    {% endif %}
-                {% endif %}
-            </div>
-        </div>
-        <div class="form-group buttons">
-            {% if preferred_provider %}
-                {% for provider, settings in login_providers.items %}
-                    {% if provider == preferred_provider and settings.state %}
-                        <a href='{% url "plugins:socialauth:social.oauth.login" provider %}{% append_next request.GET.next %}'
-                           data-method="post" class="btn btn-primary btn-block">
-                            {% with provider|capfirst as provider_capitalized %}
-                                {% blocktranslate %}Login with {{ provider_capitalized }}{% endblocktranslate %}
-                            {% endwith %}
-                        </a>
-                        <p class="login-separator">{% translate "or use the following:" %}</p>
-                    {% endif %}
-                {% endfor %}
-            {% endif %}
-            <button type="button" id="toggle-login" class="btn btn-primary btn-block" data-toggle="collapse" data-target="#login-form">
-                {% translate "Login with Email" %}
-            </button>
-            {% if login_providers %}
-                {% for provider, settings in login_providers.items %}
-                    {% if settings.state and provider != preferred_provider %}
-                        <a href='{% url "plugins:socialauth:social.oauth.login" provider %}{% append_next request.GET.next %}'
-                           data-method="post" class="btn btn-primary btn-block">
-                            {% with provider|capfirst as provider_capitalized %}
-                                {% blocktranslate %}Login with {{ provider_capitalized }}{% endblocktranslate %}
-                            {% endwith %}
-                        </a>
-                    {% endif %}
-                {% endfor %}
-            {% endif %}
-        </div>
+        {% if preferred_provider %}
+            {% include 'eventyay_common/auth/_login_options.html' %}
+            {% include 'eventyay_common/auth/_login_form.html' %}
+        {% else %}
+            {% include 'eventyay_common/auth/_login_form.html' %}
+            {% include 'eventyay_common/auth/_login_options.html' %}
+        {% endif %}
     </form>
 {% endblock %}

--- a/app/eventyay/eventyay_common/views/auth.py
+++ b/app/eventyay/eventyay_common/views/auth.py
@@ -52,6 +52,30 @@ from eventyay.multidomain.middlewares import get_cookie_domain
 logger = logging.getLogger(__name__)
 
 
+def _order_login_providers(login_providers):
+    """Return login_providers as a dict with the preferred provider first."""
+    if not login_providers:
+        return login_providers
+    preferred = _get_preferred_provider(login_providers)
+    ordered = {}
+    if preferred and preferred in login_providers and login_providers[preferred].get('state'):
+        ordered[preferred] = login_providers[preferred]
+    for key, value in login_providers.items():
+        if key != preferred:
+            ordered[key] = value
+    return ordered
+
+
+def _get_preferred_provider(login_providers):
+    """Return the provider key that is preferred, or None."""
+    if not login_providers:
+        return None
+    for key, config in login_providers.items():
+        if config.get('state') and config.get('is_preferred'):
+            return key
+    return None
+
+
 def get_used_backend(request):
     backend_str = request.session[BACKEND_SESSION_KEY]
     backend = load_backend(backend_str)
@@ -154,7 +178,9 @@ def login(request):
     ctx['backend'] = backend
 
     gs = GlobalSettingsObject()
-    ctx['login_providers'] = gs.settings.get('login_providers', as_type=dict)
+    raw_providers = gs.settings.get('login_providers', as_type=dict)
+    ctx['login_providers'] = _order_login_providers(raw_providers)
+    ctx['preferred_provider'] = _get_preferred_provider(raw_providers)
     return render(request, 'eventyay_common/auth/login.html', ctx)
 
 

--- a/app/eventyay/plugins/socialauth/schemas/login_providers.py
+++ b/app/eventyay/plugins/socialauth/schemas/login_providers.py
@@ -5,6 +5,7 @@ class ProviderConfig(BaseModel):
     state: bool = Field(description='State of this providers', default=False)
     client_id: str = Field(description='Client ID of this provider', default='')
     secret: str = Field(description='Secret of this provider', default='')
+    is_preferred: bool = Field(description='Whether this provider is the preferred login method', default=False)
 
 
 class LoginProviders(BaseModel):

--- a/app/eventyay/plugins/socialauth/templates/socialauth/social_auth_settings.html
+++ b/app/eventyay/plugins/socialauth/templates/socialauth/social_auth_settings.html
@@ -44,10 +44,19 @@
                                         </button>
                                     {% endif %}
                                 </td>
+                                <td class="text-right flip" width="25%">
+                                    {% if settings.state %}
+                                        <label class="radio-inline">
+                                            <input type="radio" name="preferred_provider" value="{{ provider }}"
+                                                {% if settings.is_preferred %}checked{% endif %}>
+                                            {% trans "Make this the preferred login method" %}
+                                        </label>
+                                    {% endif %}
+                                </td>
                             </tr>
                             {% if settings.state %}
                             <tr>
-                                <td colspan="2">
+                                <td colspan="3">
                                     <div class="form-group">
                                         <label class="col-sm-3 control-label">
                                             {% if provider == "mediawiki" %}
@@ -76,6 +85,16 @@
                             </tr>
                             {% endif %}
                         {% endfor %}
+                        <tr>
+                            <td colspan="2"></td>
+                            <td class="text-right flip">
+                                <label class="radio-inline">
+                                    <input type="radio" name="preferred_provider" value="none"
+                                        {% if not any_preferred %}checked{% endif %}>
+                                    {% trans "No preferred provider" %}
+                                </label>
+                            </td>
+                        </tr>
                     </table>
                 </div>
             </fieldset>

--- a/app/eventyay/plugins/socialauth/views.py
+++ b/app/eventyay/plugins/socialauth/views.py
@@ -30,14 +30,23 @@ adapter = get_adapter()
 class OAuthLoginView(View):
     def get(self, request: HttpRequest, provider: str) -> HttpResponse:
         self.set_oauth2_params(request)
-        
-        # Store the 'next' URL in session for redirecting user back after login
+
         next_url = request.GET.get('next', '')
         if next_url and url_has_allowed_host_and_scheme(next_url, allowed_hosts=None):
             request.session['socialauth_next_url'] = next_url
 
         gs = GlobalSettingsObject()
-        client_id = gs.settings.get('login_providers', as_type=dict).get(provider, {}).get('client_id')
+        login_providers = gs.settings.get('login_providers', as_type=dict) or {}
+        known_providers = frozenset(LoginProviders.model_fields.keys())
+        if provider not in known_providers or provider not in login_providers or not login_providers[provider].get('state'):
+            messages.error(request, _('This login method is not available.'))
+            return redirect('eventyay_common:auth.login')
+        provider_config = login_providers[provider]
+        if provider_config.get('is_preferred'):
+            request.session['socialauth_keep_logged_in'] = True
+        else:
+            request.session.pop('socialauth_keep_logged_in', None)
+        client_id = provider_config.get('client_id')
         provider_instance = adapter.get_provider(request, provider, client_id=client_id)
 
         base_url = provider_instance.get_login_url(request)
@@ -88,7 +97,9 @@ class OAuthReturnView(View):
                     # Clean up socialauth_next_url to prevent it from being used later
                     request.session.pop('socialauth_next_url', None)
                     response = process_login_and_set_cookie(request, user, False)
-                    return redirect(f'{auth_url}?{query_string}')
+                    redirect_response = redirect(f'{auth_url}?{query_string}')
+                    redirect_response.cookies.update(response.cookies)
+                    return redirect_response
                 except ValidationError as e:
                     logger.warning('Ignore invalid OAuth2 parameters: %s.', e)
             
@@ -96,10 +107,10 @@ class OAuthReturnView(View):
             # Re-validation provides defense against session tampering
             next_url = request.session.pop('socialauth_next_url', None)
             if next_url and url_has_allowed_host_and_scheme(next_url, allowed_hosts=None):
-                # Store in session with a clear key for process_login to use
                 request.session['socialauth_next_url'] = next_url
-            
-            response = process_login_and_set_cookie(request, user, False)
+
+            keep_logged_in = request.session.pop('socialauth_keep_logged_in', False)
+            response = process_login_and_set_cookie(request, user, keep_logged_in)
             return response
         except AttributeError as e:
             messages.error(request, _('Error while authorizing: no email address available.'))
@@ -173,15 +184,20 @@ class SocialLoginView(AdministratorPermissionRequiredMixin, TemplateView):
 
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
-        context['login_providers'] = self.gs.settings.get('login_providers', as_type=dict)
-        # tickets_domain is only used to append /github/..., so make sure we don't have
-        # a trailing /
+        login_providers = self.gs.settings.get('login_providers', as_type=dict)
+        context['login_providers'] = login_providers
+        context['any_preferred'] = any(
+            p.get('state', False) and p.get('is_preferred', False)
+            for p in login_providers.values()
+        )
         context['tickets_domain'] = urljoin(settings.SITE_URL, settings.BASE_PATH).rstrip("/")
         return context
 
     def post(self, request, *args, **kwargs):
         login_providers = self.gs.settings.get('login_providers', as_type=dict)
         setting_state = request.POST.get('save_credentials', '').lower()
+
+        self._apply_preferred_provider(request, login_providers)
 
         for provider in LoginProviders.model_fields.keys():
             if setting_state == self.SettingState.CREDENTIALS:
@@ -191,6 +207,33 @@ class SocialLoginView(AdministratorPermissionRequiredMixin, TemplateView):
 
         self.gs.settings.set('login_providers', login_providers)
         return redirect(self.get_success_url())
+
+    def _apply_preferred_provider(self, request, login_providers):
+        preferred = request.POST.get('preferred_provider', '').strip().lower()
+        valid_providers = set(LoginProviders.model_fields.keys())
+
+        # Explicitly selecting "none" clears all preferred flags.
+        if preferred == 'none':
+            for provider in valid_providers:
+                login_providers.setdefault(provider, {})['is_preferred'] = False
+            return
+
+        # If the field is missing or empty, leave existing preferences unchanged.
+        if not preferred:
+            return
+
+        # Ignore invalid provider values to avoid wiping existing preferences.
+        if preferred not in valid_providers:
+            logger.warning('Ignoring invalid preferred provider value: %s', preferred)
+            return
+
+        # If the selected provider is disabled, do not change the current preference.
+        if not login_providers.get(preferred, {}).get('state'):
+            return
+
+        # Set the selected provider as the only preferred one.
+        for provider in valid_providers:
+            login_providers.setdefault(provider, {})['is_preferred'] = provider == preferred
 
     def update_credentials(self, request, provider, login_providers):
         client_id_value = request.POST.get(f'{provider}_client_id', '')
@@ -211,7 +254,28 @@ class SocialLoginView(AdministratorPermissionRequiredMixin, TemplateView):
     def update_provider_state(self, request, provider, login_providers):
         setting_state = request.POST.get(f'{provider}_login', '').lower()
         if setting_state in [s.value for s in self.SettingState]:
-            login_providers[provider]['state'] = setting_state == self.SettingState.ENABLED
+            # Ensure provider dict exists
+            provider_config = login_providers.setdefault(provider, {})
 
+            is_enabled = setting_state == self.SettingState.ENABLED
+            provider_config['state'] = is_enabled
+
+            if not is_enabled:
+                # Clear preferred flag when disabling the provider
+                provider_config['is_preferred'] = False
+                # Remove SocialApp so the provider cannot be used via allauth URLs
+                SocialApp.objects.filter(provider=provider).delete()
+            else:
+                # When enabling, if we already have stored credentials, ensure SocialApp exists
+                client_id = provider_config.get('client_id')
+                secret = provider_config.get('secret')
+                if client_id and secret:
+                    SocialApp.objects.update_or_create(
+                        provider=provider,
+                        defaults={
+                            'client_id': client_id,
+                            'secret': secret,
+                        },
+                    )
     def get_success_url(self) -> str:
         return reverse('plugins:socialauth:admin.global.social.auth.settings')

--- a/app/eventyay/plugins/socialauth/views.py
+++ b/app/eventyay/plugins/socialauth/views.py
@@ -38,7 +38,11 @@ class OAuthLoginView(View):
         gs = GlobalSettingsObject()
         login_providers = gs.settings.get('login_providers', as_type=dict) or {}
         known_providers = frozenset(LoginProviders.model_fields.keys())
-        if provider not in known_providers or provider not in login_providers or not login_providers[provider].get('state'):
+        if (
+            provider not in known_providers
+            or provider not in login_providers
+            or not login_providers[provider].get('state')
+        ):
             messages.error(request, _('This login method is not available.'))
             return redirect('eventyay_common:auth.login')
         provider_config = login_providers[provider]
@@ -85,7 +89,8 @@ class OAuthReturnView(View):
     def get(self, request: HttpRequest) -> HttpResponse:
         try:
             user = self.get_or_create_user(request)
-            
+            keep_logged_in = request.session.pop('socialauth_keep_logged_in', False)
+
             # Check for OAuth2 params first (Talk module integration)
             oauth2_params = request.session.pop('oauth2_params', {})
             if oauth2_params:
@@ -96,20 +101,19 @@ class OAuthReturnView(View):
                     # OAuth2 flow takes precedence - redirect to authorization endpoint
                     # Clean up socialauth_next_url to prevent it from being used later
                     request.session.pop('socialauth_next_url', None)
-                    response = process_login_and_set_cookie(request, user, False)
+                    response = process_login_and_set_cookie(request, user, keep_logged_in)
                     redirect_response = redirect(f'{auth_url}?{query_string}')
                     redirect_response.cookies.update(response.cookies)
                     return redirect_response
                 except ValidationError as e:
                     logger.warning('Ignore invalid OAuth2 parameters: %s.', e)
-            
+
             # Retrieve and re-validate the stored 'next' URL from session
             # Re-validation provides defense against session tampering
             next_url = request.session.pop('socialauth_next_url', None)
             if next_url and url_has_allowed_host_and_scheme(next_url, allowed_hosts=None):
                 request.session['socialauth_next_url'] = next_url
 
-            keep_logged_in = request.session.pop('socialauth_keep_logged_in', False)
             response = process_login_and_set_cookie(request, user, keep_logged_in)
             return response
         except AttributeError as e:
@@ -187,10 +191,9 @@ class SocialLoginView(AdministratorPermissionRequiredMixin, TemplateView):
         login_providers = self.gs.settings.get('login_providers', as_type=dict)
         context['login_providers'] = login_providers
         context['any_preferred'] = any(
-            p.get('state', False) and p.get('is_preferred', False)
-            for p in login_providers.values()
+            p.get('state', False) and p.get('is_preferred', False) for p in login_providers.values()
         )
-        context['tickets_domain'] = urljoin(settings.SITE_URL, settings.BASE_PATH).rstrip("/")
+        context['tickets_domain'] = urljoin(settings.SITE_URL, settings.BASE_PATH).rstrip('/')
         return context
 
     def post(self, request, *args, **kwargs):
@@ -277,5 +280,6 @@ class SocialLoginView(AdministratorPermissionRequiredMixin, TemplateView):
                             'secret': secret,
                         },
                     )
+
     def get_success_url(self) -> str:
         return reverse('plugins:socialauth:admin.global.social.auth.settings')

--- a/app/eventyay/static/pretixcontrol/scss/auth.scss
+++ b/app/eventyay/static/pretixcontrol/scss/auth.scss
@@ -47,6 +47,11 @@ footer {
 	p:last-child {
 		margin-bottom: 20px;
 	}
+
+	.login-separator {
+		margin: 1em 0;
+		text-align: center;
+	}
 }
 
 .container > .alert {

--- a/app/eventyay/static/pretixcontrol/scss/auth.scss
+++ b/app/eventyay/static/pretixcontrol/scss/auth.scss
@@ -49,8 +49,50 @@ footer {
 	}
 
 	.login-separator {
+		align-items: center;
+		display: flex;
+		gap: 12px;
 		margin: 1em 0;
 		text-align: center;
+
+		&::before,
+		&::after {
+			border-top: 1px solid rgba(33, 133, 208, 0.2);
+			content: "";
+			flex: 1;
+		}
+	}
+
+	.login-separator-label {
+		color: #6c7a89;
+		font-size: 12px;
+		font-weight: 600;
+		letter-spacing: 0.08em;
+		text-transform: uppercase;
+	}
+
+	.login-options-secondary-group {
+		display: flex;
+		flex-direction: column;
+		gap: 10px;
+	}
+
+	.login-options-primary-first {
+		.login-option-secondary {
+			background: #fff;
+			border: 1px solid rgba(33, 133, 208, 0.3);
+			box-shadow: none;
+			color: #2f6ea5;
+			font-weight: 400;
+			margin-bottom: 0;
+
+			&:hover,
+			&:focus {
+				background: #f7fbff;
+				border-color: rgba(33, 133, 208, 0.45);
+				color: #245983;
+			}
+		}
 	}
 }
 

--- a/app/tests/tickets/plugins/test_socialauth.py
+++ b/app/tests/tickets/plugins/test_socialauth.py
@@ -42,6 +42,11 @@ def test_preferred_provider_renders_before_email_form(client, preferred_login_pr
 
     assert response.status_code == 200
     assert response.text.index('Login with Github') < response.text.index("id='login-form'")
+    assert 'login-option-primary' in response.text
+    assert 'login-options-secondary-group' in response.text
+    assert 'login-separator-label' in response.text
+    assert 'or use the following:' not in response.text
+    assert response.text.count('login-option-secondary') == 2
 
 
 @pytest.mark.django_db

--- a/app/tests/tickets/plugins/test_socialauth.py
+++ b/app/tests/tickets/plugins/test_socialauth.py
@@ -1,0 +1,109 @@
+from urllib.parse import parse_qs, urlparse
+
+import pytest
+from django.http import HttpResponseRedirect
+from django.urls import reverse
+
+from eventyay.base.models import User
+from eventyay.base.settings import GlobalSettingsObject
+from eventyay.plugins.socialauth.views import OAuthReturnView
+
+
+@pytest.fixture
+def preferred_login_providers():
+    GlobalSettingsObject().settings.set(
+        'login_providers',
+        {
+            'mediawiki': {
+                'state': False,
+                'client_id': '',
+                'secret': '',
+                'is_preferred': False,
+            },
+            'github': {
+                'state': True,
+                'client_id': 'github-client',
+                'secret': 'github-secret',
+                'is_preferred': True,
+            },
+            'google': {
+                'state': True,
+                'client_id': 'google-client',
+                'secret': 'google-secret',
+                'is_preferred': False,
+            },
+        },
+    )
+
+
+@pytest.mark.django_db
+def test_preferred_provider_renders_before_email_form(client, preferred_login_providers):
+    response = client.get(reverse('eventyay_common:auth.login'))
+
+    assert response.status_code == 200
+    assert response.text.index('Login with Github') < response.text.index("id='login-form'")
+
+
+@pytest.mark.django_db
+def test_failed_email_login_keeps_native_form_expanded(client, preferred_login_providers):
+    user = User.objects.create_user('dummy@dummy.dummy', 'dummy')
+
+    response = client.post(
+        reverse('eventyay_common:auth.login'),
+        data={
+            'email': user.email,
+            'password': 'wrong-password',
+        },
+    )
+
+    assert response.status_code == 200
+    assert "id='login-form' class='collapse in'" in response.text
+    assert 'This combination of credentials is not known to our system.' in response.text
+
+
+@pytest.mark.django_db
+def test_oauth_return_keeps_long_session_for_oauth2_handoff(client, monkeypatch):
+    oauth2_params = {
+        'response_type': 'code',
+        'client_id': 'oauth-client',
+        'redirect_uri': 'https://example.com/callback',
+        'scope': 'profile',
+        'state': 'expected-state',
+    }
+    session = client.session
+    session['oauth2_params'] = oauth2_params
+    session['socialauth_keep_logged_in'] = True
+    session.save()
+
+    captured = {}
+
+    def fake_process_login_and_set_cookie(request, user, keep_logged_in):
+        captured['keep_logged_in'] = keep_logged_in
+        response = HttpResponseRedirect('/after-login/')
+        response.set_cookie('sso_token', 'test-token')
+        return response
+
+    monkeypatch.setattr(
+        'eventyay.plugins.socialauth.views.process_login_and_set_cookie',
+        fake_process_login_and_set_cookie,
+    )
+    monkeypatch.setattr(
+        'eventyay.plugins.socialauth.views.reverse',
+        lambda name: '/oauth/authorize/' if name == 'eventyay_common:oauth2_provider.authorize' else reverse(name),
+    )
+    monkeypatch.setattr(
+        OAuthReturnView,
+        'get_or_create_user',
+        lambda self, request: object(),
+    )
+
+    response = client.get(reverse('plugins:socialauth:social.oauth.return'))
+
+    assert response.status_code == 302
+    assert captured['keep_logged_in'] is True
+    assert 'sso_token' in response.cookies
+    assert 'socialauth_keep_logged_in' not in client.session
+
+    parsed_redirect = urlparse(response['Location'])
+    assert parsed_redirect.path == '/oauth/authorize/'
+    assert parse_qs(parsed_redirect.query) == {key: [value] for key, value in oauth2_params.items()}


### PR DESCRIPTION
Closes #1525

**Summary**
Adds a way for admins to choose one social login provider as the preferred (default) option. That provider is shown first on the login page and gets “Keep me logged in” by default; other methods stay available under “or use the following”.

**Changes**
Admin (Social Auth settings)


https://github.com/user-attachments/assets/02e0f20e-cd0b-4140-9415-c2fdae6713c0

## Summary by Sourcery

Introduce configurable preferred social login provider that is highlighted on the login page and used to keep users logged in by default.

New Features:
- Allow admins to mark one enabled social login provider as the preferred default in Social Auth settings.
- Display the preferred social login provider prominently on the login page, with other providers grouped under an alternate options section.

Bug Fixes:
- Prevent logins via social providers that are disabled in the admin settings and show an error instead.

Enhancements:
- Ensure the preferred provider is ordered first when rendering login options and automatically clears preference when a provider is disabled.
- Propagate the preferred-provider choice to the login session so that the "keep me logged in" behavior is applied for that provider only.