### PR TITLE
Fixes #3074

### DIFF
--- a/app/eventyay/control/middleware.py
+++ b/app/eventyay/control/middleware.py
@@ -42,6 +42,7 @@ class PermissionMiddleware:
         'auth.forgot.recover',
         'auth.invite',
         'user.settings.notifications.off',
+        'account.locale',
         'oauth2_provider',
     )
 

--- a/app/eventyay/presale/templates/pretixpresale/event/index.html
+++ b/app/eventyay/presale/templates/pretixpresale/event/index.html
@@ -326,16 +326,6 @@
             {% endif %}
         {% endif %}
     {% endif %}
-    {% if subevent or not event.has_subevents %}
-        {% if featured_speakers %}
-            <section class="front-page" id="featured-speakers" aria-label="{% trans 'Featured Speakers' %}">
-                <script id="pretalx-schedule-data" type="application/json">{{ featured_speakers_widget_schedule_json|safe }}</script>
-                <script type="text/javascript" src="{{ request.event.urls.schedule_widget_script }}" async></script>
-                <pretalx-schedule event-url="{{ request.event.urls.base }}" locale="{{ request.LANGUAGE_CODE }}" view="featured-speakers" style="--pretalx-clr-primary: {{ request.event.visible_primary_color }}"></pretalx-schedule>
-            </section>
-        {% endif %}
-    {% endif %}
-    </main>
     {% if show_vouchers %}
         {% if can_view_tickets %}
         {% if request.event.live or is_organiser %}
@@ -369,6 +359,17 @@
         {% endif %}
         {% endif %}
     {% endif %}
+    {% if subevent or not event.has_subevents %}
+        {% if featured_speakers %}
+            <section class="front-page" id="featured-speakers" aria-label="{% trans 'Featured Speakers' %}">
+                <script id="pretalx-schedule-data" type="application/json">{{ featured_speakers_widget_schedule_json|safe }}</script>
+                <script type="text/javascript" src="{{ request.event.urls.schedule_widget_script }}" async></script>
+                <pretalx-schedule event-url="{{ request.event.urls.base }}" locale="{{ request.LANGUAGE_CODE }}" view="featured-speakers" style="--pretalx-clr-primary: {{ request.event.visible_primary_color }}"></pretalx-schedule>
+            </section>
+        {% endif %}
+    {% endif %}
+    </main>
+
     {% if guest_checkout_allowed %}
         {% if not cart_namespace %}
             {% eventsignal event "eventyay.presale.signals.front_page_bottom" subevent=subevent request=request %}


### PR DESCRIPTION
Fixes #3074

This PR addresses two bugs in the eventyay presale and control modules.

## Changes

### 1. Locale middleware permission fix (`middleware.py`)
Added `'account.locale'` to the permission-exempt URL list in `PermissionMiddleware`, allowing unauthenticated users to switch the interface language without being blocked.

### 2. Featured speakers display order fix (`index.html`)
Moved the Featured Speakers section and closing `</main>` tag to render **after** the vouchers/tickets block in the presale event page template, fixing incorrect display ordering.

**Visual impact:** The event front page now shows ticket purchasing and voucher redemption options before the Featured Speakers widget, which is the correct and expected layout order.

## Screenshots
### middleware.py diff
<img width="1469" height="341" alt="image" src="https://github.com/user-attachments/assets/783f9d62-f38e-425b-8a88-a763d0517506" />

### index.html diff (template reordering)
Initial position: <img width="1439" height="502" alt="image" src="https://github.com/user-attachments/assets/39e80574-de72-4aea-aec7-c1079651763b" />

Alteration implemented:
<img width="1898" height="1006" alt="image" src="https://github.com/user-attachments/assets/89a21d9b-5756-4823-9b85-4d5d8311b681" />

## Checklist
- [x] All CI checks passing (9/9 ✅)
- [x] No merge conflicts with base branch
- [x] Changes are minimal and focused on the linked issue
- [x] PR is associated with issue #3074
