### PR TITLE
fix(time): update cfp form to show correct deadline

### DIFF
--- a/app/eventyay/base/middleware.py
+++ b/app/eventyay/base/middleware.py
@@ -1,7 +1,7 @@
+import zoneinfo
 from collections import OrderedDict
 from urllib.parse import urlsplit
 
-import pytz
 from django.conf import settings
 from django.http import Http404, HttpRequest, HttpResponse
 from django.middleware.common import CommonMiddleware
@@ -75,10 +75,11 @@ class LocaleMiddleware(MiddlewareMixin):
             tzname = request.user.timezone
         if tzname:
             try:
-                timezone.activate(pytz.timezone(tzname))
+                timezone.activate(zoneinfo.ZoneInfo(tzname))
                 request.timezone = tzname
-            except pytz.UnknownTimeZoneError:
-                pass
+            except zoneinfo.ZoneInfoNotFoundError:
+                timezone.deactivate()
+                request.timezone = None
         else:
             timezone.deactivate()
 

--- a/app/eventyay/orga/forms/cfp.py
+++ b/app/eventyay/orga/forms/cfp.py
@@ -39,6 +39,7 @@ class CfPGeneralSettingsForm(ReadOnlyFlag, I18nHelpText, JsonSubfieldMixin, I18n
     Form for general CfP settings stored in event.cfp.settings.
     requires an 'obj' argument in __init__ which must be an Event instance with a related 'cfp' object.
     """
+
     use_tracks = forms.BooleanField(
         label=_('Use tracks'),
         required=False,
@@ -77,13 +78,19 @@ class CfPGeneralSettingsForm(ReadOnlyFlag, I18nHelpText, JsonSubfieldMixin, I18n
         self.initial['count_length_in'] = obj.cfp.settings.get('count_length_in', 'chars')
 
     def save(self, *args, **kwargs):
-        current_count_length_in = self.instance.cfp.settings.get('count_length_in', 'chars')
-        if 'count_length_in' in self.cleaned_data:
-            new_count_length_in = self.cleaned_data.get('count_length_in') or current_count_length_in
-        else:
-            new_count_length_in = current_count_length_in
-        self.instance.cfp.settings['count_length_in'] = new_count_length_in
-        self.instance.cfp.save()
+        persist_cfp = kwargs.pop('persist_cfp', True)
+        update_count_length_in = kwargs.pop('update_count_length_in', True)
+
+        if update_count_length_in:
+            current_count_length_in = self.instance.cfp.settings.get('count_length_in', 'chars')
+            if 'count_length_in' in self.cleaned_data:
+                new_count_length_in = self.cleaned_data.get('count_length_in') or current_count_length_in
+            else:
+                new_count_length_in = current_count_length_in
+            self.instance.cfp.settings['count_length_in'] = new_count_length_in
+
+        if persist_cfp:
+            self.instance.cfp.save(update_fields=['settings'])
         super().save(*args, **kwargs)
 
     class Meta:
@@ -100,6 +107,7 @@ class CfPSettingsForm(CfPGeneralSettingsForm):
     """
     Form for full CfP settings, including specific field requirements and custom questions.
     """
+
     def __init__(self, *args, obj, **kwargs):
         super().__init__(*args, obj=obj, **kwargs)
         self.length_fields = [
@@ -164,7 +172,7 @@ class CfPSettingsForm(CfPGeneralSettingsForm):
                         ('required', _('Ask and require input')),
                     ],
                 )
-        
+
         # Add fields for custom questions
         # We use all_objects because we want to include reviewer questions and inactive questions
         # (so they can be re-activated)
@@ -176,7 +184,7 @@ class CfPSettingsForm(CfPGeneralSettingsForm):
                     initial = 'required'
                 else:
                     initial = 'optional'
-            
+
             self.fields[field_name] = forms.ChoiceField(
                 required=False,
                 initial=initial,
@@ -208,11 +216,11 @@ class CfPSettingsForm(CfPGeneralSettingsForm):
                 self.instance.cfp.fields[key]['visibility'] = 'required'
             else:
                 self.instance.cfp.fields[key]['visibility'] = self.cleaned_data.get(f'cfp_ask_{key}')
-        
+
         for key in self.length_fields:
             self.instance.cfp.fields[key]['min_length'] = self.cleaned_data.get(f'cfp_{key}_min_length')
             self.instance.cfp.fields[key]['max_length'] = self.cleaned_data.get(f'cfp_{key}_max_length')
-            
+
         # Save custom questions
         for question in TalkQuestion.all_objects.filter(event=self.instance):
             field_name = f'question_{question.pk}'
@@ -228,7 +236,8 @@ class CfPSettingsForm(CfPGeneralSettingsForm):
                         question.question_required = TalkQuestionRequired.OPTIONAL
                 question.save()
 
-        super().save(*args, **kwargs)
+        super().save(*args, persist_cfp=False, update_count_length_in=False, **kwargs)
+        self.instance.cfp.save(update_fields=['settings', 'fields'])
 
 
 class CfPForm(ReadOnlyFlag, I18nHelpText, JsonSubfieldMixin, I18nModelForm):
@@ -240,7 +249,9 @@ class CfPForm(ReadOnlyFlag, I18nHelpText, JsonSubfieldMixin, I18nModelForm):
     hide_after_deadline = forms.BooleanField(
         label=_('Do not show Call for Speakers on the menu after the deadline'),
         required=False,
-        help_text=_('If enabled, the Call for Speakers link will be hidden from navigation menus once the submission deadline has passed.'),
+        help_text=_(
+            'If enabled, the Call for Speakers link will be hidden from navigation menus once the submission deadline has passed.'
+        ),
     )
 
     class Meta:
@@ -469,15 +480,9 @@ class TrackForm(ReadOnlyFlag, I18nHelpText, I18nModelForm):
                 if instance_color:
                     initial['color'] = instance_color
                 elif event:
-                    existing_colors = {
-                        color.lower()
-                        for color in event.tracks.values_list('color', flat=True)
-                        if color
-                    }
+                    existing_colors = {color.lower() for color in event.tracks.values_list('color', flat=True) if color}
                     try:
-                        initial['color'] = generate_random_high_contrast_color(
-                            exclude_colors=existing_colors
-                        )
+                        initial['color'] = generate_random_high_contrast_color(exclude_colors=existing_colors)
                     except ValueError:
                         # If we cannot generate a color, fall back to no initial color
                         pass


### PR DESCRIPTION
This PR resolves:
- CFP deadlines for non-UTC events were being saved with the wrong local time.
- On save, datetime-local values were parsed under a pytz request timezone, which produced the wrong offset for zones like America/Edmonton.
- This caused values like 05:00 to come back as 06:34 after saving.
- Updated request timezone activation to use zoneinfo.ZoneInfo(...) so datetime parsing matches the event timezone correctly.
- Restricted CFP settings saves to only the fields they own, avoiding accidental overwrites of freshly saved deadline values.
- Other changes are for ruff.

## Summary by Sourcery

Fix CFP configuration handling and timezone activation to preserve correct local deadlines for events.

Bug Fixes:
- Ensure CFP settings save only their own fields to avoid overwriting freshly updated deadline values.
- Use zoneinfo-based timezone activation on requests so CFP datetimes are parsed with the correct local offset for the event timezone.

Enhancements:
- Tighten CfP model save calls with update_fields for more precise persistence of settings and fields.
- Apply minor style and formatting cleanups in CFP forms.