### PR TITLE
Fix horizontal scrollbar in order form for long questions

### DIFF
--- a/app/eventyay/control/templates/pretixcontrol/order/change_questions.html
+++ b/app/eventyay/control/templates/pretixcontrol/order/change_questions.html
@@ -53,7 +53,9 @@
                                     <legend>+ {{ form.pos.item }}</legend>
                                 {% endif %}
                                 {% for field in form.regular_fields %}
-                                    {% bootstrap_field field layout="control" %}
+                                    <div style="word-break: break-word; overflow-wrap: break-word;">
+                                        {% bootstrap_field field layout="control" %}
+                                    </div>
                                 {% endfor %}
 
                                 {% if form.badge_option_fields %}


### PR DESCRIPTION
Fixes #2882

### Changes
- Wrapped form fields in a container to prevent horizontal overflow
- Ensured long question text wraps properly within available width

### Why
- Long question text caused horizontal scrolling on smaller screens
- This fix improves responsiveness and usability

### Scope
- UI-only change
- No backend impact

## Summary by Sourcery

Enhancements:
- Wrap order form question fields in a container that forces long text to break within the available width, preventing horizontal overflow.