### PR TITLE
fix(images): add url support for header images and logo

### DIFF
--- a/app/eventyay/api/serializers/fields.py
+++ b/app/eventyay/api/serializers/fields.py
@@ -1,7 +1,12 @@
 from collections import OrderedDict
 
 from django.core.exceptions import ValidationError
+from django.core.files.storage import default_storage
+from django.core.validators import URLValidator
+from hierarkey.proxy import HierarkeyProxy
 from rest_framework import serializers
+
+from eventyay.common.urls import get_file_url_path, get_url_scheme, is_http_url, normalize_url_scheme
 
 
 def remove_duplicates_from_list(data):
@@ -70,3 +75,41 @@ class UploadedFileField(serializers.Field):
             return None
         request = self.context['request']
         return request.build_absolute_uri(url)
+
+
+class UploadedFileOrURLField(UploadedFileField):
+    default_error_messages = {
+        **UploadedFileField.default_error_messages,
+        'invalid_url': 'Enter a valid URL.',
+    }
+
+    def get_attribute(self, instance):
+        if isinstance(instance, HierarkeyProxy):
+            return instance.get(self.source_attrs[-1], as_type=str, default=None)
+        return super().get_attribute(instance)
+
+    def to_internal_value(self, data):
+        if isinstance(data, str):
+            if is_http_url(data):
+                data = normalize_url_scheme(data)
+                try:
+                    URLValidator(schemes=['http', 'https'])(data)
+                except ValidationError:
+                    self.fail('invalid_url')
+                return data
+            if get_url_scheme(data) and not data.startswith('file:'):
+                self.fail('invalid_url')
+        return super().to_internal_value(data)
+
+    def to_representation(self, value):
+        if not value:
+            return None
+        if isinstance(value, str):
+            if is_http_url(value):
+                return value
+            file_path = get_file_url_path(value)
+            if file_path:
+                url = default_storage.url(file_path)
+                request = self.context.get('request')
+                return request.build_absolute_uri(url) if request else url
+        return super().to_representation(value)

--- a/app/eventyay/api/serializers/settings.py
+++ b/app/eventyay/api/serializers/settings.py
@@ -7,8 +7,10 @@ from hierarkey.proxy import HierarkeyProxy
 from rest_framework import serializers
 from rest_framework.exceptions import ValidationError
 
-from eventyay.api.serializers.fields import UploadedFileField
+from eventyay.api.serializers.fields import UploadedFileField, UploadedFileOrURLField
 from eventyay.base.settings import DEFAULTS
+from eventyay.common.urls import get_file_url_path
+
 
 logger = logging.getLogger(__name__)
 
@@ -29,7 +31,7 @@ class SettingsSerializer(serializers.Serializer):
             if callable(form_kwargs):
                 form_kwargs = form_kwargs()
             if 'serializer_class' not in DEFAULTS[fname]:
-                raise ValidationError('{} has no serializer class'.format(fname))
+                raise ValidationError(f'{fname} has no serializer class')
             f = DEFAULTS[fname]['serializer_class'](**kwargs)
             f._label = form_kwargs.get('label', fname)
             f._help_text = form_kwargs.get('help_text')
@@ -39,18 +41,48 @@ class SettingsSerializer(serializers.Serializer):
     def update(self, instance: HierarkeyProxy, validated_data):
         for attr, value in validated_data.items():
             if isinstance(value, FieldFile):
-                # Delete old file
-                fname = instance.get(attr, as_type=File)
-                if fname:
-                    try:
-                        default_storage.delete(fname.name)
-                    except OSError:  # pragma: no cover
-                        logger.error('Deleting file %s failed.' % fname.name)
+                if isinstance(self.fields[attr], UploadedFileOrURLField):
+                    current_value = instance.get(attr, as_type=str, default=None)
+                    current_file = get_file_url_path(current_value)
+                    if current_file:
+                        try:
+                            default_storage.delete(current_file)
+                        except OSError:  # pragma: no cover
+                            logger.error('Deleting file %s failed.', current_file)
+                else:
+                    fname = instance.get(attr, as_type=File)
+                    if fname:
+                        try:
+                            default_storage.delete(fname.name)
+                        except OSError:  # pragma: no cover
+                            logger.error('Deleting file %s failed.', fname.name)
 
                 # Create new file
                 newname = default_storage.save(self.get_new_filename(value.name), value)
                 instance.set(attr, File(file=value, name=newname))
                 self.changed_data.append(attr)
+            elif isinstance(self.fields[attr], UploadedFileOrURLField) and type(value) is str:
+                current_value = instance.get(attr, as_type=str)
+                current_file = get_file_url_path(current_value)
+                if current_file:
+                    try:
+                        default_storage.delete(current_file)
+                    except OSError:  # pragma: no cover
+                        logger.error('Deleting file %s failed.', current_file)
+                if current_value != value:
+                    instance.set(attr, value)
+                    self.changed_data.append(attr)
+            elif isinstance(self.fields[attr], UploadedFileOrURLField) and value is None:
+                current_value = instance.get(attr, as_type=str, default=None)
+                current_file = get_file_url_path(current_value)
+                if current_file:
+                    try:
+                        default_storage.delete(current_file)
+                    except OSError:  # pragma: no cover
+                        logger.error('Deleting file %s failed.', current_file)
+                if current_value is not None:
+                    instance.delete(attr)
+                    self.changed_data.append(attr)
             elif isinstance(self.fields[attr], UploadedFileField):
                 if value is None:
                     fname = instance.get(attr, as_type=File)
@@ -58,7 +90,7 @@ class SettingsSerializer(serializers.Serializer):
                         try:
                             default_storage.delete(fname.name)
                         except OSError:  # pragma: no cover
-                            logger.error('Deleting file %s failed.' % fname.name)
+                            logger.error('Deleting file %s failed.', fname.name)
                     instance.delete(attr)
                 else:
                     # file is unchanged

