### PR TITLE
chore: add better user overview on users page for video webapp

### DIFF
--- a/app/eventyay/base/models/auth.py
+++ b/app/eventyay/base/models/auth.py
@@ -1061,6 +1061,8 @@ the eventyay team"""
         if include_admin_info:
             d["moderation_state"] = self.moderation_state
             d["token_id"] = self.token_id
+            d["email"] = self.email
+            d["wikimedia_username"] = self.wikimedia_username
         if include_client_state:
             d["client_state"] = self.client_state
         if include_personal_data:

--- a/app/eventyay/base/services/user.py
+++ b/app/eventyay/base/services/user.py
@@ -1,26 +1,367 @@
-import datetime as dt
-import json
 import operator
 from collections import namedtuple
 from datetime import timedelta
 from functools import reduce
 
-import jwt
-import requests
 from channels.db import database_sync_to_async
 from channels.layers import get_channel_layer
+from django.core.cache import cache
 from django.core.paginator import InvalidPage, Paginator
 from django.db.models import Q
 from django.db.transaction import atomic
-from django.shortcuts import get_object_or_404
 from django.utils.timezone import now
+from django_scopes import scopes_disabled
 
+from eventyay.eventyay_common.utils import encode_email
 from eventyay.features.live.channels import GROUP_USER
 from eventyay.base.models import AuditLog
 from eventyay.base.models.auth import User
 from eventyay.base.models.room import AnonymousInvite
-from eventyay.base.models.event import Event, EventView
+from eventyay.base.models.event import EventView
+from eventyay.base.models.orders import Order, OrderPosition
 from eventyay.core.permissions import Permission
+
+_WIKI_PROFILE_FIELD_KEYS = (
+    "wikimedia_username",
+    "wikimania_username",
+    "wiki_username",
+)
+
+# Non-empty sentinel: Redis cache may not round-trip empty strings reliably.
+_EMAIL_HASH_CACHE_MISS = "-"
+
+
+def display_wikimedia_username_from_profile(profile, stored_username):
+    if stored_username:
+        return stored_username
+    fields = (profile or {}).get("fields") or {}
+    for key in _WIKI_PROFILE_FIELD_KEYS:
+        val = fields.get(key)
+        if isinstance(val, str) and val.strip():
+            return val.strip()
+    return ""
+
+
+def _is_email_hash_uid_token(token_id):
+    if not token_id or len(token_id) != 7:
+        return False
+    return all(c in "0123456789ABCDEFabcdef" for c in token_id)
+
+
+def _ticket_lookup(mapping, token_id):
+    """Return a ticket/account row dict keyed by token_id (case-insensitive)."""
+    if not token_id or not mapping:
+        return {}
+    if token_id in mapping:
+        return mapping[token_id]
+    token_upper = token_id.upper()
+    for key, value in mapping.items():
+        if key.upper() == token_upper:
+            return value
+    return {}
+
+
+def _order_email_hash_keys(email):
+    """Return upper-case hash keys for an order email (raw and lowercased)."""
+    normalized = (email or "").strip()
+    if not normalized:
+        return ()
+    keys = {encode_email(normalized).upper()}
+    lowered = normalized.lower()
+    if lowered != normalized:
+        keys.add(encode_email(lowered).upper())
+    return tuple(keys)
+
+
+def _make_ticket_row(order_code, ticket_code, contact_email):
+    return {
+        "order_code": order_code,
+        "ticket_code": ticket_code,
+        "contact_email": (contact_email or "").strip(),
+    }
+
+
+def _cache_email_hash_hits(event_id, email):
+    for h in _order_email_hash_keys(email):
+        cache.set(f'video:email_hash:{event_id}:{h}', email, 1800)
+
+
+def _unresolved_hash_tokens(token_ids, ticket_by_token):
+    return [
+        t
+        for t in token_ids
+        if t and _is_email_hash_uid_token(t) and not _ticket_lookup(ticket_by_token, t)
+    ]
+
+
+def admin_public_fields_from_user_row(user_row, ticket_by_token, account_by_token=None):
+    """Admin-only list fields derived from a User values() row and ticket lookup."""
+    tid = user_row["token_id"]
+    ticket = _ticket_lookup(ticket_by_token, tid)
+    account = _ticket_lookup(account_by_token, tid)
+    return {
+        "moderation_state": user_row["moderation_state"],
+        "token_id": tid,
+        "email": (user_row.get("email") or "").strip()
+        or ticket.get("contact_email", "")
+        or account.get("email", ""),
+        "wikimedia_username": display_wikimedia_username_from_profile(
+            user_row["profile"],
+            user_row.get("wikimedia_username") or account.get("wikimedia_username"),
+        ),
+        "order_code": ticket.get("order_code"),
+        "ticket_code": ticket.get("ticket_code"),
+    }
+
+
+def resolve_wikimedia_usernames_by_email(emails):
+    """Return a lowercase email -> Wikimedia username map from account users."""
+    uniq = list(dict.fromkeys((e or "").strip().lower() for e in emails if e))
+    if not uniq:
+        return {}
+    email_conditions = reduce(
+        operator.or_, (Q(email__iexact=e) for e in uniq), Q()
+    )
+    with scopes_disabled():
+        rows = list(
+            User.objects.filter(event__isnull=True)
+            .filter(email_conditions)
+            .exclude(wikimedia_username__isnull=True)
+            .exclude(wikimedia_username__exact="")
+            .values("email", "wikimedia_username")
+        )
+    result = {}
+    for row in rows:
+        email = (row.get("email") or "").strip().lower()
+        if email and email not in result:
+            result[email] = (row.get("wikimedia_username") or "").strip()
+    return result
+
+
+def resolve_account_fields_by_token_ids(token_ids):
+    """Map video JWT uid (email hash) to account email and Wikimedia username."""
+    hash_tokens = [t for t in token_ids if t and _is_email_hash_uid_token(t)]
+    if not hash_tokens:
+        return {}
+    wanted = {t.upper() for t in hash_tokens}
+    result = {}
+    with scopes_disabled():
+        for row in (
+            User.objects.filter(event__isnull=True)
+            .exclude(email__isnull=True)
+            .exclude(email__exact="")
+            .values("email", "wikimedia_username")
+            .iterator(chunk_size=2000)
+        ):
+            email = (row.get("email") or "").strip()
+            if not email:
+                continue
+            for h in _order_email_hash_keys(email):
+                if h in wanted and h not in result:
+                    result[h] = {
+                        "email": email,
+                        "wikimedia_username": (
+                            row.get("wikimedia_username") or ""
+                        ).strip(),
+                    }
+            if len(result) >= len(wanted):
+                break
+    keyed = {
+        token: result[token.upper()]
+        for token in hash_tokens
+        if token.upper() in result
+    }
+    return keyed
+
+
+def _latest_paid_ticket_row_for_email(event_id, email):
+    """Return the latest paid ticket row for an order email on this event."""
+    normalized = (email or "").strip()
+    if not normalized:
+        return None
+    with scopes_disabled():
+        pos = (
+            OrderPosition.objects.filter(
+                order__event_id=event_id,
+                order__email__iexact=normalized,
+                order__status=Order.STATUS_PAID,
+                addon_to__isnull=True,
+                canceled=False,
+            )
+            .select_related("order")
+            .order_by("-order__datetime", "positionid")
+            .first()
+        )
+    if not pos:
+        return None
+    return _make_ticket_row(pos.order.code, pos.secret, pos.order.email)
+
+
+def build_admin_ticket_rows_by_token(event_id, token_ids):
+    """
+    Map a video user's JWT ``uid`` (stored as ``User.token_id``) to Pretix order data.
+
+    Tokens are either ``OrderPosition.pseudonymization_id`` or ``encode_email(order.email)``
+    (seven hex characters) as used by presale video join links.
+    """
+    uniq = list(dict.fromkeys(t for t in token_ids if t))
+    if not uniq:
+        return {}
+    result = {}
+    pseudonym_q = reduce(
+        operator.or_, (Q(pseudonymization_id__iexact=t) for t in uniq), Q()
+    )
+    with scopes_disabled():
+        for row in OrderPosition.objects.filter(
+            pseudonym_q,
+            order__event_id=event_id,
+            addon_to__isnull=True,
+            canceled=False,
+            order__status=Order.STATUS_PAID,
+        ).values(
+            "pseudonymization_id",
+            "secret",
+            "order__code",
+            "order__email",
+        ):
+            pid = row["pseudonymization_id"]
+            for t in uniq:
+                if pid and t and pid.upper() == t.upper() and not _ticket_lookup(result, t):
+                    result[t] = _make_ticket_row(
+                        row["order__code"], row["secret"], row["order__email"]
+                    )
+                    break
+    need_hash = [
+        t
+        for t in uniq
+        if not _ticket_lookup(result, t) and _is_email_hash_uid_token(t)
+    ]
+    if need_hash:
+        need_hash_upper = {t.upper() for t in need_hash}
+        hash_to_email = {}
+
+        # Satisfy as many tokens as possible from the per-token cache.
+        # Each entry is small (one email string) and stable — a token_id derived
+        # from encode_email(email) never changes for a given address.
+        uncached = set()
+        for h in need_hash_upper:
+            val = cache.get(f'video:email_hash:{event_id}:{h}')
+            if val is not None:
+                if val and val != _EMAIL_HASH_CACHE_MISS:
+                    hash_to_email[h] = val
+                # Sentinel marks a cached negative lookup (no matching email).
+            else:
+                uncached.add(h)
+
+        # Stream DB only for tokens that were not in cache.
+        if uncached:
+            with scopes_disabled():
+                for email in (
+                    Order.objects.filter(event_id=event_id)
+                    .filter(status=Order.STATUS_PAID)
+                    .exclude(email__isnull=True)
+                    .exclude(email__exact="")
+                    .values_list('email', flat=True)
+                    .iterator(chunk_size=2000)
+                ):
+                    matched_hash = None
+                    for h in _order_email_hash_keys(email):
+                        if h in uncached and h not in hash_to_email:
+                            matched_hash = h
+                            break
+                    if matched_hash:
+                        hash_to_email[matched_hash] = email
+                        _cache_email_hash_hits(event_id, email)
+                        uncached.discard(matched_hash)
+                        if not uncached:
+                            break
+        for h in need_hash_upper:
+            if h not in hash_to_email:
+                cache.set(
+                    f'video:email_hash:{event_id}:{h}', _EMAIL_HASH_CACHE_MISS, 1800
+                )
+
+        resolved = [
+            hash_to_email[t.upper()]
+            for t in need_hash
+            if t.upper() in hash_to_email
+        ]
+        emails = list(dict.fromkeys(resolved))
+        positions_by_email = {}
+        if emails:
+            email_conditions = reduce(
+                operator.or_, (Q(order__email__iexact=e) for e in emails), Q()
+            )
+            with scopes_disabled():
+                rows = (
+                    OrderPosition.objects.filter(
+                        email_conditions,
+                        order__event_id=event_id,
+                        order__status=Order.STATUS_PAID,
+                        addon_to__isnull=True,
+                        canceled=False,
+                    )
+                    .select_related("order")
+                    .order_by("order__email", "-order__datetime", "positionid")
+                )
+                for pos in rows:
+                    key = (pos.order.email or "").strip().lower()
+                    if key and key not in positions_by_email:
+                        positions_by_email[key] = _make_ticket_row(
+                            pos.order.code, pos.secret, pos.order.email
+                        )
+        for t in need_hash:
+            email = hash_to_email.get(t.upper())
+            if not email:
+                continue
+            row = positions_by_email.get(email.strip().lower())
+            if row:
+                result[t] = dict(row)
+    return result
+
+
+def build_admin_ticket_lookups(event_id, token_ids):
+    """Return ticket and account lookup maps for admin user list fields."""
+    uniq = list(dict.fromkeys(t for t in token_ids if t))
+    ticket_by_token = build_admin_ticket_rows_by_token(event_id, uniq)
+    unresolved = _unresolved_hash_tokens(uniq, ticket_by_token)
+    account_by_token = (
+        resolve_account_fields_by_token_ids(unresolved) if unresolved else {}
+    )
+    for token in unresolved:
+        email = (_ticket_lookup(account_by_token, token).get("email") or "").strip()
+        if not email:
+            continue
+        row = _latest_paid_ticket_row_for_email(event_id, email)
+        if row:
+            ticket_by_token[token] = row
+            _cache_email_hash_hits(event_id, email)
+    return ticket_by_token, account_by_token
+
+
+def _resolve_admin_fields_for_users(event_id, users_data):
+    """Build admin-only list fields for event-scoped user rows."""
+    if not users_data:
+        return {}
+    token_ids = [u["token_id"] for u in users_data if u.get("token_id")]
+    ticket_by_token, account_by_token = build_admin_ticket_lookups(event_id, token_ids)
+    admin_fields_by_id = {}
+    emails_to_resolve = []
+    for u in users_data:
+        fields = admin_public_fields_from_user_row(
+            u, ticket_by_token, account_by_token
+        )
+        admin_fields_by_id[u["id"]] = fields
+        if fields.get("email") and not fields.get("wikimedia_username"):
+            emails_to_resolve.append(fields["email"])
+    if emails_to_resolve:
+        email_to_wikimedia = resolve_wikimedia_usernames_by_email(emails_to_resolve)
+        for fields in admin_fields_by_id.values():
+            if not fields.get("wikimedia_username"):
+                email = (fields.get("email") or "").strip().lower()
+                if email and email in email_to_wikimedia:
+                    fields["wikimedia_username"] = email_to_wikimedia[email]
+    return admin_fields_by_id
 
 
 def get_user_by_id(event_id, user_id):
@@ -49,11 +390,27 @@ def get_public_user(event_id, id, include_admin_info=False, trait_badges_map=Non
     user = get_user_by_id(event_id, id)
     if not user:
         return None
-    return user.serialize_public(
+    data = user.serialize_public(
         include_admin_info=include_admin_info,
         trait_badges_map=trait_badges_map,
         include_client_state=include_admin_info and user.type == User.UserType.KIOSK,
     )
+    if include_admin_info:
+        admin_fields = _resolve_admin_fields_for_users(
+            event_id,
+            [
+                {
+                    "id": user.id,
+                    "token_id": user.token_id,
+                    "moderation_state": user.moderation_state,
+                    "email": user.email or "",
+                    "wikimedia_username": user.wikimedia_username or "",
+                    "profile": user.profile,
+                }
+            ],
+        ).get(user.id, {})
+        data.update(admin_fields)
+    return data
 
 
 @database_sync_to_async
@@ -84,6 +441,31 @@ def get_public_users(
         qs = qs.filter(type=type)
     if not include_banned:
         qs = qs.exclude(moderation_state=User.ModerationState.BANNED)
+
+    value_fields = (
+        "id",
+        "type",
+        "profile",
+        "deleted",
+        "moderation_state",
+        "token_id",
+        "traits",
+        "last_login",
+        "pretalx_id",
+        "client_state",
+    )
+
+    if include_admin_info:
+        users_data = list(qs.values(*value_fields, "email", "wikimedia_username"))
+    else:
+        users_data = qs.values(*value_fields).iterator()
+
+    admin_fields_by_id = (
+        _resolve_admin_fields_for_users(event_id, users_data)
+        if include_admin_info and users_data
+        else {}
+    )
+
     return [
         dict(
             id=str(u["id"]),
@@ -112,26 +494,12 @@ def get_public_users(
                 else {}
             ),
             **(
-                {
-                    "moderation_state": u["moderation_state"],
-                    "token_id": u["token_id"],
-                }
+                admin_fields_by_id.get(u["id"], {})
                 if include_admin_info
                 else {}
             ),
         )
-        for u in qs.values(
-            "id",
-            "type",
-            "profile",
-            "deleted",
-            "moderation_state",
-            "token_id",
-            "traits",
-            "last_login",
-            "pretalx_id",
-            "client_state",
-        )
+        for u in users_data
     ]
 
 
@@ -594,18 +962,32 @@ def list_users(
         qs = qs.filter(reduce(operator.or_, conditions))
 
     try:
+        value_fields = (
+            "id",
+            "profile",
+            "traits",
+            "last_login",
+            "moderation_state",
+            "token_id",
+            "pretalx_id",
+        )
+        if include_admin_info:
+            qs_values = qs.order_by("profile__display_name").values(
+                *value_fields,
+                "email",
+                "wikimedia_username",
+            )
+        else:
+            qs_values = qs.order_by("profile__display_name").values(*value_fields)
         p = Paginator(
-            qs.order_by("profile__display_name").values(
-                "id",
-                "profile",
-                "traits",
-                "last_login",
-                "moderation_state",
-                "token_id",
-                "pretalx_id",
-            ),
+            qs_values,
             page_size,
         ).page(page)
+        admin_fields_by_id = (
+            _resolve_admin_fields_for_users(event_id, p.object_list)
+            if include_admin_info and p.object_list
+            else {}
+        )
         return {
             "results": sorted(
                 (
@@ -629,10 +1011,7 @@ def list_users(
                             else []
                         ),
                         **(
-                            dict(
-                                moderation_state=u["moderation_state"],
-                                token_id=u["token_id"],
-                            )
+                            admin_fields_by_id.get(u["id"], {})
                             if include_admin_info
                             else {}
                         ),

--- a/app/eventyay/features/live/modules/auth.py
+++ b/app/eventyay/features/live/modules/auth.py
@@ -61,6 +61,13 @@ class AuthModule(BaseModule):
         """Return event config dict (never None)."""
         return (getattr(self.consumer.event, "config", None) or {}) if self.consumer.event else {}
 
+    async def _include_admin_user_info(self):
+        """Admin user list/detail fields match EVENT_USERS_LIST UI, not only manage."""
+        return await self.consumer.event.has_permission_async(
+            user=self.consumer.user,
+            permission=Permission.EVENT_USERS_LIST,
+        )
+
     async def login(self, body):
         kwargs = {
             "event": self.consumer.event,
@@ -299,9 +306,7 @@ class AuthModule(BaseModule):
     @command("fetch")
     @require_event_permission(Permission.EVENT_VIEW)
     async def fetch(self, body):
-        admin = await self.consumer.event.has_permission_async(
-            user=self.consumer.user, permission=Permission.EVENT_USERS_MANAGE
-        )
+        admin = await self._include_admin_user_info()
         if "ids" in body:
             users = await get_public_users(
                 self.consumer.event.id,
@@ -355,10 +360,7 @@ class AuthModule(BaseModule):
         body = body or {}
         users = await get_public_users(
             self.consumer.event.pk,
-            include_admin_info=await self.consumer.event.has_permission_async(
-                user=self.consumer.user,
-                permission=Permission.EVENT_USERS_MANAGE,
-            ),
+            include_admin_info=await self._include_admin_user_info(),
             type=body.get("type", User.UserType.PERSON),
             include_banned=not body
             or body.get("include_banned", True)
@@ -395,10 +397,7 @@ class AuthModule(BaseModule):
                 search_term=body["search_term"],
                 badge=badge,
                 search_fields=search_fields,
-                include_admin_info=await self.consumer.event.has_permission_async(
-                    user=self.consumer.user,
-                    permission=Permission.EVENT_USERS_MANAGE,
-                ),
+                include_admin_info=await self._include_admin_user_info(),
                 include_banned=body.get("include_banned", True)
                 and await self.consumer.event.has_permission_async(
                     user=self.consumer.user,

--- a/app/eventyay/webapp/video/src/components/ChatUserCard.vue
+++ b/app/eventyay/webapp/video/src/components/ChatUserCard.vue
@@ -21,10 +21,10 @@
 						.block(v-else, @click="userAction = 'block'") {{ $t('UserAction:action.block:label') }}
 						template(v-if="hasPermission('room:chat.moderate') && user.id !== ownUser.id")
 							.divider {{ $t('UserAction:moderator-actions:title') }}
-							.reactivate(v-if="user.moderation_state", @click="userAction = 'reactivate'")
-								| {{ user.moderation_state === 'banned' ? $t('UserAction:action.unban:label') : $t('UserAction:action.unsilence:label') }}
 							.ban(v-if="user.moderation_state !== 'banned'", @click="userAction = 'ban'") {{ $t('UserAction:action.ban:label') }}
 							.silence(v-if="!user.moderation_state", @click="userAction = 'silence'") {{ $t('UserAction:action.silence:label') }}
+							.reactivate(v-if="user.moderation_state", @click="userAction = 'reactivate'")
+								| {{ user.moderation_state === 'banned' ? $t('UserAction:action.unban:label') : $t('UserAction:action.unsilence:label') }}
 	user-action-prompt(v-if="userAction", :action="userAction", :user="user", @close="$emit('close')")
 </template>
 <script>

--- a/app/eventyay/webapp/video/src/components/UserListPage.vue
+++ b/app/eventyay/webapp/video/src/components/UserListPage.vue
@@ -31,10 +31,10 @@
 				template(v-if="hasPermission('room:chat.moderate') && selectedUser.id !== user.id")
 					.devider {{ $t('UserAction:moderator-actions:title') }}
 					.action-row
-						bunt-button.reactivate(v-if="selectedUser.moderation_state", @click="userAction = 'reactivate'")
-							| {{ selectedUser.moderation_state === 'banned' ? $t('UserAction:action.unban:label') : $t('UserAction:action.unsilence:label') }}
 						bunt-button.ban(v-if="selectedUser.moderation_state !== 'banned'", @click="userAction = 'ban'") {{ $t('UserAction:action.ban:label') }}
 						bunt-button.silence(v-if="!selectedUser.moderation_state", @click="userAction = 'silence'") {{ $t('UserAction:action.silence:label') }}
+						bunt-button.reactivate(v-if="selectedUser.moderation_state", @click="userAction = 'reactivate'")
+							| {{ selectedUser.moderation_state === 'banned' ? $t('UserAction:action.unban:label') : $t('UserAction:action.unsilence:label') }}
 		.placeholder(v-else)
 			h2 {{ $t('UserListPage:placeholder:text') }}
 	user-action-prompt(v-if="userAction", :action="userAction", :user="selectedUser", @close="updateProfile")

--- a/app/eventyay/webapp/video/src/views/admin/user.vue
+++ b/app/eventyay/webapp/video/src/views/admin/user.vue
@@ -7,11 +7,11 @@
 			.actions(v-if="user.id !== ownUser.id")
 				bunt-button.btn-dm(v-if="hasPermission('world:chat.direct') && !user.deleted", @click="openDM") message
 				bunt-button.btn-call(v-if="hasPermission('world:chat.direct') && !user.deleted", @click="startCall") call
-				bunt-button.btn-reactivate(v-if="hasPermission('world:users.manage') && user.moderation_state", @click="userAction = 'reactivate'")
-					| {{ user.moderation_state === 'banned' ? 'unban' : 'unsilence'}}
 				bunt-button.btn-delete(v-if="hasPermission('world:users.manage') && !user.deleted", @click="userAction = 'delete'") {{ $t('UserAction:action.delete:label') }}
 				bunt-button.btn-ban(v-if="hasPermission('world:users.manage') && !user.deleted && user.moderation_state !== 'banned'", @click="userAction = 'ban'") ban
 				bunt-button.btn-silence(v-if="hasPermission('world:users.manage') && !user.deleted && !user.moderation_state", @click="userAction = 'silence'") silence
+				bunt-button.btn-reactivate(v-if="hasPermission('world:users.manage') && user.moderation_state", @click="userAction = 'reactivate'")
+					| {{ user.moderation_state === 'banned' ? 'unban' : 'unsilence'}}
 				bunt-button#btn-save(v-if="edit", :disabled="v$.$invalid && v$.$dirty", :loading="saving", @click="save") {{ $t('preferences/index:btn-save:label') }}
 				bunt-button#btn-edit(v-if="!user.deleted", @click="edit=true") edit
 		scrollbars.user-info(y)
@@ -20,7 +20,11 @@
 				bunt-button#btn-change-avatar(@click="showChangeAvatar = true", v-if="edit") {{ $t('preferences/index:btn-change-avatar:label') }}
 			bunt-input.display-name(name="displayName", :label="$t('profile/GreetingPrompt:displayname:label')", v-model.trim="user.profile.display_name", :validation="v$.user.profile.display_name", :disabled="!edit")
 			bunt-input(name="id", label="ID", :modelValue="user.id", :disabled="true")
-			bunt-input(name="token_id", label="External ID", :modelValue="user.token_id", :disabled="true")
+			bunt-input(name="token_id", label="Login UID (JWT uid)", :modelValue="user.token_id || '–'", :disabled="true")
+			bunt-input(name="email", label="Email", :modelValue="user.email || '–'", :disabled="true")
+			bunt-input(name="wikimedia_username", label="Wikimedia / Wikimania username", :modelValue="user.wikimedia_username || '–'", :disabled="true")
+			bunt-input(name="order_code", label="Order code", :modelValue="user.order_code || '–'", :disabled="true")
+			bunt-input(name="ticket_code", label="Ticket code (position secret)", :modelValue="user.ticket_code || '–'", :disabled="true")
 			bunt-input(name="mod_state", label="Moderation state", :modelValue="user.moderation_state || '-'", :disabled="true")
 			change-additional-fields(v-model="user.profile.fields", :disabled="!edit")
 	bunt-progress-circular(v-else, size="huge")

--- a/app/eventyay/webapp/video/src/views/admin/users.vue
+++ b/app/eventyay/webapp/video/src/views/admin/users.vue
@@ -9,28 +9,44 @@
 			.id ID
 			.tokenid External ID
 			.name Name
+			.email Email
+			.ticket-info
+				span.ticket-info-head-order Order/
+				span.ticket-info-head-ticket Ticket code
+			.wikimedia Wikimedia
 			.state State
-			.actions
-		RecycleScroller.tbody.bunt-scrollbar(v-if="filteredUsers", :items="filteredUsers", :item-size="48", v-slot="{item: user}", v-scrollbar.y="")
-			router-link(:to="{name: 'admin:user', params: {userId: user.id}}", :class="{error: user.error, updating: user.updating}").user.table-row
-				avatar.avatar(:user="user", :size="32")
+		RecycleScroller.tbody.bunt-scrollbar(v-if="filteredUsers", :items="filteredUsers", :item-size="56", v-slot="{item: user}", v-scrollbar.y="")
+			.user.table-row(
+				:class="{error: user.error, updating: user.updating}",
+				tabindex="0",
+				role="link",
+				:aria-label="userRowAriaLabel(user)",
+				@click="goToUser(user)",
+				@keydown.enter.self.prevent="goToUser(user)"
+			)
+				avatar.avatar(:user="user", :size="24")
 				.id(:title="user.id") {{ user.id }}
-				.tokenid(:title="user.token_id") {{ user.token_id }}
+				.tokenid(:title="user.token_id || ''") {{ user.token_id || '–' }}
 				.name
 					| {{ user.profile.display_name }}
 					.ui-badge(v-for="badge in user.badges") {{ badge }}
-				.state {{ user.moderation_state }}
-				.actions(v-if="user.id !== ownUser.id", @click.prevent.stop="")
-					.placeholder.mdi.mdi-dots-horizontal
+				.email(:title="user.email || ''") {{ user.email || '–' }}
+				.ticket-info(@click.stop="")
+					template(v-if="user.order_code && eventRouting.organizer && eventRouting.event")
+						a.order-link(
+							:href="`/control/event/${encodeURIComponent(eventRouting.organizer)}/${encodeURIComponent(eventRouting.event)}/orders/${encodeURIComponent(user.order_code)}/`",
+							target="_blank",
+							rel="noopener noreferrer",
+							:title="user.order_code",
+							@click.stop
+						) {{ user.order_code }}
+						span.ticket-code(v-if="user.ticket_code", :title="user.ticket_code") {{ user.ticket_code }}
+					span.ticket-code-only(v-else-if="user.ticket_code", :title="user.ticket_code") {{ user.ticket_code }}
+					span.ticket-empty(v-else) –
+				.wikimedia(:title="user.wikimedia_username || ''") {{ user.wikimedia_username || '–' }}
+				.state {{ user.moderation_state || '–' }}
+				.row-actions(v-if="user.id !== ownUser.id", @click.stop="")
 					bunt-button.btn-open-dm(v-if="hasPermission('world:chat.direct')", @click="$store.dispatch('chat/openDirectMessage', {users: [user]})") message
-					bunt-button.btn-reactivate(
-						v-if="hasPermission('world:users.manage') && user.moderation_state",
-						:key="`${user.id}-reactivate`",
-						:loading="user.updating === 'reactivate'",
-						:error-message="(user.error && user.error.action === 'reactivate') ? user.error.message : null",
-						tooltipPlacement="left", 
-						@click="doAction(user, 'reactivate', null)")
-						| {{ user.moderation_state === 'banned' ? 'unban' : 'unsilence'}}
 					bunt-button.btn-ban(
 						v-if="hasPermission('world:users.manage') && user.moderation_state !== 'banned'",
 						:key="`${user.id}-ban`",
@@ -47,6 +63,14 @@
 						tooltipPlacement="left",
 						@click="doAction(user, 'silence', 'silenced')")
 						| silence
+					bunt-button.btn-reactivate(
+						v-if="hasPermission('world:users.manage') && user.moderation_state",
+						:key="`${user.id}-reactivate`",
+						:loading="user.updating === 'reactivate'",
+						:error-message="(user.error && user.error.action === 'reactivate') ? user.error.message : null",
+						tooltipPlacement="left",
+						@click="doAction(user, 'reactivate', null)")
+						| {{ user.moderation_state === 'banned' ? 'unban' : 'unsilence'}}
 		bunt-progress-circular(v-else, size="huge", :page="true")
 </template>
 <script>
@@ -70,11 +94,20 @@ export default {
 		...mapState({
 			ownUser: 'user'
 		}),
-		...mapGetters(['hasPermission']),
+		...mapGetters(['hasPermission', 'eventRouting']),
 		filteredUsers() {
 			if (!this.users) return
-			if (!this.search) return this.users
-			return this.users.filter(user => user.id.startsWith(this.search.trim()) || (user.token_id && user.token_id.startsWith(this.search.trim())) || fuzzysearch(this.search.toLowerCase(), user.profile?.display_name?.toLowerCase()))
+			const q = this.search.trim()
+			if (!q) return this.users
+			const ql = q.toLowerCase()
+			return this.users.filter(
+				user =>
+					user.id.startsWith(q) ||
+					(user.token_id && user.token_id.startsWith(q)) ||
+					fuzzysearch(ql, user.profile?.display_name?.toLowerCase()) ||
+					(user.email && fuzzysearch(ql, user.email.toLowerCase())) ||
+					(user.ticket_code && fuzzysearch(ql, user.ticket_code.toLowerCase()))
+			)
 		}
 	},
 	async created() {
@@ -87,6 +120,13 @@ export default {
 		})
 	},
 	methods: {
+		goToUser(user) {
+			this.$router.push({ name: 'admin:user', params: { userId: user.id } })
+		},
+		userRowAriaLabel(user) {
+			const name = user.profile?.display_name
+			return name ? `User ${name}` : `User ${user.id}`
+		},
 		async doAction(user, action, postState) {
 			user.updating = action
 			user.error = null
@@ -115,42 +155,160 @@ export default {
 	.header
 		background-color: $clr-grey-50
 	h2
-		margin: 16px
+		margin: 8px 12px 4px
+		font-size: 20px
 	.search
 		input-style(size: compact)
 		padding: 0
-		margin: 8px
+		margin: 4px 8px 6px
 		flex: none
 	.users-list
 		flex-table()
-		.user
+		font-size: 12px
+		// flex-table uses overflow: hidden — allow horizontal scroll when needed
+		overflow-x: auto
+		overflow-y: hidden
+		> .header, .tbody .user.table-row
+			width: 100%
+			min-width: 0
+			max-width: 100%
+			box-sizing: border-box
+		> .header > *, .tbody .user.table-row > *
+			padding: 3px 6px
+			box-sizing: border-box
+		.avatar, .id, .tokenid, .wikimedia, .state
+			flex-shrink: 0
+		.id, .tokenid, .wikimedia, .state, .name, .email
+			overflow: hidden
+			text-overflow: ellipsis
+			white-space: nowrap
+		> .header > *
+			line-height: 1.2
+			white-space: normal
+			overflow: visible
+			text-overflow: clip
+		.header, .user.table-row
+			height: auto
+			min-height: 56px
+			line-height: 1.2
+			align-items: stretch
+			> .ticket-info
+				line-height: 1.15
+				padding-top: 2px
+				padding-bottom: 2px
+				justify-content: center
+				white-space: normal
+				overflow: visible
+				text-overflow: clip
+		.tbody .table-row
+			overflow: visible
+			position: relative
+		.user.table-row
 			display: flex
-			align-items: center
+			align-items: stretch
 			color: $clr-primary-text-light
+			cursor: pointer
+			&:focus-visible
+				outline: 2px solid $clr-primary
+				outline-offset: 2px
+			> *:not(.ticket-info)
+				align-self: center
+		.header
+			> *:not(.ticket-info)
+				align-self: center
 		.avatar
 			display: flex
-			width: 32px
-			padding-right: 0
-		.id
-			width: 128px
-			ellipsis()
-		.tokenid
-			width: 128px
-			ellipsis()
-		.name
-			flex: auto
-		.state
-			width: 78px
-		.actions
-			flex: none
-			width: 260px
-			padding: 0 24px 0 0
-			display: flex
+			flex: 0 0 40px
+			width: 40px
+			min-width: 40px
+			padding-left: 4px
+			padding-right: 4px
 			align-items: center
-			justify-content: flex-end
-			.placeholder
-				flex: none
+			justify-content: flex-start
+			box-sizing: border-box
+		.id
+			flex: 0 0 56px
+			width: 56px
+			min-width: 56px
+			max-width: 56px
+		.tokenid
+			flex: 0 0 108px
+			width: 108px
+			min-width: 108px
+			max-width: 108px
+		.name
+			flex: 0.6 1 0
+			min-width: 0
+			width: 0
+			max-width: 150px
+		.email
+			flex: 0.75 1 0
+			min-width: 0
+			width: 0
+			max-width: 200px
+		.ticket-info
+			flex: 0.75 1 0
+			min-width: 0
+			width: 0
+			max-width: 240px
+			flex-shrink: 1
+			overflow: hidden
+			display: flex
+			flex-direction: column
+			align-items: flex-start
+			justify-content: center
+			gap: 1px
+			box-sizing: border-box
+			.ticket-info-head-order, .ticket-info-head-ticket
+				display: block
+				font-weight: 600
+				color: $clr-primary-text
+				font-size: 9px
+				line-height: 1.1
+				text-transform: uppercase
+				letter-spacing: 0.02em
+			.order-link
+				flex: 0 1 auto
+				min-width: 0
+				max-width: 100%
+				color: $clr-primary
+				text-decoration: none
+				font-size: 11px
+				overflow: hidden
+				text-overflow: ellipsis
+				white-space: nowrap
+				&:hover
+					text-decoration: underline
+			.ticket-code, .ticket-code-only
 				color: $clr-secondary-text-light
+				font-size: 10px
+				font-family: ui-monospace, monospace
+				max-width: 100%
+				overflow: hidden
+				text-overflow: ellipsis
+				white-space: nowrap
+			.ticket-empty
+				color: $clr-secondary-text-light
+		.wikimedia
+			flex: 0 0 264px
+			width: 264px
+			min-width: 264px
+			max-width: 264px
+		.state
+			flex: 0 0 88px
+			width: 88px
+			min-width: 88px
+			max-width: 88px
+		.row-actions
+			display: none
+			position: absolute
+			right: 0
+			top: 50%
+			transform: translateY(-50%)
+			align-items: center
+			gap: 2px
+			padding: 0 8px
+			z-index: 1
 			.btn-open-dm
 				button-style(style: clear)
 			.btn-reactivate
@@ -159,10 +317,7 @@ export default {
 				button-style(style: clear, color: $clr-danger, text-color: $clr-danger)
 			.btn-silence
 				button-style(style: clear, color: $clr-deep-orange, text-color: $clr-deep-orange)
-		.user:not(:hover):not(.error):not(.updating)
-			.actions .bunt-button
-				display: none
-		.user:hover, .user.error, .user.updating
-			.actions .placeholder
-				display: none
+		.user.table-row:hover .row-actions,
+		.user.table-row:focus-within .row-actions
+			display: flex
 </style>


### PR DESCRIPTION
Fixes #3194

## Summary by Sourcery

Enhance the video admin user management views and backing services to expose richer user, ticket, and Wikimedia information for admins.

New Features:
- Display user email, ticket/order data, and Wikimedia username in the video admin users list and user detail views.
- Allow admins to open related Pretix orders directly from the users list via order links.
- Enable searching users by email and ticket code in the admin users list.

Enhancements:
- Improve layout, sizing, and interaction of the admin users table, including row click navigation and hover-visible row actions.
- Derive Wikimedia usernames from multiple possible profile fields when not explicitly stored on the user.
- Resolve ticket and contact email data for users by mapping video login tokens to Pretix orders and positions, including support for hashed email tokens.
- Include admin-only user metadata (email, Wikimedia username, order code, ticket code) in public/admin user service responses and serialization.