### PR TITLE
Fix: Add burger menu to start page header for logged-in users (#2965)

### DIFF
--- a/app/eventyay/common/templates/common/base.html
+++ b/app/eventyay/common/templates/common/base.html
@@ -83,6 +83,13 @@
         {% endif %}
         <div class="container{% block container_width %}{% endblock container_width %}" id="main-container">
             <header>
+                 {% if request.user.is_authenticated %}
+                <button type="button" class="navbar-toggle-sidebar navbar-toggle" id="sidebar-toggle" data-toggle="sidebar" style="position:absolute; left:10px; top:10px; z-index:1000;">
+                    <span class="sr-only">{% trans "Toggle sidebar" %}</span>
+                    <i class="fa fa-bars fa-lg"></i>
+                </button>
+            {% endif %}
+
                 <h1 class="public-event-header">
                     <div class="event-logo">
                         <a href="{% block nav_link %}{% endblock nav_link %}">


### PR DESCRIPTION
Fixes #2965

## Problem
The start page (event overview) did not include a burger menu for logged-in users, unlike the dashboard.  
This resulted in inconsistent navigation behavior and reduced usability.

## Verification
Tested locally by running the development server and comparing:
- Start page (event overview)
- Dashboard

Confirmed that the burger menu was missing only on the start page.

## Solution
- Reused the existing sidebar toggle button from the dashboard layout
- Added it to the start page header (`common/base.html`)
- Wrapped it inside an authentication check to ensure it only appears for logged-in users

## Result
- Consistent navigation behavior across start page and dashboard
- Logged-in users can now access the sidebar from the start page
- Improved UI consistency and usability

## Summary by Sourcery

New Features:
- Show a sidebar toggle (burger menu) in the start page header when the user is logged in.