### PR TITLE
Add avatar size validation to prevent 413 nginx error

### DIFF
--- a/app/eventyay/person/forms/profile.py
+++ b/app/eventyay/person/forms/profile.py
@@ -149,6 +149,12 @@ class SpeakerProfileForm(
         if qs.filter(email__iexact=email):
             raise ValidationError(get_email_address_error())
         return email
+    
+    def clean_avatar(self):
+        avatar = self.cleaned_data.get('avatar')
+        if avatar and avatar.size > 10 * 1024 * 1024:  # 10MB
+            raise ValidationError(_("File too large. Maximum allowed size is 10MB."))
+        return avatar
 
     def clean(self):
         data = super().clean()


### PR DESCRIPTION
Fixes an issue where uploading a large speaker profile picture
causes a 413 Request Entity Too Large error from nginx.

This PR adds backend validation in SpeakerProfileForm to check
the avatar file size and return a user-friendly validation error
if the file exceeds the 10MB limit.

## Summary by Sourcery

Bug Fixes:
- Prevent large avatar uploads for speaker profiles from causing a 413 Request Entity Too Large error by enforcing a 10MB file size limit in form validation.