### PR TITLE
Speed up schedule

### DIFF
--- a/app/eventyay/base/models/schedule.py
+++ b/app/eventyay/base/models/schedule.py
@@ -555,6 +555,11 @@ class Schedule(PretalxModel):
         the full scan set (every relevant scheduled slot), while results are only
         emitted for talks whose pk is in ``subset_pks``. This keeps overlap detection
         schedule-wide even when the caller only wants warnings for a subset.
+
+        Caller contract: every element of ``talks`` must have ``submission`` selected
+        and ``submission__speakers`` prefetched; otherwise iterating speakers here
+        regresses to an N+1. Break slots (``submission_id`` is NULL) are allowed and
+        contribute to room-overlap detection only.
         """
 
         def is_overlap(a_start, a_end, b_start, b_end):
@@ -599,10 +604,9 @@ class Schedule(PretalxModel):
         # Subset scan: only probe subset talks against their own room/speaker
         # buckets. Scales with |subset| × bucket size, not |schedule|².
         for entries in by_room.values():
-            subset_entries = [e for e in entries if e[0] in subset_pks]
-            if not subset_entries:
-                continue
-            for pk_a, start_a, end_a in subset_entries:
+            for pk_a, start_a, end_a in entries:
+                if pk_a not in subset_pks:
+                    continue
                 for pk_b, start_b, end_b in entries:
                     if pk_b == pk_a:
                         continue
@@ -610,10 +614,9 @@ class Schedule(PretalxModel):
                         room_overlap_ids.add(pk_a)
                         break
         for speaker_pk, entries in by_speaker.items():
-            subset_entries = [e for e in entries if e[0] in subset_pks]
-            if not subset_entries:
-                continue
-            for pk_a, start_a, end_a in subset_entries:
+            for pk_a, start_a, end_a in entries:
+                if pk_a not in subset_pks:
+                    continue
                 for pk_b, start_b, end_b in entries:
                     if pk_b == pk_a:
                         continue

--- a/app/eventyay/base/models/schedule.py
+++ b/app/eventyay/base/models/schedule.py
@@ -506,18 +506,29 @@ class Schedule(PretalxModel):
                 },
             )
         talk_list = list(talks)
-        # Scan ALL scheduled slots for overlaps so that a filtered subset (via
-        # filter_updated or similar) still detects conflicts with slots outside
-        # the subset — matching the original per-talk query semantics.
-        all_scheduled = list(
-            self.talks.filter(start__isnull=False, room__isnull=False, submission__isnull=False)
-            .select_related('submission')
-            .prefetch_related('submission__speakers')
-        )
-        subset_pks = {t.pk for t in talk_list}
-        room_overlap_ids, speaker_overlaps_by_talk = self._compute_overlap_maps(
-            all_scheduled, subset_pks=subset_pks
-        )
+        # Only scan the rest of the schedule when we have a subset to emit for.
+        # This keeps the incremental `since=...` polling path cheap: if no talks
+        # were updated since the last poll, we do no extra work here.
+        if talk_list:
+            is_full_scan = not filter_updated
+            subset_pks = None if is_full_scan else {t.pk for t in talk_list}
+            # Include break slots (submission is null) in the scan set so that
+            # sessions conflicting with a scheduled break still produce a
+            # room_overlap warning — matching the per-talk ``.exists()`` query
+            # at get_talk_warnings() which scans all TalkSlots in the room.
+            extra_slots_qs = self.talks.filter(
+                start__isnull=False, room__isnull=False
+            ).select_related('submission').prefetch_related('submission__speakers')
+            if is_full_scan:
+                extra_slots_qs = extra_slots_qs.filter(submission__isnull=True)
+            else:
+                extra_slots_qs = extra_slots_qs.exclude(pk__in=subset_pks)
+            scan_set = talk_list + list(extra_slots_qs)
+            room_overlap_ids, speaker_overlaps_by_talk = self._compute_overlap_maps(
+                scan_set, subset_pks=subset_pks
+            )
+        else:
+            room_overlap_ids, speaker_overlaps_by_talk = set(), {}
         result = {}
         for talk in talk_list:
             talk_warnings = self.get_talk_warnings(
@@ -560,31 +571,55 @@ class Schedule(PretalxModel):
             entry = (talk.pk, talk.start, talk.real_end)
             if talk.room_id:
                 by_room[talk.room_id].append(entry)
-            for speaker in talk.submission.speakers.all():
-                by_speaker[speaker.pk].append(entry + (speaker.pk,))
-
-        def should_emit(pk):
-            return subset_pks is None or pk in subset_pks
+            # Break slots have no submission/speakers — they contribute to
+            # room-overlap detection only.
+            if talk.submission_id:
+                for speaker in talk.submission.speakers.all():
+                    by_speaker[speaker.pk].append(entry)
 
         room_overlap_ids = set()
-        for entries in by_room.values():
-            for i, (pk_a, start_a, end_a) in enumerate(entries):
-                for pk_b, start_b, end_b in entries[i + 1:]:
-                    if is_overlap(start_a, end_a, start_b, end_b):
-                        if should_emit(pk_a):
-                            room_overlap_ids.add(pk_a)
-                        if should_emit(pk_b):
-                            room_overlap_ids.add(pk_b)
-
         speaker_overlaps_by_talk = defaultdict(set)
-        for entries in by_speaker.values():
-            for i, (pk_a, start_a, end_a, sp) in enumerate(entries):
-                for pk_b, start_b, end_b, _sp in entries[i + 1:]:
+
+        if subset_pks is None:
+            # Full-schedule scan: O(bucket²) pairwise check per room/speaker.
+            for entries in by_room.values():
+                for i, (pk_a, start_a, end_a) in enumerate(entries):
+                    for pk_b, start_b, end_b in entries[i + 1:]:
+                        if is_overlap(start_a, end_a, start_b, end_b):
+                            room_overlap_ids.add(pk_a)
+                            room_overlap_ids.add(pk_b)
+            for speaker_pk, entries in by_speaker.items():
+                for i, (pk_a, start_a, end_a) in enumerate(entries):
+                    for pk_b, start_b, end_b in entries[i + 1:]:
+                        if is_overlap(start_a, end_a, start_b, end_b):
+                            speaker_overlaps_by_talk[pk_a].add(speaker_pk)
+                            speaker_overlaps_by_talk[pk_b].add(speaker_pk)
+            return room_overlap_ids, speaker_overlaps_by_talk
+
+        # Subset scan: only probe subset talks against their own room/speaker
+        # buckets. Scales with |subset| × bucket size, not |schedule|².
+        for entries in by_room.values():
+            subset_entries = [e for e in entries if e[0] in subset_pks]
+            if not subset_entries:
+                continue
+            for pk_a, start_a, end_a in subset_entries:
+                for pk_b, start_b, end_b in entries:
+                    if pk_b == pk_a:
+                        continue
                     if is_overlap(start_a, end_a, start_b, end_b):
-                        if should_emit(pk_a):
-                            speaker_overlaps_by_talk[pk_a].add(sp)
-                        if should_emit(pk_b):
-                            speaker_overlaps_by_talk[pk_b].add(sp)
+                        room_overlap_ids.add(pk_a)
+                        break
+        for speaker_pk, entries in by_speaker.items():
+            subset_entries = [e for e in entries if e[0] in subset_pks]
+            if not subset_entries:
+                continue
+            for pk_a, start_a, end_a in subset_entries:
+                for pk_b, start_b, end_b in entries:
+                    if pk_b == pk_a:
+                        continue
+                    if is_overlap(start_a, end_a, start_b, end_b):
+                        speaker_overlaps_by_talk[pk_a].add(speaker_pk)
+                        break
         return room_overlap_ids, speaker_overlaps_by_talk
 
     @cached_property

--- a/app/eventyay/base/models/schedule.py
+++ b/app/eventyay/base/models/schedule.py
@@ -361,6 +361,8 @@ class Schedule(PretalxModel):
         room_avails=None,
         speaker_avails=None,
         speaker_profiles=None,
+        room_overlap_ids=None,
+        speaker_overlaps_by_talk=None,
     ) -> list:
         """A list of warnings that apply to this slot.
 
