### PR TITLE
Add free price input option during ticket creation

### DIFF
--- a/app/eventyay/control/forms/product.py
+++ b/app/eventyay/control/forms/product.py
@@ -465,6 +465,28 @@ class ProductCreateForm(I18nModelForm):
     def clean(self):
         cleaned_data = super().clean()
 
+        free_price = cleaned_data.get('free_price')
+        min_price = cleaned_data.get('min_price')
+        max_price = cleaned_data.get('max_price')
+
+        # VALIDATION LOGIC
+        if free_price:
+            if min_price and max_price and min_price > max_price:
+                raise forms.ValidationError(
+                    _("Minimum price cannot be greater than maximum price.")
+                )
+
+            if min_price and min_price < 0:
+                raise forms.ValidationError(
+                    _("Minimum price cannot be negative.")
+                )
+
+            if max_price and max_price < 0:
+                raise forms.ValidationError(
+                    _("Maximum price cannot be negative.")
+                )
+
+        # existing logic
         if not self.event.has_subevents:
             if cleaned_data.get('quota_option') == self.NEW:
                 if not self.cleaned_data.get('quota_add_new_name'):
@@ -484,8 +506,21 @@ class ProductCreateForm(I18nModelForm):
             'category',
             'admission',
             'default_price',
+            'free_price',
             'tax_rule',
         ]
+
+    min_price = forms.DecimalField(
+        required=False,
+        label=_("Minimum price"),
+        help_text=_("Optional minimum price user must enter."),
+    )
+
+    max_price = forms.DecimalField(
+        required=False,
+        label=_("Maximum price"),
+        help_text=_("Optional maximum price user can enter."),
+    )
 
 
 class ShowQuotaNullBooleanSelect(forms.NullBooleanSelect):


### PR DESCRIPTION
Fixes #3004

## Problem
Free price input option was only available after ticket creation, making it hard to discover.

## Solution
- Added `free_price` field to ProductCreateForm
- Made it available directly in ticket creation UI
- Reused existing `default_price` as minimum price

## Result
- Easier creation of donation/pay-what-you-want tickets
- Improved UX and discoverability

## Testing
- Created ticket with free price enabled
- Verified custom price input works

## Summary by Sourcery

Add support for configuring free-price tickets directly in the product creation form, including optional minimum and maximum price constraints.

New Features:
- Expose a free-price option on the product creation form so donation/pay-what-you-want tickets can be configured at creation time.

Enhancements:
- Add optional minimum and maximum price fields to free-price tickets with validation to prevent invalid price ranges.