### PR TITLE
Fix entrypoint script CRLF execution issue on Windows

### DIFF
--- a/app/Dockerfile
+++ b/app/Dockerfile
@@ -72,13 +72,12 @@ RUN apt-get update && apt-get install --no-install-recommends -y \
 # esbuild needed by Django-Compressor
 RUN npm install -g esbuild
 
-# copy entrypoint.sh
-COPY ./entrypoint.sh .
+# Copy application code from builder (includes .venv and entrypoint.sh)
+COPY --from=builder /usr/src/app /usr/src/app
+
+# Normalize line endings and set executable bit AFTER the bulk copy
 RUN sed -i 's/\r$//g' /usr/src/app/entrypoint.sh
 RUN chmod +x /usr/src/app/entrypoint.sh
-
-# Copy application code from builder (includes .venv)
-COPY --from=builder /usr/src/app /usr/src/app
 
 # Expose virtual env
 ENV VIRTUAL_ENV=/usr/src/app/.venv

--- a/app/Dockerfile.prod
+++ b/app/Dockerfile.prod
@@ -59,13 +59,12 @@ RUN wget -qO- https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | gpg --
     echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_22.x nodistro main" > /etc/apt/sources.list.d/nodesource.list
 RUN apt-get update && apt-get install -y --no-install-recommends netcat-traditional nodejs gettext less
 
-# copy entrypoint.prod.sh
-COPY ./entrypoint.prod.sh .
-RUN sed -i 's/\r$//g'  $APP_HOME/entrypoint.prod.sh
-RUN chmod +x  $APP_HOME/entrypoint.prod.sh
-
 # copy project
 COPY . $APP_HOME
+
+# fix line endings for entrypoint.prod.sh
+RUN sed -i 's/\r$//g'  $APP_HOME/entrypoint.prod.sh
+RUN chmod +x  $APP_HOME/entrypoint.prod.sh
 
 # schedule editor
 COPY eventyay/webapp/schedule-editor eventyay/webapp/schedule-editor


### PR DESCRIPTION
Fixes #2711

**What changed:**
Fixed the `exec /usr/src/app/entrypoint.sh: no such file or directory` error that happens for Windows users.

I changed the order of commands in [Dockerfile](cci:7://file:///a:/gsoc/app/Dockerfile:0:0-0:0) and [Dockerfile.prod](cci:7://file:///a:/gsoc/app/Dockerfile.prod:0:0-0:0) so that the line endings for `entrypoint.sh` are correctly converted to Linux format (LF) *after* the files are copied.

## Summary by Sourcery

Bug Fixes:
- Fix a Windows-originated CRLF line-ending issue that caused the container entrypoint.sh script to be undetectable or non-executable at runtime.