### PR TITLE
fix-non-sticky-footer

### DIFF
--- a/app/eventyay/static/pretixcontrol/scss/main.scss
+++ b/app/eventyay/static/pretixcontrol/scss/main.scss
@@ -1075,6 +1075,16 @@ h1 .label {
     contain: content;
 }
 
+#page-wrapper > .container-fluid {
+  min-height: calc(100vh - var(--navbar-height, 50px));
+  display: flex;
+  flex-direction: column;
+}
+
+#page-wrapper > .container-fluid > footer {
+  margin-top: auto;
+}
+    
 @media (max-width: $screen-sm-max) {
     nav.navbar {
         position: static;


### PR DESCRIPTION
Fixes #2825

Made the footer sticky by giving parent container full height with flex-col layout.

<img width="1437" height="780" alt="Screenshot 2026-03-17 at 7 03 26 PM" src="https://github.com/user-attachments/assets/fb4eda3d-85b4-48fa-a709-2d7d32a59281" />
<img width="679" height="714" alt="Screenshot 2026-03-17 at 7 01 10 PM" src="https://github.com/user-attachments/assets/57f3db9f-dbb8-4ec1-bca1-f68ca871e9ca" />

## Summary by Sourcery

Enhancements:
- Adjust the main container to use a full-height flex column layout with the footer pushed to the bottom via auto top margin.