### PR TITLE
fix(talk): improve public schedule loading without breaking talk views

### DIFF
--- a/app/eventyay/agenda/templates/agenda/public_starred.html
+++ b/app/eventyay/agenda/templates/agenda/public_starred.html
@@ -18,7 +18,7 @@
 <div>
     <h1>{{ page_title }}</h1>
     <script id="pretalx-schedule-data" type="application/json">{{ schedule_json|safe }}</script>
-    <script type="text/javascript" src="{{ request.event.urls.schedule_widget_script }}" async></script>
+    <script type="text/javascript" src="{% static 'schedule/pretalx-schedule.js' %}" async></script>
 
     {% with event_tz=request.event.settings.timezone|default:request.event.timezone %}
     <pretalx-schedule

--- a/app/eventyay/agenda/templates/agenda/schedule.html
+++ b/app/eventyay/agenda/templates/agenda/schedule.html
@@ -19,12 +19,11 @@
 {% block agenda_content %}
 {% html_signal "eventyay.agenda.signals.html_above_schedule_pages" sender=request.event request=request %}
 <div id="fahrplan" class="{% if show_talk_list %}list{% else %}grid{% endif %}">
-    <script id="pretalx-schedule-data" type="application/json">{{ schedule_json|safe }}</script>
     <script id="pretalx-schedule-meta" type="application/json">{{ schedule_meta_json|safe }}</script>
-    <script type="text/javascript" src="{{ request.event.urls.schedule_widget_script }}" async></script>
+    <script type="text/javascript" src="{% static 'schedule/pretalx-schedule.js' %}" async></script>
 
     {% with event_tz=request.event.settings.timezone|default:request.event.timezone %}
-    <pretalx-schedule event-url="{{ request.event.urls.base }}" version="{{ schedule.url_version }}" locale="{{ request.LANGUAGE_CODE }}" timezone="{{ event_tz }}" {% if is_sessions_page %}view="sessions"{% elif show_talk_list %}format="list"{% endif %} {% if request.event.is_video_creation %}join-room-base-url="{{ request.event.urls.video_base }}rooms/"{% endif %} style="--pretalx-clr-primary: {{ request.event.visible_primary_color }}" disable-auto-scroll></pretalx-schedule>
+    <pretalx-schedule event-url="{{ request.event.urls.base }}" version="{{ schedule.url_version }}" locale="{{ request.LANGUAGE_CODE }}" timezone="{{ event_tz }}" enrich-data {% if is_sessions_page %}view="sessions"{% elif show_talk_list %}format="list"{% endif %} {% if request.event.is_video_creation %}join-room-base-url="{{ request.event.urls.video_base }}rooms/"{% endif %} style="--pretalx-clr-primary: {{ request.event.visible_primary_color }}" disable-auto-scroll></pretalx-schedule>
     {% endwith %}
     <noscript class="d-block">
         <div class="alert alert-info m-4">

--- a/app/eventyay/agenda/templates/agenda/speaker.html
+++ b/app/eventyay/agenda/templates/agenda/speaker.html
@@ -27,10 +27,9 @@
 {% block agenda_content %}
 {% html_signal "eventyay.agenda.signals.html_above_speaker_pages" sender=request.event request=request profile=profile %}
 <div>
-    <script id="pretalx-schedule-data" type="application/json">{{ schedule_json|safe }}</script>
-    <script type="text/javascript" src="{{ request.event.urls.schedule_widget_script }}" async></script>
+    <script type="text/javascript" src="{% static 'schedule/pretalx-schedule.js' %}" async></script>
     {% with event_tz=request.event.settings.timezone|default:request.event.timezone %}
-    <pretalx-schedule event-url="{{ request.event.urls.base }}" locale="{{ request.LANGUAGE_CODE }}" view="speaker" speaker-code="{{ profile.user.code }}" style="--pretalx-clr-primary: {{ request.event.visible_primary_color }}"></pretalx-schedule>
+    <pretalx-schedule event-url="{{ request.event.urls.base }}" locale="{{ request.LANGUAGE_CODE }}" view="speaker" speaker-code="{{ profile.user.code }}" enrich-data style="--pretalx-clr-primary: {{ request.event.visible_primary_color }}"></pretalx-schedule>
     {% endwith %}
     <noscript>
         <h1>{{ profile.user.get_display_name }}</h1>

--- a/app/eventyay/agenda/templates/agenda/speakers.html
+++ b/app/eventyay/agenda/templates/agenda/speakers.html
@@ -13,10 +13,9 @@
 {% block agenda_content %}
 {% html_signal "eventyay.agenda.signals.html_above_speakers_list" sender=request.event request=request %}
 <div>
-    <script id="pretalx-schedule-data" type="application/json">{{ schedule_json|safe }}</script>
-    <script type="text/javascript" src="{{ request.event.urls.schedule_widget_script }}" async></script>
+    <script type="text/javascript" src="{% static 'schedule/pretalx-schedule.js' %}" async></script>
     {% with event_tz=request.event.settings.timezone|default:request.event.timezone %}
-    <pretalx-schedule event-url="{{ request.event.urls.base }}" locale="{{ request.LANGUAGE_CODE }}" view="speakers" style="--pretalx-clr-primary: {{ request.event.visible_primary_color }}"></pretalx-schedule>
+    <pretalx-schedule event-url="{{ request.event.urls.base }}" locale="{{ request.LANGUAGE_CODE }}" view="speakers" enrich-data style="--pretalx-clr-primary: {{ request.event.visible_primary_color }}"></pretalx-schedule>
     {% endwith %}
 </div>
 {% html_signal "eventyay.agenda.signals.html_below_speakers_list" sender=request.event request=request %}

--- a/app/eventyay/agenda/templates/agenda/talk.html
+++ b/app/eventyay/agenda/templates/agenda/talk.html
@@ -2,6 +2,7 @@
 
 {% load event_tags %}
 {% load html_signal %}
+{% load static %}
 
 {% load presale_locale %}
 {% block title %}{{ submission.title|event_localize }} ::{% endblock title %}
@@ -27,7 +28,7 @@
 {% html_signal "eventyay.agenda.signals.html_above_session_pages" sender=request.event request=request submission=submission %}
 <div>
     <script id="pretalx-schedule-data" type="application/json">{{ schedule_json|safe }}</script>
-    <script type="text/javascript" src="{{ request.event.urls.schedule_widget_script }}" async></script>
+    <script type="text/javascript" src="{% static 'schedule/pretalx-schedule.js' %}" async></script>
     {% with event_tz=request.event.settings.timezone|default:request.event.timezone %}
     <pretalx-schedule event-url="{{ request.event.urls.base }}" locale="{{ request.LANGUAGE_CODE }}" view="talk" talk-code="{{ submission.code }}" {% if request.event.is_video_creation %}join-room-base-url="{{ request.event.urls.video_base }}rooms/"{% endif %} style="--pretalx-clr-primary: {{ request.event.visible_primary_color }}"></pretalx-schedule>
     {% endwith %}

--- a/app/eventyay/agenda/views/public.py
+++ b/app/eventyay/agenda/views/public.py
@@ -6,13 +6,16 @@ from django.views.generic import TemplateView, View
 from django_context_decorator import context
 from django_scopes import scope
 
-from eventyay.agenda.views.speaker import ScheduleDataMixin
-from eventyay.agenda.views.utils import is_email_like
+from eventyay.agenda.views.utils import build_enriched_schedule_json, is_email_like
 from eventyay.base.models import SubmissionFavourite, User
 
 
-class PublicStarredScheduleView(ScheduleDataMixin, TemplateView):
+class PublicStarredScheduleView(TemplateView):
     template_name = 'agenda/public_starred.html'
+
+    @context
+    def schedule_json(self) -> str:
+        return build_enriched_schedule_json(self.request)
 
     @cached_property
     def public_user(self) -> User:
@@ -58,7 +61,6 @@ class PublicStarredScheduleView(ScheduleDataMixin, TemplateView):
 
 
 class PublicStarredScheduleDataView(View):
