### PR TITLE
fix: add timeout to all outbound HTTP requests to prevent worker hangs

### DIFF
--- a/app/eventyay/agenda/views/talk.py
+++ b/app/eventyay/agenda/views/talk.py
@@ -653,7 +653,7 @@ def check_user_owning_ticket(user: User, event: Event) -> TicketCheckResult:
     api_url = urljoin(base_url, f'api/v1/{organizer_slug}/{event_slug}/ticket-check')
     logger.info('To call API %s', api_url)
     # In development, we disable the SSL verification.
-    response = requests.post(api_url, json=check_payload, verify=(not settings.DEBUG))
+    response = requests.post(api_url, json=check_payload, verify=(not settings.DEBUG), timeout=15)
 
     if response.status_code != HTTPStatus.OK:
         logger.debug('Response from eventyay-ticket: %s', response.text)

--- a/app/eventyay/api/webhooks.py
+++ b/app/eventyay/api/webhooks.py
@@ -313,7 +313,7 @@ def send_webhook(self, logentry_id: int, action_type: str, webhook_id: int):
 
         try:
             try:
-                resp = requests.post(webhook.target_url, json=payload, allow_redirects=False)
+                resp = requests.post(webhook.target_url, json=payload, allow_redirects=False, timeout=30)
                 WebHookCall.objects.create(
                     webhook=webhook,
                     action_type=logentry.action_type,

--- a/app/eventyay/base/services/mail.py
+++ b/app/eventyay/base/services/mail.py
@@ -666,7 +666,7 @@ def convert_image_to_cid(image_src, cid_id, verify_ssl=True):
             path = urlparse(image_src).path
             guess_subtype = os.path.splitext(path)[1][1:]
 
-            response = requests.get(image_src, verify=verify_ssl)
+            response = requests.get(image_src, verify=verify_ssl, timeout=15)
             mime_image = MIMEImage(response.content, _subtype=guess_subtype)
 
         mime_image.add_header('Content-ID', '<%s>' % cid_id)

--- a/app/eventyay/base/services/update_check.py
+++ b/app/eventyay/base/services/update_check.py
@@ -56,7 +56,7 @@ def update_check():
         'plugins': [{'name': p.module, 'version': p.version} for p in get_all_plugins()],
     }
     try:
-        r = requests.post('https://eventyay.org/.update_check/', json=check_payload)
+        r = requests.post('https://eventyay.org/.update_check/', json=check_payload, timeout=15)
         gs.settings.set('update_check_last', now())
         if r.status_code != 200:
             gs.settings.set('update_check_result', {'error': 'http_error'})

--- a/app/eventyay/control/views/geo.py
+++ b/app/eventyay/control/views/geo.py
@@ -38,7 +38,8 @@ class GeoCodeView(LoginRequiredMixin, View):
         gs = GlobalSettingsObject()
 
         r = requests.get(
-            'https://api.opencagedata.com/geocode/v1/json?q={}&key={}'.format(quote(q), gs.settings.opencagedata_apikey)
+            'https://api.opencagedata.com/geocode/v1/json?q={}&key={}'.format(quote(q), gs.settings.opencagedata_apikey),
+            timeout=15,
         )
         r.raise_for_status()
         d = r.json()
@@ -58,7 +59,8 @@ class GeoCodeView(LoginRequiredMixin, View):
         r = requests.get(
             'https://www.mapquestapi.com/geocoding/v1/address?location={}&key={}'.format(
                 quote(q), gs.settings.mapquest_apikey
-            )
+            ),
+            timeout=15,
         )
         r.raise_for_status()
         d = r.json()

--- a/app/eventyay/core/management/commands/bbb_update_cost.py
+++ b/app/eventyay/core/management/commands/bbb_update_cost.py
@@ -17,7 +17,7 @@ class Command(BaseCommand):
     def _update_cost(self, server: BBBServer):
         try:
             meetings_url = get_url("getMeetings", {}, server.url, server.secret)
-            r = requests.get(meetings_url)
+            r = requests.get(meetings_url, timeout=15)
             r.raise_for_status()
             cost = 0
 

--- a/app/eventyay/eventyay_common/tasks.py
+++ b/app/eventyay/eventyay_common/tasks.py
@@ -61,6 +61,7 @@ def send_team_webhook(self, user_id, team):
             webhook_url,
             json=payload,
             headers=headers,