@@ -389,17 +391,20 @@ class Schedule(PretalxModel):
                         'url': url,
                     }
                 )
-        overlaps = (
-            TalkSlot.objects.filter(schedule=self, room=talk.room)
-            .filter(
-                models.Q(start__lt=talk.start, end__gt=talk.start)
-                | models.Q(start__lt=talk.real_end, end__gt=talk.real_end)
-                | models.Q(start__gt=talk.start, end__lt=talk.real_end)
-                | models.Q(start=talk.start, end=talk.real_end)
+        if room_overlap_ids is not None:
+            overlaps = talk.pk in room_overlap_ids
+        else:
+            overlaps = (
+                TalkSlot.objects.filter(schedule=self, room=talk.room)
+                .filter(
+                    models.Q(start__lt=talk.start, end__gt=talk.start)
+                    | models.Q(start__lt=talk.real_end, end__gt=talk.real_end)
+                    | models.Q(start__gt=talk.start, end__lt=talk.real_end)
+                    | models.Q(start=talk.start, end=talk.real_end)
+                )
+                .exclude(pk=talk.pk)
+                .exists()
             )
-            .exclude(pk=talk.pk)
-            .exists()
-        )
         if overlaps:
             warnings.append(
                 {
@@ -436,17 +441,20 @@ class Schedule(PretalxModel):
                             'url': url,
                         }
                     )
-            overlaps = (
-                TalkSlot.objects.filter(schedule=self, submission__speakers__in=[speaker])
-                .exclude(pk=talk.pk)
-                .filter(
-                    models.Q(start__lt=talk.start, end__gt=talk.start)
-                    | models.Q(start__lt=talk.real_end, end__gt=talk.real_end)
-                    | models.Q(start__gt=talk.start, end__lt=talk.real_end)
-                    | models.Q(start=talk.start, end=talk.real_end)
+            if speaker_overlaps_by_talk is not None:
+                overlaps = speaker.pk in speaker_overlaps_by_talk.get(talk.pk, ())
+            else:
+                overlaps = (
+                    TalkSlot.objects.filter(schedule=self, submission__speakers__in=[speaker])
+                    .exclude(pk=talk.pk)
+                    .filter(
+                        models.Q(start__lt=talk.start, end__gt=talk.start)
+                        | models.Q(start__lt=talk.real_end, end__gt=talk.real_end)
+                        | models.Q(start__gt=talk.start, end__lt=talk.real_end)
+                        | models.Q(start=talk.start, end=talk.real_end)
+                    )
+                    .exists()
                 )
-                .exists()
-            )
             if overlaps:
                 warnings.append(
                     {
@@ -497,18 +505,64 @@ class Schedule(PretalxModel):
                     for profile in SpeakerProfile.objects.filter(event=self.event).prefetch_related('availabilities')
                 },
             )
+        talk_list = list(talks)
+        room_overlap_ids, speaker_overlaps_by_talk = self._compute_overlap_maps(talk_list)
         result = {}
-        for talk in talks:
+        for talk in talk_list:
             talk_warnings = self.get_talk_warnings(
                 talk=talk,
                 with_speakers=with_speakers,
                 room_avails=room_avails.get(talk.room_id) if talk.room_id else None,
                 speaker_avails=speaker_avails,
                 speaker_profiles=speaker_profiles,
+                room_overlap_ids=room_overlap_ids,
+                speaker_overlaps_by_talk=speaker_overlaps_by_talk,
             )
             if talk_warnings:
                 result[talk] = talk_warnings
         return result
+
+    def _compute_overlap_maps(self, talks):
+        """Compute room- and speaker-overlap sets for the given scheduled talks.
+
+        Replaces per-talk ``.exists()`` probes in ``get_talk_warnings`` with a single
+        scan over all scheduled slots and the prefetched speakers. Preserves the
+        original query's semantics: strict-inequality overlap plus exact-bounds match.
+        """
+
+        def is_overlap(a_start, a_end, b_start, b_end):
+            return (
+                (b_start < a_start and b_end > a_start)
+                or (b_start < a_end and b_end > a_end)
+                or (b_start > a_start and b_end < a_end)
+                or (b_start == a_start and b_end == a_end)
+            )
+
+        by_room = defaultdict(list)
+        by_speaker = defaultdict(list)
+        for talk in talks:
+            entry = (talk.pk, talk.start, talk.real_end)
+            if talk.room_id:
+                by_room[talk.room_id].append(entry)
+            for speaker in talk.submission.speakers.all():
+                by_speaker[speaker.pk].append(entry + (speaker.pk,))
+
+        room_overlap_ids = set()
+        for entries in by_room.values():
+            for i, (pk_a, start_a, end_a) in enumerate(entries):
+                for pk_b, start_b, end_b in entries[i + 1:]:
+                    if is_overlap(start_a, end_a, start_b, end_b):
+                        room_overlap_ids.add(pk_a)
+                        room_overlap_ids.add(pk_b)
+
+        speaker_overlaps_by_talk = defaultdict(set)
+        for entries in by_speaker.values():
+            for i, (pk_a, start_a, end_a, sp) in enumerate(entries):
+                for pk_b, start_b, end_b, _sp in entries[i + 1:]:
+                    if is_overlap(start_a, end_a, start_b, end_b):
+                        speaker_overlaps_by_talk[pk_a].add(sp)
+                        speaker_overlaps_by_talk[pk_b].add(sp)
+        return room_overlap_ids, speaker_overlaps_by_talk
 
     @cached_property
     def warnings(self) -> dict:

--- a/app/eventyay/base/models/schedule.py
+++ b/app/eventyay/base/models/schedule.py
@@ -506,7 +506,18 @@ class Schedule(PretalxModel):
                 },
             )
         talk_list = list(talks)
