### PR TITLE
Fix Admin panel sidebar hover and li item display (#2768)

### DIFF
--- a/app/eventyay/static/orga/js/sidebar.js
+++ b/app/eventyay/static/orga/js/sidebar.js
@@ -1,35 +1,51 @@
 onReady(() => {
-    const element = document.querySelector("[data-toggle=sidebar]")
-    const sidebar = document.querySelector("aside.sidebar")
-    const cls = "sidebar-uncollapsed"
-    const isMobile = () => window.matchMedia("(max-width: 767px)").matches
+const element = document.querySelector("[data-toggle=sidebar]")
+const sidebar = document.querySelector("aside.sidebar")
+const cls = "sidebar-uncollapsed"
+const isMobile = () => window.matchMedia("(max-width: 767px)").matches
 
-    if (sidebar && localStorage["sidebarVisible"]) {
-        sidebar.classList.add(cls)
-    }
-    if (sidebar && element) {
-        element.addEventListener("click", () => {
-            sidebar.classList.toggle(cls)
-            localStorage["sidebarVisible"] = sidebar.classList.contains(cls)
-                ? "1"
-                : ""
-        })
-    }
 
-    if (sidebar) {
-        document.addEventListener("click", (e) => {
-            if (!isMobile() || !sidebar.classList.contains(cls)) return
-            if (sidebar.contains(e.target) || element?.contains(e.target)) return
+if (sidebar && localStorage["sidebarVisible"]) {
+    sidebar.classList.add(cls)
+}
+
+if (sidebar && element) {
+    element.addEventListener("click", (e) => {
+        e.preventDefault()
+
+        if (sidebar.classList.contains(cls)) {
             sidebar.classList.remove(cls)
             localStorage["sidebarVisible"] = ""
-        })
-        sidebar.addEventListener("click", (e) => {
-            if (!isMobile()) return
-            const link = e.target.closest("a[href]")
-            if (link && !link.getAttribute("href").startsWith("#")) {
-                sidebar.classList.remove(cls)
-                localStorage["sidebarVisible"] = ""
-            }
-        })
-    }
+        } else {
+            sidebar.classList.add(cls)
+            localStorage["sidebarVisible"] = "1"
+        }
+    })
+}
+
+if (sidebar) {
+    document.addEventListener("click", (e) => {
+        if (!isMobile() || !sidebar.classList.contains(cls)) return
+        if (sidebar.contains(e.target) || element?.contains(e.target)) return
+        sidebar.classList.remove(cls)
+        localStorage["sidebarVisible"] = ""
+    })
+
+    sidebar.addEventListener("click", (e) => {
+        if (!isMobile()) return
+        const link = e.target.closest("a[href]")
+        if (link && !link.getAttribute("href").startsWith("#")) {
+            sidebar.classList.remove(cls)
+            localStorage["sidebarVisible"] = ""
+        }
+    })
+
+    sidebar.addEventListener("mouseenter", () => {
+        if (!sidebar.classList.contains(cls)) {
+            return
+        }
+    })
+}
+
+
 })

--- a/app/eventyay/static/pretixcontrol/scss/_sidebar.scss
+++ b/app/eventyay/static/pretixcontrol/scss/_sidebar.scss
@@ -20,6 +20,12 @@
     outline: none;
   }
 
+.sidebar.collapsed:hover {
+    width: 70px;
+}
+.sidebar-collapsed .sidebar-text {
+    display: none;
+}
   .fa-bars {
     color: #fff;
   }


### PR DESCRIPTION
Fixes #2768

Changes made:
- Hide sidebar item labels when the sidebar is collapsed so only icons are visible.
- Prevent sidebar from expanding on hover when it is in collapsed state.
- Fix jerky expand/collapse behavior of the sidebar.

Tested the changes locally on the admin dashboard.

## Summary by Sourcery

Improve the admin sidebar’s collapsed behavior to provide a more consistent and predictable experience on desktop and mobile.

Bug Fixes:
- Hide sidebar item labels when the sidebar is collapsed so that only icons remain visible.
- Prevent the collapsed sidebar from unintentionally expanding or behaving jerkily on hover or mobile interactions.

Enhancements:
- Simplify and clarify sidebar toggle logic while preserving the stored visibility state across sessions.