--- a/app/eventyay/base/configurations/default_setting.py
+++ b/app/eventyay/base/configurations/default_setting.py
@@ -21,6 +21,7 @@ from rest_framework import serializers
 from eventyay.api.serializers.fields import (
     ListMultipleChoiceField,
     UploadedFileField,
+    UploadedFileOrURLField,
 )
 from eventyay.api.serializers.i18n import I18nField, I18nURLField
 from eventyay.base.configurations.lazy_i18n_string_list_base import (
@@ -897,7 +898,7 @@ DEFAULT_SETTINGS = {
             required=True,
             label=_('Active languages'),
             help_text=_(
-                "Users will be able to use eventyay in these languages, and you will be able to provide all texts in "
+                'Users will be able to use eventyay in these languages, and you will be able to provide all texts in '
                 "these languages. If you don't provide a text in the language a user selects, it will be shown in your "
                 "event's default language instead."
             ),
@@ -1292,7 +1293,7 @@ DEFAULT_SETTINGS = {
             )
         ),
         'form_kwargs': dict(
-            label=_("Allow customers to modify their information"),
+            label=_('Allow customers to modify their information'),
             widget=forms.RadioSelect,
             choices=(
                 ('no', _('No modifications after order was submitted')),
@@ -2147,7 +2148,7 @@ Your {event} team"""
                 'We recommend an image at least 1170 px wide and 120 px in height for best results.'
             ),
         ),
-        'serializer_class': UploadedFileField,
+        'serializer_class': UploadedFileOrURLField,
         'serializer_kwargs': dict(
             allowed_types=['image/png', 'image/jpeg', 'image/gif'],
             max_size=settings.MAX_SIZE_CONFIG[SizeKey.UPLOAD_SIZE_IMAGE],
@@ -2167,7 +2168,7 @@ Your {event} team"""
                 'We recommend not using small details as it will be resized on smaller screens.'
             ),
         ),
-        'serializer_class': UploadedFileField,
+        'serializer_class': UploadedFileOrURLField,
         'serializer_kwargs': dict(
             allowed_types=['image/png', 'image/jpeg', 'image/gif', 'image/svg+xml'],
             max_size=settings.MAX_SIZE_CONFIG[SizeKey.UPLOAD_SIZE_IMAGE],

--- a/app/eventyay/base/forms/__init__.py
+++ b/app/eventyay/base/forms/__init__.py
@@ -2,6 +2,7 @@ import logging
 
 import i18nfield.forms
 from django import forms
+from django.core.files import File
 from django.core.validators import URLValidator
 from django.forms.models import ModelFormMetaclass
 from django.utils.crypto import get_random_string
@@ -12,8 +13,10 @@ from hierarkey.forms import HierarkeyForm
 from i18nfield.strings import LazyI18nString
 
 from eventyay.base.reldate import RelativeDateField, RelativeDateTimeField
+from eventyay.common.urls import is_http_url
 
 from .validators import PlaceholderValidator  # NOQA
+
 
 logger = logging.getLogger(__name__)
 
@@ -65,8 +68,20 @@ class SettingsForm(i18nfield.forms.I18nFormMixin, HierarkeyForm):
         self.locales = self.obj.settings.get('locales') if self.obj else kwargs.pop('locales', None)
         kwargs['attribute_name'] = 'settings'
         kwargs['locales'] = self.locales
-        kwargs['initial'] = self.obj.settings.freeze()
-        super().__init__(*args, **kwargs)
+        kwargs['initial'] = self.get_initial_settings()
+        original_freeze = None
+
+        def freeze_with_safe_initial():
+            return kwargs['initial'].copy()
+
+        if self.obj:
+            original_freeze = self.obj.settings.freeze
+            object.__setattr__(self.obj.settings, 'freeze', freeze_with_safe_initial)
+        try:
+            super().__init__(*args, **kwargs)
+        finally:
+            if self.obj and original_freeze:
+                object.__setattr__(self.obj.settings, 'freeze', original_freeze)
         for fname in self.auto_fields:
             kwargs = DEFAULTS[fname].get('form_kwargs', {})
             if callable(kwargs):
@@ -83,6 +98,35 @@ class SettingsForm(i18nfield.forms.I18nFormMixin, HierarkeyForm):
         for k, f in self.fields.items():
             if isinstance(f, (RelativeDateTimeField, RelativeDateField)):
                 f.set_event(self.obj)
+
+    def get_initial_settings(self):
+        if not self.obj:
+            return {}
+
+        return self.build_initial_settings(self.obj.settings)
+
+    def build_initial_settings(self, settings_proxy):
+        initial = {}
+        if settings_proxy._parent:
+            initial.update(
+                self.build_initial_settings(getattr(settings_proxy._parent, settings_proxy._h.attribute_name))
+            )
+
+        for key, default in settings_proxy._h.defaults.items():
+            initial[key] = self.get_initial_setting_value(settings_proxy, key, default.type, default.value)
+
+        for key in settings_proxy._cache():
+            declared_type = settings_proxy._h.get_declared_type(key)
+            initial[key] = self.get_initial_setting_value(settings_proxy, key, declared_type)
+
+        return initial
+
+    def get_initial_setting_value(self, settings_proxy, key, declared_type, default=None):
+        if declared_type is File:
+            value = settings_proxy.get(key, as_type=str, default=default)
+            if isinstance(value, str) and is_http_url(value):
+                return value
+        return settings_proxy.get(key, as_type=declared_type, default=default)
 
     def save(self):
         for k, v in self.cleaned_data.items():
@@ -140,7 +184,7 @@ class SecretKeySettingsWidget(forms.TextInput):
             {
                 'autocomplete': 'new-password',  # see https://bugs.chromium.org/p/chromium/issues/detail?id=370363#c7
                 'type': 'password',
-                'class': (attrs.get('class', '') + ' secret-key-input').strip()
+                'class': (attrs.get('class', '') + ' secret-key-input').strip(),
             }
         )
         super().__init__(attrs)
@@ -192,12 +236,11 @@ class I18nMarkdownTextarea(i18nfield.forms.I18nTextarea):
 
 
 class I18nAutoExpandingTextarea(i18nfield.forms.I18nTextarea):
-
     def __init__(self, attrs=None, **kwargs):
         default_attrs = {
             'class': 'form-control auto-expanding-textarea',
             'data-auto-expand': 'true',
-            'style': 'min-height: 320px; max-height: 400px; overflow-y: auto; resize: vertical; transition: height 0.2s ease-in-out; box-sizing: border-box;'
+            'style': 'min-height: 320px; max-height: 400px; overflow-y: auto; resize: vertical; transition: height 0.2s ease-in-out; box-sizing: border-box;',
         }
         if attrs:
             if 'class' in attrs:

--- a/app/eventyay/base/middleware.py
+++ b/app/eventyay/base/middleware.py
@@ -18,10 +18,12 @@ from django.utils.translation.trans_real import (
 
 from eventyay.base.i18n import get_language_without_region
 from eventyay.base.settings import global_settings_object
+from eventyay.common.urls import get_url_origin
 from eventyay.multidomain.urlreverse import (
     get_event_domain,
     get_organizer_domain,
 )
+
 
 _supported = None
 
@@ -185,6 +187,59 @@ def _merge_csp(a, b):
             a[k] = b[k]
 
 
+def is_event_settings_preview_request(request: HttpRequest) -> bool:
+    view_name = getattr(getattr(request, 'resolver_match', None), 'view_name', None) or ''
+    if view_name.endswith('event.update'):
+        return True
+
+    return '/event/' in request.path and request.path.endswith('/settings/')
+
+
+def get_startpage_events(request: HttpRequest):
+    view_name = getattr(getattr(request, 'resolver_match', None), 'view_name', None)
+    if view_name not in ('index', 'presale:index'):
+        return []
+
+    from django.db.models import Q
+    from django_scopes import scopes_disabled
+
+    from eventyay.base.models import Event
+
+    search_query = request.GET.get('q', '').strip()
+    with scopes_disabled():
+        qs = Event.objects.select_related('organizer').prefetch_related('_settings_objects').filter(live=True)
+        if search_query:
+            qs = qs.filter(name__icontains=search_query)
+        else:
+            qs = qs.filter(Q(startpage_visible=True) | Q(startpage_featured=True))
+
+        return [event for event in qs.order_by('date_from') if not event.has_component_testmode]
+
+
+def get_external_image_csp_sources(request: HttpRequest) -> list[str]:
+    if is_event_settings_preview_request(request):
+        sources = ['https:']
+        if settings.SITE_URL.startswith('http://'):
+            sources.append('http:')
+        return sources
+
+    sources = []
+
+    if hasattr(request, 'event') and request.event:
+        for image_url in (request.event.visible_header_image_url, request.event.visible_logo_url):
+            origin = get_url_origin(image_url)
+            if origin:
+                sources.append(origin)
+
+    for event in get_startpage_events(request):
+        for image_url in (event.visible_header_image_url, event.visible_logo_url):
+            origin = get_url_origin(image_url)
+            if origin:
+                sources.append(origin)
+
+    return list(OrderedDict.fromkeys(sources))
+
+
 class SecurityMiddleware(MiddlewareMixin):
     CSP_EXEMPT = ('/api/v1/docs/',)
 
@@ -205,6 +260,7 @@ class SecurityMiddleware(MiddlewareMixin):
         resp['Referrer-Policy'] = 'strict-origin-when-cross-origin'
 
         img_src = []
+        external_img_src = get_external_image_csp_sources(request)
         gs = global_settings_object(request)
         if gs.settings.leaflet_tiles:
             img_src.append(gs.settings.leaflet_tiles[: gs.settings.leaflet_tiles.index('/', 10)].replace('{s}', '*'))
@@ -233,7 +289,9 @@ class SecurityMiddleware(MiddlewareMixin):
                 "'unsafe-inline'",  # allow inline styles
             ],
             'connect-src': ['{dynamic}', '{media}', 'https://checkout.stripe.com', 'https:', 'blob:'],
-            'img-src': ['{static}', '{media}', 'data:', 'https://*.stripe.com', 'https://twemoji.maxcdn.com'] + img_src,
+            'img-src': ['{static}', '{media}', 'data:', 'https://*.stripe.com', 'https://twemoji.maxcdn.com']
+            + external_img_src
+            + img_src,
             'font-src': [
                 '{static}',
                 'https://fonts.gstatic.com',  # fix Google Fonts
@@ -292,8 +350,8 @@ class SecurityMiddleware(MiddlewareMixin):
 
         # Add DEBUG mode settings before rendering CSP
         if settings.DEBUG:
-            h.setdefault('script-src', []).extend(["'unsafe-inline'", "http://localhost:8080"])
-            h.setdefault('connect-src', []).extend(["http://localhost:8080", "ws://localhost:8080"])
+            h.setdefault('script-src', []).extend(["'unsafe-inline'", 'http://localhost:8080'])
+            h.setdefault('connect-src', []).extend(['http://localhost:8080', 'ws://localhost:8080'])
 
         if request.path not in self.CSP_EXEMPT and not getattr(resp, '_csp_ignore', False):
             for k, v in h.items():

--- a/app/eventyay/base/models/event.py
+++ b/app/eventyay/base/models/event.py
@@ -50,7 +50,7 @@ from eventyay.base.validators import EventSlugBanlistValidator
 from eventyay.common.language import LANGUAGE_NAMES
 from eventyay.common.text.path import path_with_hash
 from eventyay.common.text.phrases import phrases
-from eventyay.common.urls import EventUrls
+from eventyay.common.urls import EventUrls, is_http_url
 from eventyay.consts import TIMEZONE_CHOICES
 from eventyay.core.permissions import (
     MAX_PERMISSIONS_IF_SILENCED,
@@ -938,12 +938,22 @@ class Event(
     def social_image(self):
         from eventyay.multidomain.urlreverse import build_absolute_uri
 
+        def get_image_value(setting_name: str) -> str:
+            value = self.settings.get(setting_name, as_type=str, default='') or ''
+            if value.startswith('file://'):
+                return value[7:]
+            return value
+
         img = None
-        logo_file = self.settings.get('logo_image', as_type=str, default='')[7:]
-        og_file = self.settings.get('og_image', as_type=str, default='')[7:]
+        logo_file = get_image_value('logo_image')
+        og_file = get_image_value('og_image')
         if og_file:
+            if is_http_url(og_file):
+                return og_file
             img = get_thumbnail(og_file, '1200').thumb.url
         elif logo_file:
+            if is_http_url(logo_file):
+                return logo_file
             img = get_thumbnail(logo_file, '5000x120').thumb.url
         if img:
             return urljoin(build_absolute_uri(self, 'presale:event.index'), img)
@@ -2385,19 +2395,19 @@ class Event(
 
         # Only check event_logo_image - NOT logo_image (which is for header images)
         for key in ('event_logo_image',):
-            settings_logo = self.settings.get(key, default=None) or getattr(self.settings, key, None)
+            settings_logo = self.settings.get(key, as_type=str, default=None)
             path = _extract_path(settings_logo)
             if not path:
                 continue
 
             # Keep full URLs
-            if path.startswith(('http://', 'https://')):
+            if is_http_url(path):
                 return path
 
             # Strip file:// scheme if present
             parsed = urlparse(path)
             if parsed.scheme == 'file':
-                path = parsed.path
+                path = f'{parsed.netloc}{parsed.path}'
 
             # Normalize absolute filesystem paths to be relative to MEDIA_ROOT
             abs_path = os.path.abspath(path)
@@ -2444,17 +2454,17 @@ class Event(
         # header image for the site is stored in common settings under logo_image (historical)
         # and in the legacy field header_image; prefer the settings value first
         for key in ('logo_image', 'header_image'):
-            settings_header = self.settings.get(key, default=None) or getattr(self.settings, key, None)
+            settings_header = self.settings.get(key, as_type=str, default=None)
             path = _extract_path(settings_header)
             if not path:
                 continue
 
-            if path.startswith(('http://', 'https://')):
+            if is_http_url(path):
                 return path
 
             parsed = urlparse(path)
             if parsed.scheme == 'file':
-                path = parsed.path
+                path = f'{parsed.netloc}{parsed.path}'
 
             abs_path = os.path.abspath(path)
             media_root = os.path.abspath(settings.MEDIA_ROOT)
@@ -2490,7 +2500,7 @@ class Event(
             return None
         with suppress(Exception):
             # If already a full URL, return as-is
-            if str(self._visible_logo_path).startswith(('http://', 'https://')):
+            if is_http_url(str(self._visible_logo_path)):
                 return self._visible_logo_path
             return default_storage.url(self._visible_logo_path)
         return None
@@ -2502,7 +2512,7 @@ class Event(
         if not self._visible_logo_path:
             return None
         with suppress(Exception):
-            if str(self._visible_logo_path).startswith(('http://', 'https://')):
+            if is_http_url(str(self._visible_logo_path)):
                 return None
             return default_storage.open(self._visible_logo_path)
 
@@ -2513,7 +2523,7 @@ class Event(
         if not self._visible_header_image_path:
             return None
         with suppress(Exception):
-            if str(self._visible_header_image_path).startswith(('http://', 'https://')):
+            if is_http_url(str(self._visible_header_image_path)):
                 return self._visible_header_image_path
             return default_storage.url(self._visible_header_image_path)
 
@@ -2524,7 +2534,7 @@ class Event(
         if not self._visible_header_image_path:
             return None
         with suppress(Exception):
-            if str(self._visible_header_image_path).startswith(('http://', 'https://')):
+            if is_http_url(str(self._visible_header_image_path)):
                 return None
             return default_storage.open(self._visible_header_image_path)
         return None
@@ -2651,7 +2661,9 @@ class Event(
     def reviewers(self):
         from eventyay.base.models import User
 
-        return User.objects.filter(teams__in=self.teams.filter(Q(is_reviewer=True) | Q(can_change_submissions=True))).distinct()
+        return User.objects.filter(
+            teams__in=self.teams.filter(Q(is_reviewer=True) | Q(can_change_submissions=True))
+        ).distinct()
 
     @cached_property
     def active_review_phase(self):

--- a/app/eventyay/base/templates/pretixbase/email/simple_logo.html
+++ b/app/eventyay/base/templates/pretixbase/email/simple_logo.html
@@ -197,15 +197,22 @@
     <table width="600"><tr><td align="center"
     <![endif]-->
     <table class="layout" width="600" border="0" cellspacing="0">
-        {% if event.settings.logo_image %}
+        {% if event.visible_header_image_url %}
             <!--[if !mso]><!-- -->
             <tr>
                 <td style="line-height: 0;" align="center" class="logo">
-                    {% if event.settings.logo_image|thumb:'5000x120'|first == '/' %}
-                        <img src="{{ site_url }}{{ event.settings.logo_image|thumb:'5000x120' }}" alt="{{ event.name }}"
-                             style="height: auto; max-width: 100%;" />
+                    {% if event.visible_header_image_file %}
+                        {% with header_thumb=event.visible_header_image_file|thumb:'5000x120' %}
+                            {% if header_thumb|first == '/' %}
+                                <img src="{{ site_url }}{{ header_thumb }}" alt="{{ event.name }}"
+                                     style="height: auto; max-width: 100%;" />
+                            {% else %}
+                                <img src="{{ header_thumb }}" alt="{{ event.name }}"
+                                     style="height: auto; max-width: 100%;" />
+                            {% endif %}
+                        {% endwith %}
                     {% else %}
-                        <img src="{{ event.settings.logo_image|thumb:'5000x120' }}" alt="{{ event.name }}"
+                        <img src="{{ event.visible_header_image_url }}" alt="{{ event.name }}"
                              style="height: auto; max-width: 100%;" />
                     {% endif %}
                 </td>

--- a/app/eventyay/common/urls.py
+++ b/app/eventyay/common/urls.py
@@ -1,5 +1,5 @@
 from contextlib import suppress
-from urllib.parse import urljoin, urlparse
+from urllib.parse import urljoin, urlparse, urlsplit, urlunsplit
 
 from django.conf import settings
 from django.urls import register_converter, resolve, reverse
@@ -37,6 +37,46 @@ def get_base_url(event=None, url=None):
 def build_absolute_uri(urlname, event=None, args=None, kwargs=None):
     url = get_base_url(event)
     return urljoin(url, reverse(urlname, args=args, kwargs=kwargs))
+
+
+def get_url_scheme(value: str | None) -> str:
+    if not isinstance(value, str):
+        return ''
+    return urlsplit(value).scheme.lower()
+
+
+def is_http_url(value: str | None) -> bool:
+    return get_url_scheme(value) in ('http', 'https')
+
+
+def is_file_url(value: str | None) -> bool:
+    return get_url_scheme(value) == 'file'
+
+
+def normalize_url_scheme(value: str) -> str:
+    parsed = urlsplit(value)
+    if not parsed.scheme:
+        return value
+    return urlunsplit(parsed._replace(scheme=parsed.scheme.lower()))
+
+
+def get_url_origin(value: str | None) -> str | None:
+    if not is_http_url(value):
+        return None
+
+    parsed = urlsplit(value)
+    if not parsed.netloc:
+        return None
+
+    return urlunsplit((parsed.scheme.lower(), parsed.netloc.lower(), '', '', ''))
+
+
+def get_file_url_path(value: str | None) -> str | None:
+    if not is_file_url(value):
+        return None
+
+    parsed = urlsplit(value)
+    return f'{parsed.netloc}{parsed.path}' or None
 
 
 class EventUrls(Urls):

--- a/app/eventyay/eventyay_common/forms/event.py
+++ b/app/eventyay/eventyay_common/forms/event.py
@@ -1,29 +1,57 @@
-from django import forms
-from django.utils.translation import gettext_lazy as _
-from pytz import common_timezones
-from django.core.exceptions import ValidationError
-from django.conf import settings as django_settings
 from urllib.parse import urlparse
 
-from eventyay.base.forms import SettingsForm
-from eventyay.base.settings import validate_event_settings
+from django import forms
+from django.conf import settings as django_settings
+from django.core.exceptions import ValidationError
+from django.core.files.storage import default_storage
+from django.core.files.uploadedfile import UploadedFile
+from django.utils.translation import gettext_lazy as _
+from pytz import common_timezones
+
+from eventyay.base.forms import I18nModelForm, SettingsForm
 from eventyay.base.models import Event
+from eventyay.base.settings import validate_event_settings
 from eventyay.common.language import get_language_choices_native_with_ui_name
-from eventyay.orga.forms.widgets import MultipleLanguagesWidget
-from eventyay.control.forms import (
-     SplitDateTimeField,
-     SplitDateTimePickerWidget,
-     SlugWidget,
-    )
-from eventyay.base.forms import I18nModelForm
+from eventyay.common.urls import get_file_url_path, is_http_url, normalize_url_scheme
+from eventyay.control.forms import SlugWidget, SplitDateTimeField, SplitDateTimePickerWidget
 from eventyay.multidomain.models import KnownDomain
+from eventyay.orga.forms.widgets import MultipleLanguagesWidget
+
+
+def is_external_image_url(value: str) -> bool:
+    return is_http_url(value)
 
 
 class EventCommonSettingsForm(SettingsForm):
+    event_logo_image_url = forms.URLField(
+        label=_('Logo URL'),
+        required=False,
+        help_text=_('Use an external image URL instead of uploading a logo file.'),
+    )
+    logo_image_url = forms.URLField(
+        label=_('Header image URL'),
+        required=False,
+        help_text=_('Use an external image URL instead of uploading a header image file.'),
+    )
     timezone = forms.ChoiceField(
         choices=((a, a) for a in common_timezones),
         label=_('Event timezone'),
     )
+
+    image_url_fields = {
+        'event_logo_image': 'event_logo_image_url',
+        'logo_image': 'logo_image_url',
+    }
+
+    @property
+    def image_source_states(self):
+        states = {}
+        for image_field in self.image_url_fields:
+            current_value = self.event.settings.get(image_field, as_type=str, default='') or ''
+            states[image_field] = {
+                'has_uploaded_file': bool(current_value and not is_external_image_url(current_value)),
+            }
+        return states
 
     auto_fields = [
         'locales',
@@ -48,14 +76,52 @@ class EventCommonSettingsForm(SettingsForm):
 
     def clean(self):
         data = super().clean()
-        settings_dict = self.event.settings.freeze()
-        settings_dict.update(data)
-        validate_event_settings(self.event, data)
+
+        for image_field, url_field in self.image_url_fields.items():
+            image_url = data.get(url_field) or ''
+            submitted_image = self.fields[image_field].widget.value_from_datadict(
+                self.data,
+                self.files,
+                self.add_prefix(image_field),
+            )
+            has_new_upload = isinstance(submitted_image, UploadedFile)
+            if image_url and has_new_upload:
+                message = _('Either upload a file or enter an external URL, not both.')
+                self.add_error(image_field, message)
+                self.add_error(url_field, message)
+                continue
+
+            current_value = self.event.settings.get(image_field, as_type=str, default='') or ''
+            if image_url:
+                data[image_field] = normalize_url_scheme(image_url)
+            elif is_external_image_url(current_value) and not has_new_upload:
+                data[image_field] = None
+
+        settings_dict = self.get_initial_settings()
+        settings_dict.update({k: v for k, v in data.items() if k not in self.image_url_fields.values()})
+        validate_event_settings(self.event, settings_dict)
         return data
+
+    def save(self):
+        for image_field, url_field in self.image_url_fields.items():
+            current_value = self.event.settings.get(image_field, as_type=str, default='') or ''
+            new_value = self.cleaned_data.get(image_field)
+            if is_external_image_url(current_value) and (isinstance(new_value, UploadedFile) or not new_value):
+                del self.event.settings[image_field]
+            current_file = get_file_url_path(current_value)
+            if type(new_value) is str and current_file and current_value != new_value:
+                default_storage.delete(current_file)
+            self.cleaned_data[url_field] = None
+        return super().save()
 
     def __init__(self, *args, **kwargs):
         self.event = kwargs['obj']
         super().__init__(*args, **kwargs)
+        for image_field, url_field in self.image_url_fields.items():
+            current_value = self.event.settings.get(image_field, as_type=str, default='') or ''
+            if is_external_image_url(current_value):
+                self.initial[image_field] = None
+                self.initial[url_field] = current_value
         localized_language_choices = get_language_choices_native_with_ui_name()
         for fname in ('locales', 'content_locales'):
             if fname in self.fields:
@@ -93,7 +159,7 @@ class EventUpdateForm(I18nModelForm):
             self.fields['slug'].widget.attrs['readonly'] = 'readonly'
         self.fields['location'].widget.attrs['rows'] = '3'
         self.fields['location'].widget.attrs['placeholder'] = _('Sample Conference Center\nHeidelberg, Germany')
-        
+
         # Configure email field with canonical label and help text
         self.fields['email'].required = True
         self.fields['email'].label = _('Organizer email address')
@@ -150,11 +216,21 @@ class EventUpdateForm(I18nModelForm):
     class Meta:
         model = Event
         fields = [
-            'name', 'slug', 'date_from', 'date_to', 'date_admission',
-            'is_public', 'location', 'geo_lat', 'geo_lon', 'email',
+            'name',
+            'slug',
+            'date_from',
+            'date_to',
+            'date_admission',
+            'is_public',
+            'location',
+            'geo_lat',
+            'geo_lon',
+            'email',
         ]
         field_classes = {
-            'date_from': SplitDateTimeField, 'date_to': SplitDateTimeField, 'date_admission': SplitDateTimeField,
+            'date_from': SplitDateTimeField,
+            'date_to': SplitDateTimeField,
+            'date_admission': SplitDateTimeField,
         }
         widgets = {
             'slug': SlugWidget(attrs={'data-slug-source': 'name'}),

--- a/app/eventyay/eventyay_common/templates/eventyay_common/event/settings.html
+++ b/app/eventyay/eventyay_common/templates/eventyay_common/event/settings.html
@@ -8,6 +8,7 @@
 {% block custom_header %}
 {{ block.super }}
 <link type="text/css" rel="stylesheet" href='{% url "control:pdf.css" %}'>
+<script defer src="{% static 'eventyay-common/js/event-image-source.js' %}"></script>
 {{ sform.media }}
 {% endblock %}
 {% block inside %}
@@ -169,9 +170,43 @@
         </fieldset>
         <fieldset>
             <legend>{{ _('Design') }}</legend>
-            {% bootstrap_field sform.event_logo_image layout="control" %}
+            <div
+                data-image-source-pair
+                data-file-input-id="{{ sform.event_logo_image.id_for_label }}"
+                data-url-input-id="{{ sform.event_logo_image_url.id_for_label }}"
+                data-has-current-file="{{ sform.image_source_states.event_logo_image.has_uploaded_file|yesno:'true,false' }}"
+            >
+                {% bootstrap_field sform.event_logo_image layout="control" %}
+                {% bootstrap_field sform.event_logo_image_url layout="control" %}
+                <div class="form-group" data-image-url-preview hidden>
+                    <label class="col-md-3 control-label">{% trans "Logo preview" %}</label>
+                    <div class="col-md-9">
+                        <a data-image-url-preview-link href="" target="_blank" rel="noopener noreferrer">
+                            <img loading="lazy" data-image-url-preview-image class="img-responsive img-thumbnail" alt="{% trans 'Logo preview' %}" hidden>
+                        </a>
+                        <p class="help-block text-danger" data-image-url-preview-error hidden>{% trans "We could not load this image preview." %}</p>
+                    </div>
+                </div>
+            </div>
             {% bootstrap_field sform.logo_show_title layout="control" %}
-            {% bootstrap_field sform.logo_image layout="control" %}
+            <div
+                data-image-source-pair
+                data-file-input-id="{{ sform.logo_image.id_for_label }}"
+                data-url-input-id="{{ sform.logo_image_url.id_for_label }}"
+                data-has-current-file="{{ sform.image_source_states.logo_image.has_uploaded_file|yesno:'true,false' }}"
+            >
+                {% bootstrap_field sform.logo_image layout="control" %}
+                {% bootstrap_field sform.logo_image_url layout="control" %}
+                <div class="form-group" data-image-url-preview hidden>
+                    <label class="col-md-3 control-label">{% trans "Header image preview" %}</label>
+                    <div class="col-md-9">
+                        <a data-image-url-preview-link href="" target="_blank" rel="noopener noreferrer">
+                            <img loading="lazy" data-image-url-preview-image class="img-responsive img-thumbnail" alt="{% trans 'Header image preview' %}" hidden>
+                        </a>
+                        <p class="help-block text-danger" data-image-url-preview-error hidden>{% trans "We could not load this image preview." %}</p>
+                    </div>
+                </div>
+            </div>
             {% bootstrap_field sform.logo_image_large layout="control" %}
             {% bootstrap_field sform.og_image layout="control" %}
             {% url "eventyay_common:organizer.edit" organizer=request.organizer.slug as org_url %}

--- a/app/eventyay/presale/context.py
+++ b/app/eventyay/presale/context.py
@@ -28,6 +28,7 @@ from .signals import (
     html_page_header,
 )
 
+
 logger = logging.getLogger(__name__)
 
 
@@ -106,6 +107,7 @@ def _default_context(request):
             if cache.add(lock_key, True, 60):
                 try:
                     from eventyay.presale.style import regenerate_css
+
                     regenerate_css.apply_async(args=(request.event.pk,))
                 except Exception:
                     cache.delete(lock_key)
@@ -119,10 +121,8 @@ def _default_context(request):
         if request.event.settings.presale_css_file:
             ctx['css_file'] = default_storage.url(request.event.settings.presale_css_file)
 
-        # FIXME: We should avoid hardcoding truncate length here.
-        # It is not flexible because it requires the media folder to be at "/data/media/".
-        ctx['event_logo'] = request.event.settings.get('logo_image', as_type=str, default='')[7:]
-        ctx['event_logo_image'] = request.event.settings.get('event_logo_image', as_type=str, default='')[7:]
+        ctx['event_logo'] = request.event.visible_header_image_url or ''
+        ctx['event_logo_image'] = request.event.visible_logo_url or ''
         try:
             ctx['social_image'] = request.event.cache.get_or_set('social_image_url', request.event.social_image, 60)
         except (ValueError, OSError) as e:
@@ -167,15 +167,8 @@ def _default_context(request):
 
     # Check to show organizer area (only for team members or admins)
     ctx['show_organizer_area'] = False
-    if (
-        request.user
-        and request.user.is_authenticated
-        and hasattr(request, 'event')
-        and request.event
-    ):
-        ctx['show_organizer_area'] = is_event_organiser(
-            request.user, request, request.event
-        )
+    if request.user and request.user.is_authenticated and hasattr(request, 'event') and request.event:
+        ctx['show_organizer_area'] = is_event_organiser(request.user, request, request.event)
 
     ctx['show_link_in_header_for_all_pages'] = Page.objects.filter(link_in_system=True, link_in_header=True)
     ctx['show_link_in_footer_for_all_pages'] = Page.objects.filter(link_in_system=True, link_in_footer=True)

--- a/app/eventyay/presale/templates/pretixpresale/fragment_login_status.html
+++ b/app/eventyay/presale/templates/pretixpresale/fragment_login_status.html
@@ -4,7 +4,7 @@
 {% load event_tags %}
 
 {{ 'popover-profile'|json_script:"popover_toggle" }}
-<nav class="login-hdr" aria-label="{% translate 'account' %}" style="{% if request.event and request.event.settings.event_logo_image %}margin-right: 18rem{% else %}margin-right: 0{% endif %}">
+<nav class="login-hdr" aria-label="{% translate 'account' %}" style="{% if request.event and request.event.visible_logo_url %}margin-right: 18rem{% else %}margin-right: 0{% endif %}">
 
     {% if request.user.is_authenticated %}
         <div class="navigation-button">

--- a/app/eventyay/static/eventyay-common/js/event-image-source.js
+++ b/app/eventyay/static/eventyay-common/js/event-image-source.js
@@ -1,0 +1,105 @@
+const setDisabledState = function(input, disabled) {
+    if (!input) return
+    input.disabled = disabled
+    input.setAttribute('aria-disabled', disabled ? 'true' : 'false')
+}
+
+const setVisibleState = function(element, visible) {
+    if (!element) return
+    element.hidden = !visible
+    element.style.display = visible ? '' : 'none'
+}
+
+const updatePreview = function(pair, url) {
+    const preview = pair.querySelector('[data-image-url-preview]')
+    const previewLink = pair.querySelector('[data-image-url-preview-link]')
+    const previewImage = pair.querySelector('[data-image-url-preview-image]')
+    const previewError = pair.querySelector('[data-image-url-preview-error]')
+
+    if (!preview || !previewLink || !previewImage) return
+
+    const normalizedUrl = url.trim()
+    if (!normalizedUrl) {
+        setVisibleState(preview, false)
+        previewLink.removeAttribute('href')
+        previewImage.removeAttribute('src')
+        setVisibleState(previewImage, false)
+        setVisibleState(previewError, false)
+        return
+    }
+
+    setVisibleState(preview, true)
+    previewLink.href = normalizedUrl
+    setVisibleState(previewImage, true)
+    if (previewImage.src !== normalizedUrl) {
+        previewImage.src = normalizedUrl
+    }
+    setVisibleState(previewError, false)
+}
+
+const initImageSourcePair = function(pair) {
+    const fileInput = document.getElementById(pair.dataset.fileInputId)
+    const urlInput = document.getElementById(pair.dataset.urlInputId)
+
+    if (!fileInput || !urlInput) return
+
+    const clearCheckboxName = `${fileInput.name}-clear`
+    const clearCheckbox = fileInput.form?.elements?.[clearCheckboxName] || null
+
+    const syncState = function() {
+        const urlValue = urlInput.value.trim()
+        const hasUrl = urlValue.length > 0
+        const hasSelectedFile = Boolean(fileInput.files && fileInput.files.length > 0)
+        const hasCurrentFile = pair.dataset.hasCurrentFile === 'true' && !(clearCheckbox && clearCheckbox.checked)
+
+        if (hasUrl && hasSelectedFile) {
+            fileInput.value = ''
+        }
+
+        setDisabledState(fileInput, hasUrl)
+        setDisabledState(clearCheckbox, hasUrl)
+        setDisabledState(urlInput, !hasUrl && (hasSelectedFile || hasCurrentFile))
+        updatePreview(pair, urlValue)
+    }
+
+    const previewImage = pair.querySelector('[data-image-url-preview-image]')
+    const previewError = pair.querySelector('[data-image-url-preview-error]')
+    if (previewImage) {
+        previewImage.addEventListener('load', function() {
+            setVisibleState(previewImage, true)
+            setVisibleState(previewError, false)
+        })
+        previewImage.addEventListener('error', function() {
+            if (!urlInput.value.trim()) return
+            if (previewImage.complete && previewImage.naturalWidth > 0) {
+                setVisibleState(previewError, false)
+                return
+            }
+            setVisibleState(previewImage, false)
+            setVisibleState(previewError, true)
+        })
+    }
+
+    urlInput.addEventListener('input', syncState)
+    fileInput.addEventListener('change', function() {
+        if (fileInput.files && fileInput.files.length > 0) {
+            urlInput.value = ''
+        }
+        syncState()
+    })
+    if (clearCheckbox) {
+        clearCheckbox.addEventListener('change', syncState)
+    }
+
+    syncState()
+}
+
+const initImageSourceInputs = function() {
+    document.querySelectorAll('[data-image-source-pair]').forEach(initImageSourcePair)
+}
+
+if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', initImageSourceInputs)
+} else {
+    initImageSourceInputs()
+}

--- a/app/tests/tickets/api/test_events.py
+++ b/app/tests/tickets/api/test_events.py
@@ -8,8 +8,6 @@ from django.conf import settings
 from django.core.files.base import ContentFile
 from django_countries.fields import Country
 from django_scopes import scopes_disabled
-from pytz import UTC
-
 from pretix.base.models import (
     Event,
     InvoiceAddress,
@@ -19,6 +17,7 @@ from pretix.base.models import (
 )
 from pretix.base.models.orders import OrderFee
 from pretix.testutils.mock import mocker_context
+from pytz import UTC
 
 
 @pytest.fixture
@@ -1114,6 +1113,14 @@ def test_patch_event_settings_file(token_client, organizer, event):
 
     resp = token_client.patch(
         '/api/v1/organizers/{}/events/{}/settings/'.format(organizer.slug, event.slug),
+        {'logo_image': 'https://cdn.example.com/header.png'},
+        format='json',
+    )
+    assert resp.status_code == 200
+    assert resp.data['logo_image'] == 'https://cdn.example.com/header.png'
+
+    resp = token_client.patch(
+        '/api/v1/organizers/{}/events/{}/settings/'.format(organizer.slug, event.slug),
         {'logo_image': file_id_png},
         format='json',
     )
@@ -1127,3 +1134,72 @@ def test_patch_event_settings_file(token_client, organizer, event):
     )
     assert resp.status_code == 200
     assert resp.data['logo_image'] is None
+
+
+@pytest.mark.django_db
+def test_patch_event_settings_external_image_urls(token_client, organizer, event):
+    header_url = 'HTTPS://cdn.example.com/header.png'
+    normalized_header_url = 'https://cdn.example.com/header.png'
+    logo_url = 'https://cdn.example.com/logo.svg'
+
+    resp = token_client.patch(
+        '/api/v1/organizers/{}/events/{}/settings/'.format(organizer.slug, event.slug),
+        {
+            'logo_image': header_url,
+            'event_logo_image': logo_url,
+        },
+        format='json',
+    )
+    assert resp.status_code == 200
+    assert resp.data['logo_image'] == normalized_header_url
+    assert resp.data['event_logo_image'] == logo_url
+
+    resp = token_client.get(
+        '/api/v1/organizers/{}/events/{}/settings/'.format(organizer.slug, event.slug),
+        format='json',
+    )
+    assert resp.status_code == 200
+    assert resp.data['logo_image'] == normalized_header_url
+    assert resp.data['event_logo_image'] == logo_url
+
+    event = Event.objects.get(pk=event.pk)
+    assert event.visible_header_image_url == normalized_header_url
+    assert event.visible_logo_url == logo_url
+    assert event.social_image == normalized_header_url
+
+    resp = token_client.patch(
+        '/api/v1/organizers/{}/events/{}/settings/'.format(organizer.slug, event.slug),
+        {
+            'logo_image': None,
+            'event_logo_image': None,
+        },
+        format='json',
+    )
+    assert resp.status_code == 200
+    assert resp.data['logo_image'] is None
+    assert resp.data['event_logo_image'] is None
+
+    resp = token_client.get(
+        '/api/v1/organizers/{}/events/{}/settings/'.format(organizer.slug, event.slug),
+        format='json',
+    )
+    assert resp.status_code == 200
+    assert resp.data['logo_image'] is None
+    assert resp.data['event_logo_image'] is None
+
+    event = Event.objects.get(pk=event.pk)
+    assert event.visible_header_image_url is None
+    assert event.visible_logo_url is None
+    assert event.social_image is None
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize('invalid_url', ['ftp://cdn.example.com/header.png', 'javascript:alert(1)'])
+def test_patch_event_settings_external_image_urls_reject_invalid_urls(token_client, organizer, event, invalid_url):
+    resp = token_client.patch(
+        '/api/v1/organizers/{}/events/{}/settings/'.format(organizer.slug, event.slug),
+        {'logo_image': invalid_url},
+        format='json',
+    )
+    assert resp.status_code == 400
+    assert resp.data == {'logo_image': ['Enter a valid URL.']}

--- a/app/tests/tickets/base/test_middleware.py
+++ b/app/tests/tickets/base/test_middleware.py
@@ -1,8 +1,21 @@
-from django.conf import settings
-from django.test import Client, TestCase
-from django.utils.timezone import now
+from types import SimpleNamespace
 
+from django.conf import settings
+from django.http import HttpResponse
+from django.test import Client, RequestFactory, TestCase
+from django.test.utils import override_settings
+from django.utils.timezone import now
 from pretix.base.models import Event, Organizer, User
+
+from eventyay.base.middleware import SecurityMiddleware
+
+
+def get_csp_directive_values(policy: str, directive: str) -> list[str]:
+    for part in policy.split('; '):
+        if part.startswith(f'{directive} '):
+            return part[len(f'{directive} ') :].split(' ')
+
+    raise AssertionError(f'Missing {directive} in Content-Security-Policy')
 
 
 class LocaleDeterminationTest(TestCase):
@@ -80,3 +93,59 @@ class LocaleDeterminationTest(TestCase):
         response = c.get('/control/login')
         language = response['Content-Language']
         self.assertEqual(language, 'de')
+
+
+class SecurityMiddlewareTest(TestCase):
+    def setUp(self):
+        super().setUp()
+        self.organizer = Organizer.objects.create(name='Dummy', slug='dummy')
+        self.event = Event.objects.create(
+            organizer=self.organizer,
+            name='Dummy',
+            slug='dummy',
+            date_from=now(),
+            live=True,
+        )
+        self.factory = RequestFactory()
+        self.middleware = SecurityMiddleware(lambda request: HttpResponse('ok'))
+
+    def build_response(self, path: str, *, event=None, view_name: str | None = None) -> HttpResponse:
+        request = self.factory.get(path)
+        request.organizer = event.organizer if event else None
+        request.event = event
+        request.resolver_match = SimpleNamespace(view_name=view_name)
+        return self.middleware.process_response(request, HttpResponse('ok'))
+
+    @override_settings(SITE_URL='https://example.com')
+    def test_security_middleware_restricts_event_image_hosts(self):
+        self.event.settings.set('logo_image', 'HTTPS://CDN.EXAMPLE.COM/header.png')
+        self.event.settings.set('event_logo_image', 'http://assets.example.org/logo.png')
+
+        response = self.build_response('/dummy/', event=self.event, view_name='presale:event.index')
+
+        img_src = get_csp_directive_values(response['Content-Security-Policy'], 'img-src')
+        assert 'https://cdn.example.com' in img_src
+        assert 'http://assets.example.org' in img_src
+        assert 'https:' not in img_src
+        assert 'http:' not in img_src
+
+    @override_settings(SITE_URL='http://example.com')
+    def test_security_middleware_keeps_broad_preview_sources_on_event_settings_page(self):
+        response = self.build_response(
+            '/event/dummy/dummy/settings/',
+            event=self.event,
+            view_name='event.update',
+        )
+
+        img_src = get_csp_directive_values(response['Content-Security-Policy'], 'img-src')
+        assert 'https:' in img_src
+        assert 'http:' in img_src
+
+    @override_settings(SITE_URL='https://example.com')
+    def test_security_middleware_allows_external_images_on_start_page(self):
+        self.event.settings.set('logo_image', 'https://cdn.example.com/header.png')
+
+        response = self.build_response('/', view_name='presale:index')
+
+        img_src = get_csp_directive_values(response['Content-Security-Policy'], 'img-src')
+        assert 'https://cdn.example.com' in img_src


### PR DESCRIPTION
This PR adds a feature to support image urls for header images and event logos.

<img width="2028" height="1162" alt="image" src="https://github.com/user-attachments/assets/9ac42089-c4ca-4750-9f38-1d5145b805db" />

## Summary by Sourcery

Add support for using external image URLs for event header images and logos across forms, APIs, rendering, and security policies.

New Features:
- Allow organizers to configure event logo and header images via external URLs in the event settings form and API.
- Provide live previews and mutual exclusivity handling between uploaded files and URL-based images in the event design settings UI.
- Expose visible header and logo image URLs (including external URLs) for use in presale pages and email templates.

Bug Fixes:
- Ensure event image paths are correctly normalized when stored with file:// schemes in event settings.
- Prevent stale file-based images from lingering when switching to URL-based images through the API or forms.

Enhancements:
- Extend settings initialization to correctly handle file and URL types when building initial form data from hierarchical settings.
- Update social image and email logo computation to work seamlessly with both file-backed images and external URLs.
- Relax the Content Security Policy to allow external images from HTTP(S) origins when needed.
- Clean up query logic, logging, and string formatting for better readability and consistency.

Tests:
- Add API tests verifying that event settings accept and persist external logo and header image URLs and that derived properties reflect them.