-        room_overlap_ids, speaker_overlaps_by_talk = self._compute_overlap_maps(talk_list)
+        # Scan ALL scheduled slots for overlaps so that a filtered subset (via
+        # filter_updated or similar) still detects conflicts with slots outside
+        # the subset — matching the original per-talk query semantics.
+        all_scheduled = list(
+            self.talks.filter(start__isnull=False, room__isnull=False, submission__isnull=False)
+            .select_related('submission')
+            .prefetch_related('submission__speakers')
+        )
+        subset_pks = {t.pk for t in talk_list}
+        room_overlap_ids, speaker_overlaps_by_talk = self._compute_overlap_maps(
+            all_scheduled, subset_pks=subset_pks
+        )
         result = {}
         for talk in talk_list:
             talk_warnings = self.get_talk_warnings(
@@ -522,12 +533,17 @@ class Schedule(PretalxModel):
                 result[talk] = talk_warnings
         return result
 
-    def _compute_overlap_maps(self, talks):
+    def _compute_overlap_maps(self, talks, subset_pks=None):
         """Compute room- and speaker-overlap sets for the given scheduled talks.
 
         Replaces per-talk ``.exists()`` probes in ``get_talk_warnings`` with a single
         scan over all scheduled slots and the prefetched speakers. Preserves the
         original query's semantics: strict-inequality overlap plus exact-bounds match.
+
+        If ``subset_pks`` is provided, the ``talks`` argument is expected to contain
+        the full scan set (every relevant scheduled slot), while results are only
+        emitted for talks whose pk is in ``subset_pks``. This keeps overlap detection
+        schedule-wide even when the caller only wants warnings for a subset.
         """
 
         def is_overlap(a_start, a_end, b_start, b_end):
@@ -547,21 +563,28 @@ class Schedule(PretalxModel):
             for speaker in talk.submission.speakers.all():
                 by_speaker[speaker.pk].append(entry + (speaker.pk,))
 
+        def should_emit(pk):
+            return subset_pks is None or pk in subset_pks
+
         room_overlap_ids = set()
         for entries in by_room.values():
             for i, (pk_a, start_a, end_a) in enumerate(entries):
                 for pk_b, start_b, end_b in entries[i + 1:]:
                     if is_overlap(start_a, end_a, start_b, end_b):
-                        room_overlap_ids.add(pk_a)
-                        room_overlap_ids.add(pk_b)
+                        if should_emit(pk_a):
+                            room_overlap_ids.add(pk_a)
+                        if should_emit(pk_b):
+                            room_overlap_ids.add(pk_b)
 
         speaker_overlaps_by_talk = defaultdict(set)
         for entries in by_speaker.values():
             for i, (pk_a, start_a, end_a, sp) in enumerate(entries):
                 for pk_b, start_b, end_b, _sp in entries[i + 1:]:
                     if is_overlap(start_a, end_a, start_b, end_b):
-                        speaker_overlaps_by_talk[pk_a].add(sp)
-                        speaker_overlaps_by_talk[pk_b].add(sp)
+                        if should_emit(pk_a):
+                            speaker_overlaps_by_talk[pk_a].add(sp)
+                        if should_emit(pk_b):
+                            speaker_overlaps_by_talk[pk_b].add(sp)
         return room_overlap_ids, speaker_overlaps_by_talk
 
     @cached_property

--- a/app/eventyay/orga/views/schedule.py
+++ b/app/eventyay/orga/views/schedule.py
@@ -401,14 +401,15 @@ class ScheduleAvailabilities(EventPermissionRequired, View):
             .select_related('submission')
             .prefetch_related('submission__speakers')
         ):
