### PR TITLE
fix for UI changes replacing "Quota" with Capacity

### DIFF
--- a/app/eventyay/base/models/product.py
+++ b/app/eventyay/base/models/product.py
@@ -1518,12 +1518,12 @@ class Quota(LoggedModel):
         related_name='quotas',
         verbose_name=pgettext_lazy('subevent', 'Date'),
     )
-    name = models.CharField(max_length=200, verbose_name=_('Name'))
+    name = models.CharField(max_length=200, verbose_name=_('Capacity name'), help_text=_('Use a name to identify this shared capacity.'))
     size = models.PositiveIntegerField(
-        verbose_name=_('Total capacity'),
+        verbose_name=_('Maximum number'),
         null=True,
         blank=True,
-        help_text=_('Leave empty for an unlimited number of tickets.'),
+        help_text=_('Leave empty for unlimited tickets.'),
     )
     products = models.ManyToManyField(Product, verbose_name=_('Product'), related_name='quotas', blank=True)
     variations = models.ManyToManyField(
@@ -1531,25 +1531,17 @@ class Quota(LoggedModel):
     )
 
     close_when_sold_out = models.BooleanField(
-        verbose_name=_('Close this quota permanently once it is sold out'),
+        verbose_name=_('Stop selling permanently when capacity is reached'),
         help_text=_(
-            'If you enable this, when the quota is sold out once, no more tickets will be sold, '
-            'even if tickets become available again through cancellations or expiring orders. Of course, '
-            'you can always re-open it manually.'
+            'Even if tickets are later refunded or cancelled, sales will not resume automatically.'
         ),
         default=False,
     )
     closed = models.BooleanField(default=False)
 
     release_after_exit = models.BooleanField(
-        verbose_name=_('Allow to sell more tickets once people have checked out'),
-        help_text=_(
-            'With this option, quota will be released as soon as people are scanned at an exit of your event. '
-            'This will only happen if they have been scanned both at an entry and at an exit and the exit '
-            'is the more recent scan. It does not matter which check-in list either of the scans was on, '
-            'but check-in lists are ignored if they are set to "Allow re-entering after an exit scan" to '
-            'prevent accidental overbooking.'
-        ),
+        verbose_name=_('Reuse capacity when attendees leave'),
+        help_text=_('When attendees are checked out, their spot becomes available again for new tickets.'),
         default=False,
     )
 