+            timeout=15,
         )
         response.raise_for_status()  # Raise exception for bad status codes
     except requests.RequestException as e:
@@ -101,6 +102,7 @@ def create_world(self, is_video_creation: bool, event_data: dict) -> Optional[di
                 urljoin(settings.VIDEO_SERVER_HOSTNAME, 'api/v1/create-world/'),
                 json=payload,
                 headers=headers,
+                timeout=30,
             )
             response.raise_for_status()
             return response.json()

--- a/app/eventyay/features/analytics/graphs/utils.py
+++ b/app/eventyay/features/analytics/graphs/utils.py
@@ -101,7 +101,7 @@ def get_schedule(event: Event, fail_silently=True):
         return {}
 
     try:
-        r = requests.get(url)
+        r = requests.get(url, timeout=15)
         r.raise_for_status()
         return r.json()
     except requests.RequestException:

--- a/app/eventyay/features/importers/conftool.py
+++ b/app/eventyay/features/importers/conftool.py
@@ -36,7 +36,8 @@ def fetch_schedule_from_conftool(url, password):
         f"&form_export_sessions_options[]=presentations_abstracts&form_export_sessions_options[]=presentations_subpapers"
         f"&form_export_sessions_options[]=presentations_downloads"
         f"&export_form_export_sessions_options[]=presentations_authors_extended_firstname"
-        f"&form_export_sessions_options[]=all"
+        f"&form_export_sessions_options[]=all",
+        timeout=30,
     )
     r.encoding = "utf-8"
     root = etree.fromstring(r.text.encode())
@@ -196,7 +197,8 @@ def mirror_conftool_file(event, url, password, nonce, preview=False):
     try:
         passhash = hashlib.sha256((str(nonce) + password).encode()).hexdigest()
         r = requests.get(
-            f"{url.replace('index.php', 'rest.php')}&nonce={nonce}&passhash={passhash}"
+            f"{url.replace('index.php', 'rest.php')}&nonce={nonce}&passhash={passhash}",
+            timeout=30,
         )
         r.raise_for_status()
 
@@ -294,8 +296,9 @@ def create_posters_from_conftool(
         f"&form_export_papers_options[]=newlines"
         f"&form_export_format=xml"
         f"&form_status={status}"
-        f"&cmd_create_export=true"
+        f"&cmd_create_export=true",
         # TODO: filter by form_track ?
+        timeout=30,
     )
     r.raise_for_status()
     r.encoding = "utf-8"

--- a/app/eventyay/features/integrations/platforms/storage/nanocdn.py
+++ b/app/eventyay/features/integrations/platforms/storage/nanocdn.py
@@ -86,7 +86,7 @@ class NanoCDNStorage(Storage):
         return NanoCDNFile(name, self, mode)
 
     def _read(self, name):
-        resp = requests.get(urllib.parse.urljoin(self.base_url, name), stream=True)
+        resp = requests.get(urllib.parse.urljoin(self.base_url, name), stream=True, timeout=30)
         if resp.status_code == 404:
             raise FileNotFoundError()
         resp.raise_for_status()
@@ -120,6 +120,7 @@ class NanoCDNStorage(Storage):
             urllib.parse.urljoin(self.base_url, os.path.join("upload", name)),
             data=content,
             allow_redirects=False,
+            timeout=30,
         )
         if resp.status_code != 409:
             resp.raise_for_status()
@@ -141,7 +142,7 @@ class NanoCDNStorage(Storage):
     def delete(self, name):
         if isinstance(name, NanoCDNFile):
             name = name.name
-        resp = requests.delete(urllib.parse.urljoin(self.base_url, name))
+        resp = requests.delete(urllib.parse.urljoin(self.base_url, name), timeout=15)
         if resp.status_code == 404:
             return resp  # That is fine
         resp.raise_for_status()

