### PR TITLE
fix: block poll updates after close or archive state

### DIFF
--- a/app/eventyay/base/services/poll.py
+++ b/app/eventyay/base/services/poll.py
@@ -62,10 +62,12 @@ def get_polls(room, moderator=False, early_results=False, for_user=None, **kwarg
     ]
 
 
+# AFTER:
 @database_sync_to_async
 def update_poll(**kwargs):
-    # TODO: do we want to block updates after close/archive?
     poll = Poll.objects.get(pk=kwargs["id"], room=kwargs["room"])
+    if poll.state in (Poll.States.CLOSED, Poll.States.ARCHIVED):
+        raise ValueError("Cannot update a poll that is closed or archived.")
     options = kwargs.pop("options", None)
     for key, value in kwargs.items():
         setattr(poll, key, value)


### PR DESCRIPTION
## Problem
`update_poll()` had a TODO comment questioning whether updates 
should be blocked after a poll is closed or archived.

## Fix
Added a state check at the start of `update_poll()`. Raises 
ValueError if poll is in CLOSED or ARCHIVED state, preventing 
unintended modifications to finalized polls.

## Changes
- `app/eventyay/base/services/poll.py`: Added state guard 
  in update_poll()

## Summary by Sourcery

Bug Fixes:
- Prevent updates to polls that are in CLOSED or ARCHIVED state by raising an error instead of allowing modifications.