### PR TITLE
Remove internal identifier from order forms overview

### DIFF
--- a/app/eventyay/control/templates/pretixcontrol/items/orderforms.html
+++ b/app/eventyay/control/templates/pretixcontrol/items/orderforms.html
@@ -343,7 +343,6 @@
                                     {{ q.question }}
                                     </a>
                                 </strong>
-                                <br><small class="text-muted">{{ q.identifier }}</small>
                             </th>
                             <td class="text-center">
                                 <label class="toggle-switch"


### PR DESCRIPTION
Fixes #3013

## Problem
The order forms overview displays an internal identifier below each question, which is not useful for organizers and adds visual clutter.

## Solution
- Removed the display of `q.identifier` from the order forms overview template
- Kept backend functionality unchanged

## Result
- Cleaner UI
- Improved usability for organizers
- Reduced unnecessary technical noise

## Testing
- Verified order forms page no longer shows internal identifiers
- Confirmed no impact on functionality

## Summary by Sourcery

Enhancements:
- Clean up the order forms overview by hiding internal question identifiers that are not relevant to organizers.