### PR TITLE
Fix: update login button text to 'Log in with email'

### DIFF
--- a/app/eventyay/eventyay_common/templates/eventyay_common/auth/_login_options.html
+++ b/app/eventyay/eventyay_common/templates/eventyay_common/auth/_login_options.html
@@ -18,7 +18,7 @@
   {% endif %}
   <div class='login-options-secondary-group'>
     <button type='button' id='toggle-login' class='btn btn-primary btn-block login-option-secondary' data-toggle='collapse' data-target='#login-form'>
-      {% translate 'Login with Email' %}
+      {% translate 'Log in with email' %}
     </button>
     {% if login_providers %}
       {% for provider, settings in login_providers.items %}


### PR DESCRIPTION
Fixes #3099
The login page had inconsistent button text where "Login with Email" did not match the "Log in" wording used on the primary button and elsewhere in the authentication flow. This PR updates the button label in _login_options.html from "Login with Email" to "Log in with email" to bring it in line with the existing UI wording.

**Screenshots**
Before:
<img width="959" height="539" alt="before picture" src="https://github.com/user-attachments/assets/f59b37d4-e8c7-47f5-8192-e0577e4de050" />

After:
<img width="959" height="539" alt="after picture" src="https://github.com/user-attachments/assets/a7d81b4e-bbdf-4d8f-9a3d-a632ab741309" />

**Screencast**
[Watch here](https://www.loom.com/share/bd736135369a4720803e3d98b3f925f6)

**Test Steps**

- Run the development server using python manage.py runserver
- Navigate to http://127.0.0.1:8000/common/login/
- Observe the secondary button now reads "Log in with email" instead of "Login with Email"
- Confirm it matches the wording of the primary "Log in" button above it

## Summary by Sourcery

Bug Fixes:
- Correct inconsistent login button label by changing "Login with Email" to "Log in with email" on the login options template.