### PR TITLE
Change deployment parameters so that long running task does not make gunicorn die

### DIFF
--- a/deployment/docker-compose.yml
+++ b/deployment/docker-compose.yml
@@ -4,7 +4,7 @@ services:
   web:
     image: eventyay/eventyay-next:${TAG}
     container_name: eventyay-next-web
-    command: gunicorn eventyay.config.wsgi:application --bind 0.0.0.0:8000
+    command: gunicorn eventyay.config.wsgi:application --bind 0.0.0.0:8000 --workers 2 --timeout 120 --graceful-timeout 90
     volumes:
       - ${DATA_DIR:-./data}/static:/home/app/web/eventyay/static.dist
       - ${DATA_DIR:-./data}/data:/home/app/web/eventyay/data


### PR DESCRIPTION
## Summary by Sourcery

Deployment:
- Update docker-compose web service gunicorn command to use two workers and increased timeout/graceful-timeout settings.