### PR TITLE
Unlink event language on unsupported UI choice

### DIFF
--- a/app/eventyay/eventyay_common/views/account/basic.py
+++ b/app/eventyay/eventyay_common/views/account/basic.py
@@ -25,6 +25,7 @@ from eventyay.base.models import Event, LogEntry, NotificationSetting, User
 from eventyay.base.notifications import get_all_notification_types
 from eventyay.common.utils.language import (
     get_event_enforce_ui_language,
+    get_event_enforce_ui_language_cookie_name,
     get_event_language_cookie_name,
     strict_match_language,
 )
@@ -383,6 +384,23 @@ class LanguageSwitchView(View):
                             response,
                             event_cookie_name,
                             linked_event_language,
+                            max_age=max_age,
+                            expires=expires.strftime('%a, %d-%b-%Y %H:%M:%S GMT'),
+                            domain=settings.SESSION_COOKIE_DOMAIN,
+                            path='/',
+                        )
+                    else:
+                        # If the selected UI language is outside event locales,
+                        # automatically unlink so the UI choice can be applied independently.
+                        enforce_cookie_name = get_event_enforce_ui_language_cookie_name(
+                            event.slug,
+                            event.organizer.slug,
+                        )
+                        set_cookie_without_samesite(
+                            request,
+                            response,
+                            enforce_cookie_name,
+                            '0',
                             max_age=max_age,
                             expires=expires.strftime('%a, %d-%b-%Y %H:%M:%S GMT'),
                             domain=settings.SESSION_COOKIE_DOMAIN,

--- a/app/tests/tickets/presale/test_locale.py
+++ b/app/tests/tickets/presale/test_locale.py
@@ -1,4 +1,5 @@
 from django.conf import settings
+from django.urls import reverse
 from django.test import Client, TestCase
 from django.utils.timezone import now
 
@@ -88,6 +89,30 @@ class EventLanguageEnforceDefaultTest(TestCase):
         self.assertEqual(response.wsgi_request.event_language, 'de')
         self.assertEqual(response['Content-Language'], 'en')
         self.assertEqual(c.cookies[self.enforce_cookie].value, '0')
+
+    def test_ui_selection_outside_event_locales_unlinks_languages(self):
+        """Selecting an unsupported UI language should auto-disable linking."""
+        c = Client()
+        c.cookies[self.enforce_cookie] = '1'
+
+        response = c.post(
+            reverse('eventyay_common:account.locale'),
+            data={
+                'locale': 'fr',
+                'event': self.event.slug,
+                'organizer': self.organizer.slug,
+                'next': '/%s/%s/' % (self.organizer.slug, self.event.slug),
+            },
+        )
+
+        self.assertEqual(response.status_code, 302)
+        self.assertEqual(response.cookies[self.enforce_cookie].value, '0')
+
+        event_page = self._get_event_page(c)
+        self.assertEqual(event_page.status_code, 200)
+        self.assertFalse(event_page.wsgi_request.event_language_enforce_ui)
+        self.assertEqual(event_page.wsgi_request.event_language, 'de')
+        self.assertEqual(event_page['Content-Language'], 'fr')
 
     def test_enforce_on_toggle_via_locale_view(self):
         """EventLocaleSet view correctly sets the enforce cookie to '0' when toggled."""


### PR DESCRIPTION
fixes #3007



https://github.com/user-attachments/assets/330f9012-ad99-4bff-a822-48919356f550



## Summary by Sourcery

Handle unsupported UI locale selections by automatically unlinking event language enforcement and add coverage for this behavior.

Bug Fixes:
- Ensure selecting a UI language not included in an event's locales disables event-UI language linking so the UI preference can be applied independently.

Tests:
- Add a regression test verifying that choosing an unsupported UI locale clears the event language enforcement cookie and applies the chosen UI language.