### PR TITLE
Support markdown rendering for featured speaker biographies

### DIFF
--- a/app/eventyay/webapp/schedule/src/components/FeaturedSpeakers.vue
+++ b/app/eventyay/webapp/schedule/src/components/FeaturedSpeakers.vue
@@ -17,8 +17,9 @@
 								path(fill="currentColor", d="M12,1A5.8,5.8 0 0,1 17.8,6.8A5.8,5.8 0 0,1 12,12.6A5.8,5.8 0 0,1 6.2,6.8A5.8,5.8 0 0,1 12,1M12,15C18.63,15 24,17.67 24,21V23H0V21C0,17.67 5.37,15 12,15Z")
 						.caption.text-center
 							h4 {{ speaker.name || t.speaker_fallback }}
-							markdown-content.featured-speaker-preview-bio(v-if="speaker.biography", :markdown="speaker.biography")
+							markdown-content.featured-speaker-preview-bio(v-if="speaker.biography", :markdown="speaker.biography", :disable-links="true")
 				.featured-speaker-details
+					markdown-content.featured-speaker-bio(v-if="speaker.biography", :markdown="speaker.biography")
 					template(v-if="speaker.sessions && speaker.sessions.length")
 						hr.featured-speaker-divider
 						.featured-speaker-sessions
@@ -282,14 +283,7 @@ export default {
 						line-height: inherit
 					a
 						color: inherit
-
-	.featured-speaker-card[open] .featured-speaker-summary .thumbnail .caption .featured-speaker-preview-bio
-		display: block
-		-webkit-line-clamp: unset
-		-webkit-box-orient: unset
-		overflow: visible
-		p + p
-			margin-top: 8px
+						pointer-events: none
 
 	.avatar-placeholder
 		width: 100%
@@ -308,6 +302,18 @@ export default {
 		padding: 12px
 		background: $clr-grey-100
 		border-top: 1px solid $clr-grey-300
+
+	.featured-speaker-bio
+		font-size: 14px
+		line-height: 1.5
+		color: $clr-primary-text-light
+		overflow-wrap: anywhere
+		p
+			margin: 0
+		p + p
+			margin-top: 8px
+		a
+			color: var(--pretalx-clr-primary, var(--clr-primary))
 
 	.featured-speaker-divider
 		margin: 12px 0 8px

--- a/app/eventyay/webapp/schedule/src/components/FeaturedSpeakers.vue
+++ b/app/eventyay/webapp/schedule/src/components/FeaturedSpeakers.vue
@@ -17,7 +17,7 @@
 								path(fill="currentColor", d="M12,1A5.8,5.8 0 0,1 17.8,6.8A5.8,5.8 0 0,1 12,12.6A5.8,5.8 0 0,1 6.2,6.8A5.8,5.8 0 0,1 12,1M12,15C18.63,15 24,17.67 24,21V23H0V21C0,17.67 5.37,15 12,15Z")
 						.caption.text-center
 							h4 {{ speaker.name || t.speaker_fallback }}
-							p.featured-speaker-preview-bio(v-if="speaker.biography") {{ speaker.biography }}
+							markdown-content.featured-speaker-preview-bio(v-if="speaker.biography", :markdown="speaker.biography")
 				.featured-speaker-details
 					template(v-if="speaker.sessions && speaker.sessions.length")
 						hr.featured-speaker-divider
@@ -40,10 +40,12 @@
 
 <script>
 import moment from 'moment-timezone'
+import MarkdownContent from './MarkdownContent.vue'
 import { getLocalizedString } from '../utils'
 
 export default {
 	name: 'FeaturedSpeakers',
+	components: { MarkdownContent },
 	inject: {
 		scheduleData: { default: null },
 		eventUrl: { default: '' },
@@ -274,13 +276,20 @@ export default {
 					-webkit-box-orient: vertical
 					overflow: hidden
 					overflow-wrap: anywhere
+					p
+						margin: 0
+						font-size: inherit
+						line-height: inherit
+					a
+						color: inherit
 
 	.featured-speaker-card[open] .featured-speaker-summary .thumbnail .caption .featured-speaker-preview-bio
 		display: block
 		-webkit-line-clamp: unset
 		-webkit-box-orient: unset
 		overflow: visible
-		white-space: pre-wrap
+		p + p
+			margin-top: 8px
 
 	.avatar-placeholder
 		width: 100%

--- a/app/eventyay/webapp/schedule/src/components/MarkdownContent.vue
+++ b/app/eventyay/webapp/schedule/src/components/MarkdownContent.vue
@@ -9,21 +9,43 @@ const markdownIt = MarkdownIt({
 	breaks: true
 })
 
+const markdownItWithoutLinks = MarkdownIt({
+	linkify: false,
+	breaks: true
+})
+
+markdownItWithoutLinks.renderer.rules.link_open = () => ''
+markdownItWithoutLinks.renderer.rules.link_close = () => ''
+
+function escapeHtml(text) {
+	return String(text)
+		.replace(/&/g, '&amp;')
+		.replace(/</g, '&lt;')
+		.replace(/>/g, '&gt;')
+		.replace(/"/g, '&quot;')
+		.replace(/'/g, '&#39;')
+}
+
 export default {
 	name: 'MarkdownContent',
 	props: {
 		markdown: {
 			type: String,
 			default: ''
+		},
+		disableLinks: {
+			type: Boolean,
+			default: false
 		}
 	},
 	computed: {
 		rendered () {
 			if (!this.markdown) return ''
 			try {
-				return markdownIt.render(this.markdown)
+				const parser = this.disableLinks ? markdownItWithoutLinks : markdownIt
+				return parser.render(this.markdown)
 			} catch {
-				return this.markdown
+				return `<p>${escapeHtml(this.markdown)}</p>`
 			}
 		}
 	}


### PR DESCRIPTION
Before:
<img width="496" height="566" alt="Screenshot 2026-04-06 at 5 11 07 PM" src="https://github.com/user-attachments/assets/8d260a35-7b46-4916-aa7b-b16d9bb86064" />


After:
<img width="555" height="489" alt="Screenshot 2026-04-06 at 5 10 48 PM" src="https://github.com/user-attachments/assets/f2101a84-674f-44c8-a9d5-ec9a3932c524" />

## Summary by Sourcery

Render featured speaker biographies as markdown content in the schedule view and adjust preview styling for multi-paragraph bios.

New Features:
- Support markdown rendering for featured speaker biographies in the schedule view.

Enhancements:
- Improve featured speaker bio preview styling, including paragraph spacing and link color inheritance for expanded cards.