### PR TITLE
Fix manual refund validation error when entering negative amounts 

### DIFF
--- a/app/eventyay/control/views/orders.py
+++ b/app/eventyay/control/views/orders.py
@@ -996,37 +996,46 @@ class OrderRefundView(OrderView):
             manual_value = formats.sanitize_separators(manual_value)
             try:
                 manual_value = Decimal(manual_value)
+                manual_value = round_decimal(manual_value, self.request.event.currency)
             except (DecimalException, TypeError):
                 messages.error(self.request, _('You entered an invalid number.'))
                 is_valid = False
             else:
-                refund_selected += manual_value
-                if manual_value:
-                    refunds.append(
-                        OrderRefund(
-                            order=self.order,
-                            payment=None,
-                            source=OrderRefund.REFUND_SOURCE_ADMIN,
-                            state=(
-                                OrderRefund.REFUND_STATE_DONE
-                                if self.request.POST.get('manual_state') == 'done'
-                                else OrderRefund.REFUND_STATE_CREATED
-                            ),
-                            amount=manual_value,
-                            comment=comment,
-                            provider='manual',
+                if manual_value < 0:
+                    messages.error(self.request, _('Refund values can not be negative.'))
+                    is_valid = False
+                else:
+                    refund_selected += manual_value
+                    if manual_value > 0:
+                        refunds.append(
+                            OrderRefund(
+                                order=self.order,
+                                payment=None,
+                                source=OrderRefund.REFUND_SOURCE_ADMIN,
+                                state=(
+                                    OrderRefund.REFUND_STATE_DONE
+                                    if self.request.POST.get('manual_state') == 'done'
+                                    else OrderRefund.REFUND_STATE_CREATED
+                                ),
+                                amount=manual_value,
+                                comment=comment,
+                                provider='manual',
+                            )
                         )
-                    )
 
             giftcard_value = self.request.POST.get('refund-new-giftcard', '0') or '0'
             giftcard_value = formats.sanitize_separators(giftcard_value)
             try:
                 giftcard_value = Decimal(giftcard_value)
+                giftcard_value = round_decimal(giftcard_value, self.request.event.currency)
             except (DecimalException, TypeError):
                 messages.error(self.request, _('You entered an invalid number.'))
                 is_valid = False
             else:
-                if giftcard_value:
+                if giftcard_value < 0:
+                    messages.error(self.request, _('Refund values can not be negative.'))
+                    is_valid = False
+                elif giftcard_value > 0:
                     refund_selected += giftcard_value
                     giftcard = self.request.organizer.issued_gift_cards.create(
                         expires=self.request.organizer.default_gift_card_expiry,
@@ -1052,11 +1061,15 @@ class OrderRefundView(OrderView):
             offsetting_value = formats.sanitize_separators(offsetting_value)
             try:
                 offsetting_value = Decimal(offsetting_value)
+                offsetting_value = round_decimal(offsetting_value, self.request.event.currency)
             except (DecimalException, TypeError):
                 messages.error(self.request, _('You entered an invalid number.'))
                 is_valid = False
             else:
-                if offsetting_value:
+                if offsetting_value < 0:
+                    messages.error(self.request, _('Refund values can not be negative.'))
+                    is_valid = False
+                elif offsetting_value > 0:
                     refund_selected += offsetting_value
                     try:
                         order = Order.objects.get(
@@ -1089,8 +1102,13 @@ class OrderRefundView(OrderView):
                 prof_value = formats.sanitize_separators(prof_value)
                 try:
                     prof_value = Decimal(prof_value)
+                    prof_value = round_decimal(prof_value, self.request.event.currency)
                 except (DecimalException, TypeError):
                     messages.error(self.request, _('You entered an invalid number.'))
+                    is_valid = False
+                    continue
+                if prof_value < Decimal('0.00'):
+                    messages.error(self.request, _('Refund values can not be negative.'))
                     is_valid = False
                     continue
                 if prof_value > Decimal('0.00'):
@@ -1112,10 +1130,15 @@ class OrderRefundView(OrderView):
                 value = formats.sanitize_separators(value)
                 try:
                     value = Decimal(value)
+                    value = round_decimal(value, self.request.event.currency)
                 except (DecimalException, TypeError):
                     messages.error(self.request, _('You entered an invalid number.'))
                     is_valid = False
                 else:
+                    if value < 0:
+                        messages.error(self.request, _('Refund values can not be negative.'))
+                        is_valid = False
+                        continue
                     if value == 0:
                         continue
                     elif value > p.available_amount:
@@ -1147,6 +1170,8 @@ class OrderRefundView(OrderView):
                         )
 
             any_success = False
+            refund_selected = round_decimal(refund_selected, self.request.event.currency)
+            full_refund = round_decimal(full_refund, self.request.event.currency)
             if refund_selected == full_refund and is_valid:
                 for r in refunds:
                     r.save()
@@ -1243,10 +1268,21 @@ class OrderRefundView(OrderView):
                             )
                 return redirect(self.get_order_url())
             else:
-                messages.error(
-                    self.request,
-                    _('The refunds you selected do not match the selected total refund amount.'),
-                )
+                if is_valid:
+                    logger.warning(
+                        'Refund amount mismatch for order %s: selected=%s expected=%s',
+                        self.order.code,
+                        refund_selected,
+                        full_refund,
+                    )
+                    messages.error(
+                        self.request,
+                        _('The refunds you selected do not match the selected total refund amount. '
+                          'Selected: {selected}, expected: {expected}.').format(
+                            selected=money_filter(refund_selected, self.request.event.currency),
+                            expected=money_filter(full_refund, self.request.event.currency),
+                        ),
+                    )
 
         new_refunds = []
         for identifier, prov in self.request.event.get_payment_providers().items():

--- a/app/tests/tickets/control/test_orders.py
+++ b/app/tests/tickets/control/test_orders.py
@@ -2225,7 +2225,7 @@ def test_refund_amount_does_not_match_or_invalid(client, env):
         follow=True,
     )
     assert b'alert-danger' in resp.content
