### PR TITLE
fix: private test mode orders treated as test orders (#3193)

### DIFF
--- a/app/eventyay/base/services/orders.py
+++ b/app/eventyay/base/services/orders.py
@@ -998,7 +998,9 @@ def _create_order(
             datetime=now_dt,
             locale=get_language_without_region(locale),
             total=total,
-            testmode=True if sales_channel.testmode_supported and event.testmode else False,
+            testmode=True if sales_channel.testmode_supported and (
+                event.testmode or getattr(event, "private_test_mode", False)
+            ) else False,
             meta_info=json.dumps(meta_info or {}),
             require_approval=any(p.requires_approval for p in positions),
             sales_channel=sales_channel.identifier,


### PR DESCRIPTION
## Fix: Private Test Mode Orders Treated as Real Orders (#3193)

### Problem
Orders created in Private Test Mode were treated as real orders and could not be deleted.

### Solution
Updated order creation logic to mark orders as test orders when private test mode is enabled.

### Result
- Orders are now deletable in private test mode
- Behavior matches public test mode
- No impact on real orders

Closes #3193

## Summary by Sourcery

Bug Fixes:
- Mark orders as test orders when created under an event’s private test mode so they are treated consistently with other test orders and remain deletable.