### PR TITLE
fix(ui): prevent text overflow in change history panel

### DIFF
--- a/app/eventyay/control/templates/pretixcontrol/includes/logs.html
+++ b/app/eventyay/control/templates/pretixcontrol/includes/logs.html
@@ -3,7 +3,7 @@
 
 <ul class="list-group">
     {% for log in obj.top_logentries %}
-        <li class="list-group-item logentry" style="overflow-wrap: anywhere;">
+        <li class="list-group-item logentry">
 
             <p class="meta">
                 <span class="fa fa-clock-o"></span> {{ log.datetime|date:"SHORT_DATETIME_FORMAT" }}
@@ -56,7 +56,7 @@
     {% endfor %}
 
     {% if obj.all_logentries_link and obj.top_logentries_has_more %}
-        <li class="list-group-item logentry" style="overflow-wrap: anywhere;">
+        <li class="list-group-item logentry">
             <a href="{{ obj.all_logentries_link }}">
                 {% trans "View full log" %}
             </a>

--- a/app/eventyay/static/common/css/base.css
+++ b/app/eventyay/static/common/css/base.css
@@ -1138,3 +1138,6 @@ pl-0 {
     margin: 5mm;
   }
 }
+.logentry {
+    overflow-wrap: anywhere;
+}


### PR DESCRIPTION
## Problem
Email text in the "Change history" panel overflows outside the container, breaking the layout and reducing readability.

## Solution
Moved overflow handling to the existing `.logentry` CSS class by adding:

CSS: overflow-wrap: anywhere;

This ensures long text (e.g., email addresses) wraps properly within the container.

## Changes
- Removed inline styles from template
- Added overflow handling in `base.css` under `.logentry`

## Result
- Text now wraps correctly
- UI layout remains intact
- Cleaner and reusable implementation

Fixes #2872

Improved Check Screenshots:
<img width="960" height="451" alt="solve 4" src="https://github.com/user-attachments/assets/566584fe-2c5f-42b0-b3b1-77c66e8eeb7a" />
<img width="960" height="453" alt="solve 3" src="https://github.com/user-attachments/assets/2bc5613a-db11-4aab-809d-1c5c035de533" />
<img width="956" height="455" alt="solve 2" src="https://github.com/user-attachments/assets/f491db17-5d4d-48fb-a220-405c20e37278" />
<img width="107" height="359" alt="solve 1" src="https://github.com/user-attachments/assets/0c1a99f8-0cb3-4211-b6ae-399e8bcbc150" />