-    assert b'do not match the' in resp.content
+    assert b'can not be negative' in resp.content
     resp = client.post(
         '/control/event/dummy/dummy/orders/FOO/refund',
         {
@@ -2241,6 +2241,35 @@ def test_refund_amount_does_not_match_or_invalid(client, env):
     )
     assert b'alert-danger' in resp.content
     assert b'invalid number' in resp.content
+
+
+@pytest.mark.django_db
+def test_refund_negative_giftcard_does_not_create_giftcard(client, env):
+    with scopes_disabled():
+        p = env[2].payments.last()
+        p.confirm()
+        giftcard_count_before = GiftCard.objects.count()
+
+    client.login(email='dummy@dummy.dummy', password='dummy')
+    resp = client.post(
+        '/control/event/dummy/dummy/orders/FOO/refund',
+        {
+            'start-partial_amount': '7.00',
+            'start-mode': 'partial',
+            'start-action': 'mark_pending',
+            'refund-new-giftcard': '-1.00',
+            'refund-{}'.format(p.pk): '8.00',
+            'manual_state': 'pending',
+            'perform': 'on',
+        },
+        follow=True,
+    )
+
+    assert b'alert-danger' in resp.content
+    assert b'can not be negative' in resp.content
+
+    with scopes_disabled():
+        assert GiftCard.objects.count() == giftcard_count_before
 
 
 @pytest.mark.django_db


### PR DESCRIPTION
Fixes #3096 
## The Problem

When trying to process refunds manually, you get an error:
"The refunds you selected do not match the selected total refund amount."

Root causes:
- Form was accepting negative values without validation
- Decimal precision wasn't normalized before comparing amounts  
- Negative amounts could create phantom refund records

##  Fixes

Manual refund validation layer:
- Added negative value checks on all refund input fields
- Fixed currency rounding/precision before amount comparison  
- Better error messages showing what was selected vs what was expected
- Prevented invalid refund records from being created
- Added logging and regression tests

## Notes

Stripe webhook refund syncing is handled by the eventyay-stripe plugin (separate repo).
If Stripe webhooks aren't syncing refunds:
1. Verify plugin webhook endpoint is registered in Stripe dashboard
2. Check plugin logs/issues if the endpoint is registered but failing

This PR focuses on unblocking manual refund processing immediately.