### PR TITLE
fix: add condition to dashboard alert

### DIFF
--- a/app/eventyay/eventyay_common/templates/eventyay_common/dashboard/dashboard.html
+++ b/app/eventyay/eventyay_common/templates/eventyay_common/dashboard/dashboard.html
@@ -32,7 +32,9 @@
               </div>
           </div>
         {% empty %}
-        <div class="alert alert-info">{% trans "You have no upcoming events" %}</div>
+        {% if not can_create_event %}
+            <div class="alert alert-info">{% trans "You have no upcoming events" %}</div>
+        {% endif %}
       {% endfor %}
     </div>
     {% if upcoming %}


### PR DESCRIPTION
Fixes: #2979

## Summary by Sourcery

Bug Fixes:
- Show the 'You have no upcoming events' alert only when the user is not allowed to create events, preventing incorrect messaging for users who can create events.