### PR TITLE
fix(zod): update zod schema

### DIFF
--- a/app/eventyay/base/middleware.py
+++ b/app/eventyay/base/middleware.py
@@ -269,6 +269,7 @@ class SecurityMiddleware(MiddlewareMixin):
             'default-src': ['{static}'],
             'script-src': [
                 '{static}',
+                'https://static.cloudflareinsights.com',
                 'https://checkout.stripe.com',
                 'https://js.stripe.com',
                 'http://localhost:8080',
@@ -288,7 +289,14 @@ class SecurityMiddleware(MiddlewareMixin):
                 '{media}',
                 "'unsafe-inline'",  # allow inline styles
             ],
-            'connect-src': ['{dynamic}', '{media}', 'https://checkout.stripe.com', 'https:', 'blob:'],
+            'connect-src': [
+                '{dynamic}',
+                '{media}',
+                'https://checkout.stripe.com',
+                'https://cloudflareinsights.com',
+                'https:',
+                'blob:',
+            ],
             'img-src': ['{static}', '{media}', 'data:', 'https://*.stripe.com', 'https://twemoji.maxcdn.com']
             + external_img_src
             + img_src,
@@ -345,7 +353,7 @@ class SecurityMiddleware(MiddlewareMixin):
             if domain:
                 siteurlsplit = urlsplit(settings.SITE_URL)
                 if siteurlsplit.port and siteurlsplit.port not in (80, 443):
-                    domain = '%s:%d' % (domain, siteurlsplit.port)
+                    domain = f'{domain}:{siteurlsplit.port}'
                 dynamicdomain += ' ' + domain
 
         # Add DEBUG mode settings before rendering CSP

--- a/app/eventyay/base/middleware.py
+++ b/app/eventyay/base/middleware.py
@@ -293,7 +293,7 @@ class SecurityMiddleware(MiddlewareMixin):
                 '{dynamic}',
                 '{media}',
                 'https://checkout.stripe.com',
-                'https://cloudflareinsights.com',
+                'https://static.cloudflareinsights.com',
                 'https:',
                 'blob:',
             ],

--- a/app/eventyay/webapp/schedule-editor/src/App.vue
+++ b/app/eventyay/webapp/schedule-editor/src/App.vue
@@ -54,7 +54,8 @@
 							label.data-label.col-form-label.col-md-3 {{ $t('Speakers') }}
 							.col-md-9.data-value
 								span(v-for="speaker, index of editorSession.speakers")
-									a(:href="`/orga/event/${eventSlug}/speakers/${speaker.code}/`") {{speaker.name || speaker.code}}
+									a(v-if="speaker.code", :href="`/orga/event/${eventSlug}/speakers/${speaker.code}/`") {{ speaker.name || speaker.code }}
+									span(v-else) {{ speaker.name }}
 									span(v-if="index != editorSession.speakers.length - 1") {{', '}}
 								span.text-warning(v-if="editorSession.speakers.some(s => !s.name)")  ({{ $t('some speakers have not shared their names') }})
 						.data-row(v-else).form-group.row
@@ -101,7 +102,7 @@ import { getLocalizedString } from '~/utils'
 import type { AvailabilityEntry } from '~/schemas';
 
 interface Speaker {
-  code: string
+  code?: string | null
   name: string
 }
 
