### PR TITLE
Fix button wrap due to small column width

### DIFF
--- a/app/eventyay/static/orga/css/question-toggles.css
+++ b/app/eventyay/static/orga/css/question-toggles.css
@@ -223,6 +223,10 @@ select.required-status-dropdown[data-current="after_deadline"] {
     vertical-align: middle;
 }
 
+.cfp-option-table td.text-right {
+    white-space: nowrap;
+}
+
 .cfp-option-table .btn-info {
     --highlight-color: #2a8fd7;
     border-color: #2a8fd7;


### PR DESCRIPTION
when a custom question is created the buttons wrap and appear vertically. I used nowrap for the text-right to ensure buttons appear in the same row.

<img width="952" height="398" alt="image" src="https://github.com/user-attachments/assets/82298bcd-2ba4-4327-be6d-486006dd84d3" />

related to #2523

## Summary by Sourcery

Bug Fixes:
- Ensure CFP option table action buttons remain on a single row instead of wrapping vertically in narrow columns.