### PR TITLE
fix: organizer name link in sidebar not navigating to dashboard

### DIFF
--- a/app/eventyay/orga/templates/orga/base.html
+++ b/app/eventyay/orga/templates/orga/base.html
@@ -182,7 +182,7 @@
             <aside class="nav flex-column sidebar">
                 <div class="dropdown nav-link p-0" id="nav-search-wrapper">
                     {% block nav_top_header %}
-                        <div id="nav-search" class="summary-div" aria-haspopup="true" aria-expanded="false">
+                        <div id="nav-search" class="summary-div">
                             <a href="{% get_dashboard_url %}" class="d-flex align-items-center" style="text-decoration: none; color: inherit;">
                                 <span id="search-context-icon" class="fa-stack fa-lg">
                                     <i class="fa fa-circle fa-stack-2x"></i>
@@ -200,9 +200,9 @@
                                     {% endif %}
                                 </div>
                             </a>
-                            <span class="nav-search-toggle" title="{% translate 'Search' %} (Alt + k)">
-                                <i class="fa fa-search"></i>
-                            </span>
+                            <button type="button" class="nav-search-toggle" aria-label="{% translate 'Search' %}" aria-expanded="false" aria-controls="nav-search-input-wrapper" aria-haspopup="listbox">
+                                <i class="fa fa-search" aria-hidden="true"></i>
+                            </button>
                         </div>
                         <div id="nav-search-input-wrapper" class="d-none dropdown-content dropdown-menu dropdown-menu-left" aria-labelledby="nav-search" data-source="{% url 'orga:nav.typeahead' %}" data-event-typeahead data-organizer="{% if request.event %}{{ request.event.organizer.pk }}{% elif request.organizer %}{{ request.organizer.pk }}{% endif %}">
                             <div class="query-holder">

--- a/app/eventyay/orga/templates/orga/base.html
+++ b/app/eventyay/orga/templates/orga/base.html
@@ -182,36 +182,37 @@
             <aside class="nav flex-column sidebar">
                 <div class="dropdown nav-link p-0" id="nav-search-wrapper">
                     {% block nav_top_header %}
-                        <a href="{% get_dashboard_url %}" style="text-decoration: none; color: inherit;">
-                            <div id="nav-search" class="dropdown-toggle summary-div" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
-                                <div class="d-flex justify-content-between align-items-center">
-                                    <span id="search-context-icon" class="fa-stack fa-lg">
-                                        <i class="fa fa-circle fa-stack-2x"></i>
-                                        <i class="fa {% get_top_menu_item_icon_class %} fa-stack-1x fa-inverse"></i>
-                                    </span>
-                                    <div id="search-context-text">
-                                        {% if request.event %}
-                                            <span class="context-name font-weight-bold">{{ request.event.name }}</span>
-                                            <span class="context-meta">{{ request.event.get_date_range_display }}</span>
-                                        {% elif request.organizer %}
-                                            <span class="context-name font-weight-bold">{{ request.organizer.name }}</span>
-                                            <span class="context-meta">{% translate "Organizer account" %}</span>
-                                        {% else %}
-                                            <span class="context-name font-weight-bold">{% translate "Talk dashboard" %}</span>
-                                        {% endif %}
-                                    </div>
+                        <div id="nav-search" class="summary-div" aria-haspopup="true" aria-expanded="false">
+                            <a href="{% get_dashboard_url %}" class="d-flex align-items-center" style="text-decoration: none; color: inherit;">
+                                <span id="search-context-icon" class="fa-stack fa-lg">
+                                    <i class="fa fa-circle fa-stack-2x"></i>
+                                    <i class="fa {% get_top_menu_item_icon_class %} fa-stack-1x fa-inverse"></i>
+                                </span>
+                                <div id="search-context-text">
+                                    {% if request.event %}
+                                        <span class="context-name font-weight-bold">{{ request.event.name }}</span>
+                                        <span class="context-meta">{{ request.event.get_date_range_display }}</span>
+                                    {% elif request.organizer %}
+                                        <span class="context-name font-weight-bold">{{ request.organizer.name }}</span>
+                                        <span class="context-meta">{% translate "Organizer account" %}</span>
+                                    {% else %}
+                                        <span class="context-name font-weight-bold">{% translate "Talk dashboard" %}</span>
+                                    {% endif %}
+                                </div>
+                            </a>
+                            <span class="nav-search-toggle" title="{% translate 'Search' %} (Alt + k)">
+                                <i class="fa fa-search"></i>
+                            </span>
+                        </div>
+                        <div id="nav-search-input-wrapper" class="d-none dropdown-content dropdown-menu dropdown-menu-left" aria-labelledby="nav-search" data-source="{% url 'orga:nav.typeahead' %}" data-event-typeahead data-organizer="{% if request.event %}{{ request.event.organizer.pk }}{% elif request.organizer %}{{ request.organizer.pk }}{% endif %}">
+                            <div class="query-holder">
+                                <div class="form-box">
+                                    <input type="search" class="form-control" placeholder="{% translate 'Search' %} (Alt + k)" data-typeahead-query>
                                 </div>
                             </div>
