### PR TITLE
Fix email overflow in change history panel

### DIFF
--- a/app/eventyay/control/templates/pretixcontrol/includes/logs.html
+++ b/app/eventyay/control/templates/pretixcontrol/includes/logs.html
@@ -3,7 +3,7 @@
 <ul class="list-group">
     {% for log in obj.top_logentries %}
         <li class="list-group-item logentry">
-            <p class="meta">
+            <p class="meta" style="word-break: break-word; overflow-wrap: anywhere;">
                 <span class="fa fa-clock-o"></span> {{ log.datetime|date:"SHORT_DATETIME_FORMAT" }}
                 {% if log.user %}
                     {% if log.user.is_staff %}


### PR DESCRIPTION
Fixes #2872

### Changes
- Prevent text overflow in "Change history" panel
- Added CSS (word-break, overflow-wrap) to meta container

### Why
- Long email addresses were overflowing and breaking layout

### Scope
- UI-only change
- No backend impact

### Summary
Fix ensures long email text wraps properly inside the change history panel without breaking layout.
Verified locally with long email inputs to ensure proper wrapping behavior.



## Screenshots

## Before
**Full view:**
<img width="1470" height="838" alt="Before" src="https://github.com/user-attachments/assets/4612e48f-ad95-4765-8e61-fcbed207e0dc" />

**Zoomed (Overflow issue):**
<img width="227" height="644" alt="Before_zoomed" src="https://github.com/user-attachments/assets/a490fdb1-7e0d-48d9-84de-df5b4d16c62e" />

## After
**Full view:**
<img width="1470" height="838" alt="After" src="https://github.com/user-attachments/assets/a861723e-a18a-4b31-ad0f-7c148cae8d26" />

**Zoomed (Wrapped Correctly):**
<img width="226" height="666" alt="After_zoomed" src="https://github.com/user-attachments/assets/8c38e0c3-04dc-4dd3-b4f3-75c016cf88c4" />



## Summary by Sourcery

Prevent long log metadata text from overflowing and breaking the layout in the change history panel.

Bug Fixes:
- Fix layout breakage caused by long email addresses overflowing in the change history log entries.

Enhancements:
- Improve readability of change history entries by enforcing line-wrapping on log metadata text.



