### PR TITLE
fix organizer email placeholder

### DIFF
--- a/app/eventyay/control/forms/event.py
+++ b/app/eventyay/control/forms/event.py
@@ -226,6 +226,9 @@ class EventWizardBasicsForm(I18nModelForm):
         self.fields['email'].required = True
         self.fields['email'].label = _('Organizer email address')
         self.fields['email'].help_text = _("We'll show this publicly to allow attendees to contact you.")
+        if self.initial.get('email') == Event._meta.get_field('email').default:
+            self.initial['email'] = ''
+        self.fields['email'].widget.attrs['placeholder'] = _('organizer@example.org')
 
         # Generate a unique slug if none provided
         if not self.initial.get('slug'):
@@ -394,6 +397,9 @@ class EventWizardDisplayForm(forms.Form):
         super().__init__(*args, **kwargs)
         logo = Event._meta.get_field('logo')
         self.fields['logo'] = ImageField(required=False, label=logo.verbose_name, help_text=logo.help_text)
+        if self.initial.get('email') == Event._meta.get_field('email').default:
+            self.initial['email'] = ''
+        self.fields['email'].widget.attrs['placeholder'] = _('organizer@example.org')
 
     def clean_email(self):
         email = self.cleaned_data.get('email', '').strip()

--- a/app/eventyay/event/forms.py
+++ b/app/eventyay/event/forms.py
@@ -285,6 +285,9 @@ class EventWizardDisplayForm(forms.Form):
         super().__init__(*args, **kwargs)
         logo = Event._meta.get_field('logo')
         self.fields['logo'] = ImageField(required=False, label=logo.verbose_name, help_text=logo.help_text)
+        if self.initial.get('email') == Event._meta.get_field('email').default:
+            self.initial['email'] = ''
+        self.fields['email'].widget.attrs['placeholder'] = _('organizer@example.org')
 
     def clean_email(self):
         email = self.cleaned_data.get('email', '').strip()


### PR DESCRIPTION
<img width="1199" height="393" alt="Screenshot 2026-03-22 at 10 27 46 AM" src="https://github.com/user-attachments/assets/ec5b70b2-7641-4104-884b-82e07aeb199f" />
<img width="1209" height="380" alt="Screenshot 2026-03-22 at 10 29 11 AM" src="https://github.com/user-attachments/assets/dd6264be-92ea-40cd-8c1d-26aab7ce7abb" />

## Summary by Sourcery

Bug Fixes:
- Ensure the organizer email input starts empty with a clear placeholder instead of reusing or displaying unintended values in event forms.