### PR TITLE
Enable editing of product assignment in order forms overview

### DIFF
--- a/app/eventyay/control/templates/pretixcontrol/items/orderforms.html
+++ b/app/eventyay/control/templates/pretixcontrol/items/orderforms.html
@@ -375,12 +375,19 @@
                                 <ul class="list-unstyled products-list">
                                     {% for product in q.products.all %}
                                         <li>
-                                            <a href="{% url "control:event.product" organizer=request.event.organizer.slug event=request.event.slug product=product.id %}">{{ product }}</a>
+                                            <a href="{% url "control:event.product" organizer=request.event.organizer.slug event=request.event.slug product=product.id %}">
+                                                {{ product }}
+                                            </a>
                                         </li>
                                     {% empty %}
                                         <li class="text-muted">{% translate "All products" %}</li>
                                     {% endfor %}
                                 </ul>
+                            
+                                <a class="btn btn-xs btn-default"
+                                   href="{% url "control:event.products.questions.show" organizer=request.event.organizer.slug event=request.event.slug question=q.id %}">
+                                    <i class="fa fa-pencil"></i> {% trans "Edit" %}
+                                </a>
                             </td>
                             <td class="dnd-container text-center text-nowrap">
                                 {% if q.type == "DES" %}


### PR DESCRIPTION
Related to #3014

## Problem
The order forms overview displays assigned products for each field, but does not provide an easy way to modify them. This limits usability when configuring fields per ticket.

## Solution
- Added an "Edit" button in the Products column
- Button redirects to the existing question edit page
- Allows users to modify product assignments directly

## Result
- Improved usability of per-product field configuration
- Easier access to editing functionality
- Better alignment with per-ticket configuration goals

## Testing
- Verified products are displayed correctly
- Clicking "Edit" navigates to question edit page
- Product assignment changes reflect correctly

## Notes
- This is an incremental improvement towards full per-ticket configuration support (#3014)
- No backend changes were required

## Summary by Sourcery

New Features:
- Provide an Edit button in the order forms overview to access the question's product assignment page from the products column.