--- a/app/eventyay/features/social/utils.py
+++ b/app/eventyay/features/social/utils.py
@@ -24,7 +24,7 @@ def update_user_profile_from_social(
         if "/" in ext:
             ext = ".png"  # just a default guess
         try:
-            r = requests.get(avatar_url)
+            r = requests.get(avatar_url, timeout=15)
             r.raise_for_status()
             c = ContentFile(r.content)
             sf = StoredFile.objects.create(

--- a/app/eventyay/features/social/views/linkedin.py
+++ b/app/eventyay/features/social/views/linkedin.py
@@ -59,6 +59,7 @@ def return_view(request):
                 "client_id": settings.LINKEDIN_CLIENT_ID,
                 "client_secret": settings.LINKEDIN_CLIENT_SECRET,
             },
+            timeout=15,
         )
         r.raise_for_status()
         d = r.json()
@@ -85,6 +86,7 @@ def return_view(request):
             headers={
                 "Authorization": f"Bearer {access_token}",
             },
+            timeout=15,
         )
         r.raise_for_status()
         d = r.json()

--- a/app/eventyay/features/social/views/twitter.py
+++ b/app/eventyay/features/social/views/twitter.py
@@ -60,6 +60,7 @@ def return_view(request):
                 "code_verifier": request.session.get("social_twitter_challenge"),
             },
             auth=(settings.TWITTER_CLIENT_ID, settings.TWITTER_CLIENT_SECRET),
+            timeout=15,
         )
         r.raise_for_status()
         d = r.json()
@@ -85,6 +86,7 @@ def return_view(request):
             headers={
                 "Authorization": f"Bearer {access_token}",
             },
+            timeout=15,
         )
         r.raise_for_status()
         d = r.json()

--- a/app/eventyay/orga/tasks.py
+++ b/app/eventyay/orga/tasks.py
@@ -47,7 +47,7 @@ def trigger_public_schedule(self, is_show_schedule, event_slug, organizer_slug, 
             settings.EVENTYAY_TICKET_BASE_PATH,
             f'api/v1/{organizer_slug}/{event_slug}/schedule-public/',
         )
-        response = requests.post(ticket_uri, json=payload, headers=headers)
+        response = requests.post(ticket_uri, json=payload, headers=headers, timeout=15)
         response.raise_for_status()  # Raise exception for bad status codes
     except requests.RequestException as e:
         logger.error(


### PR DESCRIPTION
Fixes #2747

Several requests.get() and requests.post() calls were missing the timeout parameter, which means they could block indefinitely if a remote server accepts the connection but never responds.

This is especially critical for webhook delivery where the target URL is user-provided, a malicious or slow endpoint could tie up Celery workers permanently.

Added appropriate timeouts (15-30s depending on use case) across 14 files including webhooks, OAuth flows, geocoding, update checks, mail services, and external storage.

## Changes

  Added explicit timeouts (15–30s depending on use case) to all outbound HTTP calls across 14 files:

  - `api/webhooks.py` — webhook delivery (user-provided URL)
  - `base/services/update_check.py` — periodic update check
  - `base/services/mail.py` — mail image fetching
  - `agenda/views/talk.py` — ticket check API call
  - `control/views/geo.py` — geocoding (OpenCage, MapQuest)
  - `core/management/commands/bbb_update_cost.py` — BBB server polling
  - `eventyay_common/tasks.py` — internal webhook + video world creation
  - `orga/tasks.py` — schedule sync to tickets component
  - `features/analytics/graphs/utils.py` — schedule widget fetch
  - `features/social/views/linkedin.py` — LinkedIn OAuth
  - `features/social/views/twitter.py` — Twitter/X OAuth
  - `features/social/utils.py` — avatar download
  - `features/importers/conftool.py` — ConfTool schedule/poster import
  - `features/integrations/platforms/storage/nanocdn.py` — CDN read/write/delete

  ## Timeout values

  - **30s** for webhooks (user-provided URLs, needs tolerance for slow servers), file uploads, and large data imports
  - **15s** for internal API calls, OAuth flows, and image downloads

## Summary by Sourcery

Add explicit timeouts to all affected outbound HTTP requests to prevent indefinite blocking when remote services are slow or unresponsive.

Bug Fixes:
- Prevent potential worker hangs and indefinite blocking by adding timeouts to webhook deliveries, schedule syncs, update checks, and other HTTP-dependent operations.

Enhancements:
- Apply consistent 15s/30s timeout policy across external integrations including geocoding services, social OAuth flows, avatar and image fetching, analytics schedule retrieval, BBB server polling, ConfTool imports, and NanoCDN storage operations.