-            if talk.submission.speakers.count() == 1:
+            speakers = list(talk.submission.speakers.all())
+            if len(speakers) == 1:
                 result[talk.id] = [
-                    av.serialize(full=False) for av in speaker_avails[talk.submission.speakers.first().pk]
+                    av.serialize(full=False) for av in speaker_avails[speakers[0].pk]
                 ]
             else:
                 all_speaker_avails = [
                     speaker_avails[speaker.pk]
-                    for speaker in talk.submission.speakers.all()
+                    for speaker in speakers
                     if speaker_avails[speaker.pk]
                 ]
                 if not all_speaker_avails:


### PR DESCRIPTION
app/eventyay/base/models/schedule.py: pre-compute overlaps and warnings and get rid of O(talks * (1 + speakers)) .exists() checks

app/eventyay/orga/views/schedule.py: pre-fetch submission.speakers once instead of count/first

## Summary by Sourcery

Optimize schedule warning calculations and speaker availability lookups to reduce per-talk database queries and improve schedule view performance.

Enhancements:
- Precompute room and speaker overlap maps for scheduled talks and reuse them when generating talk warnings to avoid repeated overlap queries.
- Introduce an internal helper to scan the schedule once for overlaps while preserving existing warning semantics for full and incremental scans.
- Refine schedule view speaker availability logic to materialize submission speakers once per talk instead of repeatedly querying them.