### PR TITLE
Fix email text overflow in Change history panel UI

### DIFF
--- a/app/eventyay/control/templates/pretixcontrol/includes/logs.html
+++ b/app/eventyay/control/templates/pretixcontrol/includes/logs.html
@@ -8,8 +8,8 @@
                 {% if log.user %}
                     {% if log.user.is_staff %}
                         <span class="fa fa-id-card fa-danger fa-fw"
-                                data-toggle="tooltip"
-                                title="{% trans "This change was performed by a system administrator." %}">
+                              data-toggle="tooltip"
+                              title="{% trans "This change was performed by a system administrator." %}">
                         </span>
                     {% else %}
                         <span class="fa fa-user fa-fw"></span>
@@ -34,16 +34,17 @@
                 {% endif %}
             </p>
 
-            
-            <p style="word-break: break-word; overflow-wrap: anywhere;">
-    {{ log.display }}
-    {% if staff_session %}
-        <a href="" class="btn btn-default btn-xs" data-expandlogs data-id="{{ log.pk }}">
-            <span class="fa-eye fa fa-fw"></span>
-            {% trans "Inspect" %}
-        </a>
-    {% endif %}
-</p>
+            <p>
+                <span class="log-display-wrap">
+                    {{ log.display }}
+                </span>
+                {% if staff_session %}
+                    <a href="" class="btn btn-default btn-xs" data-expandlogs data-id="{{ log.pk }}">
+                        <span class="fa-eye fa fa-fw"></span>
+                        {% trans "Inspect" %}
+                    </a>
+                {% endif %}
+            </p>
         </li>
     {% endfor %}
     {% if obj.all_logentries_link and obj.top_logentries_has_more %}

--- a/app/eventyay/static/common/css/base.css
+++ b/app/eventyay/static/common/css/base.css
@@ -1138,3 +1138,7 @@ pl-0 {
     margin: 5mm;
   }
 }
+.log-display-wrap {
+  word-break: break-word;
+  overflow-wrap: anywhere;
+}


### PR DESCRIPTION
## Fix: Email text overflow in Change history panel

### Problem
Email text was overflowing outside the container in the Change history panel UI.

### Solution
Added CSS properties:
- word-break: break-word
- overflow-wrap: anywhere

### Result
Text now wraps properly and no horizontal overflow occurs.

## Summary by Sourcery

Bug Fixes:
- Prevent long email values in change history log entries from overflowing horizontally by enabling line wrapping in the log text container.