### PR TITLE
Fix #200: Use Event name as identifier for payments

### DIFF
--- a/app/eventyay/plugins/banktransfer/views.py
+++ b/app/eventyay/plugins/banktransfer/views.py
@@ -227,7 +227,8 @@ class ActionView(View):
             return JsonResponse({'results': []})
 
         if '-' in u:
-            code = Q(event__name__icontains=u.split('-')[0]) & Q(code__icontains=Order.normalize_code(u.split('-')[1]))
+            parts = u.rsplit('-', 1)
+            code = Q(event__name__icontains=parts[0]) & Q(code__icontains=Order.normalize_code(parts[1]))
         else:
             code = Q(code__icontains=Order.normalize_code(u))
         qs = (


### PR DESCRIPTION
…tead of short form

## Summary by Sourcery

Use event names instead of slugs as identifiers in bank transfer payment lookup and keep error responses consistent.

Bug Fixes:
- Resolve order lookup issues in bank transfer processing by matching payments against event names rather than event slugs.
- Ensure the generic error response is always returned when no valid bank transfer action is processed.