### PR TITLE
Fix horizontal scrollbar in order form for long questions

### DIFF
--- a/app/eventyay/static/pretixcontrol/scss/_forms.scss
+++ b/app/eventyay/static/pretixcontrol/scss/_forms.scss
@@ -728,3 +728,22 @@ table td > .checkbox input[type="checkbox"] {
     gap: 10px;
   }
 }
+
+
+.question-option-row,
+.table td,
+.table th {
+    white-space: normal !important;
+    word-break: break-word;
+    overflow-wrap: anywhere;
+}
+
+.table-responsive {
+    overflow-x: hidden;
+}
+
+label,
+.form-group {
+    max-width: 100%;
+    word-break: break-word;
+}


### PR DESCRIPTION
Fixes #2882

## Problem
Long question texts caused horizontal overflow and scrollbar on smaller screens.

## Solution
- Added proper text wrapping using:
  - `word-break: break-word`
  - `overflow-wrap: anywhere`
- Prevented container overflow

## Result
- No horizontal scrollbar
- Fully responsive layout
- Long text wraps correctly

## Testing
- Tested on laptop screen sizes
- Verified long text rendering

## Summary by Sourcery

Improve form layout to prevent horizontal overflow on long question text and keep the order form responsive on small screens.

Bug Fixes:
- Fix horizontal scrollbar caused by long question text in order form tables.

Enhancements:
- Ensure table cells, labels, and form groups wrap long text within available width to maintain responsive layout.