### PR TITLE
fix(denied): update subject for order denied emails

### DIFF
--- a/app/eventyay/base/services/orders.py
+++ b/app/eventyay/base/services/orders.py
@@ -396,7 +396,7 @@ def send_order_denied_notifications(order, comment='', user=None, send_mail: boo
         email_template = order.event.settings.mail_text_order_denied
         email_context = get_email_context(event=order.event, order=order, comment=comment)
         with language(order.locale, order.event.settings.region):
-            email_subject = _('Order denied: %(code)s') % {'code': order.code}
+            email_subject = _('Your order request update: %(code)s') % {'code': order.code}
             try:
                 order.send_mail(
                     email_subject,

--- a/app/eventyay/locale/ar/LC_MESSAGES/django.po
+++ b/app/eventyay/locale/ar/LC_MESSAGES/django.po
@@ -9922,8 +9922,8 @@ msgstr "أجل الموافقة عليها وتنتظر السداد: %(code)s"
 
 #: base/services/orders.py:399
 #, python-format
-msgid "Order denied: %(code)s"
-msgstr "نفى أجل: %(code)s"
+msgid "Your order request update: %(code)s"
+msgstr "تحديث على طلبك: %(code)s"
 
 #: base/services/orders.py:456 presale/views/order.py:993
 #: presale/views/order.py:1039

--- a/app/eventyay/locale/django.pot
+++ b/app/eventyay/locale/django.pot
@@ -9103,7 +9103,7 @@ msgstr ""
 
 #: base/services/orders.py:399
 #, python-format
-msgid "Order denied: %(code)s"
+msgid "Your order request update: %(code)s"
 msgstr ""
 
 #: base/services/orders.py:456 presale/views/order.py:993

--- a/app/eventyay/locale/es/LC_MESSAGES/django.po
+++ b/app/eventyay/locale/es/LC_MESSAGES/django.po
@@ -10251,8 +10251,8 @@ msgstr "Orden aprobada y pendiente de pago: %(code)s"
 
 #: base/services/orders.py:399
 #, python-format
-msgid "Order denied: %(code)s"
-msgstr "Orden denegada: %(code)s"
+msgid "Your order request update: %(code)s"
+msgstr "Actualización de tu solicitud de pedido: %(code)s"
 
 #: base/services/orders.py:456 presale/views/order.py:993
 #: presale/views/order.py:1039

--- a/app/eventyay/locale/fr/LC_MESSAGES/django.po
+++ b/app/eventyay/locale/fr/LC_MESSAGES/django.po
@@ -10344,8 +10344,8 @@ msgstr "Commande approuvée et en attente de paiement : %(code)s"
 
 #: base/services/orders.py:399
 #, python-format
-msgid "Order denied: %(code)s"
-msgstr "Commande refusée : %(code)s"
+msgid "Your order request update: %(code)s"
+msgstr "Mise à jour de votre demande de commande : %(code)s"
 
 #: base/services/orders.py:456 presale/views/order.py:993
 #: presale/views/order.py:1039


### PR DESCRIPTION
this pr resolves #3184 

<img width="1818" height="1180" alt="image" src="https://github.com/user-attachments/assets/dfa58756-9185-4b8c-99c3-c82b97dbba17" />
<img width="1818" height="1180" alt="image" src="https://github.com/user-attachments/assets/44c4b29d-72cf-45a9-b78f-1393937c8aeb" />

## Summary by Sourcery

Bug Fixes:
- Adjust the order denied notification email subject to use clearer, more accurate wording.