### PR TITLE
fix: restore Lead Scanning QR Code and Dynamic Image buttons in badge editor

### DIFF
--- a/app/eventyay/control/templates/pretixcontrol/pdf/index.html
+++ b/app/eventyay/control/templates/pretixcontrol/pdf/index.html
@@ -393,22 +393,22 @@
                         <span class="fa fa-qrcode"></span>
                         {% trans "Attendee QR Code" %}
                     </button>
-                    <!--<button class="btn btn-default btn-block" id="editor-add-qrcode-lead"
+                    <button class="btn btn-default btn-block" id="editor-add-qrcode-lead"
                             data-content="pseudonymization_id"
                             disabled>
                         <span class="fa fa-qrcode"></span>
-                        {% trans "QR code for Lead Scanning" %}
-                    </button>-->
+                        {% trans "Lead Scanning QR Code" %}
+                    </button>
                     <button class="btn btn-default btn-block" id="editor-add-poweredby"
                             data-content="dark"
                             disabled>
                         <span class="fa fa-image"></span>
                         {% trans "eventyay Logo" %}
                     </button>
-                    <!--<button class="btn btn-default btn-block" id="editor-add-image" disabled>
+                    <button class="btn btn-default btn-block" id="editor-add-image" disabled>
                         <span class="fa fa-image"></span>
-                        {% trans "Dynamic image" %}
-                    </button>-->
+                        {% trans "Dynamic Image" %}
+                    </button>
                 </div>
             </div>
 


### PR DESCRIPTION
## Summary

Restores two buttons in the badge editor that were accidentally commented out in PR #420:

- **Lead Scanning QR Code** (`#editor-add-qrcode-lead`)
- **Dynamic Image** (`#editor-add-image`)

Updated button labels to use title case for consistency.

No JavaScript changes needed — handlers in `editor.js` were already wired up for both button IDs.

## Screenshot

<img width="1458" height="706" alt="Screenshot 2026-03-24 at 5 35 36 PM" src="https://github.com/user-attachments/assets/bd6ac169-b0ce-4101-b3a3-07303e975551" />

Fixes #421

## Summary by Sourcery

Restore previously hidden badge editor controls for lead scanning QR codes and dynamic images.

New Features:
- Re-enable the Lead Scanning QR Code element option in the PDF ticket badge editor.
- Re-enable the Dynamic Image element option in the PDF ticket badge editor.

Enhancements:
- Update badge editor button labels to use consistent title case.