### PR TITLE
fix: add select_for_update to refund paths to prevent race condition

### DIFF
--- a/app/eventyay/api/views/order.py
+++ b/app/eventyay/api/views/order.py
@@ -1248,88 +1248,91 @@ class PaymentViewSet(CreateModelMixin, viewsets.ReadOnlyModelViewSet):
 
     @action(detail=True, methods=['POST'])
     def refund(self, request, **kwargs):
-        payment = self.get_object()
-        amount = serializers.DecimalField(max_digits=10, decimal_places=2).to_internal_value(
-            request.data.get('amount', str(payment.amount))
-        )
-        if 'mark_refunded' in request.data:
-            mark_refunded = request.data.get('mark_refunded', False)
-        else:
-            mark_refunded = request.data.get('mark_canceled', False)
+        with transaction.atomic():
+            payment = OrderPayment.objects.select_for_update().get(pk=self.get_object().pk)
+            amount = serializers.DecimalField(max_digits=10, decimal_places=2).to_internal_value(
+                request.data.get('amount', str(payment.amount))
+            )
+            if 'mark_refunded' in request.data:
+                mark_refunded = request.data.get('mark_refunded', False)
+            else:
+                mark_refunded = request.data.get('mark_canceled', False)
 
-        if payment.state != OrderPayment.PAYMENT_STATE_CONFIRMED:
-            return Response(
-                {'detail': 'Invalid state of payment.'},
-                status=status.HTTP_400_BAD_REQUEST,
-            )
+            if payment.state != OrderPayment.PAYMENT_STATE_CONFIRMED:
+                return Response(
+                    {'detail': 'Invalid state of payment.'},
+                    status=status.HTTP_400_BAD_REQUEST,
+                )
 
-        full_refund_possible = payment.payment_provider.payment_refund_supported(payment)
-        partial_refund_possible = payment.payment_provider.payment_partial_refund_supported(payment)
-        available_amount = payment.amount - payment.refunded_amount
+            full_refund_possible = payment.payment_provider.payment_refund_supported(payment)
+            partial_refund_possible = payment.payment_provider.payment_partial_refund_supported(payment)
+            available_amount = payment.amount - payment.refunded_amount
 
