### PR TITLE
fix(badges): update preview and options to bind custom questions

### DIFF
--- a/app/eventyay/base/pdf.py
+++ b/app/eventyay/base/pdf.py
@@ -752,7 +752,7 @@ class Renderer:
         ir = ThumbnailingImageReader(img)
         try:
             width, height = ir.resize(None, float(o['size']) * mm, 300)
-        except:
+        except Exception:
             logger.exception('Can not resize image')
             pass
         canvas.drawImage(
@@ -811,7 +811,7 @@ class Renderer:
         elif content in self.variables:
             try:
                 return self.variables[content]['evaluate'](op, order, ev)
-            except:
+            except Exception:
                 logger.exception('Failed to process variable.')
                 return '(error)'
         return ''
@@ -823,7 +823,7 @@ class Renderer:
         else:
             try:
                 image_file = self.images[o['content']]['evaluate'](op, order, ev)
-            except:
+            except Exception:
                 logger.exception('Failed to process variable.')
                 image_file = None
 
@@ -831,7 +831,7 @@ class Renderer:
             ir = ThumbnailingImageReader(image_file)
             try:
                 ir.resize(float(o['width']) * mm, float(o['height']) * mm, 300)
-            except:
+            except Exception:
                 logger.exception('Can not resize image')
                 pass
             canvas.drawImage(
@@ -887,7 +887,7 @@ class Renderer:
         reshaper = ArabicReshaper(configuration=configuration)
         try:
             text = '<br/>'.join(get_display(reshaper.reshape(l)) for l in text.split('<br/>'))
-        except:
+        except Exception:
             logger.exception('Reshaping/Bidi fixes failed on string {}'.format(repr(text)))
 
         p = Paragraph(text, style=style)

--- a/app/eventyay/control/views/pdf.py
+++ b/app/eventyay/control/views/pdf.py
@@ -3,6 +3,7 @@ import logging
 import mimetypes
 from datetime import timedelta
 from io import BytesIO
+from json import JSONDecodeError
 
 from django.conf import settings
 from django.core.files import File
@@ -118,21 +119,30 @@ class BaseEditorView(EventPermissionRequiredMixin, TemplateView):
 
     def _get_posted_layout(self):
         data = self.request.POST.get('data')
-        if not data:
-            return None
-        return self._normalize_layout(json.loads(data))
+        if data is None or not data.strip():
+            raise ValueError(_('No layout data was provided.'))
+
+        try:
+            layout = json.loads(data)
+        except JSONDecodeError as exc:
+            raise ValueError(_('Invalid layout data was provided.')) from exc
+
+        if not isinstance(layout, list):
+            raise ValueError(_('Invalid layout data was provided.'))
+
+        return self._normalize_layout(layout)
 
     def _get_posted_layout_json(self):
         layout = self._get_posted_layout()
-        if layout is None:
-            return None
         return json.dumps(layout)
 
     def get_current_layout(self):
         return self._normalize_layout(self.request.event.settings.get(self.get_layout_settings_key(), as_type=list))
 
-    def save_layout(self):
-        self.request.event.settings.set(self.get_layout_settings_key(), self._get_posted_layout_json())
+    def save_layout(self, layout_data=None):
+        if layout_data is None:
+            layout_data = self._get_posted_layout_json()
+        self.request.event.settings.set(self.get_layout_settings_key(), layout_data)
 
     def save_background(self, f: CachedFile):
         fexisting = self.request.event.settings.get(self.get_background_settings_key(), as_type=File)
@@ -225,6 +235,18 @@ class BaseEditorView(EventPermissionRequiredMixin, TemplateView):
             except CachedFile.DoesNotExist:
                 pass
 
+        layout = None
+        layout_data = None
+        if 'preview' in request.POST or 'data' in request.POST:
+            try:
+                layout = self._get_posted_layout()
+            except ValueError as exc:
+                if 'preview' in request.POST:
+                    return HttpResponseBadRequest(str(exc))
+                return JsonResponse({'status': 'error', 'error': str(exc)}, status=400)
+
+            layout_data = json.dumps(layout)
+
         if 'preview' in request.POST:
             with (
                 rolledback_transaction(),
@@ -233,7 +255,7 @@ class BaseEditorView(EventPermissionRequiredMixin, TemplateView):
                 p = self._get_preview_position()
                 fname, mimet, data = self.generate(
                     p,
-                    override_layout=self._get_posted_layout(),
+                    override_layout=layout,
                     override_background=cf.file if cf else None,
                 )
 
@@ -244,7 +266,7 @@ class BaseEditorView(EventPermissionRequiredMixin, TemplateView):
         elif 'data' in request.POST:
             if cf:
                 self.save_background(cf)
-            self.save_layout()
+            self.save_layout(layout_data)
             return JsonResponse({'status': 'ok'})
         return HttpResponseBadRequest()
 

--- a/app/eventyay/plugins/badges/views.py
+++ b/app/eventyay/plugins/badges/views.py
@@ -204,7 +204,8 @@ class LayoutEditorView(BaseEditorView):
             Question.TYPE_PHONENUMBER: '+1 202 555 0123',
         }
 
-        for question in self.request.event.questions.exclude(type=Question.TYPE_FILE):
+        questions = self.request.event.questions.exclude(type=Question.TYPE_FILE).prefetch_related('options')
+        for question in questions:
             answer_text = sample_answers.get(question.type, str(question.question))
             answer = QuestionAnswer.objects.get_or_create(
                 orderposition=p,
@@ -227,8 +228,11 @@ class LayoutEditorView(BaseEditorView):
 
         return p
 
-    def save_layout(self):
-        layout_data = self._get_posted_layout_json()
+    def save_layout(self, layout_data=None):
+        if layout_data is None:
+            layout_data = self._get_posted_layout_json()
+        if layout_data is None:
+            layout_data = '[]'
         self.layout.layout = layout_data
         self.layout.save(update_fields=['layout'])
         self.layout.log_action(

--- a/app/eventyay/plugins/ticketoutputpdf/views.py
+++ b/app/eventyay/plugins/ticketoutputpdf/views.py
@@ -39,8 +39,8 @@ class EditorView(BaseEditorView):
     def get_output(self, *args, **kwargs):
         return PdfTicketOutput(self.request.event, *args, **kwargs)
 
-    def save_layout(self):
-        super().save_layout()
+    def save_layout(self, layout_data=None):
+        super().save_layout(layout_data)
         invalidate_cache.apply_async(kwargs={'event': self.request.event.pk, 'provider': 'pdf'})
 
     def get_layout_settings_key(self):
@@ -233,13 +233,17 @@ class LayoutEditorView(BaseEditorView):
     def title(self):
         return _('Ticket PDF layout: {}').format(self.layout)
 
-    def save_layout(self):
-        self.layout.layout = self.request.POST.get('data')
+    def save_layout(self, layout_data=None):
+        if layout_data is None:
+            layout_data = self._get_posted_layout_json()
+        if layout_data is None:
+            layout_data = '[]'
+        self.layout.layout = layout_data
         self.layout.save(update_fields=['layout'])
         self.layout.log_action(
             action='eventyay.plugins.ticketoutputpdf.layout.changed',
             user=self.request.user,
-            data={'layout': self.request.POST.get('data')},
+            data={'layout': layout_data},
         )
         invalidate_cache.apply_async(kwargs={'event': self.request.event.pk, 'provider': 'pdf'})
 

--- a/app/eventyay/static/pretixcontrol/js/ui/editor.js
+++ b/app/eventyay/static/pretixcontrol/js/ui/editor.js
@@ -1027,25 +1027,14 @@ var editor = {
             }
         }).prop('disabled', !$.support.fileInput).parent().addClass($.support.fileInput ? undefined : 'disabled');
 
-        $("#toolbox input[type=number], #toolbox textarea, #toolbox input[type=text]").bind('change keydown keyup' +
+        $("#toolbox input[type=number], #toolbox textarea:not(#toolbox-content-other), #toolbox input[type=text]").bind('change keydown keyup' +
             ' input', editor._update_values_from_toolbox);
-        $("#toolbox input[type=number], #toolbox textarea, #toolbox input[type=text], #toolbox input[type=radio]").bind('change', editor._create_savepoint);
+        $("#toolbox input[type=number], #toolbox textarea:not(#toolbox-content-other), #toolbox input[type=text], #toolbox input[type=radio]").bind('change', editor._create_savepoint);
         $("#toolbox label.btn").bind('click change', editor._update_values_from_toolbox);
-        $("#toolbox select").bind('change', editor._update_values_from_toolbox);
-        $("#toolbox select").bind('change', editor._create_savepoint);
-        $("#toolbox-content, #toolbox-content-other").bind('change keyup input blur', editor._update_values_from_toolbox);
-        $("#toolbox-content, #toolbox-content-other").bind('change keyup input blur', function () {
-            if (!editor._toolbox_update_in_progress) {
-                editor._sync_active_text_object_from_toolbox();
-            }
-        });
-        $("#toolbox-content").bind('mouseup', function () {
-            window.setTimeout(function () {
-                if (!editor._toolbox_update_in_progress) {
-                    editor._sync_active_text_object_from_toolbox();
-                }
-            }, 0);
-        });
+        $("#toolbox select:not(#toolbox-content)").bind('change', editor._update_values_from_toolbox);
+        $("#toolbox select:not(#toolbox-content)").bind('change', editor._create_savepoint);
+        $("#toolbox-content").bind('change', editor._update_values_from_toolbox);
+        $("#toolbox-content-other").bind('change keyup input blur', editor._update_values_from_toolbox);
         $("#toolbox-content, #toolbox-content-other").bind('change', editor._create_savepoint);
         $("#toolbox button.toggling").bind('click change', function () {
             if ($(this).is(".option")) {


### PR DESCRIPTION
This PR solves some issues with the badge editor previously newly added text objects to the layout were unable to preserve the selected text content, which has been fixed and the preview now outputs the true preview with all the fields in the layout which was previously broken.