-                            <div id="nav-search-input-wrapper" class="d-none dropdown-content dropdown-menu dropdown-menu-left" aria-labelledby="nav-search" data-source="{% url 'orga:nav.typeahead' %}" data-event-typeahead data-organizer="{% if request.event %}{{ request.event.organizer.pk }}{% elif request.organizer %}{{ request.organizer.pk }}{% endif %}">
-                                <div class="query-holder">
-                                    <div class="form-box">
-                                        <input type="search" class="form-control" placeholder="{% translate 'Search' %} (Alt + k)" data-typeahead-query>
-                                    </div>
-                                </div>
-                                <ul id="search-results">
-                                </ul>
-                            </div>
-                        </a>
+                            <ul id="search-results">
+                            </ul>
+                        </div>
                     {% endblock %}
                 </div>
                 {% if request.event %}

--- a/app/eventyay/orga/templates/orga/user.html
+++ b/app/eventyay/orga/templates/orga/user.html
@@ -19,28 +19,29 @@
 {% endblock %}
 
 {% block nav_top_header %}
-    <a href="#" style="text-decoration: none; color: inherit;">
-        <div id="nav-search" class="dropdown-toggle summary-div" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
-            <div class="d-flex justify-content-between align-items-center">
-                <span id="search-context-icon" class="fa-stack fa-lg">
-                    <i class="fa fa-circle fa-stack-2x"></i>
-                    <i class="fa fa-user fa-stack-1x fa-inverse"></i>
-                </span>
-                <div id="search-context-text">
-                    <span class="context-name font-weight-bold">{% translate "Account" %}</span>
-                </div>
+    <div id="nav-search" class="summary-div">
+        <a href="{% url 'orga:user.view' %}" class="d-flex align-items-center" style="text-decoration: none; color: inherit;">
+            <span id="search-context-icon" class="fa-stack fa-lg">
+                <i class="fa fa-circle fa-stack-2x"></i>
+                <i class="fa fa-user fa-stack-1x fa-inverse"></i>
+            </span>
+            <div id="search-context-text">
+                <span class="context-name font-weight-bold">{% translate "Account" %}</span>
+            </div>
+        </a>
+        <button type="button" class="nav-search-toggle" aria-label="{% translate 'Search' %}" aria-expanded="false" aria-controls="nav-search-input-wrapper" aria-haspopup="listbox">
+            <i class="fa fa-search" aria-hidden="true"></i>
+        </button>
+    </div>
+    <div id="nav-search-input-wrapper" class="d-none dropdown-content dropdown-menu dropdown-menu-left" aria-labelledby="nav-search" data-source="{% url 'orga:nav.typeahead' %}" data-event-typeahead data-organizer="{% if request.event %}{{ request.event.organizer.pk }}{% elif request.organizer %}{{ request.organizer.pk }}{% endif %}">
+        <div class="query-holder">
+            <div class="form-box">
+                <input type="search" class="form-control" placeholder="{% translate 'Search' %} (Alt + k)" data-typeahead-query>
             </div>
         </div>
-        <div id="nav-search-input-wrapper" class="d-none dropdown-content dropdown-menu dropdown-menu-left" aria-labelledby="nav-search" data-source="{% url 'orga:nav.typeahead' %}" data-event-typeahead data-organizer="{% if request.event %}{{ request.event.organizer.pk }}{% elif request.organizer %}{{ request.organizer.pk }}{% endif %}">
-            <div class="query-holder">
-                <div class="form-box">
-                    <input type="search" class="form-control" placeholder="{% translate 'Search' %} (Alt + k)" data-typeahead-query>
-                </div>
-            </div>
-            <ul id="search-results">
-            </ul>
-        </div>
-    </a>
+        <ul id="search-results">
+        </ul>
+    </div>
 {% endblock %}
 
 {% block extra_title %}{% translate "User settings" %} :: {% endblock extra_title %}

