### PR TITLE
Make event name and date clickable and link to event start page

### DIFF
--- a/app/eventyay/presale/templates/pretixpresale/event/index.html
+++ b/app/eventyay/presale/templates/pretixpresale/event/index.html
@@ -162,7 +162,11 @@
             </div>
         </div>
         {% if subevent %}
-            <h2 class="subevent-head">{{ subevent.name|event_localize }}</h2>
+            <h2 class="subevent-head">
+                <a href="{% eventurl event 'presale:event.index' subevent=subevent.pk %}">
+                    {{ subevent.name|event_localize }}
+                </a>
+            </h2>
             {% if frontpage_text and not cart_namespace %}
                 <div>
                     {{ frontpage_text|event_localize|rich_text }}
@@ -172,17 +176,29 @@
     {% else %}
         {% if event_logo_image and request.event.settings.logo_show_title %}
             <h2 class="content-header">
-                {{ event.name|event_localize }}
+                <a href="{% eventurl event 'presale:event.index' %}">
+                    {{ event.name|event_localize }}
+                </a>
                 {% if request.event.settings.show_dates_on_frontpage %}
-                    <small>{{ event.get_date_range_display }}</small>
+                    <small>
+                        <a href="{% eventurl event 'presale:event.index' %}">
+                            {{ event.get_date_range_display }}
+                        </a>
+                    </small>
                 {% endif %}
             </h2>
         {% endif %}
         {% if not event_logo_image %}
             <h2 class="content-header">
-                {{ event.name|event_localize }}
+                <a href="{% eventurl event 'presale:event.index' %}">
+                    {{ event.name|event_localize }}
+                </a>
                 {% if request.event.settings.show_dates_on_frontpage %}
-                    <small>{{ event.get_date_range_display }}</small>
+                    <small>
+                        <a href="{% eventurl event 'presale:event.index' %}">
+                            {{ event.get_date_range_display }}
+                        </a>
+                    </small>
                 {% endif %}
             </h2>
         {% endif %}


### PR DESCRIPTION
Fixes #3003

## Problem
Event name and date were displayed as static text, preventing users from easily navigating back to the event start page.

## Solution
- Wrapped event name in anchor tag linking to event start page
- Wrapped event date in anchor tag linking to event start page
- Added same functionality for subevent title

## Result
- Improved navigation and usability
- Consistent clickable behavior across event pages

## Testing
- Verified clicking event name redirects to event start page
- Verified clicking event date redirects correctly
- Verified subevent navigation works as expected

## Summary by Sourcery

Make event and subevent headers on the presale index page link back to the event start page to improve navigation.

Enhancements:
- Make the subevent title clickable, linking directly to the subevent’s presale start page.
- Make the main event name and date clickable, linking back to the event’s presale start page for easier navigation.