### PR TITLE
Fix grammar, typos, and wording issues in README.rst

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -49,7 +49,7 @@ Depending on your distribution.
 3. **Create a PostgreSQL database**
 
 The default database name required by the project is ``eventyay-db``. If you are using Linux, the simplest way
-to work with database is to use its "peer" mode (no need to remember password).
+to work with the database is to use its "peer" mode (no need to remember a password).
 
 Create a Postgres user with the same name as your Linux user:
 


### PR DESCRIPTION
This PR improves documentation clarity and fixes several minor grammar and wording issues in README.rst.

Changes include:

* Fixed typo: "own" → "owned"
* Corrected spelling: "loose" → "lose"
* Updated "Docker based development" to "Docker-based development"
* Improved wording for Linux package installation instructions
* Improved sentence clarity in the database configuration section
* Fixed grammar in configuration section (`override ones` → `override the ones`)

These changes improve readability and maintain consistency in the project documentation without modifying any functionality.

Please let me know if any further adjustments are required.

## Summary by Sourcery

Improve clarity, grammar, and wording in the main README documentation without changing functionality.

Documentation:
- Fix typos, grammar issues, and inconsistent hyphenation in README.rst.
- Improve wording and clarity in sections covering Docker-based development, Linux package installation, and database/configuration guidance.