### PR TITLE
fix(ui): prevent text overflow in change history panel

### DIFF
--- a/app/eventyay/control/templates/pretixcontrol/includes/logs.html
+++ b/app/eventyay/control/templates/pretixcontrol/includes/logs.html
@@ -3,7 +3,7 @@
 <ul class="list-group">
     {% for log in obj.top_logentries %}
         <li class="list-group-item logentry">
-            <p class="meta">
+            <p class="meta" style="overflow-wrap: anywhere; word-break: break-word;">
                 <span class="fa fa-clock-o"></span> {{ log.datetime|date:"SHORT_DATETIME_FORMAT" }}
                 {% if log.user %}
                     {% if log.user.is_staff %}


### PR DESCRIPTION
## Problem
Email address in the "Change history" panel overflows 
outside the container breaking the layout.

## Fix
Added `overflow-wrap: anywhere` and `word-break: break-word` 
to the meta paragraph in logs.html to ensure long text 
wraps properly within the container.

Closes #2872

## Summary by Sourcery

Bug Fixes:
- Prevent long email addresses and other meta text in the change history panel from overflowing outside their container.