### PR TITLE
Improvements to schedule loading

### DIFF
--- a/app/eventyay/base/models/schedule.py
+++ b/app/eventyay/base/models/schedule.py
@@ -52,12 +52,15 @@ if TYPE_CHECKING:
     from .track import Track
 
 
-@lru_cache(maxsize=512)
+@lru_cache(maxsize=16384)
 def make_qr_svg(url: str) -> str:
     """Generate an SVG QR code string for the given URL.
 
     Results are cached because the same export URLs are generated on every
-    schedule page load and QR encoding is CPU-intensive.
+    schedule page load and QR encoding is CPU-intensive. The cache needs to
+    be large enough to hold (6 exports × talks) + (6 exports × speakers)
+    entries for the biggest event on a given process; 512 thrashed on
+    mid-sized events.
     """
     image = qr_lib.make(url, image_factory=SvgPathFillImage)
     return xml_tostring(image.get_image()).decode()
@@ -808,22 +811,31 @@ class Schedule(PretalxModel):
         show_do_not_record = self.event.cfp.request_do_not_record
         base_url = str(self.event.urls.base)
         full_base_url = str(self.event.urls.base.full())
+        # Resolve recording providers once; providers are event-level, not per-talk.
+        recording_providers = []
+        if enrich:
+            for __, response in register_recording_provider.send_robust(self.event):
+                if (
+                    response
+                    and not isinstance(response, Exception)
+                    and getattr(response, 'get_recording', None)
+                ):
+                    recording_providers.append(response)
         for talk in talk_list:
             # Only add room if it's not deleted
             if talk.room and not talk.room.deleted:
                 rooms.add(talk.room)
             if talk.submission:
                 tracks.add(talk.submission.track)
-                speakers |= set(talk.submission.speakers.all())
+                talk_speakers = list(talk.submission.speakers.all())
+                speakers.update(talk_speakers)
                 talk_data = {
-                    'code': talk.submission.code if talk.submission else None,
+                    'code': talk.submission.code,
                     'id': talk.id,
-                    'title': (talk.submission.title if talk.submission else talk.description),
-                    'abstract': (talk.submission.abstract if talk.submission else None),
-                    'description': (talk.submission.description if talk.submission else None),
-                    'speakers': (
-                        [speaker.code for speaker in talk.submission.speakers.all()] if talk.submission else None
-                    ),
+                    'title': talk.submission.title,
+                    'abstract': talk.submission.abstract,
+                    'description': talk.submission.description,
+                    'speakers': [speaker.code for speaker in talk_speakers],
                     'track': talk.submission.track_id if talk.submission else None,
                     'start': talk.local_start,
                     'end': talk.local_end,
@@ -913,16 +925,11 @@ class Schedule(PretalxModel):
                     }
                     # Recording iframe from provider plugins
                     recording_iframe = ''
-                    for __, response in register_recording_provider.send_robust(self.event):
-                        if (
-                            response
-                            and not isinstance(response, Exception)
-                            and getattr(response, 'get_recording', None)
-                        ):
-                            rec = response.get_recording(talk.submission)
-                            if rec and rec.get('iframe'):
-                                recording_iframe = rec['iframe']
-                                break
+                    for provider in recording_providers:
+                        rec = provider.get_recording(talk.submission)
+                        if rec and rec.get('iframe'):
+                            recording_iframe = rec['iframe']
+                            break
                     talk_data['recording_iframe'] = recording_iframe
                 result['talks'].append(talk_data)
             else:


### PR DESCRIPTION
- make qr lru cache bigger, even med size meetings will have more than 512 entries since we need 6 entries per talk/speaker.
- recording providers resolved once before the per-talk loop
- talk.submission.speakers.all() materialized once into talk_speakers per talk and reused

## Summary by Sourcery

Optimize schedule building performance and QR code caching for event exports.

Enhancements:
- Increase the QR code SVG LRU cache size to better accommodate exports for larger events without cache thrashing.
- Pre-resolve recording provider plugins once per schedule build instead of per talk to avoid redundant signal processing.
- Reuse a materialized speakers list per talk when building schedule data to reduce repeated database queries and set operations.