### PR TITLE
Fix mobile UI breakage in search dropdown

### DIFF
--- a/app/eventyay/static/pretixpresale/scss/startpage.scss
+++ b/app/eventyay/static/pretixpresale/scss/startpage.scss
@@ -83,6 +83,11 @@ nav.navbar .navbar-top-links .dropdown-content {
   color: var(--color-text);
 }
 
+.navbar {
+    position: relative;
+    z-index: 1000;
+}
+
 .startpage-search-nav {
   display: flex;
   align-items: center;
@@ -162,15 +167,16 @@ nav.navbar .navbar-top-links .dropdown-content {
   border-radius: 12px;
   box-shadow: 0 16px 30px rgba(0, 0, 0, 0.2);
   display: none;
-  left: 0;
-  max-height: 320px;
-  overflow-y: auto;
   position: absolute;
   top: 100%;
+  left: 0;
+  width: 100%;
+  max-width: 100%;
+  max-height: 320px;
+  overflow-y: auto;
   margin-top: 10px;
   transform: none;
-  width: 320px;
-  z-index: 1200;
+  z-index: 2000;
 }
 
 .startpage-search-results.is-open {
@@ -347,6 +353,15 @@ body.startpage-search-results-page #main-card {
 @media (max-width: 640px) {
   .startpage-event-list {
     grid-template-columns: 1fr;
+  }
+}
+
+@media (max-width: 768px) {
+  .startpage-search-results {
+    width: 100%;
+    max-width: 100%;
+    left: 0;
+    right: 0;
   }
 }
 


### PR DESCRIPTION
## Issue
Fixes #3027

## Problem
Search dropdown was misaligned and overlapping UI on mobile devices due to fixed width and improper positioning.

## Solution
- Replaced fixed width (320px) with responsive width (100%)
- Added position: relative to search container
- Improved dropdown positioning and z-index
- Added mobile responsive fixes

## Result
- Proper dropdown alignment below search input
- No overflow or UI breakage
- Fully responsive across devices

## Summary by Sourcery

Improve layout and layering of the start page search dropdown for better mobile behavior and correct alignment.

Bug Fixes:
- Fix misaligned and overflowing start page search dropdown on mobile by making it responsive and properly positioned.

Enhancements:
- Increase navbar and search dropdown z-index to ensure they layer correctly over surrounding content and remain visible on all devices.
- Make the search dropdown width fully responsive, matching the container width instead of using a fixed pixel width.
- Add a mobile-specific layout rule for the search dropdown to span full width and align within the viewport on small screens.