### PR TITLE
Fix: Remove internal identifier from order forms overview

### DIFF
--- a/app/eventyay/control/templates/pretixcontrol/items/orderforms.html
+++ b/app/eventyay/control/templates/pretixcontrol/items/orderforms.html
@@ -343,7 +343,7 @@
                                     {{ q.question }}
                                     </a>
                                 </strong>
-                                <br><small class="text-muted">{{ q.identifier }}</small>
+                               
                             </th>
                             <td class="text-center">
                                 <label class="toggle-switch"


### PR DESCRIPTION
Fixes #3013

### Changes
- Removed internal identifier display from Order Forms overview page

### Why
- Internal identifiers are system-level details and not useful for event organizers
- Improves UI clarity and reduces unnecessary visual noise