--- a/app/eventyay/static/orga/css/_layout.css
+++ b/app/eventyay/static/orga/css/_layout.css
@@ -344,14 +344,37 @@ aside.sidebar {
     color: var(--color-primary);
     height: 56px;
 
-    &:hover #search-context-icon,
-    &:hover #search-context-text .context-name {
+    > a {
+      flex-grow: 1;
+      min-width: 0;
+      color: inherit;
+      text-decoration: none;
+    }
+
+    > a:hover #search-context-icon,
+    > a:hover #search-context-text .context-name {
       color: var(--color-primary-hover);
     }
 
     &:after {
       /* dropdown indicator */
-      margin-right: 12px;
+      display: none;
+    }
+
+    .nav-search-toggle {
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      width: 36px;
+      cursor: pointer;
+      color: var(--color-primary);
+      opacity: 0.7;
+      flex-shrink: 0;
+
+      &:hover {
+        opacity: 1;
+        color: var(--color-primary-hover);
+      }
     }
 
     #search-context-icon {

--- a/app/eventyay/static/orga/css/_layout.css
+++ b/app/eventyay/static/orga/css/_layout.css
@@ -361,19 +361,25 @@ aside.sidebar {
       display: none;
     }
 
-    .nav-search-toggle {
+    button.nav-search-toggle {
       display: flex;
       align-items: center;
       justify-content: center;
       width: 36px;
+      flex-shrink: 0;
       cursor: pointer;
       color: var(--color-primary);
       opacity: 0.7;
-      flex-shrink: 0;
+      background: none;
+      border: none;
+      padding: 0;
 
-      &:hover {
+      &:hover,
+      &:focus-visible {
         opacity: 1;
         color: var(--color-primary-hover);
+        outline: 2px solid var(--color-primary);
+        outline-offset: 2px;
       }
     }
 

--- a/app/eventyay/static/orga/js/typeahead.js
+++ b/app/eventyay/static/orga/js/typeahead.js
@@ -79,17 +79,22 @@ const initNavSearch = () => {
         const isOpen = !searchWrapper.classList.contains("d-none")
         if (isOpen) {
             searchWrapper.classList.add("d-none")
+            searchWrapper.setAttribute("aria-hidden", "true")
+            if (searchToggle) searchToggle.setAttribute("aria-expanded", "false")
             searchInput.value = ""
             lastQuery = null
         } else {
             searchWrapper.classList.remove("d-none")
+            searchWrapper.removeAttribute("aria-hidden")
+            if (searchToggle) searchToggle.setAttribute("aria-expanded", "true")
             triggerSearch()
             setTimeout(() => searchInput.focus(), 0)
         }
     }
 
-    if (searchToggle) {
-        searchToggle.addEventListener("click", (ev) => {
+    const toggleClickTarget = searchToggle || wrapper.querySelector("#nav-search")
+    if (toggleClickTarget) {
+        toggleClickTarget.addEventListener("click", (ev) => {
             ev.preventDefault()
             ev.stopPropagation()
             toggleSearchDropdown()
@@ -100,6 +105,8 @@ const initNavSearch = () => {
     document.addEventListener("click", (ev) => {
         if (!wrapper.contains(ev.target) && !searchWrapper.classList.contains("d-none")) {
             searchWrapper.classList.add("d-none")
+            searchWrapper.setAttribute("aria-hidden", "true")
+            if (searchToggle) searchToggle.setAttribute("aria-expanded", "false")
             searchInput.value = ""
             lastQuery = null
         }

--- a/app/eventyay/static/orga/js/typeahead.js
+++ b/app/eventyay/static/orga/js/typeahead.js
@@ -1,6 +1,6 @@
 const initNavSearch = () => {
     const wrapper = document.querySelector("#nav-search-wrapper")
-    const summary = wrapper.querySelector(".summary-div")
+    const searchToggle = wrapper.querySelector(".nav-search-toggle")
     const searchInput = wrapper.querySelector("input")
     const searchWrapper = wrapper.querySelector("#nav-search-input-wrapper")
     const apiURL = searchWrapper.getAttribute("data-source")
@@ -74,17 +74,35 @@ const initNavSearch = () => {
 
     searchInput.addEventListener("input", () => {triggerSearch()})
 
-    // Focus search input when dropdown is expanded, and trigger empty search
-    wrapper.addEventListener("click", () => {
-        triggerSearch()
-        setTimeout(() => {
-            if (wrapper.getAttribute("open") === "") {
-                searchInput.focus()
-            } else {
-                // Clear search input when dropdown is collapsed
-                searchInput.value = ""
-            }
-        }, 0)
+    // Toggle search dropdown when search icon is clicked
+    const toggleSearchDropdown = () => {
+        const isOpen = !searchWrapper.classList.contains("d-none")
+        if (isOpen) {
+            searchWrapper.classList.add("d-none")
+            searchInput.value = ""
+            lastQuery = null
+        } else {
+            searchWrapper.classList.remove("d-none")
+            triggerSearch()
+            setTimeout(() => searchInput.focus(), 0)
+        }
+    }
+
+    if (searchToggle) {
+        searchToggle.addEventListener("click", (ev) => {
+            ev.preventDefault()
+            ev.stopPropagation()
+            toggleSearchDropdown()
+        })
+    }
+
+    // Close search dropdown when clicking outside
+    document.addEventListener("click", (ev) => {
+        if (!wrapper.contains(ev.target) && !searchWrapper.classList.contains("d-none")) {
+            searchWrapper.classList.add("d-none")
+            searchInput.value = ""
+            lastQuery = null
+        }
     })
 
     searchInput.addEventListener("keyup", (ev) => {
@@ -121,8 +139,8 @@ const initNavSearch = () => {
     // Open search dropdown with alt+k
     document.addEventListener("keydown", (ev) => {
         if (ev.altKey && ev.key === "k") {
-            if (summary.open) return
-            summary.click()
+            if (!searchWrapper.classList.contains("d-none")) return
+            toggleSearchDropdown()
             ev.preventDefault()
             ev.stopPropagation()
         }


### PR DESCRIPTION
This solves #3183 

 ## Summary

  Fixes a broken navigation issue where clicking the organizer name in the
  top-left of the sidebar did nothing. The link existed in the HTML but was
  intercepted by Bootstrap's `data-toggle="dropdown"` on the inner element,
  which captured all clicks to open a search dropdown instead.

  ## Changes

  - **`base.html`**: Restructured the sidebar header — the organizer name + icon is now a standalone `<a>` link to the dashboard, and a separate search icon (🔍) serves as the dropdown toggle. Removed `data-toggle="dropdown"` and `dropdown-toggle` class that blocked navigation.
  - **`typeahead.js`**: Search dropdown is now triggered by the `.nav-search-toggle` icon only. Replaced Bootstrap   dropdown mechanism with explicit `d-none` class toggling. Added click-outside-to-close. Alt+K shortcut preserved.
  - **`_layout.css`**: Added flex layout for the `<a>` inside `#nav-search`, hover styles, and styling for the new `.nav-search-toggle` icon.
  
 ##Screen Recording

https://github.com/user-attachments/assets/3f2e4737-cad0-4ddb-bcb0-af2a3bb69af2



  ## Testing

  - Logged in as organiser → sidebar shows organizer name with search icon
  - Clicking the organizer name/icon navigates to `/orga/organizer/<slug>/` ✅
  - Clicking the 🔍 icon opens the typeahead search dropdown ✅
  - Alt+K shortcut opens the search dropdown ✅
  - Click outside closes the dropdown ✅
  - Works from both the organizer dashboard and event sub-pages ✅

## Summary by Sourcery

Restore correct navigation from the sidebar header while decoupling it from the organizer search dropdown.

Bug Fixes:
- Fix organizer/event name link in the sidebar so it correctly navigates to the dashboard instead of being intercepted by the search dropdown trigger.

Enhancements:
- Separate the search dropdown trigger into its own icon and toggle logic, including click-outside-to-close behavior and Alt+K keyboard shortcut support.
- Adjust sidebar layout and styling to accommodate the standalone dashboard link and dedicated search icon without relying on Bootstrap dropdown behavior.