### PR TITLE
Speed up speakers page loading

### DIFF
--- a/app/eventyay/agenda/templates/agenda/speakers.html
+++ b/app/eventyay/agenda/templates/agenda/speakers.html
@@ -15,7 +15,7 @@
 <div>
     <script type="text/javascript" src="{% static 'schedule/pretalx-schedule.js' %}" async></script>
     {% with event_tz=request.event.settings.timezone|default:request.event.timezone %}
-    <pretalx-schedule event-url="{{ request.event.urls.base }}" locale="{{ request.LANGUAGE_CODE }}" view="speakers" enrich-data style="--pretalx-clr-primary: {{ request.event.visible_primary_color }}"></pretalx-schedule>
+    <pretalx-schedule event-url="{{ request.event.urls.base }}" locale="{{ request.LANGUAGE_CODE }}" view="speakers" style="--pretalx-clr-primary: {{ request.event.visible_primary_color }}"></pretalx-schedule>
     {% endwith %}
 </div>
 {% html_signal "eventyay.agenda.signals.html_below_speakers_list" sender=request.event request=request %}

--- a/app/eventyay/agenda/views/speaker.py
+++ b/app/eventyay/agenda/views/speaker.py
@@ -1,5 +1,4 @@
 import io
-from collections import defaultdict
 from urllib.parse import quote, urlparse
 
 import vobject
@@ -47,16 +46,7 @@ class SpeakerList(EventPermissionRequired, Filterable, ListView):
             .select_related('user', 'event', 'event__organizer')
             .order_by('user__fullname')
         )
-        qs = self.filter_queryset(qs)
-
-        speaker_mapping = defaultdict(list)
-        for talk in self.request.event.talks.all().prefetch_related('speakers'):
-            for speaker in talk.speakers.all():
-                speaker_mapping[speaker.code].append(talk)
-
-        for profile in qs:
-            profile.talks = speaker_mapping[profile.user.code]
-        return qs
+        return self.filter_queryset(qs)
 
     def get_context_data(self, **kwargs):
         return super().get_context_data(**kwargs)


### PR DESCRIPTION
- drop dead code - all the talks * speaker loading is nowhere used
- don't load with enrich, since we don't have any QR codes there, and the rest is loaded from vue

## Summary by Sourcery

Simplify speaker listing to rely on filtered speaker profiles only and remove unnecessary data enrichment for the speakers view.

Enhancements:
- Remove unused server-side aggregation of talks per speaker from the speakers view queryset.
- Disable client-side data enrichment for the speakers schedule component on the speakers page to reduce overhead.