### PR TITLE
fix(ui): correct modal layering to prevent navbar overlap

### DIFF
--- a/app/eventyay/static/api/css/api.css
+++ b/app/eventyay/static/api/css/api.css
@@ -49,3 +49,11 @@ a.js-tooltip,
   font-size: 14px;
   border-radius: var(--size-border-radius);
 }
+/* Fix navbar overlapping modal */
+.modal.show {
+  z-index: 1055;
+}
+
+.modal-backdrop.show {
+  z-index: 1050;
+}


### PR DESCRIPTION
## Fixes #2940

### Problem
Navbar was overlapping modal due to incorrect stacking order.

### Solution
Used Bootstrap's modal and backdrop classes to ensure proper layering.

### Changes
- Applied z-index to `.modal.show`
- Applied z-index to `.modal-backdrop.show`
- Avoided global overrides

### Result
Modal correctly appears above navbar without affecting other components.

## Summary by Sourcery

Bug Fixes:
- Resolve navbar overlapping active modals by increasing the z-index of visible modal and backdrop elements.