### PR TITLE
Improve Stripe documentation with webhook and OAuth setup details (#2969)

### DIFF
--- a/doc/user/payments/stripe.rst
+++ b/doc/user/payments/stripe.rst
@@ -32,3 +32,60 @@ Again, you can choose between live mode and test mode here.
 
 .. _stripe.com: https://dashboard.stripe.com/register
 .. _test cards: https://stripe.com/docs/testing#cards
+
+Stripe Webhook Configuration (Detailed)
+
+To ensure proper communication between Stripe and Eventyay, webhooks need to be configured correctly.
+
+1. Go to the Stripe Dashboard
+2. Navigate to Developers → Webhooks
+3. Click on "Add endpoint"
+
+In the "URL to be called" field, enter the webhook URL provided in Eventyay (usually found in the payment settings section).
+
+Select the following events:
+- payment_intent.succeeded
+- payment_intent.payment_failed
+- charge.refunded
+- checkout.session.completed
+
+After creating the webhook, click on it and copy the "Signing secret". This secret should be added to Eventyay in the Stripe settings to verify incoming webhook requests.
+
+---
+
+Stripe OAuth Configuration
+
+Stripe OAuth allows users to connect their Stripe accounts directly with Eventyay.
+
+1. Go to Stripe Dashboard
+2. Navigate to Settings → Connect Settings
+3. Enable Stripe Connect if not already enabled
+
+You will need the following credentials:
+- Client ID
+- Publishable Key
+- Secret Key
+
+These credentials can be entered in the Eventyay payment settings.
+
+---
+
+Redirect URIs
+
+Make sure the following redirect URI is configured in your Stripe application:
+
+/_stripe/oauth_return/
+
+For local development, you may need to use:
+http://localhost:8000/_stripe/oauth_return/
+
+For production:
+https://your-domain.com/_stripe/oauth_return/
+
+---
+
+Notes
+
+- Ensure you are using the correct mode (test or live) while configuring keys and webhooks.
+- Test mode should be used during development.
+- Live mode should only be used in production environments.


### PR DESCRIPTION
FFixes #2969

### Summary
The existing Stripe documentation covered API keys and basic setup, but it was missing clear instructions for configuring webhooks and OAuth.

### Changes made
- Added step-by-step guide for creating Stripe webhooks
- Included required events needed for proper integration
- Documented how to retrieve and use the webhook signing secret
- Added explanation for setting up Stripe OAuth
- Listed required redirect URIs for both local and production environments

### Why this change
Without proper documentation, setting up Stripe can be confusing and requires trial and error. These additions aim to make the setup process more straightforward and easier to follow.

### Additional notes
- The new content was added to the existing documentation without altering the current structure
- Kept the format consistent with the rest of the file for readability

## Summary by Sourcery

Document Stripe webhook and OAuth configuration to make payment integration setup clearer.

Documentation:
- Expand Stripe payment docs with step-by-step webhook configuration, required events, and signing secret usage.
- Add guidance for configuring Stripe OAuth, including required redirect URIs for local and production environments.