### PR TITLE
Move CSV export to async Celery task

### DIFF
--- a/app/eventyay/orga/forms/export.py
+++ b/app/eventyay/orga/forms/export.py
@@ -9,7 +9,7 @@ from django.utils.translation import gettext_lazy as _
 from i18nfield.utils import I18nJSONEncoder
 
 from eventyay.base.models import CachedFile
-from eventyay.base.services.export import export
+from eventyay.orga.tasks import run_csv_export
 from eventyay.common.text.phrases import phrases
 
 
@@ -161,16 +161,16 @@ class ExportForm(forms.Form):
                 expires=now() + timedelta(hours=24),
             )
 
-            export.delay(
+            run_csv_export.delay(
                 self.event.id,
                 str(cf.id),
-                self.Meta.model._meta.model_name,
-                {
+                f'{self.__class__.__module__}.{self.__class__.__qualname__}',
+               { 
                     "fields": fields,
                     "questions": [q.pk for q in questions],
                     "delimiter": self.cleaned_data.get("data_delimiter"),
                 }
-            )
+           )
 
             return JsonResponse(
                 {

--- a/app/eventyay/orga/forms/export.py
+++ b/app/eventyay/orga/forms/export.py
@@ -139,7 +139,13 @@ class ExportForm(forms.Form):
         queryset = self.get_queryset()
 
         if not queryset.exists():
-            return
+            return JsonResponse(
+                {
+                    "status": "error",
+                    "message": "No data to export.",
+                },
+                status=400
+            )
 
         # Extract selected fields
         fields = [f for f in self.export_field_names if self.cleaned_data.get(f)]
@@ -158,8 +164,8 @@ class ExportForm(forms.Form):
             export.delay(
                 self.event.id,
                 str(cf.id),
-                self.Meta.model._meta.model_name,
-                form_data={
+                self.Meta.model._meta.model_name
+                {
                     "fields": fields,
                     "questions": [q.pk for q in questions],
                     "delimiter": self.cleaned_data.get("data_delimiter"),
@@ -170,7 +176,7 @@ class ExportForm(forms.Form):
                 {
                     "status": "processing",
                     "file_id": str(cf.id),
-                    "message": "Export started",
+                    "message": "Export started. Use file_id to check status.",
                 },
                 status=202
             )
@@ -181,7 +187,13 @@ class ExportForm(forms.Form):
         data = self.get_data(queryset, fields, questions)
 
         if not data:
-            return
+            return JsonResponse(
+                {
+                    "status": "error",
+                    "message": "No data to export.",
+                },
+                status=400
+            )
 
         return self.json_export(data)
 

--- a/app/eventyay/orga/forms/export.py
+++ b/app/eventyay/orga/forms/export.py
@@ -164,7 +164,7 @@ class ExportForm(forms.Form):
             export.delay(
                 self.event.id,
                 str(cf.id),
-                self.Meta.model._meta.model_name
+                self.Meta.model._meta.model_name,
                 {
                     "fields": fields,
                     "questions": [q.pk for q in questions],

--- a/app/eventyay/orga/forms/export.py
+++ b/app/eventyay/orga/forms/export.py
@@ -1,13 +1,15 @@
 import json
-from io import StringIO
+from datetime import timedelta
 
-from defusedcsv import csv
+from django.utils.timezone import now
 from django import forms
-from django.http import HttpResponse
+from django.http import HttpResponse, JsonResponse
 from django.utils.functional import cached_property
 from django.utils.translation import gettext_lazy as _
 from i18nfield.utils import I18nJSONEncoder
 
+from eventyay.base.models import CachedFile
+from eventyay.base.services.export import export
 from eventyay.common.text.phrases import phrases
 
 
@@ -15,7 +17,6 @@ class ExportForm(forms.Form):
     export_format = forms.ChoiceField(
         required=True,
         label=_('Export format'),
-        help_text=_('A CSV export can be opened directly in Excel and similar applications.'),
         choices=(
             ('csv', _('CSV export')),
             ('json', _('JSON export')),
@@ -23,12 +24,10 @@ class ExportForm(forms.Form):
         widget=forms.RadioSelect,
         initial='csv',
     )
+
     data_delimiter = forms.ChoiceField(
         required=False,
         label=_('Data delimiter'),
-        help_text=_(
-            'How do you want to separate data within a single cell (for example, multiple speakers in one session/multiple sessions for one speaker)?'
-        ),
         choices=(
             ('comma', _('Comma')),
             ('newline', _('Newline')),
@@ -42,9 +41,10 @@ class ExportForm(forms.Form):
         super().__init__(*args, **kwargs)
         self._build_model_fields()
         self._build_question_fields()
-        if 'data_delimiter' in self.fields:
-            self.fields['data_delimiter'].widget.attrs['class'] = 'hide-optional'
 
+    # -----------------------------
+    # ABSTRACT
+    # -----------------------------
     @property
     def questions(self):
         raise NotImplementedError
@@ -53,16 +53,12 @@ class ExportForm(forms.Form):
     def filename(self):
         raise NotImplementedError
 
+    # -----------------------------
+    # FIELD BUILDING
+    # -----------------------------
     @cached_property
     def question_field_names(self):
-        return [f'question_{question.pk}' for question in self.questions]
-
-    @cached_property
-    def export_fields(self):
-        return [
-            forms.BoundField(self, self.fields[field], field)
-            for field in self.export_field_names + self.question_field_names
-        ]
+        return [f'question_{q.pk}' for q in self.questions]
 
     def _build_model_fields(self):
         for field in self.Meta.model_fields:
@@ -72,18 +68,24 @@ class ExportForm(forms.Form):
             )
 
     def _build_question_fields(self):
-        for question in self.questions:
-            self.fields[f'question_{question.pk}'] = forms.BooleanField(
+        for q in self.questions:
+            self.fields[f'question_{q.pk}'] = forms.BooleanField(
                 required=False,
-                label=f'{phrases.base.quotation_open}{question.question}{phrases.base.quotation_close}',
+                label=f'{phrases.base.quotation_open}{q.question}{phrases.base.quotation_close}',
             )
 
+    # -----------------------------
+    # CLEAN
+    # -----------------------------
     def clean(self):
         data = super().clean()
-        if data.get('export_format') == 'csv' and 'data_delimiter' in self.fields and not data.get('data_delimiter'):
-            data['data_delimiter'] = 'comma'
+        if data.get('export_format') == 'csv':
+            data['data_delimiter'] = data.get('data_delimiter') or 'comma'
         return data
 
+    # -----------------------------
+    # DATA HELPERS
+    # -----------------------------
     def get_object_attribute(self, obj, attribute):
         method = getattr(self, f'_get_{attribute}_value', None)
         if method:
@@ -92,73 +94,105 @@ class ExportForm(forms.Form):
 
     def get_data(self, queryset, fields, questions):
         data = []
+        delimiter = '\n' if self.cleaned_data.get("data_delimiter") == "newline" else ', '
 
         for obj in queryset:
-            object_data = {}
+            row = {}
+
+            # ID
             code = getattr(obj, 'code', None)
             if code:
-                object_data['ID'] = code
+                row['ID'] = code
+
+            # Optional preprocessing
             prepare_method = getattr(self, '_prepare_object_data', None)
             if prepare_method:
                 obj = prepare_method(obj)
+
+            # Model fields
             for field in fields:
-                object_data[str(self.fields[field].label)] = self.get_object_attribute(obj, field)
+                value = self.get_object_attribute(obj, field)
 
-            for question in questions:
-                answer = self.get_answer(question, obj)
-                if answer:
-                    object_data[str(question.question)] = answer.answer_string
-                else:
-                    object_data[str(question.question)] = None
+                if isinstance(value, list):
+                    value = delimiter.join(str(v) for v in value if v is not None)
 
+                row[str(self.fields[field].label)] = value
+
+            # Questions
+            for q in questions:
+                answer = self.get_answer(q, obj)
+                value = answer.answer_string if answer else None
+                row[str(q.question)] = value
+
+            # Additional data
             if hasattr(self, 'get_additional_data'):
-                object_data.update(**self.get_additional_data(obj))
-            data.append(object_data)
+                row.update(self.get_additional_data(obj))
+
+            data.append(row)
+
         return data
 
+    # -----------------------------
+    # MAIN EXPORT
+    # -----------------------------
     def export_data(self):
-        fields = [field_name for field_name in self.export_field_names if self.cleaned_data.get(field_name)]
-        questions = [question for question in self.questions if self.cleaned_data.get(f'question_{question.pk}')]
-        data = self.get_data(self.get_queryset(), fields, questions)
+        queryset = self.get_queryset()
+
+        if not queryset.exists():
+            return
+
+        # Extract selected fields
+        fields = [f for f in self.export_field_names if self.cleaned_data.get(f)]
+        questions = [q for q in self.questions if self.cleaned_data.get(f'question_{q.pk}')]
+
+        # -------------------------
+        # CSV → ASYNC (CELERY)
+        # -------------------------
+        if self.cleaned_data.get('export_format') == 'csv':
+            cf = CachedFile.objects.create(
+                web_download=False,
+                date=now(),
+                expires=now() + timedelta(hours=24),
+            )
+
+            export.delay(
+                self.event.id,
+                str(cf.id),
+                self.Meta.model._meta.model_name,
+                form_data={
+                    "fields": fields,
+                    "questions": [q.pk for q in questions],
+                    "delimiter": self.cleaned_data.get("data_delimiter"),
+                }
+            )
+
+            return JsonResponse(
+                {
+                    "status": "processing",
+                    "file_id": str(cf.id),
+                    "message": "Export started",
+                },
+                status=202
+            )
+
+        # -------------------------
+        # JSON → SYNC
+        # -------------------------
+        data = self.get_data(queryset, fields, questions)
+
         if not data:
             return
-        if self.cleaned_data.get('export_format') == 'csv':
-            return self.csv_export(data)
+
         return self.json_export(data)
 
-    def csv_export(self, data):
-        delimiters = {
-            'newline': '\n',
-            'comma': ', ',
-        }
-        delimiter = delimiters[self.cleaned_data.get('data_delimiter') or 'newline']
-
-        for row in data:
-            for key, value in row.items():
-                if isinstance(value, list):
-                    row[key] = delimiter.join(str(item) for item in value if item is not None)
-
-        output = StringIO()
-        writer = csv.DictWriter(output, fieldnames=data[0].keys())
-        writer.writeheader()
-        writer.writerows(data)
-        content = output.getvalue()
-        return HttpResponse(
-            content,
-            content_type='text/plain; charset=utf-8',
-            headers={
-                'Content-Disposition': f'attachment; filename="{self.filename}.csv"',
-                'Access-Control-Allow-Origin': '*',
-            },
-        )
-
+    # -----------------------------
+    # JSON EXPORT
+    # -----------------------------
     def json_export(self, data):
-        content = json.dumps(data, cls=I18nJSONEncoder, indent=2)
         return HttpResponse(
-            content,
+            json.dumps(data, cls=I18nJSONEncoder, indent=2),
             content_type='application/json; charset=utf-8',
             headers={
                 'Content-Disposition': f'attachment; filename="{self.filename}.json"',
-                'Access-Control-Allow-Origin': '*',
             },
         )

--- a/app/eventyay/orga/forms/export.py
+++ b/app/eventyay/orga/forms/export.py
@@ -6,7 +6,7 @@ from django import forms
 from django.http import HttpResponse
 from django.utils.functional import cached_property
 from django.utils.translation import gettext_lazy as _
-from i18nfield.utils import I18nJSONEncod
+from i18nfield.utils import I18nJSONEncoder
 from eventyay.orga.tasks import run_csv_export
 from eventyay.base.models import CachedFile
 from django.utils.timezone import now

--- a/app/eventyay/orga/forms/export.py
+++ b/app/eventyay/orga/forms/export.py
@@ -1,15 +1,18 @@
 import json
-from datetime import timedelta
+from io import StringIO
 
-from django.utils.timezone import now
+from defusedcsv import csv
 from django import forms
-from django.http import HttpResponse, JsonResponse
+from django.http import HttpResponse
 from django.utils.functional import cached_property
 from django.utils.translation import gettext_lazy as _
-from i18nfield.utils import I18nJSONEncoder
-
-from eventyay.base.models import CachedFile
+from i18nfield.utils import I18nJSONEncod
 from eventyay.orga.tasks import run_csv_export
+from eventyay.base.models import CachedFile
+from django.utils.timezone import now
+from datetime import timedelta
+from django.http import JsonResponse
+
 from eventyay.common.text.phrases import phrases
 
 
@@ -17,6 +20,7 @@ class ExportForm(forms.Form):
     export_format = forms.ChoiceField(
         required=True,
         label=_('Export format'),
+        help_text=_('A CSV export can be opened directly in Excel and similar applications.'),
         choices=(
             ('csv', _('CSV export')),
             ('json', _('JSON export')),
@@ -24,10 +28,12 @@ class ExportForm(forms.Form):
         widget=forms.RadioSelect,
         initial='csv',
     )
-
     data_delimiter = forms.ChoiceField(
         required=False,
         label=_('Data delimiter'),
+        help_text=_(
+            'How do you want to separate data within a single cell (for example, multiple speakers in one session/multiple sessions for one speaker)?'
+        ),
         choices=(
             ('comma', _('Comma')),
             ('newline', _('Newline')),
@@ -41,10 +47,9 @@ class ExportForm(forms.Form):
         super().__init__(*args, **kwargs)
         self._build_model_fields()
         self._build_question_fields()
+        if 'data_delimiter' in self.fields:
+            self.fields['data_delimiter'].widget.attrs['class'] = 'hide-optional'
 
-    # -----------------------------
-    # ABSTRACT
-    # -----------------------------
     @property
     def questions(self):
         raise NotImplementedError
@@ -53,12 +58,16 @@ class ExportForm(forms.Form):
     def filename(self):
         raise NotImplementedError
 
-    # -----------------------------
-    # FIELD BUILDING
-    # -----------------------------
     @cached_property
     def question_field_names(self):
-        return [f'question_{q.pk}' for q in self.questions]
+        return [f'question_{question.pk}' for question in self.questions]
+
+    @cached_property
+    def export_fields(self):
+        return [
+            forms.BoundField(self, self.fields[field], field)
+            for field in self.export_field_names + self.question_field_names
+        ]
 
     def _build_model_fields(self):
         for field in self.Meta.model_fields:
@@ -68,24 +77,18 @@ class ExportForm(forms.Form):
             )
 
     def _build_question_fields(self):
-        for q in self.questions:
-            self.fields[f'question_{q.pk}'] = forms.BooleanField(
+        for question in self.questions:
+            self.fields[f'question_{question.pk}'] = forms.BooleanField(
                 required=False,
-                label=f'{phrases.base.quotation_open}{q.question}{phrases.base.quotation_close}',
+                label=f'{phrases.base.quotation_open}{question.question}{phrases.base.quotation_close}',
             )
 
-    # -----------------------------
-    # CLEAN
-    # -----------------------------
     def clean(self):
         data = super().clean()
-        if data.get('export_format') == 'csv':
-            data['data_delimiter'] = data.get('data_delimiter') or 'comma'
+        if data.get('export_format') == 'csv' and 'data_delimiter' in self.fields and not data.get('data_delimiter'):
+            data['data_delimiter'] = 'comma'
         return data
 
-    # -----------------------------
-    # DATA HELPERS
-    # -----------------------------
     def get_object_attribute(self, obj, attribute):
         method = getattr(self, f'_get_{attribute}_value', None)
         if method:
@@ -94,66 +97,36 @@ class ExportForm(forms.Form):
 
     def get_data(self, queryset, fields, questions):
         data = []
-        delimiter = '\n' if self.cleaned_data.get("data_delimiter") == "newline" else ', '
 
         for obj in queryset:
-            row = {}
-
-            # ID
+            object_data = {}
             code = getattr(obj, 'code', None)
             if code:
-                row['ID'] = code
-
-            # Optional preprocessing
+                object_data['ID'] = code
             prepare_method = getattr(self, '_prepare_object_data', None)
             if prepare_method:
                 obj = prepare_method(obj)
-
-            # Model fields
             for field in fields:
-                value = self.get_object_attribute(obj, field)
+                object_data[str(self.fields[field].label)] = self.get_object_attribute(obj, field)
 
-                if isinstance(value, list):
-                    value = delimiter.join(str(v) for v in value if v is not None)
+            for question in questions:
+                answer = self.get_answer(question, obj)
+                if answer:
+                    object_data[str(question.question)] = answer.answer_string
+                else:
+                    object_data[str(question.question)] = None
 
-                row[str(self.fields[field].label)] = value
-
-            # Questions
-            for q in questions:
-                answer = self.get_answer(q, obj)
-                value = answer.answer_string if answer else None
-                row[str(q.question)] = value
-
-            # Additional data
             if hasattr(self, 'get_additional_data'):
-                row.update(self.get_additional_data(obj))
-
-            data.append(row)
-
+                object_data.update(**self.get_additional_data(obj))
+            data.append(object_data)
         return data
 
-    # -----------------------------
-    # MAIN EXPORT
-    # -----------------------------
     def export_data(self):
-        queryset = self.get_queryset()
-
-        if not queryset.exists():
-            return JsonResponse(
-                {
-                    "status": "error",
-                    "message": "No data to export.",
-                },
-                status=400
-            )
-
-        # Extract selected fields
-        fields = [f for f in self.export_field_names if self.cleaned_data.get(f)]
-        questions = [q for q in self.questions if self.cleaned_data.get(f'question_{q.pk}')]
-
-        # -------------------------
-        # CSV → ASYNC (CELERY)
-        # -------------------------
+        fields = [field_name for field_name in self.export_field_names if self.cleaned_data.get(field_name)]
+        questions = [question for question in self.questions if self.cleaned_data.get(f'question_{question.pk}')]
+        data = self.get_data(self.get_queryset(), fields, questions)
+        if not data:
+            return
         if self.cleaned_data.get('export_format') == 'csv':
             cf = CachedFile.objects.create(
                 web_download=False,
@@ -165,12 +138,12 @@ class ExportForm(forms.Form):
                 self.event.id,
                 str(cf.id),
                 f'{self.__class__.__module__}.{self.__class__.__qualname__}',
-               { 
+                { 
                     "fields": fields,
                     "questions": [q.pk for q in questions],
                     "delimiter": self.cleaned_data.get("data_delimiter"),
-                }
-           )
+                } 
+            )
 
             return JsonResponse(
                 {
@@ -180,31 +153,41 @@ class ExportForm(forms.Form):
                 },
                 status=202
             )
-
-        # -------------------------
-        # JSON → SYNC
-        # -------------------------
-        data = self.get_data(queryset, fields, questions)
-
-        if not data:
-            return JsonResponse(
-                {
-                    "status": "error",
-                    "message": "No data to export.",
-                },
-                status=400
-            )
-
         return self.json_export(data)
 
-    # -----------------------------
-    # JSON EXPORT
-    # -----------------------------
-    def json_export(self, data):
+    def csv_export(self, data):
+        delimiters = {
+            'newline': '\n',
+            'comma': ', ',
+        }
+        delimiter = delimiters[self.cleaned_data.get('data_delimiter') or 'newline']
+
+        for row in data:
+            for key, value in row.items():
+                if isinstance(value, list):
+                    row[key] = delimiter.join(str(item) for item in value if item is not None)
+
+        output = StringIO()
+        writer = csv.DictWriter(output, fieldnames=data[0].keys())
+        writer.writeheader()
+        writer.writerows(data)
+        content = output.getvalue()
         return HttpResponse(
-            json.dumps(data, cls=I18nJSONEncoder, indent=2),
+            content,
+            content_type='text/plain; charset=utf-8',
+            headers={
+                'Content-Disposition': f'attachment; filename="{self.filename}.csv"',
+                'Access-Control-Allow-Origin': '*',
+            },
+        )
+
+    def json_export(self, data):
+        content = json.dumps(data, cls=I18nJSONEncoder, indent=2)
+        return HttpResponse(
+            content,
             content_type='application/json; charset=utf-8',
             headers={
                 'Content-Disposition': f'attachment; filename="{self.filename}.json"',
+                'Access-Control-Allow-Origin': '*',
             },
         )

--- a/app/eventyay/orga/tasks.py
+++ b/app/eventyay/orga/tasks.py
@@ -62,3 +62,102 @@ def trigger_public_schedule(self, is_show_schedule, event_slug, organizer_slug, 
             self.retry(exc=e)
         except self.MaxRetriesExceededError:
             logger.error('Max retries exceeded for sending organizer webhook.')
+
+
+import io
+import importlib
+import traceback
+
+from defusedcsv import csv as defcsv
+from django.core.files.base import ContentFile
+
+
+@app.task(
+    bind=True,
+    name='eventyay.orga.run_csv_export',
+    max_retries=2,
+    default_retry_delay=30,
+    queue='longrunning',
+)
+def run_csv_export(self, event_id, cached_file_id, form_class_path, options):
+    """
+    Generates a CSV export in the background and stores it in a CachedFile.
+    Triggered by ExportForm.export_data() when export_format == 'csv'.
+
+    Args:
+        event_id       : PK of the Event
+        cached_file_id : UUID str of the CachedFile that will hold the result
+        form_class_path: dotted path e.g. 'eventyay.orga.forms.speaker.SpeakerExportForm'
+        options        : cleaned_data dict — fields, questions (pks), delimiter
+    """
+    from eventyay.base.models import CachedFile, Event
+    from django_scopes import scope
+
+    try:
+        event = Event.objects.get(pk=event_id)
+        cf    = CachedFile.objects.get(pk=cached_file_id)
+
+        # Rebuild the form instance so we can call its helpers (get_queryset, etc.)
+        module_path, class_name = form_class_path.rsplit('.', 1)
+        FormClass = getattr(importlib.import_module(module_path), class_name)
+        form = FormClass(event=event)
+        form.cleaned_data = options        # already validated; skip re-validation
+
+        fields       = options.get('fields', [])
+        question_pks = options.get('questions', [])
+        delimiter    = '\n' if options.get('delimiter') == 'newline' else ', '
+        questions    = [q for q in form.questions if q.pk in question_pks]
+        queryset     = form.get_queryset()
+
+        import tempfile
+
+        temp_file = tempfile.NamedTemporaryFile(mode='w+', newline='', delete=False)
+        writer = defcsv.writer(temp_file)
+        header_written = False
+
+        with scope(event=event):
+            for obj in queryset.iterator(chunk_size=200):
+                row = {}
+
+                code = getattr(obj, 'code', None)
+                if code:
+                    row['ID'] = code
+
+                prepare = getattr(form, '_prepare_object_data', None)
+                if prepare:
+                    obj = prepare(obj)
+
+                for field in fields:
+                    value = form.get_object_attribute(obj, field)
+                    if isinstance(value, list):
+                        value = delimiter.join(str(v) for v in value if v is not None)
+                    row[str(form.fields[field].label)] = value
+
+                for question in questions:
+                    answer = form.get_answer(question, obj)
+                    row[str(question.question)] = answer.answer_string if answer else None
+
+                if hasattr(form, 'get_additional_data'):
+                    row.update(form.get_additional_data(obj))
+
+                if not header_written:
+                    writer.writerow(list(row.keys()))
+                    header_written = True
+
+                writer.writerow(['' if v is None else v for v in row.values()])
+
+        # Persist the finished file into the CachedFile record
+        temp_file.flush()
+        temp_file.seek(0)
+
+        cf.file.save(
+            f'{cached_file_id}.csv',
+            ContentFile(temp_file.read().encode('utf-8')) 
+        )
+
+        temp_file.close()
+        cf.save()
+
+    except Exception as exc:
+        logger.error('CSV export failed for CachedFile %s:\n%s', cached_file_id, traceback.format_exc())
+        raise self.retry(exc=exc)

--- a/app/eventyay/orga/urls.py
+++ b/app/eventyay/orga/urls.py
@@ -16,6 +16,7 @@ from eventyay.orga.views import (
     submission,
     typeahead,
 )
+from eventyay.orga.views import export_status as export_views
 
 
 app_name = 'orga'
@@ -535,6 +536,16 @@ urlpatterns = [
                     'mails/outbox/purge',
                     mails.OutboxPurge.as_view(),
                     name='mails.outbox.purge',
+                ),
+                path(
+                    'export/status/<uuid:job_id>/',
+                    export_views.export_status,
+                    name='export.status',
+                ),  
+                path(
+                    'export/download/<uuid:job_id>/',
+                    export_views.export_download,
+                name='export.download',
                 ),
             ]
         ),

--- a/app/eventyay/orga/views/export_status.py
+++ b/app/eventyay/orga/views/export_status.py
@@ -1,0 +1,56 @@
+from django.http import FileResponse, Http404, JsonResponse
+from django.utils.timezone import now
+
+from eventyay.base.models import CachedFile
+
+
+def export_status(request, event_slug, job_id):
+    """
+    GET /orga/event/<event>/export/status/<job_id>/
+    Polled by the browser. Derives status from CachedFile state:
+      - file saved         → done
+      - expires passed     → failed (worker crashed or never ran)
+      - otherwise          → processing
+    """
+    try:
+        cf = CachedFile.objects.get(pk=job_id)
+    except CachedFile.DoesNotExist:
+        raise Http404
+
+    if cf.file:
+        return JsonResponse({
+            'status': 'done',
+            'download_url': request.build_absolute_uri(
+                f'/orga/event/{event_slug}/export/download/{job_id}/'
+            ),
+        })
+
+    if cf.expires and cf.expires < now():
+        return JsonResponse({
+            'status': 'failed',
+            'error': 'Export did not complete in time. Please try again.',
+        })
+
+    return JsonResponse({'status': 'processing'})
+
+
+def export_download(request, event_slug, job_id):
+    """
+    GET /orga/event/<event>/export/download/<job_id>/
+    Streams the finished CSV to the browser.
+    """
+    try:
+        cf = CachedFile.objects.get(pk=job_id)
+    except CachedFile.DoesNotExist:
+        raise Http404
+
+    if not cf.file:
+        raise Http404('Export file is not ready yet.')
+
+    filename = getattr(cf, 'filename', None) or f'export-{job_id}.csv'
+    return FileResponse(
+        cf.file.open('rb'),
+        content_type='text/csv; charset=utf-8',
+        as_attachment=True,
+        filename=filename,
+    )


### PR DESCRIPTION
### Problem
The current CSV export runs synchronously within the request lifecycle, which can lead to:
- Blocking HTTP requests for large datasets
- Increased CPU and database load during export
- Poor handling of concurrent export requests

### Solution
This PR moves CSV export processing to an asynchronous Celery task.

- Triggers export as a background job instead of processing in request
- Uses existing CachedFile model for storing generated files
- Returns immediate response (202) with a file_id
- Adds endpoints to check export status and download the file

### Changes
- Added Celery task `run_csv_export` for background processing
- Updated export form to trigger async task instead of synchronous CSV export
- Added status and download API endpoints
- Wired new endpoints in URLs

### Result
- Reduces request blocking during export
- Moves heavy processing outside the request lifecycle
- Improves handling of concurrent export requests

### Testing & Limitations
This change has been tested in a development environment to verify correctness and functionality.

Since local development does not replicate production-level concurrency or resource constraints, the actual performance impact under heavy load has not been benchmarked.

This implementation focuses on moving export processing out of the request lifecycle. It does not eliminate the computational cost of large exports, but isolates it to background workers. The scalability benefits will depend on worker configuration, available system resources, and production traffic patterns.

### Notes
- No new models or migrations introduced
- Existing JSON export remains unchanged
- Uses existing project patterns (CachedFile, Celery)

Closes #3266