@@ -139,7 +140,7 @@ interface Talk {
 
 interface SessionData {
   id: number
-  code: string
+  code?: string
   title: Record<string, string> | string
   abstract?: string
   speakers?: Speaker[]
@@ -246,10 +247,19 @@ const tracksLookup = computed<Record<string, Track>>(() => {
 const speakersLookup = computed<Record<string, Speaker>>(() => {
   if (!schedule.value) return {}
   return schedule.value.speakers.reduce((acc, speaker) => {
-    acc[speaker.code] = speaker
+    if (speaker.code) {
+      acc[speaker.code] = speaker
+    }
     return acc
   }, {} as Record<string, Speaker>)
 })
+
+function resolveSessionSpeakers(speakers?: string[]): Speaker[] {
+  if (!speakers?.length) return []
+  return speakers
+    .map((speakerCode) => speakersLookup.value[speakerCode])
+    .filter((speaker): speaker is Speaker => Boolean(speaker))
+}
 
 // Sort methods for unassigned sessions
 const unassignedSortMethods = computed<SortMethod[]>(() => {
@@ -274,7 +284,7 @@ const unscheduled = computed<SessionData[]>(() => {
       code: session.code,
       title: session.title,
       abstract: session.abstract,
-      speakers: session.speakers?.map((s) => speakersLookup.value[s]) ?? [],
+      speakers: resolveSessionSpeakers(session.speakers),
       track: tracksLookup.value[session.track ?? ''],
       duration: session.duration,
       state: session.state,
@@ -334,7 +344,7 @@ const sessions = computed<SessionData[]>(() => {
     start: moment(session.start),
     end: moment(session.end),
     duration: moment(session.end).diff(moment(session.start), 'minutes'),
-    speakers: session.speakers?.map((s) => speakersLookup.value[s]) ?? [],
+    speakers: resolveSessionSpeakers(session.speakers),
     track: tracksLookup.value[session.track ?? ''],
     state: session.state,
     room: roomsLookup.value[session.room ?? ''],

--- a/app/eventyay/webapp/schedule-editor/src/schemas.ts
+++ b/app/eventyay/webapp/schedule-editor/src/schemas.ts
@@ -19,8 +19,23 @@ const LocalizedTextSchema = z.union([
 
 const NullableTextSchema = z.string().nullable().optional().transform(val => val ?? '');
 
+const SpeakerReferenceSchema = z.union([
+  z.string(),
+  z.null(),
+  z.object({
+    name: z.string().nullable().optional(),
+    code: z.string().nullable().optional(),
+  }).passthrough(),
+]);
+
+const toSpeakerReference = (val: z.infer<typeof SpeakerReferenceSchema>): string | undefined => {
+  if (typeof val === 'string') return val;
+  if (!val) return undefined;
+  return val.code ?? val.name ?? undefined;
+};
+
 export const SpeakerSchema = z.object({
-  code: z.string(),
+  code: z.string().nullable().optional(),
   name: z.string().nullable().transform(val => val ?? ''),
 });
 
@@ -47,16 +62,10 @@ export const TalkSchema = z.object({
   title: LocalizedTextSchema,
   abstract: NullableTextSchema,
   description: NullableTextSchema,
-  speakers: z.union([
-    z.array(z.string()),
-    z.array(z.object({ name: z.string() }))
-  ]).transform(val => {
-    // Transform to array of strings (speaker names) for consistency
-    if (val.length === 0) return [];
-    if (typeof val[0] === 'string') {
-      return val as string[];
-    }
-    return (val as { name: string }[]).map(speaker => speaker.name);
+  speakers: z.array(SpeakerReferenceSchema).transform(val => {
+    return val
+      .map(toSpeakerReference)
+      .filter((speaker): speaker is string => typeof speaker === 'string' && speaker.length > 0);
   }).optional().default([]),
   room: z.union([
     z.number(),

--- a/app/eventyay/webapp/schedule-editor/src/schemas.ts
+++ b/app/eventyay/webapp/schedule-editor/src/schemas.ts
@@ -31,7 +31,7 @@ const SpeakerReferenceSchema = z.union([
 const toSpeakerReference = (val: z.infer<typeof SpeakerReferenceSchema>): string | undefined => {
   if (typeof val === 'string') return val;
   if (!val) return undefined;
-  return val.code ?? val.name ?? undefined;
+  return val.code ?? undefined;
 };
 
 export const SpeakerSchema = z.object({


### PR DESCRIPTION
This PR fixes an issue with Zod that prevent's the schedule editor from loading

<img width="2028" height="1162" alt="image" src="https://github.com/user-attachments/assets/82474997-3cdc-4ad8-abcb-4eebacb25f38" />

## Summary by Sourcery

Improve schedule editor handling of speaker references and relax CSP for Cloudflare analytics.

Bug Fixes:
- Allow talks to reference speakers by nullable codes or objects and robustly resolve them for display in the schedule editor, preventing crashes when speaker data is incomplete.

Enhancements:
- Generalize Zod schemas and frontend types to support nullable/optional speaker codes while keeping speaker name display consistent.
- Guard speaker links in the schedule editor UI when no speaker code is available, falling back to plain text names.
- Add a helper to resolve session speaker codes into existing speakers, filtering out invalid references.
- Extend content security policy to permit Cloudflare Insights scripts and connections and modernize domain/port string formatting.