--- a/app/eventyay/control/forms/product.py
+++ b/app/eventyay/control/forms/product.py
@@ -329,7 +329,7 @@ class ProductCreateForm(I18nModelForm):
                 choices.remove(choices[1])
 
             self.fields['quota_option'] = forms.ChoiceField(
-                label=_('Quota options'),
+                label=_('Capacity options'),
                 widget=forms.RadioSelect,
                 choices=choices,
                 initial=self.NONE,

--- a/app/eventyay/control/navigation.py
+++ b/app/eventyay/control/navigation.py
@@ -160,7 +160,7 @@ def get_event_navigation(request: HttpRequest):
                 or 'event.product.' in url.url_name,
             },
             {
-                'label': _('Quotas'),
+                'label': _('Capacity'),
                 'url': reverse(
                     'control:event.products.quotas',
                     kwargs={

--- a/app/eventyay/control/templates/pretixcontrol/item/create.html
+++ b/app/eventyay/control/templates/pretixcontrol/item/create.html
@@ -94,7 +94,7 @@
         </fieldset>
         {% if form.quota_option %}
             <fieldset>
-                <legend>{% trans "Quota settings" %}</legend>
+                <legend>{% trans "Capacity settings" %}</legend>
                 {% bootstrap_field form.quota_option layout="control" %}
                 <div id="existing-quota-group">
                     {% bootstrap_field form.quota_add_existing layout="control" %}

--- a/app/eventyay/control/templates/pretixcontrol/items/quota_edit.html
+++ b/app/eventyay/control/templates/pretixcontrol/items/quota_edit.html
@@ -15,7 +15,7 @@
                 {% if question %}
                     <h1>{% blocktrans with name=quota.name %}Quota: {{ name }}{% endblocktrans %}</h1>
                 {% else %}
-                    <h1>{% trans "Quota" %}</h1>
+                    <h1>{% trans "Capacity rule" %}</h1>
                 {% endif %}
             </div>
             {% include "pretixcontrol/event/component_link.html" %}
@@ -25,7 +25,8 @@
         {% csrf_token %}
         {% bootstrap_form_errors form %}
         <fieldset>
-            <legend>{% trans "General information" %}</legend>
+            <legend>{% trans "Capacity settings" %}</legend>
+            <!-- work to be done -->
             {% bootstrap_field form.name layout="control" %}
             {% bootstrap_field form.size layout="control" %}
             {% if form.subevent %}
@@ -33,13 +34,10 @@
             {% endif %}
         </fieldset>
         <fieldset>
-            <legend>{% trans "Items" %}</legend>
+            <legend>{% trans "Applies to ticket types" %}</legend>
             <p>
                 {% blocktrans trimmed %}
-                    Please select the products or product variations this quota should be applied to. If you apply two
-                    quotas to the same product, it will only be available if
-                    <strong>both</strong> quotas have capacity
-                    left.
+                    Select which ticket types or products share this capacity. If multiple ticket types or products are selected, they will use the same pool of available capacity. If a ticket or product type is limited by multiple capacities, it will only be available while all limits still have remaining capacity.
                 {% endblocktrans %}
             </p>
             {% bootstrap_field form.productvars layout="control" %}

--- a/app/eventyay/control/templates/pretixcontrol/items/quotas.html
+++ b/app/eventyay/control/templates/pretixcontrol/items/quotas.html
@@ -6,14 +6,14 @@
     <nav id="event-nav" class="header-nav">
         <div class="navigation">
             <div class="navigation-title">
-                <h1>{% trans "Quotas" %}</h1>
+                <h1>{% trans "Capacity" %}</h1>
             </div>
             {% include "pretixcontrol/event/component_link.html" %}
         </div>
     </nav>
     <p>
         {% blocktrans trimmed %}
-        To ensure your products are available as intended, you need to set quotas. Quotas determine how many instances of your product can be sold on the platform. This allows you to configure whether your event can accommodate an unlimited number of attendees or if the number of attendees is capped. You can assign a product to multiple quotas to meet more complex requirements, such as limiting the total number of tickets sold while also restricting the number of specific ticket types simultaneously.
+        Define how many tickets can be sold. You can set limits for the entire event or for individual ticket types. Multiple ticket types can also share a common capacity.
         {% endblocktrans %}
     </p>
     {% if request.event.has_subevents %}
@@ -34,18 +34,18 @@
             </p>
 
             <a href="{% url "control:event.products.quotas.add" organizer=request.event.organizer.slug event=request.event.slug %}"
-                    class="btn btn-primary btn-lg"><i class="fa fa-plus"></i> {% trans "Create a new quota" %}</a>
+                    class="btn btn-primary btn-lg"><i class="fa fa-plus"></i> {% trans "Add capacity rule" %}</a>
         </div>
     {% else %}
         <p>
-            <a href="{% url "control:event.products.quotas.add" organizer=request.event.organizer.slug event=request.event.slug %}" class="btn btn-default"><i class="fa fa-plus"></i> {% trans "Create a new quota" %}
+            <a href="{% url "control:event.products.quotas.add" organizer=request.event.organizer.slug event=request.event.slug %}" class="btn btn-default"><i class="fa fa-plus"></i> {% trans "Add capacity rule" %}
             </a>
         </p>
         <div class="table-responsive">
             <table class="table table-hover table-quotas">
                 <thead>
                 <tr>
-                    <th>{% trans "Quota name" %}
+                    <th>{% trans "Capacity rule name" %}
                         <a href="?{% url_replace request 'ordering' '-name' %}"><i class="fa fa-caret-down"></i></a>
                         <a href="?{% url_replace request 'ordering' 'name' %}"><i class="fa fa-caret-up"></i></a></th>
                     </th>
@@ -60,7 +60,7 @@
                         <a href="?{% url_replace request 'ordering' '-size' %}"><i class="fa fa-caret-down"></i></a>
                         <a href="?{% url_replace request 'ordering' 'size' %}"><i class="fa fa-caret-up"></i></a></th>
                     </th>
-                    <th>{% trans "Capacity left" %}</th>
+                    <th>{% trans "Available capacity" %}</th>
                     <th class="action-col-2"></th>
                 </tr>
                 </thead>


### PR DESCRIPTION
Fixes #3132

Made changes as per proposed changes .

<img width="1439" height="778" alt="Screenshot 2026-04-02 at 12 14 41 PM" src="https://github.com/user-attachments/assets/41e5d586-d109-4e76-90d0-5ce107a9d3dc" />

<img width="1438" height="776" alt="Screenshot 2026-04-02 at 12 12 06 PM" src="https://github.com/user-attachments/assets/2352dae0-c8db-4ca9-a84a-db6a1daa999e" />

<img width="1438" height="727" alt="Screenshot 2026-04-02 at 12 20 27 PM" src="https://github.com/user-attachments/assets/301cd3ae-7bc1-4ed7-8ef3-b01ef9aeacb3" />

## Summary by Sourcery

Update event capacity management terminology and copy across models and admin UI to replace quotas with clearer capacity-focused language.

Enhancements:
- Rename quota-related labels and headings in the admin UI to use capacity-focused terminology (e.g. capacity rule, capacity options, available capacity).
- Adjust capacity-related help texts and field labels on the Quota model to better explain shared capacities, maximum numbers, and reuse behavior when attendees leave.
- Update navigation and item creation screens to reflect the new capacity terminology and group related settings under capacity settings.