### PR TITLE
fix: search result popup overlap issue on mobile view

### DIFF
--- a/app/eventyay/plugins/webcheckin/static/pretixplugins/webcheckin/scss/main.scss
+++ b/app/eventyay/plugins/webcheckin/static/pretixplugins/webcheckin/scss/main.scss
@@ -209,6 +209,17 @@ a.searchresult {
   overflow: auto;
 }
 
+/* 🔥 2nd PR FIX: TEXT OVERFLOW */
+.panel-body {
+  word-break: break-word;
+  overflow-wrap: anywhere;
+  max-width: 100%;
+}
+
+.panel-body a {
+  word-break: break-all;
+}
+
 @-webkit-keyframes blinking {
   0%, 49% {
     background-color: $brand-primary;
@@ -228,7 +239,7 @@ a.searchresult {
   margin-left: 10px;
 }
 
-/* 📱 MOBILE FIX (REVIEW SAFE) */
+/* 📱 MOBILE FIX */
 @media (max-width: 768px) {
   .modal-dialog {
     width: 95%;


### PR DESCRIPTION
### 🐛 Issue

Search result popup was overlapping content on smaller screens.

### ✅ Fix

* Adjusted z-index for modal and popup
* Improved mobile responsiveness
* Fixed layout to prevent overlap

### 📱 Result

* Popup displays correctly on mobile devices
* No content overlap issue

### 📸 Screenshots

(Add before and after screenshots here)

## Summary by Sourcery

Adjust modal and popup stacking order and mobile layout to prevent search result popup overlapping content on small screens.

Bug Fixes:
- Resolve search result popup overlapping underlying content by adjusting modal, backdrop, and popup z-index values.
- Improve mobile modal layout to better fit small screens and avoid overflow issues.