-        if amount <= 0:
-            return Response(
-                {'amount': ['Invalid refund amount.']},
-                status=status.HTTP_400_BAD_REQUEST,
+            if amount <= 0:
+                return Response(
+                    {'amount': ['Invalid refund amount.']},
+                    status=status.HTTP_400_BAD_REQUEST,
+                )
+            if amount > available_amount:
+                return Response(
+                    {'amount': ['Invalid refund amount, only {} are available to refund.'.format(available_amount)]},
+                    status=status.HTTP_400_BAD_REQUEST,
+                )
+            if amount != payment.amount and not partial_refund_possible:
+                return Response(
+                    {'amount': ['Partial refund not available for this payment method.']},
+                    status=status.HTTP_400_BAD_REQUEST,
+                )
+            if amount == payment.amount and not full_refund_possible:
+                return Response(
+                    {'amount': ['Full refund not available for this payment method.']},
+                    status=status.HTTP_400_BAD_REQUEST,
+                )
+            r = payment.order.refunds.create(
+                payment=payment,
+                source=OrderRefund.REFUND_SOURCE_ADMIN,
+                state=OrderRefund.REFUND_STATE_CREATED,
+                amount=amount,
+                provider=payment.provider,
             )
-        if amount > available_amount:
-            return Response(
-                {'amount': ['Invalid refund amount, only {} are available to refund.'.format(available_amount)]},
-                status=status.HTTP_400_BAD_REQUEST,
-            )
-        if amount != payment.amount and not partial_refund_possible:
-            return Response(
-                {'amount': ['Partial refund not available for this payment method.']},
-                status=status.HTTP_400_BAD_REQUEST,
-            )
-        if amount == payment.amount and not full_refund_possible:
-            return Response(
-                {'amount': ['Full refund not available for this payment method.']},
-                status=status.HTTP_400_BAD_REQUEST,
-            )
-        r = payment.order.refunds.create(
-            payment=payment,
-            source=OrderRefund.REFUND_SOURCE_ADMIN,
-            state=OrderRefund.REFUND_STATE_CREATED,
-            amount=amount,
-            provider=payment.provider,
-        )
 
         try:
             r.payment_provider.execute_refund(r)
         except PaymentException as e:
-            r.state = OrderRefund.REFUND_STATE_FAILED
-            r.save()
+            with transaction.atomic():
+                r.state = OrderRefund.REFUND_STATE_FAILED
+                r.save()
             return Response(
                 {'detail': 'External error: {}'.format(str(e))},
                 status=status.HTTP_400_BAD_REQUEST,
             )
         else:
-            payment.order.log_action(
-                'eventyay.event.order.refund.created',
-                {
-                    'local_id': r.local_id,
-                    'provider': r.provider,
-                },
-                user=self.request.user if self.request.user.is_authenticated else None,
-                auth=self.request.auth,
-            )
-            if payment.order.pending_sum > 0:
-                if mark_refunded:
-                    mark_order_refunded(
-                        payment.order,
-                        user=self.request.user if self.request.user.is_authenticated else None,
-                        auth=self.request.auth,
-                    )
-                else:
-                    payment.order.status = Order.STATUS_PENDING
-                    payment.order.set_expires(
-                        now(),
-                        payment.order.event.subevents.filter(
-                            id__in=payment.order.positions.values_list('subevent_id', flat=True)
-                        ),
-                    )
-                    payment.order.save(update_fields=['status', 'expires'])
+            with transaction.atomic():
+                payment.order.log_action(
+                    'eventyay.event.order.refund.created',
+                    {
+                        'local_id': r.local_id,
+                        'provider': r.provider,
+                    },
+                    user=self.request.user if self.request.user.is_authenticated else None,
+                    auth=self.request.auth,
+                )
+                if payment.order.pending_sum > 0:
+                    if mark_refunded:
+                        mark_order_refunded(
+                            payment.order,
+                            user=self.request.user if self.request.user.is_authenticated else None,
+                            auth=self.request.auth,
+                        )
+                    else:
+                        payment.order.status = Order.STATUS_PENDING
+                        payment.order.set_expires(
+                            now(),
+                            payment.order.event.subevents.filter(
+                                id__in=payment.order.positions.values_list('subevent_id', flat=True),
+                            ),
+                        )
+                        payment.order.save(update_fields=['status', 'expires'])
             return Response(OrderRefundSerializer(r).data, status=status.HTTP_200_OK)
 
     @action(detail=True, methods=['POST'])

--- a/app/eventyay/base/payment.py
+++ b/app/eventyay/base/payment.py
@@ -1422,7 +1422,9 @@ class GiftCardPayment(BasePaymentProvider):
     def execute_refund(self, refund: OrderRefund):
         from .models import GiftCard
 
-        gc = GiftCard.objects.get(pk=refund.info_data.get('gift_card') or refund.payment.info_data.get('gift_card'))
+        gc = GiftCard.objects.select_for_update().get(
+            pk=refund.info_data.get('gift_card') or refund.payment.info_data.get('gift_card')
+        )
         trans = gc.transactions.create(value=refund.amount, order=refund.order, refund=refund)
         refund.info_data = {
             'gift_card': gc.pk,

--- a/app/tests/tickets/api/test_refund_concurrency.py
+++ b/app/tests/tickets/api/test_refund_concurrency.py
@@ -1,0 +1,86 @@
+from decimal import Decimal
+
+import pytest
+
+# We import from eventyay to match the API View's locking logic
+from eventyay.base.models import OrderPayment, OrderRefund
+
+
+@pytest.mark.django_db
+def test_refund_available_amount_includes_created_refunds(token_client, organizer, event, order, scopes_disabled):
+    """
+    Verifies that the available_amount calculation correctly includes refunds that are
+    currently in the 'created' state. This ensures that even if a refund process is
+    ongoing (and the lock has been released), a subsequent request will see the
+    reserved amount and refuse to over-refund.
+    """
+    with scopes_disabled():
+        # Using the order fixture's payments manager ensures compatibility
+        payment = order.payments.create(
+            state=OrderPayment.PAYMENT_STATE_CONFIRMED,
+            amount=Decimal('100.00'),
+            provider='banktransfer',
+        )
+
+        # Simulate an ongoing refund that reached 'created' state but hasn't finished
+        order.refunds.create(
+            payment=payment,
+            source=OrderRefund.REFUND_SOURCE_ADMIN,
+            state=OrderRefund.REFUND_STATE_CREATED,
+            amount=Decimal('60.00'),
+            provider='banktransfer',
+        )
+
+    # Now try to refund another 60.00 via API.
+    # It should fail because only 100 - 60 = 40.00 are available.
+    resp = token_client.post(
+        '/api/v1/organizers/{}/events/{}/orders/{}/payments/{}/refund/'.format(
+            organizer.slug,
+            event.slug,
+            order.code,
+            payment.pk,
+        ),
+        format='json',
+        data={'amount': '60.00'},
+    )
+
+    assert resp.status_code == 400
+    assert 'only 40.00 are available to refund' in resp.data['amount'][0]
+
+
+@pytest.mark.django_db
+def test_refund_serialization_locking(token_client, organizer, event, order, monkeypatch, scopes_disabled):
+    """
+    Verifies that PaymentViewSet.refund uses select_for_update() to lock the payment row.
+    Specifically patches the eventyay namespace used by the API view logic.
+    """
+    select_for_update_called = False
+    original_select_for_update = OrderPayment.objects.select_for_update
+
+    def mock_select_for_update(*args, **kwargs):
+        nonlocal select_for_update_called
+        select_for_update_called = True
+        return original_select_for_update(*args, **kwargs)
+
+    # We patch the eventyay-namespaced model because that's what the View uses
+    monkeypatch.setattr(OrderPayment.objects, 'select_for_update', mock_select_for_update)
+
+    with scopes_disabled():
+        payment = order.payments.create(
+            state=OrderPayment.PAYMENT_STATE_CONFIRMED,
+            amount=Decimal('100.00'),
+            provider='banktransfer',
+        )
+
+    token_client.post(
+        '/api/v1/organizers/{}/events/{}/orders/{}/payments/{}/refund/'.format(
+            organizer.slug,
+            event.slug,
+            order.code,
+            payment.pk,
+        ),
+        format='json',
+        data={'amount': '100.00'},
+    )
+
+    assert select_for_update_called


### PR DESCRIPTION

Fixes #2824

Adds `select_for_update()` row-level locking to the GiftCard refund path to prevent a race condition that could allow duplicate refund transactions.

### Problem

`GiftCardPayment.execute_payment` correctly uses `select_for_update()` when deducting funds (line 1401), but [execute_refund](file://wsl.localhost/Ubuntu/home/lightning/eventyay/app/eventyay/base/payment.py#1134-1151) does not lock the GiftCard row when depositing refunds. Additionally, `PaymentViewSet.refund` reads `payment.refunded_amount` without locking the [OrderPayment](file://wsl.localhost/Ubuntu/home/lightning/eventyay/app/eventyay/base/models/orders.py#1474-1873) row, allowing concurrent requests to bypass the `available_amount` validation.

**Note:** This endpoint requires `can_change_orders` permission (organizer/team-only), so the race condition is not exploitable by arbitrary end users.

### Changes

**[app/eventyay/base/payment.py](file://wsl.localhost/Ubuntu/home/lightning/eventyay/app/eventyay/base/payment.py)**
- Added `select_for_update()` to `GiftCardPayment.execute_refund` when retrieving the [GiftCard](file://wsl.localhost/Ubuntu/home/lightning/eventyay/app/eventyay/base/payment.py#1171-1435) object, matching the existing pattern in [execute_payment](file://wsl.localhost/Ubuntu/home/lightning/eventyay/app/eventyay/base/payment.py#923-928)

**[app/eventyay/api/views/order.py](file://wsl.localhost/Ubuntu/home/lightning/eventyay/app/eventyay/api/views/order.py)**
- Wrapped `PaymentViewSet.refund` body in `transaction.atomic()` 
- Re-fetch [OrderPayment](file://wsl.localhost/Ubuntu/home/lightning/eventyay/app/eventyay/base/models/orders.py#1474-1873) with `select_for_update()` before reading [refunded_amount](file://wsl.localhost/Ubuntu/home/lightning/eventyay/app/eventyay/base/models/orders.py#1809-1822) and processing the refund

### How It Works

1. **Before:** Concurrent refund requests all read the same [refunded_amount](file://wsl.localhost/Ubuntu/home/lightning/eventyay/app/eventyay/base/models/orders.py#1809-1822) → all pass validation → duplicate refund transactions created
2. **After:** The first request acquires a row lock → subsequent requests block until it completes → they then read the updated [refunded_amount](file://wsl.localhost/Ubuntu/home/lightning/eventyay/app/eventyay/base/models/orders.py#1809-1822) and correctly reject the duplicate

### Testing

- Verified the fix follows the same locking pattern used in [execute_payment](file://wsl.localhost/Ubuntu/home/lightning/eventyay/app/eventyay/base/payment.py#923-928) (line 1400-1401)
- All other callers of [execute_refund](file://wsl.localhost/Ubuntu/home/lightning/eventyay/app/eventyay/base/payment.py#1134-1151) ([services/orders.py](file://wsl.localhost/Ubuntu/home/lightning/eventyay/app/eventyay/base/services/orders.py), [control/views/orders.py](file://wsl.localhost/Ubuntu/home/lightning/eventyay/app/eventyay/control/views/orders.py)) are protected by either existing `transaction.atomic()` blocks or sequential execution context
- No new imports required [transaction](file://wsl.localhost/Ubuntu/home/lightning/eventyay/app/eventyay/helpers/database.py#13-32), [OrderPayment](file://wsl.localhost/Ubuntu/home/lightning/eventyay/app/eventyay/base/models/orders.py#1474-1873), and `select_for_update()` are already used in both files

---
