### PR TITLE
fix(api): harden EventThemeView error path and exception logging

### DIFF
--- a/app/eventyay/api/views/event.py
+++ b/app/eventyay/api/views/event.py
@@ -468,8 +468,7 @@ class EventThemeView(APIView):
                 kwargs["event_id"],
             )
             return Response(
-                "error happened when trying to get theme data of event: "
-                + kwargs["event_id"],
+                f'error happened when trying to get theme data of event: {kwargs["event_id"]}',
                 status=503,
             )
 
@@ -561,8 +560,8 @@ class CreateEventView(APIView):
                 protocol = get_protocol(site_url)
                 event.domain = "{}://{}".format(protocol, domain_path)
                 return JsonResponse(model_to_dict(event, exclude=["roles"]), status=201)
-            except IntegrityError as e:
-                logger.error(f"Database integrity error while saving event: {e}")
+            except IntegrityError:
+                logger.exception("Database integrity error while saving event")
                 return JsonResponse(
                     {
                         "error": "An event with this ID already exists or database constraint violated"
@@ -570,10 +569,10 @@ class CreateEventView(APIView):
                     status=400,
                 )
             except ValidationError as e:
-                logger.error(f"Validation error while saving event: {e}")
+                logger.exception("Validation error while saving event")
                 return JsonResponse({"error": str(e)}, status=400)
-            except Exception as e:
-                logger.error(f"Unexpected error creating event: {e}")
+            except Exception:
+                logger.exception("Unexpected error creating event")
                 return JsonResponse(
                     {"error": "An unexpected error occurred"}, status=500
                 )

--- a/app/tests/tickets/api/test_event_theme_view.py
+++ b/app/tests/tickets/api/test_event_theme_view.py
@@ -1,0 +1,20 @@
+from unittest import mock
+
+from rest_framework.test import APIRequestFactory
+
+from eventyay.api.views.event import EventThemeView
+
+
+def test_event_theme_view_handles_missing_theme_key():
+    request = APIRequestFactory().get("/api/v1/events/123/theme/")
+    serializer_instance = mock.Mock()
+    serializer_instance.data = {"config": {}}
+
+    with (
+        mock.patch("eventyay.api.views.event.get_object_or_404", return_value=object()),
+        mock.patch("eventyay.api.views.event.RoomsEventSerializer", return_value=serializer_instance),
+    ):
+        response = EventThemeView.as_view()(request, event_id=123)
+
+    assert response.status_code == 503
+    assert response.data == "error happened when trying to get theme data of event: 123"


### PR DESCRIPTION
## Summary
- Fix `EventThemeView.get()` fallback response to avoid type errors when `event_id` is not a string.
- Standardize exception logging in `CreateEventView` by replacing f-string logger usage with `logger.exception(...)` in exception handlers.
- Add a focused test for `EventThemeView` error-path behavior when theme config is missing.

## Changes
- Updated `app/eventyay/api/views/event.py`
  - `EventThemeView.get()`: safe error message formatting for `event_id`.
  - `CreateEventView.post()`: improved exception logging for:
    - `IntegrityError`
    - `ValidationError`
    - generic unexpected exceptions
- Added `app/tests/tickets/api/test_event_theme_view.py`
  - Verifies `503` response and expected message when theme key is absent.

## Why
This improves API reliability on error paths and keeps exception logging consistent and more useful for diagnostics.

## Test plan
- [ ] Run: `pytest tests/tickets/api/test_event_theme_view.py`
- [ ] (Optional) Run related API tests for events module
- [ ] Confirm `EventThemeView` returns `503` with a stable message when theme config is missing

## Summary by Sourcery

Harden event theme error handling and standardize event creation exception logging while adding regression coverage for the theme error path.

Bug Fixes:
- Prevent type-related issues when formatting error responses in EventThemeView for invalid or non-string event identifiers.

Enhancements:
- Use structured exception logging via logger.exception in CreateEventView for integrity, validation, and unexpected errors.

Tests:
- Add a focused API test ensuring EventThemeView returns a 503 with a stable error message when the theme configuration is missing.