### PR TITLE
Make event name and date clickable in check-in list

### DIFF
--- a/app/eventyay/control/templates/pretixcontrol/checkin/index.html
+++ b/app/eventyay/control/templates/pretixcontrol/checkin/index.html
@@ -107,7 +107,7 @@
                             <td>{{ e.product }}{% if e.variation %} – {{ e.variation }}{% endif %}</td>
                             {% if request.event.has_subevents and not checkinlist.subevent %}
                                 <td>
-                                    {{ e.subevent.name }} – {{ e.subevent.get_date_range_display }} {{ e.subevent.date_from|date:"TIME_FORMAT" }}
+                                    <a href="{{ e.subevent.urls.base }}">{{ e.subevent.name }} – {{ e.subevent.get_date_range_display }}</a>
                                 </td>
                             {% endif %}
                             {% if seats %}


### PR DESCRIPTION
Addresses #3003

### Changes
- Made event name and date clickable in the check-in list view
- Wrapped subevent name and date inside a link pointing to the event page

### Why
- Improves navigation by allowing organizers to quickly access the event page
- Enhances usability without changing any backend logic

### Scope
- UI-only change
- No impact on existing functionality

## Summary by Sourcery

New Features:
- Allow clicking the subevent name and date in the check-in list to navigate to the subevent page.