### PR TITLE
fix: syntax typo in README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -101,7 +101,7 @@ In case you cannot take advantage of PostgreSQL *peer* mode, you need to create 
 
 7. **Activate virtual environment**
 
-After running ``uv sync```, activate a virtual environment
+After running ``uv sync``, activate a virtual environment
 
 .. code-block:: sh
 


### PR DESCRIPTION
Line 104 had an extra backtick for inline code literal. RST uses double backticks for inline literals.

## Summary by Sourcery

Documentation:
- Correct README inline code literal syntax to remove an extra backtick in the RST markup.