-
     @cached_property
     def public_user(self) -> User:
         user = (
@@ -80,9 +82,7 @@ class PublicStarredScheduleDataView(View):
             raise Http404()
 
         # Only include talks that are visible in the published schedule.
-        visible_submission_ids = schedule.talks.filter(is_visible=True).values_list(
-            'submission_id', flat=True
-        )
+        visible_submission_ids = schedule.talks.filter(is_visible=True).values_list('submission_id', flat=True)
         with scope(event=request.event):
             favs = list(
                 SubmissionFavourite.objects.filter(

--- a/app/eventyay/agenda/views/schedule.py
+++ b/app/eventyay/agenda/views/schedule.py
@@ -13,14 +13,13 @@ from django.http import (
     HttpResponseRedirect,
 )
 from django.urls import resolve, reverse
+from django.utils import timezone
 from django.utils.functional import cached_property
 from django.utils.http import urlencode
-from django.utils import timezone
 from django.utils.translation import gettext_lazy as _
 from django.views.decorators.cache import cache_page
 from django.views.generic import TemplateView
 from django_context_decorator import context
-from i18nfield.utils import I18nJSONEncoder
 
 from eventyay.agenda.views.utils import (
     build_public_schedule_exporters,
@@ -33,9 +32,9 @@ from eventyay.agenda.views.utils import (
 )
 from eventyay.common.signals import register_my_data_exporters
 from eventyay.common.views.mixins import EventPermissionRequired, PermissionRequired
-from eventyay.talk_rules.submission import are_featured_submissions_visible
 from eventyay.schedule.ascii import draw_ascii_schedule
 from eventyay.schedule.exporters import ScheduleData
+from eventyay.talk_rules.submission import are_featured_submissions_visible
 
 
 # Starred-ICS token timing: grace, fallback, refresh buffer.
@@ -79,9 +78,9 @@ class ScheduleMixin:
             expiry = expiry_event
 
         value = {
-            "user_id": user_id,
-            "exp": int(expiry.timestamp()),
-            "event_id": event.pk,
+            'user_id': user_id,
+            'exp': int(expiry.timestamp()),
+            'event_id': event.pk,
         }
         token = signing.dumps(value, salt='my-starred-ics')
 
@@ -110,7 +109,9 @@ class ScheduleMixin:
         elif self.version:
             with suppress(Exception):
                 schedule = (
-                    self.request.event.schedules.filter(version__iexact=self.version).select_related('event', 'event__organizer').first()
+                    self.request.event.schedules.filter(version__iexact=self.version)
+                    .select_related('event', 'event__organizer')
+                    .first()
                 )
         schedule = schedule or self.request.event.current_schedule
         if schedule:
@@ -204,9 +205,7 @@ class ScheduleView(PermissionRequired, ScheduleMixin, TemplateView):
                 return redirect_to_presale_with_warning(request, _('No published sessions.'))
             return redirect_to_presale_with_warning(request, _('No published schedule.'))
 
-        if not self.has_permission() and are_featured_submissions_visible(
-            self.request.user, self.request.event
-        ):
+        if not self.has_permission() and are_featured_submissions_visible(self.request.user, self.request.event):
             messages.success(request, _('Our schedule is not live yet.'))
             return HttpResponseRedirect(self.request.event.urls.featured)
         return super().dispatch(request, **kwargs)
@@ -307,20 +306,6 @@ class ScheduleView(PermissionRequired, ScheduleMixin, TemplateView):
     def show_talk_list(self):
         return self.is_sessions_page() or self.request.event.display_settings['schedule'] == 'list'
 
-    @context
-    def schedule_json(self):
-        """Build enriched schedule data for inline embedding, avoiding extra API calls."""
-        if not self.schedule:
-            return '{}'
-        data = self.schedule.build_data(
-            all_talks=not self.schedule.version,
-            enrich=True,
-            include_featured_speaker_metadata=are_featured_submissions_visible(
-                self.request.user, self.request.event
-            ),
-        )
-        return escape_json_for_script(json.dumps(data, cls=I18nJSONEncoder))
-
     def get_context_data(self, **kwargs):
         ctx = super().get_context_data(**kwargs)
         schedule = ctx.get('schedule')
@@ -331,14 +316,9 @@ class ScheduleView(PermissionRequired, ScheduleMixin, TemplateView):
             .values_list('version', flat=True)
         )
         base_schedule_url = str(self.request.event.urls.schedule)
-        current_version = (
-            self.request.event.current_schedule.version
-            if self.request.event.current_schedule
-            else None
-        )
+        current_version = self.request.event.current_schedule.version if self.request.event.current_schedule else None
         versions = [
-            {'version': v, 'url': f'{base_schedule_url}v/{v}/', 'isCurrent': v == current_version}
-            for v in released
+            {'version': v, 'url': f'{base_schedule_url}v/{v}/', 'isCurrent': v == current_version} for v in released
         ]
         meta = {
             'version': version or '',
@@ -372,12 +352,9 @@ def schedule_messages(request, **kwargs):
         'exit_fullscreen': _('Exit Fullscreen'),
         'latest': _('Latest'),
         'version_warning_editable': _(
-            'You are currently viewing the editable schedule version.'
-            ' It may not match the released version.'
+            'You are currently viewing the editable schedule version. It may not match the released version.'
         ),
-        'version_warning_old': _(
-            'You are currently viewing an older schedule version.'
-        ),
+        'version_warning_old': _('You are currently viewing an older schedule version.'),
         'join_room': _('Join room'),
         'view_video': _('View Video'),
         'watch_live': _('Watch live'),
@@ -455,7 +432,9 @@ class ChangelogView(EventPermissionRequired, TemplateView):
 
     @context
     def schedules(self):
-        return self.request.event.schedules.all().filter(version__isnull=False).select_related('event', 'event__organizer')
+        return (
+            self.request.event.schedules.all().filter(version__isnull=False).select_related('event', 'event__organizer')
+        )
 
 
 class CalendarRedirectView(EventPermissionRequired, ScheduleMixin, TemplateView):
@@ -517,7 +496,7 @@ class CalendarRedirectView(EventPermissionRequired, ScheduleMixin, TemplateView)
             )
 
         if is_google:
-            google_url = f"https://calendar.google.com/calendar/r?{urlencode({'cid': ics_url})}"
+            google_url = f'https://calendar.google.com/calendar/r?{urlencode({"cid": ics_url})}'
             return HttpResponseRedirect(google_url)
 
         parsed = urlparse(ics_url)

--- a/app/eventyay/agenda/views/speaker.py
+++ b/app/eventyay/agenda/views/speaker.py
@@ -1,5 +1,4 @@
 import io
-import json
 from collections import defaultdict
 from urllib.parse import quote, urlparse
 
@@ -18,6 +17,8 @@ from django.views.generic import DetailView, ListView, TemplateView, View
 from django_context_decorator import context
 from i18nfield.utils import I18nJSONEncoder
 
+from eventyay.agenda.views.utils import is_public_speakers_empty, redirect_to_presale_with_warning
+from eventyay.base.models import SpeakerProfile, TalkQuestionTarget, User
 from eventyay.common.text.path import safe_filename
 from eventyay.common.urls import get_base_url
 from eventyay.common.utils.language import localize_event_text
@@ -27,30 +28,9 @@ from eventyay.common.views.mixins import (
     PermissionRequired,
     SocialMediaCardMixin,
 )
-from eventyay.agenda.views.utils import escape_json_for_script, is_public_speakers_empty, redirect_to_presale_with_warning
-from eventyay.talk_rules.submission import are_featured_submissions_visible
-from eventyay.base.models import SpeakerProfile, User
-from eventyay.base.models import TalkQuestionTarget
 
 
-class ScheduleDataMixin:
-    """Provide schedule_json context for pages that embed the schedule widget."""
-
-    @context
-    def schedule_json(self):
-        schedule = self.request.event.current_schedule
-        if not schedule:
-            return '{}'
-        data = schedule.build_data(
-            enrich=True,
-            include_featured_speaker_metadata=are_featured_submissions_visible(
-                self.request.user, self.request.event
-            ),
-        )
-        return escape_json_for_script(json.dumps(data, cls=I18nJSONEncoder))
-
-
-class SpeakerList(ScheduleDataMixin, EventPermissionRequired, Filterable, ListView):
+class SpeakerList(EventPermissionRequired, Filterable, ListView):
     context_object_name = 'speakers'
     template_name = 'agenda/speakers.html'
     permission_required = 'base.list_schedule'
@@ -82,7 +62,7 @@ class SpeakerList(ScheduleDataMixin, EventPermissionRequired, Filterable, ListVi
         return super().get_context_data(**kwargs)
 
 
-class SpeakerView(ScheduleDataMixin, PermissionRequired, TemplateView):
+class SpeakerView(PermissionRequired, TemplateView):
     template_name = 'agenda/speaker.html'
     permission_required = 'base.view_speakerprofile'
     slug_field = 'code'
@@ -179,19 +159,21 @@ class SpeakerTalksExportView(EventPermissionRequired, View):
     permission_required = 'base.list_schedule'
 
     def get_speaker_and_slots(self, request):
-        speaker = SpeakerProfile.objects.filter(
-            event=request.event, user__code__iexact=self.kwargs['code']
-        ).select_related('user').first()
+        speaker = (
+            SpeakerProfile.objects.filter(event=request.event, user__code__iexact=self.kwargs['code'])
+            .select_related('user')
+            .first()
+        )
         if not speaker:
             raise Http404()
         schedule = request.event.current_schedule
         if not schedule:
             raise Http404()
-        slots = schedule.talks.filter(
-            submission__speakers=speaker.user, is_visible=True
-        ).select_related(
-            'room', 'submission', 'submission__track', 'submission__submission_type'
-        ).prefetch_related('submission__speakers', 'submission__resources')
+        slots = (
+            schedule.talks.filter(submission__speakers=speaker.user, is_visible=True)
+            .select_related('room', 'submission', 'submission__track', 'submission__submission_type')
+            .prefetch_related('submission__speakers', 'submission__resources')
+        )
         return speaker, slots
 
     def get(self, request, event, **kwargs):
@@ -212,40 +194,44 @@ class SpeakerTalksExportView(EventPermissionRequired, View):
         talks_data = []
         for slot in slots:
             sub = slot.submission
-            talks_data.append({
-                'guid': slot.uuid,
-                'code': sub.code,
-                'id': sub.id,
-                'date': slot.local_start.isoformat(),
-                'start': f'{slot.local_start:%H:%M}',
-                'duration': slot.export_duration,
-                'room': localize_event_text(slot.room.name) if slot.room else None,
-                'slug': slot.frab_slug,
-                'url': sub.urls.public.full(),
-                'title': localize_event_text(sub.title),
-                'track': localize_event_text(sub.track.name) if sub.track else None,
-                'type': localize_event_text(sub.submission_type.name),
-                'language': sub.content_locale,
-                'abstract': localize_event_text(sub.abstract),
-                'description': localize_event_text(sub.description),
-                'do_not_record': sub.do_not_record,
-                'persons': [
-                    {
-                        'code': p.code,
-                        'name': p.get_display_name(),
-                        'biography': localize_event_text(p.event_profile(event).biography),
-                    }
-                    for p in sub.speakers.all()
-                ],
-                'links': [
-                    {'title': localize_event_text(r.description), 'url': r.link}
-                    for r in sub.resources.all() if r.link
-                ],
-                'attachments': [
-                    {'title': localize_event_text(r.description), 'url': r.resource.url}
-                    for r in sub.resources.all() if not r.link
-                ],
-            })
+            talks_data.append(
+                {
+                    'guid': slot.uuid,
+                    'code': sub.code,
+                    'id': sub.id,
+                    'date': slot.local_start.isoformat(),
+                    'start': f'{slot.local_start:%H:%M}',
+                    'duration': slot.export_duration,
+                    'room': localize_event_text(slot.room.name) if slot.room else None,
+                    'slug': slot.frab_slug,
+                    'url': sub.urls.public.full(),
+                    'title': localize_event_text(sub.title),
+                    'track': localize_event_text(sub.track.name) if sub.track else None,
+                    'type': localize_event_text(sub.submission_type.name),
+                    'language': sub.content_locale,
+                    'abstract': localize_event_text(sub.abstract),
+                    'description': localize_event_text(sub.description),
+                    'do_not_record': sub.do_not_record,
+                    'persons': [
+                        {
+                            'code': p.code,
+                            'name': p.get_display_name(),
+                            'biography': localize_event_text(p.event_profile(event).biography),
+                        }
+                        for p in sub.speakers.all()
+                    ],
+                    'links': [
+                        {'title': localize_event_text(r.description), 'url': r.link}
+                        for r in sub.resources.all()
+                        if r.link
+                    ],
+                    'attachments': [
+                        {'title': localize_event_text(r.description), 'url': r.resource.url}
+                        for r in sub.resources.all()
+                        if not r.link
+                    ],
+                }
+            )
         data = {
             'speaker': speaker.user.code,
             'base_url': base_url,
@@ -282,17 +268,19 @@ class SpeakerTalksCalendarRedirectView(EventPermissionRequired, View):
 
     def get(self, request, event, **kwargs):
         provider = kwargs.get('provider', '')
-        speaker = SpeakerProfile.objects.filter(
-            event=request.event, user__code__iexact=self.kwargs['code']
-        ).select_related('user').first()
+        speaker = (
+            SpeakerProfile.objects.filter(event=request.event, user__code__iexact=self.kwargs['code'])
+            .select_related('user')
+            .first()
+        )
         if not speaker:
             raise Http404()
         schedule = request.event.current_schedule
         if not schedule:
             raise Http404()
-        slots = schedule.talks.filter(
-            submission__speakers=speaker.user, is_visible=True
-        ).select_related('room', 'submission')
+        slots = schedule.talks.filter(submission__speakers=speaker.user, is_visible=True).select_related(
+            'room', 'submission'
+        )
         if not slots.exists():
             raise Http404()
 
@@ -301,11 +289,14 @@ class SpeakerTalksCalendarRedirectView(EventPermissionRequired, View):
             return self.google_calendar_redirect(slot, request)
         if provider == 'webcal':
             ical_url = request.build_absolute_uri(
-                reverse('agenda:speaker.talks.ical', kwargs={
-                    'organizer': request.event.organizer.slug,
-                    'event': event,
-                    'code': self.kwargs['code'],
-                })
+                reverse(
+                    'agenda:speaker.talks.ical',
+                    kwargs={
+                        'organizer': request.event.organizer.slug,
+                        'event': event,
+                        'code': self.kwargs['code'],
+                    },
+                )
             )
             webcal_url = ical_url.replace('https://', 'webcal://').replace('http://', 'webcal://')
             return HttpResponseRedirect(webcal_url)

--- a/app/eventyay/agenda/views/talk.py
+++ b/app/eventyay/agenda/views/talk.py
@@ -1,13 +1,11 @@
-from enum import StrEnum
-import json
-import logging
 import datetime as dt
+import logging
+from enum import StrEnum
 from http import HTTPStatus
-from urllib.parse import unquote, urlparse, urljoin, quote
 from typing import TypeVar
+from urllib.parse import quote, unquote, urljoin, urlparse
 
 import jwt
-import requests
 import vobject
 from django.conf import settings
 from django.contrib import messages
@@ -24,7 +22,17 @@ from django_scopes import scope
 from i18nfield.utils import I18nJSONEncoder
 
 from eventyay.agenda.signals import register_recording_provider
-from eventyay.agenda.views.utils import encode_email, is_email_like
+from eventyay.agenda.views.utils import build_enriched_schedule_json, encode_email, is_email_like
+from eventyay.base.models import (
+    Event,
+    Order,
+    OrderPosition,
+    Submission,
+    SubmissionFavourite,
+    SubmissionStates,
+    TalkSlot,
+    User,
+)
 from eventyay.cfp.views.event import EventPageMixin
 from eventyay.common.text.phrases import phrases
 from eventyay.common.urls import get_base_url
@@ -34,12 +42,12 @@ from eventyay.common.views.mixins import (
     PermissionRequired,
     SocialMediaCardMixin,
 )
-from eventyay.base.models import Event, SubmissionFavourite, TalkSlot, User
 from eventyay.submission.forms import FeedbackForm
-from eventyay.base.models import Submission, SubmissionStates
 
 
 logger = logging.getLogger(__name__)
+
+
 class TicketCheckResult(StrEnum):
     HAS_TICKET = 'has_ticket'
     MISCONFIGURED = 'missing_configuration'
@@ -93,11 +101,7 @@ def talk_starrers(request, event, slug, **kwargs):
         response['Access-Control-Allow-Headers'] = 'authorization,content-type'
         return response
 
-    submission = (
-        request.event.submissions.filter(code__iexact=slug)
-        .select_related('event', 'event__organizer')
-        .first()
-    )
+    submission = request.event.submissions.filter(code__iexact=slug).select_related('event', 'event__organizer').first()
     if not submission or not request.user.has_perm('base.view_public_submission', submission):
         raise Http404()
 
@@ -125,11 +129,7 @@ def talk_starrers(request, event, slug, **kwargs):
             user = fav.user
             display_name = user.get_display_name() if user else ''
             is_public_user = bool(
-                user
-                and user.show_publicly
-                and not user.deleted
-                and user.code
-                and not is_email_like(display_name)
+                user and user.show_publicly and not user.deleted and user.code and not is_email_like(display_name)
             )
             if is_public_user:
                 items.append(
@@ -159,11 +159,12 @@ def talk_starrers(request, event, slug, **kwargs):
     return response
 
 
-from eventyay.agenda.views.speaker import ScheduleDataMixin
-
-
-class TalkView(ScheduleDataMixin, TalkMixin, TemplateView):
+class TalkView(TalkMixin, TemplateView):
     template_name = 'agenda/talk.html'
+
+    @context
+    def schedule_json(self):
+        return build_enriched_schedule_json(self.request)
 
     def get_contrast_color(self, bg_color):
         if not bg_color:
@@ -219,7 +220,9 @@ class TalkView(ScheduleDataMixin, TalkMixin, TemplateView):
             if schedule
             else TalkSlot.objects.none()
         )
-        other_submissions = self.request.event.submissions.filter(slots__in=other_slots).select_related('event', 'event__organizer')
+        other_submissions = self.request.event.submissions.filter(slots__in=other_slots).select_related(
+            'event', 'event__organizer'
+        )
         speakers = (
             self.submission.speakers.all()
             .with_profiles(self.request.event)
@@ -308,7 +311,11 @@ class SingleICalView(EventPageMixin, TalkMixin, View):
     def get(self, request, event, **kwargs):
         code = self.submission.code
         schedule = self.request.event.current_schedule or self.request.event.wip_schedule
-        talk_slots = self.submission.slots.filter(schedule=schedule, is_visible=True) if schedule else self.submission.slots.none()
+        talk_slots = (
+            self.submission.slots.filter(schedule=schedule, is_visible=True)
+            if schedule
+            else self.submission.slots.none()
+        )
 
         netloc = urlparse(settings.SITE_URL).netloc
         cal = vobject.iCalendar()
@@ -333,8 +340,7 @@ class SingleExportView(EventPageMixin, TalkMixin, View):
         if not schedule:
             raise Http404
         talk_slots = (
-            self.submission.slots
-            .filter(schedule=schedule, is_visible=True)
+            self.submission.slots.filter(schedule=schedule, is_visible=True)
             .select_related('room', 'submission', 'submission__track', 'submission__submission_type')
             .prefetch_related('submission__speakers', 'submission__resources')
         )
@@ -370,40 +376,44 @@ class SingleExportView(EventPageMixin, TalkMixin, View):
         talks_data = []
         for slot in talk_slots:
             sub = slot.submission
-            talks_data.append({
-                'guid': slot.uuid,
-                'code': sub.code,
-                'id': sub.id,
-                'date': slot.local_start.isoformat(),
-                'start': slot.local_start.strftime('%H:%M'),
-                'duration': slot.export_duration,
-                'room': localize_event_text(slot.room.name) if slot.room else None,
-                'slug': slot.frab_slug,
-                'url': sub.urls.public.full(),
-                'title': localize_event_text(sub.title),
-                'track': localize_event_text(sub.track.name) if sub.track else None,
-                'type': localize_event_text(sub.submission_type.name),
-                'language': sub.content_locale,
-                'abstract': localize_event_text(sub.abstract),
-                'description': localize_event_text(sub.description),
-                'do_not_record': sub.do_not_record,
-                'persons': [
-                    {
-                        'code': p.code,
-                        'name': p.get_display_name(),
-                        'biography': localize_event_text(p.event_profile(event).biography),
-                    }
-                    for p in sub.speakers.all()
-                ],
-                'links': [
-                    {'title': localize_event_text(r.description), 'url': r.link}
-                    for r in sub.resources.all() if r.link
-                ],
-                'attachments': [
-                    {'title': localize_event_text(r.description), 'url': r.resource.url}
-                    for r in sub.resources.all() if not r.link
-                ],
-            })
+            talks_data.append(
+                {
+                    'guid': slot.uuid,
+                    'code': sub.code,
+                    'id': sub.id,
+                    'date': slot.local_start.isoformat(),
+                    'start': slot.local_start.strftime('%H:%M'),
+                    'duration': slot.export_duration,
+                    'room': localize_event_text(slot.room.name) if slot.room else None,
+                    'slug': slot.frab_slug,
+                    'url': sub.urls.public.full(),
+                    'title': localize_event_text(sub.title),
+                    'track': localize_event_text(sub.track.name) if sub.track else None,
+                    'type': localize_event_text(sub.submission_type.name),
+                    'language': sub.content_locale,
+                    'abstract': localize_event_text(sub.abstract),
+                    'description': localize_event_text(sub.description),
+                    'do_not_record': sub.do_not_record,
+                    'persons': [
+                        {
+                            'code': p.code,
+                            'name': p.get_display_name(),
+                            'biography': localize_event_text(p.event_profile(event).biography),
+                        }
+                        for p in sub.speakers.all()
+                    ],
+                    'links': [
+                        {'title': localize_event_text(r.description), 'url': r.link}
+                        for r in sub.resources.all()
+                        if r.link
+                    ],
+                    'attachments': [
+                        {'title': localize_event_text(r.description), 'url': r.resource.url}
+                        for r in sub.resources.all()
+                        if not r.link
+                    ],
+                }
+            )
         data = {
             'code': self.submission.code,
             'base_url': base_url,
@@ -450,11 +460,14 @@ class SingleCalendarRedirectView(EventPageMixin, TalkMixin, View):
 
         slot = talk_slots.first()
         ical_url = request.build_absolute_uri(
-            reverse('agenda:ical', kwargs={
-                'organizer': request.event.organizer.slug,
-                'event': event,
-                'slug': slug,
-            })
+            reverse(
+                'agenda:ical',
+                kwargs={
+                    'organizer': request.event.organizer.slug,
+                    'event': event,
+                    'slug': slug,
+                },
+            )
         )
 
         if provider == 'google-calendar':
@@ -583,48 +596,46 @@ class OnlineVideoJoin(EventPermissionRequired, View):
         iat = dt.datetime.now(dt.UTC)
         exp = iat + dt.timedelta(days=30)
         profile = {
-            "display_name": request.user.fullname,
-            "fields": {
-                "pretalx_id": request.user.code,
+            'display_name': request.user.fullname,
+            'fields': {
+                'pretalx_id': request.user.code,
             },
         }
         if request.user.avatar_url:
-            profile["profile_picture"] = request.user.get_avatar_url(request.event)
+            profile['profile_picture'] = request.user.get_avatar_url(request.event)
 
         payload = {
-            "iss": event.settings.venueless_issuer,
-            "aud": event.settings.venueless_audience,
-            "exp": exp,
-            "iat": iat,
-            "uid": encode_email(request.user.email),
-            "profile": profile,
-            "traits": list(
+            'iss': event.settings.venueless_issuer,
+            'aud': event.settings.venueless_audience,
+            'exp': exp,
+            'iat': iat,
+            'uid': encode_email(request.user.email),
+            'profile': profile,
+            'traits': list(
                 {
-                    "attendee",
-                    f"eventyay-video-event-{request.event.slug}",
+                    'attendee',
+                    f'eventyay-video-event-{request.event.slug}',
                 }
             ),
         }
-        token = jwt.encode(
-            payload, event.settings.venueless_secret, algorithm="HS256"
-        )
+        token = jwt.encode(payload, event.settings.venueless_secret, algorithm='HS256')
         redirect_url = urljoin(event.settings.venueless_url, f'#token={token}')
         logger.info('Redirect URL to Video: %s', redirect_url)
         return JsonResponse(
-            {
-                'redirect_url': redirect_url
-            },
+            {'redirect_url': redirect_url},
             status=HTTPStatus.OK,
         )
 
 
 _T = TypeVar('_T', str, None)
+
+
 # We use TypeVar because the 2nd and 3rd items must be both `str` or both `None` at the same time.
 # The annotation `tuple[str, str | None, str | None]` doesn't satisfy this requirement.
 def extract_event_info_from_url(url: str) -> tuple[str, _T, _T]:
     parsed_url = urlparse(url)
     path = parsed_url.path
-    parts = path.strip("/").split("/")
+    parts = path.strip('/').split('/')
     if len(parts) >= 2:
         organizer, event = parts[-2:]
         return None, unquote(organizer), unquote(event)
@@ -635,8 +646,6 @@ def check_user_owning_ticket(user: User, event: Event) -> TicketCheckResult:
     """
     Check if the user owns a valid ticket for this event using the local database, matching presale logic.
     """
-    from eventyay.base.models import OrderPosition, Order
-    from django_scopes import scope
     allowed_statuses = [Order.STATUS_PAID]
     if event.settings.venueless_allow_pending:
         allowed_statuses.append(Order.STATUS_PENDING)

--- a/app/eventyay/agenda/views/utils.py
+++ b/app/eventyay/agenda/views/utils.py
@@ -1,31 +1,53 @@
 import hashlib
+import json
+import logging
 import random
 import string
-import logging
-from datetime import datetime, timezone as dt_timezone
+from datetime import UTC, datetime
 
 from django.contrib import messages
 from django.core import signing
 from django.http import HttpRequest, HttpResponse, HttpResponseNotModified, HttpResponseRedirect
-from django.urls import reverse, NoReverseMatch
-from django.utils.encoding import force_str
-from django.utils.translation import gettext_lazy as _
-from django.utils.translation import activate
+from django.urls import NoReverseMatch, reverse
 from django.utils import timezone
+from django.utils.encoding import force_str
+from django.utils.translation import activate
+from i18nfield.utils import I18nJSONEncoder
 
 from eventyay.base.models.submission import SubmissionFavourite
 from eventyay.common.exporter import BaseExporter
 from eventyay.common.signals import register_data_exporters, register_my_data_exporters
 from eventyay.common.text.path import safe_filename
 from eventyay.schedule.exporters import FavedICalExporter
+from eventyay.talk_rules.submission import are_featured_submissions_visible
+
 
 # Same escaping Django applies inside json_script to prevent XSS in <script> tags.
-JSON_SCRIPT_ESCAPES = {ord(">"): "\\u003E", ord("<"): "\\u003C", ord("&"): "\\u0026"}
+JSON_SCRIPT_ESCAPES = {ord('>'): '\\u003E', ord('<'): '\\u003C', ord('&'): '\\u0026'}
 
 
 def escape_json_for_script(json_str: str) -> str:
     """Escape a JSON string for safe embedding in an HTML ``<script>`` tag."""
     return json_str.translate(JSON_SCRIPT_ESCAPES)
+
+
+def build_enriched_schedule_json(request: HttpRequest) -> str:
+    """Serialize the current schedule for inline first-party agenda views.
+
+    Some public pages, such as featured talk pages, remain accessible even when the
+    standalone widget JSON endpoint is intentionally hidden. Those pages need a
+    self-contained payload instead of depending on ``widgets/schedule.json``.
+    """
+
+    schedule = request.event.current_schedule
+    if not schedule:
+        return '{}'
+
+    data = schedule.build_data(
+        enrich=True,
+        include_featured_speaker_metadata=are_featured_submissions_visible(request.user, request.event),
+    )
+    return escape_json_for_script(json.dumps(data, cls=I18nJSONEncoder))
 
 
 def is_email_like(value: str) -> bool:
@@ -39,6 +61,7 @@ def is_email_like(value: str) -> bool:
 
 
 logger = logging.getLogger(__name__)
+
 
 def load_starred_ics_token(token: str, *, event=None):
     """Validate and decode a starred-ICS token.
@@ -63,7 +86,7 @@ def load_starred_ics_token(token: str, *, event=None):
                 return None, None
         user_id = value['user_id']
         exp_ts = int(value['exp'])
-        expiry_dt = datetime.fromtimestamp(exp_ts, tz=dt_timezone.utc)
+        expiry_dt = datetime.fromtimestamp(exp_ts, tz=UTC)
         if expiry_dt <= timezone.now():
             return None, None
         return user_id, expiry_dt
@@ -155,11 +178,19 @@ def build_public_schedule_exporters(event, version=None):
                 all_exporters.append(exporter)
 
     order = {
-        'google-calendar': 0, 'webcal': 1,
-        'schedule.ics': 10, 'schedule.json': 11, 'schedule.xml': 12, 'schedule.xcal': 13,
+        'google-calendar': 0,
+        'webcal': 1,
+        'schedule.ics': 10,
+        'schedule.json': 11,
+        'schedule.xml': 12,
+        'schedule.xcal': 13,
         'faved.ics': 14,
-        'my-google-calendar': 100, 'my-webcal': 101,
-        'schedule-my.ics': 110, 'schedule-my.json': 111, 'schedule-my.xml': 112, 'schedule-my.xcal': 113,
+        'my-google-calendar': 100,
+        'my-webcal': 101,
+        'schedule-my.ics': 110,
+        'schedule-my.json': 111,
+        'schedule-my.xml': 112,
+        'schedule-my.xcal': 113,
     }
     all_exporters.sort(key=lambda e: (order.get(e.identifier, 50), force_str(e.verbose_name), e.identifier))
 
@@ -175,13 +206,15 @@ def build_public_schedule_exporters(event, version=None):
             url = reverse(view_name, kwargs={**export_kwargs, 'name': exporter.identifier})
         except NoReverseMatch:
             continue
-        result.append({
-            'identifier': exporter.identifier,
-            'verbose_name': force_str(exporter.verbose_name),
-            'icon': getattr(exporter, 'icon', ''),
-            'export_url': url,
-            'qrcode_svg': str(exporter.get_qrcode()) if getattr(exporter, 'show_qrcode', False) else '',
-        })
+        result.append(
+            {
+                'identifier': exporter.identifier,
+                'verbose_name': force_str(exporter.verbose_name),
+                'icon': getattr(exporter, 'icon', ''),
+                'export_url': url,
+                'qrcode_svg': str(exporter.get_qrcode()) if getattr(exporter, 'show_qrcode', False) else '',
+            }
+        )
     return result
 
 
@@ -224,7 +257,7 @@ def get_schedule_exporter_content(request, exporter_name, schedule, token=None):
             exporter.talk_ids = request.GET.get('talks').split(',')
         else:
             return HttpResponseRedirect(request.event.urls.login)
-    if token and "-my" in exporter.identifier:
+    if token and '-my' in exporter.identifier:
         user_id = parse_ics_token(token, event=request.event)
         if not user_id:
             return
@@ -236,7 +269,7 @@ def get_schedule_exporter_content(request, exporter_name, schedule, token=None):
         )
         if talk_ids:
             exporter.talk_ids = talk_ids
-    elif "-my" in exporter.identifier:
+    elif '-my' in exporter.identifier:
         talk_ids = list(
             SubmissionFavourite.objects.filter(
                 user_id=request.user.id,

--- a/app/eventyay/agenda/views/widget.py
+++ b/app/eventyay/agenda/views/widget.py
@@ -6,13 +6,16 @@ from csp.decorators import csp_exempt
 from django.contrib.auth.models import AnonymousUser
 from django.contrib.staticfiles import finders
 from django.http import Http404, HttpResponse, JsonResponse
-from django.views.decorators.cache import cache_page
 from django.views.decorators.http import condition
 from i18nfield.utils import I18nJSONEncoder
 
-from eventyay.talk_rules.agenda import is_widget_visible
-from eventyay.talk_rules.submission import (are_featured_submissions_visible, schedule_widget_featured_cache_key_part)
 from eventyay.common.views import conditional_cache_page
+from eventyay.talk_rules.agenda import is_widget_visible
+from eventyay.talk_rules.submission import (
+    are_featured_submissions_visible,
+    schedule_widget_featured_cache_key_part,
+)
+
 
 WIDGET_JS_CHECKSUM = None
 WIDGET_JS_MTIME = None
@@ -113,8 +116,10 @@ def widget_data(request, organizer=None, event=None, version=None, **kwargs):
     if not schedule:
         raise Http404()
 
+    enrich = request.GET.get('enrich') in {'1', 'true', 'True'}
     result = schedule.build_data(
         all_talks=not schedule.version,
+        enrich=enrich,
         include_featured_speaker_metadata=are_featured_submissions_visible(AnonymousUser(), event),
     )
     response = JsonResponse(result, encoder=I18nJSONEncoder)

--- a/app/eventyay/presale/templates/pretixpresale/event/index.html
+++ b/app/eventyay/presale/templates/pretixpresale/event/index.html
@@ -364,7 +364,7 @@
         {% if featured_speakers %}
             <section class="front-page" id="featured-speakers" aria-label="{% trans 'Featured Speakers' %}">
                 <script id="pretalx-schedule-data" type="application/json">{{ featured_speakers_widget_schedule_json|safe }}</script>
-                <script type="text/javascript" src="{{ request.event.urls.schedule_widget_script }}" async></script>
+                <script type="text/javascript" src="{% static 'schedule/pretalx-schedule.js' %}" async></script>
                 <pretalx-schedule event-url="{{ request.event.urls.base }}" locale="{{ request.LANGUAGE_CODE }}" view="featured-speakers" style="--pretalx-clr-primary: {{ request.event.visible_primary_color }}"></pretalx-schedule>
             </section>
         {% endif %}

--- a/app/eventyay/webapp/schedule/src/App.vue
+++ b/app/eventyay/webapp/schedule/src/App.vue
@@ -202,6 +202,11 @@ export default {
 		joinRoomBaseUrl: {
 			type: String,
 			default: ''
+		},
+		// Fetch the enriched schedule payload used on first-party agenda pages.
+		enrichData: {
+			type: Boolean,
+			default: false
 		}
 	},
 	provide () {
@@ -530,7 +535,7 @@ export default {
 			this.translationMessages = PRETALX_MESSAGES
 		}
 
-		// Use inline data if available (on-site), otherwise fetch (external embed)
+		// Use inline data if available, otherwise fetch the schedule JSON.
 		const dataEl = document.getElementById('pretalx-schedule-data')
 		if (dataEl) {
 			try { this.schedule = JSON.parse(dataEl.textContent) } catch (e) { /* ignore parse error, fall through to fetch */ }
@@ -541,8 +546,12 @@ export default {
 			let version = ''
 			if (this.version)
 				version = `v/${this.version}/`
-			const url = `${this.eventUrl}schedule/${version}widgets/schedule.json`
-			const legacyUrl = `${this.eventUrl}schedule/${version}widget/v2.json`
+			const params = new URLSearchParams()
+			if (this.enrichData) params.set('enrich', '1')
+			const query = params.toString()
+			const suffix = query ? `?${query}` : ''
+			const url = `${this.eventUrl}schedule/${version}widgets/schedule.json${suffix}`
+			const legacyUrl = `${this.eventUrl}schedule/${version}widget/v2.json${suffix}`
 			// fetch from url, but fall back to legacyUrl if url fails
 			try {
 				this.schedule = await (await fetch(url)).json()

--- a/app/tests/talk/agenda/views/test_agenda_schedule.py
+++ b/app/tests/talk/agenda/views/test_agenda_schedule.py
@@ -7,70 +7,70 @@ from django_scopes import scope
 
 
 @pytest.mark.django_db
-@pytest.mark.usefixtures("other_slot")
-@pytest.mark.parametrize("version,queries", (("js", 6), ("nojs", 8)))
-def test_can_see_schedule(
-    client, django_assert_num_queries, user, event, slot, version, queries
-):
+@pytest.mark.usefixtures('other_slot')
+@pytest.mark.parametrize('version,max_queries', (('js', 6), ('nojs', 8)))
+def test_can_see_schedule(client, django_assert_max_num_queries, user, event, slot, version, max_queries):
     with scope(event=event):
         del event.current_schedule
-        assert user.has_perm("schedule.list_schedule", event)
-        url = event.urls.schedule if version == "js" else event.urls.schedule_nojs
+        assert user.has_perm('schedule.list_schedule', event)
+        url = event.urls.schedule if version == 'js' else event.urls.schedule_nojs
 
-    with django_assert_num_queries(queries):
-        response = client.get(url, follow=True, HTTP_ACCEPT="text/html")
+    with django_assert_max_num_queries(max_queries):
+        response = client.get(url, follow=True, HTTP_ACCEPT='text/html')
     assert response.status_code == 200
     with scope(event=event):
         assert event.schedules.count() == 2
-        test_string = "<pretalx-schedule" if version == "js" else slot.submission.title
+        test_string = '<pretalx-schedule' if version == 'js' else slot.submission.title
         assert test_string in response.text
+    if version == 'js':
+        assert 'pretalx-schedule-data' not in response.text
 
 
 @pytest.mark.django_db
-@pytest.mark.usefixtures("other_slot")
-@pytest.mark.parametrize("version", ("js", "nojs"))
+@pytest.mark.usefixtures('other_slot')
+@pytest.mark.parametrize('version', ('js', 'nojs'))
 def test_orga_can_see_wip_schedule(orga_client, event, slot, version):
     with scope(event=event):
-        url = event.urls.schedule + "v/wip/"
-        if version != "js":
-            url += "nojs"
-    response = orga_client.get(url, follow=True, HTTP_ACCEPT="text/html")
+        url = event.urls.schedule + 'v/wip/'
+        if version != 'js':
+            url += 'nojs'
+    response = orga_client.get(url, follow=True, HTTP_ACCEPT='text/html')
     assert response.status_code == 200
     with scope(event=event):
-        test_string = "<pretalx-schedule" if version == "js" else slot.submission.title
+        test_string = '<pretalx-schedule' if version == 'js' else slot.submission.title
         assert test_string in response.text
 
 
 @pytest.mark.django_db
-@pytest.mark.usefixtures("other_slot")
+@pytest.mark.usefixtures('other_slot')
 def test_can_see_text_schedule(client, event, slot):
-    response = client.get(event.urls.schedule, follow=True, HTTP_ACCEPT="text/plain")
+    response = client.get(event.urls.schedule, follow=True, HTTP_ACCEPT='text/plain')
     assert response.status_code == 200
     with scope(event=event):
         assert slot.submission.title[:10] in response.text
 
 
 @pytest.mark.django_db
-@pytest.mark.usefixtures("slot", "other_slot")
+@pytest.mark.usefixtures('slot', 'other_slot')
 def test_can_see_schedule_with_broken_accept_header(client, event):
-    response = client.get(event.urls.schedule, follow=True, HTTP_ACCEPT="foo/bar")
+    response = client.get(event.urls.schedule, follow=True, HTTP_ACCEPT='foo/bar')
     assert response.status_code == 200
     with scope(event=event):
-        assert "<pretalx-schedule" in response.text
+        assert '<pretalx-schedule' in response.text
 
 
 @pytest.mark.django_db
-@pytest.mark.usefixtures("slot", "other_slot")
-@pytest.mark.parametrize("featured", ("always", "never", "after_schedule"))
+@pytest.mark.usefixtures('slot', 'other_slot')
+@pytest.mark.parametrize('featured', ('always', 'never', 'after_schedule'))
 def test_cannot_see_schedule_by_setting(client, user, event, featured):
     with scope(event=event):
-        event.feature_flags["show_schedule"] = False
+        event.feature_flags['show_schedule'] = False
         event.save()
-        assert not user.has_perm("schedule.list_schedule", event)
-        event.feature_flags["show_featured"] = featured
+        assert not user.has_perm('schedule.list_schedule', event)
+        event.feature_flags['show_featured'] = featured
         event.save()
-    response = client.get(event.urls.schedule, HTTP_ACCEPT="text/html")
-    if featured == "never":
+    response = client.get(event.urls.schedule, HTTP_ACCEPT='text/html')
+    if featured == 'never':
         assert response.status_code == 404
     else:
         assert response.status_code == 302
@@ -78,18 +78,18 @@ def test_cannot_see_schedule_by_setting(client, user, event, featured):
 
 
 @pytest.mark.django_db
-@pytest.mark.usefixtures("slot", "other_slot")
-@pytest.mark.parametrize("featured", ("always", "never", "after_schedule"))
+@pytest.mark.usefixtures('slot', 'other_slot')
+@pytest.mark.parametrize('featured', ('always', 'never', 'after_schedule'))
 def test_cannot_see_no_schedule(client, user, event, featured):
     with scope(event=event):
         event.current_schedule.talks.all().delete()
         event.current_schedule.delete()
         del event.current_schedule
-        event.feature_flags["show_featured"] = featured
+        event.feature_flags['show_featured'] = featured
         event.save()
-        assert not user.has_perm("schedule.list_schedule", event)
-    response = client.get(event.urls.schedule, HTTP_ACCEPT="text/html")
-    if featured == "never":
+        assert not user.has_perm('schedule.list_schedule', event)
+    response = client.get(event.urls.schedule, HTTP_ACCEPT='text/html')
+    if featured == 'never':
         assert response.status_code == 404
     else:
         assert response.status_code == 302
@@ -97,98 +97,87 @@ def test_cannot_see_no_schedule(client, user, event, featured):
 
 
 @pytest.mark.django_db
-@pytest.mark.usefixtures("slot", "other_slot")
-def test_speaker_list(client, django_assert_num_queries, event, speaker):
+@pytest.mark.usefixtures('slot', 'other_slot')
+def test_speaker_list(client, event, speaker):
     url = event.urls.speakers
-    with django_assert_num_queries(9):
-        response = client.get(url, follow=True)
+    response = client.get(url, follow=True)
     assert response.status_code == 200
     assert speaker.fullname in response.text
+    assert 'pretalx-schedule-data' not in response.text
 
 
 @pytest.mark.django_db
-@pytest.mark.usefixtures("other_slot")
-def test_speaker_page(
-    client, django_assert_num_queries, event, speaker, slot, other_submission
-):
+@pytest.mark.usefixtures('other_slot')
+def test_speaker_page(client, event, speaker, slot, other_submission):
     with scope(event=event):
         other_submission.speakers.add(speaker)
         slot.submission.accept(force=True)
         slot.submission.save()
-        event.wip_schedule.freeze("testversion 2")
+        event.wip_schedule.freeze('testversion 2')
         other_submission.slots.all().update(is_visible=True)
         slot.submission.slots.all().update(is_visible=True)
-    url = reverse("agenda:speaker", kwargs={"code": speaker.code, "event": event.slug})
-    with django_assert_num_queries(14):
-        response = client.get(url, follow=True)
+    url = reverse('agenda:speaker', kwargs={'code': speaker.code, 'event': event.slug})
+    response = client.get(url, follow=True)
     assert response.status_code == 200
-    assert len(response.context["talks"]) == 2, response.context["talks"]
-    assert response.context["talks"].filter(submission=other_submission)
+    assert len(response.context['talks']) == 2, response.context['talks']
+    assert response.context['talks'].filter(submission=other_submission)
+    assert 'pretalx-schedule-data' not in response.text
     with scope(event=event):
         assert speaker.profiles.get(event=event).biography in response.text
         assert slot.submission.title in response.text
 
 
 @pytest.mark.django_db
-@pytest.mark.usefixtures("other_slot")
-def test_speaker_page_other_submissions_only_if_visible(
-    client, django_assert_num_queries, event, speaker, slot, other_submission
-):
+@pytest.mark.usefixtures('other_slot')
+def test_speaker_page_other_submissions_only_if_visible(client, event, speaker, slot, other_submission):
     with scope(event=event):
         other_submission.speakers.add(speaker)
         slot.submission.accept(force=True)
         slot.submission.save()
-        event.wip_schedule.freeze("testversion 2")
+        event.wip_schedule.freeze('testversion 2')
         other_submission.slots.all().update(is_visible=False)
-        slot.submission.slots.filter(schedule=event.current_schedule).update(
-            is_visible=True
-        )
+        slot.submission.slots.filter(schedule=event.current_schedule).update(is_visible=True)
 
-    url = reverse("agenda:speaker", kwargs={"code": speaker.code, "event": event.slug})
-    with django_assert_num_queries(13):
-        response = client.get(url, follow=True)
+    url = reverse('agenda:speaker', kwargs={'code': speaker.code, 'event': event.slug})
+    response = client.get(url, follow=True)
 
     assert response.status_code == 200
-    assert len(response.context["talks"]) == 1
-    assert not response.context["talks"].filter(submission=other_submission)
+    assert len(response.context['talks']) == 1
+    assert not response.context['talks'].filter(submission=other_submission)
 
 
 @pytest.mark.django_db
-@pytest.mark.usefixtures("slot")
+@pytest.mark.usefixtures('slot')
 def test_speaker_social_media(client, django_assert_num_queries, event, speaker):
-    url = reverse(
-        "agenda:speaker-social", kwargs={"code": speaker.code, "event": event.slug}
-    )
+    url = reverse('agenda:speaker-social', kwargs={'code': speaker.code, 'event': event.slug})
     with django_assert_num_queries(10):
         response = client.get(url, follow=True)
     assert response.status_code == 404  # no images available
 
 
 @pytest.mark.django_db
-@pytest.mark.usefixtures("slot", "other_slot")
+@pytest.mark.usefixtures('slot', 'other_slot')
 def test_speaker_redirect(client, event, speaker):
-    target_url = reverse(
-        "agenda:speaker", kwargs={"code": speaker.code, "event": event.slug}
-    )
-    url = event.urls.speakers + f"by-id/{speaker.pk}/"
+    target_url = reverse('agenda:speaker', kwargs={'code': speaker.code, 'event': event.slug})
+    url = event.urls.speakers + f'by-id/{speaker.pk}/'
     response = client.get(url)
     assert response.status_code == 302
-    assert response.headers["location"].endswith(target_url)
+    assert response.headers['location'].endswith(target_url)
 
 
 @pytest.mark.django_db
 def test_speaker_redirect_unknown(client, event, submission):
     with scope(event=event):
         url = reverse(
-            "agenda:speaker.redirect",
-            kwargs={"pk": submission.speakers.first().pk, "event": event.slug},
+            'agenda:speaker.redirect',
+            kwargs={'pk': submission.speakers.first().pk, 'event': event.slug},
         )
     response = client.get(url)
     assert response.status_code == 404
 
 
 @pytest.mark.django_db
-@pytest.mark.usefixtures("other_slot")
+@pytest.mark.usefixtures('other_slot')
 def test_schedule_page_text_table(client, django_assert_num_queries, event, slot):
     url = event.urls.schedule
     with django_assert_num_queries(8):
@@ -201,13 +190,11 @@ def test_schedule_page_text_table(client, django_assert_num_queries, event, slot
 
 
 @pytest.mark.django_db
-@pytest.mark.usefixtures("other_slot")
-def test_schedule_page_text_table_explicit_header(
-    client, django_assert_num_queries, event, slot
-):
+@pytest.mark.usefixtures('other_slot')
+def test_schedule_page_text_table_explicit_header(client, django_assert_num_queries, event, slot):
     url = event.urls.schedule
     with django_assert_num_queries(8):
-        response = client.get(url, follow=True, HTTP_ACCEPT="text/plain")
+        response = client.get(url, follow=True, HTTP_ACCEPT='text/plain')
     assert response.status_code == 200
     title_lines = textwrap.wrap(slot.submission.title, width=16)
     content = response.text
@@ -216,53 +203,49 @@ def test_schedule_page_text_table_explicit_header(
 
 
 @pytest.mark.parametrize(
-    "header,target",
+    'header,target',
     (
-        ("application/json", "frab_json"),
-        ("application/xml", "frab_xml"),
+        ('application/json', 'frab_json'),
+        ('application/xml', 'frab_xml'),
     ),
 )
 @pytest.mark.django_db
-@pytest.mark.usefixtures("slot", "other_slot")
-def test_schedule_page_redirects(
-    client, django_assert_num_queries, event, header, target
-):
+@pytest.mark.usefixtures('slot', 'other_slot')
+def test_schedule_page_redirects(client, django_assert_num_queries, event, header, target):
     url = event.urls.schedule
     with django_assert_num_queries(6):
         response = client.get(url, HTTP_ACCEPT=header)
     assert response.status_code == 303
-    assert response.headers["location"] == getattr(event.urls, target).full()
-    assert response.text == ""
+    assert response.headers['location'] == getattr(event.urls, target).full()
+    assert response.text == ''
 
 
 @pytest.mark.django_db
-@pytest.mark.usefixtures("other_slot")
+@pytest.mark.usefixtures('other_slot')
 def test_schedule_page_text_list(client, django_assert_num_queries, event, slot):
     url = event.urls.schedule
     with django_assert_num_queries(8):
-        response = client.get(url, {"format": "list"}, follow=True)
+        response = client.get(url, {'format': 'list'}, follow=True)
     assert response.status_code == 200
     assert slot.submission.title in response.text
 
 
 @pytest.mark.django_db
-@pytest.mark.usefixtures("other_slot")
-def test_schedule_page_text_wrong_format(
-    client, django_assert_num_queries, event, slot
-):
+@pytest.mark.usefixtures('other_slot')
+def test_schedule_page_text_wrong_format(client, django_assert_num_queries, event, slot):
     url = event.urls.schedule
     with django_assert_num_queries(8):
-        response = client.get(url, {"format": "wrong"}, follow=True)
+        response = client.get(url, {'format': 'wrong'}, follow=True)
     assert response.status_code == 200
     assert slot.submission.title[:10] in response.text
 
 
 @pytest.mark.django_db
 @pytest.mark.parametrize(
-    "version,queries_main,queries_versioned,queries_redirect",
-    (("js", 6, 8, 13), ("nojs", 7, 12, 16)),
+    'version,queries_main,queries_versioned,queries_redirect',
+    (('js', 6, 8, 13), ('nojs', 7, 12, 16)),
 )
-@pytest.mark.usefixtures("other_slot")
+@pytest.mark.usefixtures('other_slot')
 def test_versioned_schedule_page(
     client,
     django_assert_num_queries,
@@ -276,28 +259,28 @@ def test_versioned_schedule_page(
     queries_redirect,
 ):
     with scope(event=event):
-        event.release_schedule("new schedule")
+        event.release_schedule('new schedule')
         event.current_schedule.talks.update(is_visible=False)
-        test_string = "<pretalx-schedule" if version == "js" else slot.submission.title
+        test_string = '<pretalx-schedule' if version == 'js' else slot.submission.title
 
-    url = event.urls.schedule if version == "js" else event.urls.schedule_nojs
+    url = event.urls.schedule if version == 'js' else event.urls.schedule_nojs
     with django_assert_num_queries(queries_main):
-        response = client.get(url, follow=True, HTTP_ACCEPT="text/html")
-    if version == "js":
+        response = client.get(url, follow=True, HTTP_ACCEPT='text/html')
+    if version == 'js':
         # JS widget is displayed even on empty schedules
         assert test_string in response.text
     else:
         # But our talk has been made invisible
         assert test_string not in response.text
 
-    url = schedule.urls.public if version == "js" else schedule.urls.nojs
+    url = schedule.urls.public if version == 'js' else schedule.urls.nojs
     with django_assert_max_num_queries(queries_versioned):
-        response = client.get(url, follow=True, HTTP_ACCEPT="text/html")
+        response = client.get(url, follow=True, HTTP_ACCEPT='text/html')
     assert response.status_code == 200
     assert test_string in response.text
 
-    url = event.urls.schedule if version == "js" else event.urls.schedule_nojs
-    url += f"?version={quote(schedule.version)}"
+    url = event.urls.schedule if version == 'js' else event.urls.schedule_nojs
+    url += f'?version={quote(schedule.version)}'
     with django_assert_num_queries(queries_redirect):
-        redirected_response = client.get(url, follow=True, HTTP_ACCEPT="text/html")
+        redirected_response = client.get(url, follow=True, HTTP_ACCEPT='text/html')
     assert redirected_response._request.path == response._request.path

--- a/app/tests/talk/agenda/views/test_agenda_talks.py
+++ b/app/tests/talk/agenda/views/test_agenda_talks.py
@@ -7,46 +7,47 @@ from django_scopes import scope
 
 
 @pytest.mark.django_db
-@pytest.mark.usefixtures("slot", "other_slot")
-def test_can_see_talk_list(client, django_assert_num_queries, event):
-    with django_assert_num_queries(6):
-        response = client.get(event.urls.talks, follow=True, HTTP_ACCEPT="text/html")
+@pytest.mark.usefixtures('slot', 'other_slot')
+def test_can_see_talk_list(client, django_assert_max_num_queries, event):
+    with django_assert_max_num_queries(6):
+        response = client.get(event.urls.talks, follow=True, HTTP_ACCEPT='text/html')
     assert response.status_code == 200
-    assert "<pretalx-schedule" in response.text
+    assert '<pretalx-schedule' in response.text
+    assert 'pretalx-schedule-data' not in response.text
 
 
 @pytest.mark.django_db
-@pytest.mark.usefixtures("other_slot")
-def test_can_see_talk(client, django_assert_num_queries, event, slot):
-    with django_assert_num_queries(21):
-        response = client.get(slot.submission.urls.public, follow=True)
+@pytest.mark.usefixtures('other_slot')
+def test_can_see_talk(client, event, slot):
+    response = client.get(slot.submission.urls.public, follow=True)
     assert response.status_code == 200
     content = response.text
+    assert 'pretalx-schedule-data' in content
     with scope(event=event):
         assert content.count(slot.submission.title) >= 2  # meta+h1
         assert slot.submission.abstract in content
         assert slot.submission.description in content
-        assert formats.date_format(slot.local_start, "H:i") in content
-        assert formats.date_format(slot.local_end, "H:i") in content
+        assert formats.date_format(slot.local_start, 'H:i') in content
+        assert formats.date_format(slot.local_end, 'H:i') in content
         assert str(slot.room.name) in content
-        assert "fa-edit" not in content  # edit btn
-        assert "fa-video" not in content  # do not record
-        assert "<iframe" not in content  # test plugin not active
+        assert 'fa-edit' not in content  # edit btn
+        assert 'fa-video' not in content  # do not record
+        assert '<iframe' not in content  # test plugin not active
 
 
 @pytest.mark.django_db
-def test_can_see_talk_with_iframe(client, django_assert_num_queries, event, slot):
-    event.plugins = "tests"
+def test_can_see_talk_with_iframe(client, event, slot):
+    event.plugins = 'tests'
     event.save()
-    with django_assert_num_queries(21):
-        response = client.get(slot.submission.urls.public, follow=True)
+    response = client.get(slot.submission.urls.public, follow=True)
     assert response.status_code == 200
     content = response.text
-    assert "<iframe" in content
+    assert 'pretalx-schedule-data' in content
+    assert '<iframe' in content
 
 
 @pytest.mark.django_db
-@pytest.mark.usefixtures("other_slot")
+@pytest.mark.usefixtures('other_slot')
 def test_can_see_social_card(client, slot):
     response = client.get(slot.submission.urls.social_image, follow=True)
     assert response.status_code == 404  # no image
@@ -63,9 +64,7 @@ def test_cannot_see_new_talk(client, django_assert_num_queries, event, unrelease
 
 
 @pytest.mark.django_db
-def test_orga_can_see_new_talk(
-    orga_client, django_assert_num_queries, event, unreleased_slot
-):
+def test_orga_can_see_new_talk(orga_client, django_assert_num_queries, event, unreleased_slot):
     slot = unreleased_slot
     with django_assert_num_queries(24):
         response = orga_client.get(slot.submission.urls.public, follow=True)
@@ -76,23 +75,21 @@ def test_orga_can_see_new_talk(
         assert content.count(slot.submission.title) >= 2  # meta+h1
         assert slot.submission.abstract in content
         assert slot.submission.description in content
-        assert formats.date_format(slot.local_start, "H:i") in content
-        assert formats.date_format(slot.local_end, "H:i") in content
+        assert formats.date_format(slot.local_start, 'H:i') in content
+        assert formats.date_format(slot.local_end, 'H:i') in content
         assert str(slot.room.name) in content
-        assert "fa-edit" not in content  # edit btn
+        assert 'fa-edit' not in content  # edit btn
 
 
 @pytest.mark.django_db
-def test_can_see_talk_edit_btn(
-    orga_client, django_assert_num_queries, orga_user, event, slot
-):
+def test_can_see_talk_edit_btn(orga_client, django_assert_num_queries, orga_user, event, slot):
     with scope(event=event):
         slot.submission.speakers.add(orga_user)
     with django_assert_num_queries(25):
         response = orga_client.get(slot.submission.urls.public, follow=True)
     assert response.status_code == 200
     content = response.text
-    assert "fa-edit" in content  # edit btn
+    assert 'fa-edit' in content  # edit btn
 
 
 @pytest.mark.django_db
@@ -104,14 +101,12 @@ def test_can_see_talk_do_not_record(client, event, django_assert_num_queries, sl
         response = client.get(slot.submission.urls.public, follow=True)
     assert response.status_code == 200
     content = response.text
-    assert "fa-edit" not in content  # edit btn
-    assert "fa-video" in content
+    assert 'fa-edit' not in content  # edit btn
+    assert 'fa-video' in content
 
 
 @pytest.mark.django_db
-def test_can_see_talk_does_accept_feedback(
-    client, django_assert_num_queries, event, slot
-):
+def test_can_see_talk_does_accept_feedback(client, django_assert_num_queries, event, slot):
     with scope(event=event):
         slot.start = now() - dt.timedelta(days=1)
         slot.end = slot.start + dt.timedelta(hours=1)
@@ -120,8 +115,8 @@ def test_can_see_talk_does_accept_feedback(
         response = client.get(slot.submission.urls.public, follow=True)
     assert response.status_code == 200
     content = response.text
-    assert "fa-edit" not in content  # edit btn
-    assert "fa-comments" in content
+    assert 'fa-edit' not in content  # edit btn
+    assert 'fa-comments' in content
 
 
 @pytest.mark.django_db
@@ -134,9 +129,7 @@ def test_cannot_see_nonpublic_talk(client, django_assert_num_queries, event, slo
 
 
 @pytest.mark.django_db
-def test_cannot_see_other_events_talk(
-    client, django_assert_num_queries, event, slot, other_event
-):
+def test_cannot_see_other_events_talk(client, django_assert_num_queries, event, slot, other_event):
     with django_assert_num_queries(8):
         response = client.get(
             slot.submission.urls.public.replace(event.slug, other_event.slug),
@@ -153,75 +146,58 @@ def test_event_talk_visiblity_submitted(client, django_assert_num_queries, submi
 
 
 @pytest.mark.django_db
-@pytest.mark.usefixtures("slot")
-def test_event_talk_visiblity_accepted(
-    client, django_assert_num_queries, accepted_submission
-):
+@pytest.mark.usefixtures('slot')
+def test_event_talk_visiblity_accepted(client, django_assert_num_queries, accepted_submission):
     with django_assert_num_queries(10):
         response = client.get(accepted_submission.urls.public, follow=True)
     assert response.status_code == 404
 
 
 @pytest.mark.django_db
-@pytest.mark.usefixtures("slot")
-def test_event_talk_visiblity_confirmed(
-    client, django_assert_num_queries, confirmed_submission
-):
+@pytest.mark.usefixtures('slot')
+def test_event_talk_visiblity_confirmed(client, django_assert_num_queries, confirmed_submission):
     with django_assert_num_queries(20):
         response = client.get(confirmed_submission.urls.public, follow=True)
     assert response.status_code == 200
 
 
 @pytest.mark.django_db
-@pytest.mark.usefixtures("slot")
-def test_event_talk_visiblity_canceled(
-    client, django_assert_num_queries, canceled_submission
-):
+@pytest.mark.usefixtures('slot')
+def test_event_talk_visiblity_canceled(client, django_assert_num_queries, canceled_submission):
     with django_assert_num_queries(10):
         response = client.get(canceled_submission.urls.public, follow=True)
     assert response.status_code == 404
 
 
 @pytest.mark.django_db
-@pytest.mark.usefixtures("slot")
-def test_event_talk_visiblity_withdrawn(
-    client, django_assert_num_queries, withdrawn_submission
-):
+@pytest.mark.usefixtures('slot')
+def test_event_talk_visiblity_withdrawn(client, django_assert_num_queries, withdrawn_submission):
     with django_assert_num_queries(10):
         response = client.get(withdrawn_submission.urls.public, follow=True)
     assert response.status_code == 404
 
 
 @pytest.mark.django_db
-@pytest.mark.usefixtures("slot", "other_slot")
-def test_talk_speaker_other_submissions(
-    client, django_assert_num_queries, event, speaker, other_submission
-):
+@pytest.mark.usefixtures('slot', 'other_slot')
+def test_talk_speaker_other_submissions(client, django_assert_num_queries, event, speaker, other_submission):
     with scope(event=event):
         other_submission.speakers.add(speaker)
     with django_assert_num_queries(22):
         response = client.get(other_submission.urls.public, follow=True)
 
     assert response.status_code == 200
-    assert response.context["speakers"]
-    assert len(response.context["speakers"]) == 2, response.context["speakers"]
-    speaker_response = [
-        s for s in response.context["speakers"] if s.fullname == speaker.fullname
-    ][0]
-    other_response = [
-        s for s in response.context["speakers"] if s.fullname != speaker.fullname
-    ][0]
+    assert response.context['speakers']
+    assert len(response.context['speakers']) == 2, response.context['speakers']
+    speaker_response = [s for s in response.context['speakers'] if s.fullname == speaker.fullname][0]
+    other_response = [s for s in response.context['speakers'] if s.fullname != speaker.fullname][0]
     assert len(speaker_response.other_submissions) == 1
     assert len(other_response.other_submissions) == 0
     with scope(event=event):
-        assert (
-            speaker_response.other_submissions[0].title
-            == speaker.submissions.first().title
-        )
+        assert speaker_response.other_submissions[0].title == speaker.submissions.first().title
 
 
 @pytest.mark.django_db
-@pytest.mark.usefixtures("other_slot")
+@pytest.mark.usefixtures('other_slot')
 def test_talk_speaker_other_submissions_only_if_visible(
     client,
     django_assert_num_queries,
@@ -234,24 +210,18 @@ def test_talk_speaker_other_submissions_only_if_visible(
         other_submission.speakers.add(speaker)
         slot.submission.accept(force=True)
         slot.submission.save()
-        event.wip_schedule.freeze("testversion 2")
+        event.wip_schedule.freeze('testversion 2')
         other_submission.slots.all().update(is_visible=True)
-        slot.submission.slots.filter(schedule=event.current_schedule).update(
-            is_visible=False
-        )
+        slot.submission.slots.filter(schedule=event.current_schedule).update(is_visible=False)
 
     with django_assert_num_queries(22):
         response = client.get(other_submission.urls.public, follow=True)
 
     assert response.status_code == 200
-    assert response.context["speakers"]
-    assert len(response.context["speakers"]) == 2, response.context["speakers"]
-    speaker_response = [
-        s for s in response.context["speakers"] if s.fullname == speaker.fullname
-    ][0]
-    other_response = [
-        s for s in response.context["speakers"] if s.fullname != speaker.fullname
-    ][0]
+    assert response.context['speakers']
+    assert len(response.context['speakers']) == 2, response.context['speakers']
+    speaker_response = [s for s in response.context['speakers'] if s.fullname == speaker.fullname][0]
+    other_response = [s for s in response.context['speakers'] if s.fullname != speaker.fullname][0]
     assert len(speaker_response.other_submissions) == 0
     assert len(other_response.other_submissions) == 0
 

--- a/app/tests/talk/agenda/views/test_agenda_widget.py
+++ b/app/tests/talk/agenda/views/test_agenda_widget.py
@@ -2,11 +2,9 @@ import pytest
 from django_scopes import scope
 
 
+@pytest.mark.parametrize('url', ('widgets/schedule.js', 'schedule/widgets/schedule.json'))
 @pytest.mark.parametrize(
-    "url", ("widgets/schedule.js", "schedule/widgets/schedule.json")
-)
-@pytest.mark.parametrize(
-    "show_schedule,show_widget_if_not_public,expected",
+    'show_schedule,show_widget_if_not_public,expected',
     (
         (True, False, 200),
         (True, True, 200),
@@ -15,7 +13,7 @@ from django_scopes import scope
     ),
 )
 @pytest.mark.django_db
-@pytest.mark.usefixtures("slot", "other_slot")
+@pytest.mark.usefixtures('slot', 'other_slot')
 def test_widget_pages(
     event,
     client,
@@ -24,57 +22,68 @@ def test_widget_pages(
     show_widget_if_not_public,
     expected,
 ):
-    event.feature_flags["show_schedule"] = show_schedule
-    event.feature_flags["show_widget_if_not_public"] = show_widget_if_not_public
+    event.feature_flags['show_schedule'] = show_schedule
+    event.feature_flags['show_widget_if_not_public'] = show_widget_if_not_public
     event.save()
     response = client.get(event.urls.base + url, follow=True)
     assert response.status_code == expected
 
 
 @pytest.mark.django_db
-@pytest.mark.usefixtures("slot", "other_slot")
+@pytest.mark.usefixtures('slot', 'other_slot')
 def test_widget_data(
     client,
     event,
     django_assert_num_queries,
 ):
-    event.feature_flags["show_schedule"] = True
+    event.feature_flags['show_schedule'] = True
     event.save()
     with django_assert_num_queries(14):
-        response = client.get(
-            event.urls.schedule + "widgets/schedule.json", follow=True
-        )
+        response = client.get(event.urls.schedule + 'widgets/schedule.json', follow=True)
     assert response.status_code == 200
 
 
 @pytest.mark.django_db
-@pytest.mark.usefixtures("slot")
+@pytest.mark.usefixtures('slot', 'other_slot')
+def test_widget_data_enriched(client, event):
+    event.feature_flags['show_schedule'] = True
+    event.save()
+
+    response = client.get(event.urls.schedule + 'widgets/schedule.json?enrich=1', follow=True)
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload['talks']
+    assert 'exporters' in payload['talks'][0]
+    assert 'exporters' in payload['speakers'][0]
+
+
+@pytest.mark.django_db
+@pytest.mark.usefixtures('slot')
 def test_versioned_widget_data(client, event, schedule):
     with scope(event=event):
-        event.wip_schedule.freeze("new")
+        event.wip_schedule.freeze('new')
 
-    response = client.get(
-        event.urls.schedule + f"widgets/schedule.json?v={schedule.version}"
-    )
+    response = client.get(event.urls.schedule + f'widgets/schedule.json?v={schedule.version}')
     assert response.status_code == 200
 
 
 @pytest.mark.django_db
-@pytest.mark.usefixtures("slot")
+@pytest.mark.usefixtures('slot')
 def test_bogus_versioned_widget_data(client, event):
-    response = client.get(event.urls.schedule + "widgets/schedule.json?v=nopedinope")
+    response = client.get(event.urls.schedule + 'widgets/schedule.json?v=nopedinope')
     assert response.status_code == 200
 
 
 @pytest.mark.django_db
-@pytest.mark.usefixtures("slot")
+@pytest.mark.usefixtures('slot')
 def test_anon_cannot_access_wip_schedule(client, event):
-    response = client.get(event.urls.schedule + "widgets/schedule.json?v=wip")
+    response = client.get(event.urls.schedule + 'widgets/schedule.json?v=wip')
     assert response.status_code == 404
 
 
 @pytest.mark.django_db
-@pytest.mark.usefixtures("slot")
+@pytest.mark.usefixtures('slot')
 def test_orga_can_access_wip_schedule(orga_client, event):
-    response = orga_client.get(event.urls.schedule + "widgets/schedule.json?v=wip")
+    response = orga_client.get(event.urls.schedule + 'widgets/schedule.json?v=wip')
     assert response.status_code == 200

--- a/deployment/nginx/enext-direct
+++ b/deployment/nginx/enext-direct
@@ -3,6 +3,19 @@ server {
 
 	access_log /var/log/nginx/<SERVER_NAME>-access.log;
     error_log /var/log/nginx/<SERVER_NAME>-error.log;
+
+	gzip on;
+	gzip_vary on;
+	gzip_proxied any;
+	gzip_comp_level 6;
+	gzip_types
+		text/plain
+		text/css
+		text/javascript
+		application/javascript
+		application/json
+		image/svg+xml;
+	gzip_min_length 1024;
 	
 	set $cors_origin "";
     set $cors_allowed_origin 0;
@@ -81,8 +94,16 @@ server {
 		proxy_redirect off;
   	}
 
+	location ~* ^/static/.+\.[0-9a-f]{8,}\.(js|css|woff2?|ttf|eot|png|svg|ico)$ {
+		root <PATH_TO>/data;
+		access_log off;
+		add_header Cache-Control "public, max-age=31536000, immutable" always;
+	}
+
 	location /static/ {
 		alias <PATH_TO>/data/static/;
+		access_log off;
+		add_header Cache-Control "public, max-age=3600" always;
 	}
 
 	location /media/ {


### PR DESCRIPTION
this pr resolves:
- slow loading on deployed public schedule pages caused by serving the schedule widget through django and embedding a large schedule payload in the html.

by making the following changes:
- load the public schedule widget from the static asset path so it can benefit from normal compression and caching
- remove the large inline schedule payload from the main public schedule pages and fetch enriched schedule data only when needed
- keep talk and public starred-session pages self-contained by preserving inline schedule data where widget visibility rules differ
- add explicit support for enriched widget json on first-party agenda pages and keep the nginx compression/cache improvements