### PR TITLE
fix: Show complete order information in order detail and change-products views

### DIFF
--- a/app/eventyay/control/templates/pretixcontrol/order/change.html
+++ b/app/eventyay/control/templates/pretixcontrol/order/change.html
@@ -59,7 +59,7 @@
                 <div class="panel-heading">
                     <h3 class="panel-title">
                         #{{ position.positionid }} –
-                        <strong>{{ position.item }}</strong>
+                        <strong>{{ position.product }}</strong>
                         {% if position.variation %}
                             – {{ position.variation }}
                         {% endif %}
@@ -130,7 +130,7 @@
                                 <strong>{% trans "Product" %}</strong>
                             </div>
                             <div class="col-sm-5">
-                                {{ position.item }}
+                                {{ position.product }}
                                 {% if position.variation %}
                                     – {{ position.variation }}
                                 {% endif %}

--- a/app/eventyay/control/templates/pretixcontrol/order/index.html
+++ b/app/eventyay/control/templates/pretixcontrol/order/index.html
@@ -307,7 +307,7 @@
                                 {% else %}
                                     #{{ line.positionid }} –
                                 {% endif %}
-                                <strong>{{ line.item }}</strong>
+                                <strong>{{ line.product }}</strong>
                                 {% if line.variation %}
                                     – {{ line.variation }}
                                 {% endif %}
@@ -391,12 +391,12 @@
                                 {% endif %}
                                 {% if line.has_questions %}
                                     <dl>
-                                        {% if line.item.admission and event.settings.attendee_names_asked %}
+                                        {% if line.product.admission and event.settings.attendee_names_asked %}
                                             <dt>{% trans "Attendee name" %}</dt>
                                             <dd>{% if line.attendee_name %}{{ line.attendee_name }}{% else %}
                                                 <em>{% trans "not answered" %}</em>{% endif %}</dd>
                                         {% endif %}
-                                        {% if line.item.admission and event.settings.attendee_emails_asked %}
+                                        {% if line.product.admission and event.settings.attendee_emails_asked %}
                                             <dt>{% trans "Attendee email" %}</dt>
                                             <dd>
                                                 {% if line.attendee_email %}
@@ -419,7 +419,7 @@
                                                 {% endif %}
                                             </dd>
                                         {% endif %}
-                                        {% if line.item.admission and event.settings.attendee_company_asked %}
+                                        {% if line.product.admission and event.settings.attendee_company_asked %}
                                             <dt>
                                                 {% trans "Attendee company" %}
                                             </dt>
@@ -427,7 +427,7 @@
                                                 {% if line.company %}{{ line.company }}{% else %}<em>{% trans "not answered" %}</em>{% endif %}
                                             </dd>
                                         {% endif %}
-                                        {% if line.item.admission and event.settings.attendee_job_title_asked and line.job_title %}
+                                        {% if line.product.admission and event.settings.attendee_job_title_asked and line.job_title %}
                                             <dt>
                                                 {% trans "Attendee job title" %}
                                             </dt>
@@ -435,7 +435,7 @@
                                                 {{ line.job_title }}
                                             </dd>
                                         {% endif %}
-                                        {% if line.item.admission and event.settings.attendee_addresses_asked %}
+                                        {% if line.product.admission and event.settings.attendee_addresses_asked %}
                                             <dt>
                                                 {% trans "Attendee address" %}
                                             </dt>

--- a/app/eventyay/control/views/orders.py
+++ b/app/eventyay/control/views/orders.py
@@ -434,7 +434,7 @@ class OrderDetail(OrderView):
 
     def get_context_data(self, **kwargs):
         ctx = super().get_context_data(**kwargs)
-        ctx['products'] = self.get_products()
+        ctx['items'] = self.get_products()
         ctx['event'] = self.request.event
         ctx['payments'] = self.order.payments.order_by('-created')
         ctx['refunds'] = self.order.refunds.select_related('payment').order_by('-created')

--- a/app/eventyay/presale/views/order.py
+++ b/app/eventyay/presale/views/order.py
@@ -140,6 +140,9 @@ class OrderPositionDetailMixin(NoSearchIndexViewMixin):
             else:
                 return None
 
+    @cached_property
+    def order(self):
+        return self.position.order if self.position else None
 
 @method_decorator(xframe_options_exempt, 'dispatch')
 class OrderPositionJoin(EventViewMixin, OrderPositionDetailMixin, View):
@@ -253,9 +256,6 @@ class OrderPositionJoin(EventViewMixin, OrderPositionDetailMixin, View):
         logger.info('Redirecting to %s...', redirect_url)
         return redirect(redirect_url)
 
-    @cached_property
-    def order(self):
-        return self.position.order if self.position else None
 
     def get_position_url(self):
         return eventreverse(


### PR DESCRIPTION
## Summary
  Closes #3199 

  Two separate bugs were causing critical order information to be invisible to organisers.

**Bug 1 — Order detail page (Ordered items section empty):** The view passed order data to the template under the key
`'products'` but the template reads `items.positions`, `items.net_total`, `items.tax_total`, `items.total`. The key mismatch meant the entire "Ordered items" section rendered blank — no ticket names, no totals, no taxes.
  Fix: rename `ctx['products']` → `ctx['items']` in `OrderDetail.get_context_data()`.

  **Bug 2 — Change products page (product name missing):**
  The template referenced `position.item` in both the position panel header and the "Current value" column, but `item` is not a field on `OrderPosition`. The correct field is `position.product`.
Fix: replace `position.item` → `position.product` in `change.html`.

  ## Changes

  - `control/views/orders.py` — 1 line: rename context key
  - `control/templates/pretixcontrol/order/change.html` — 2 lines: fix field name
  - `control/templates/pretixcontrol/order/index.html` — fix incorrect field reference `(line.item → line.product)`
  ## Screen Recording

https://github.com/user-attachments/assets/aa1780d7-e2a9-41ff-8540-c017a589cfc1

  ## Testing

  - Order detail: "Ordered items" now shows ticket names, quantities, net total, taxes, and total 
  - Order detail: Payments section rows now populate correctly 
  - Change products: Position headers show `#1 – <Ticket Name>` 
  - Change products: "Current value" column shows the correct product name 
  - Verified across orders with single and multiple positions

## Summary by Sourcery

Ensure complete order and attendee information is visible in organiser order views.

Bug Fixes:
- Fix order detail context so ordered items and totals render correctly instead of appearing empty.
- Correct product references in order index and change-product templates so product names and admission-dependent attendee fields display properly.