### PR TITLE
Fix horizontal scrollbar on schedule page and in fullscreen view

### DIFF
--- a/app/eventyay/static/agenda/css/_agenda.css
+++ b/app/eventyay/static/agenda/css/_agenda.css
@@ -98,6 +98,15 @@ body.page-agenda .featured-page #featured-talks .talk-title small {
   line-height: 1.4;
 }
 
+/* Prevent page-level horizontal scrollbar on schedule pages. */
+body.page-agenda {
+  overflow-x: clip;
+}
+/* Same for html root in browsers that support :has(). */
+html:has(body.page-agenda) {
+  overflow-x: clip;
+}
+
 #main-container.list-schedule {
   min-width: 0;
 }
@@ -171,6 +180,9 @@ body.page-agenda .featured-page #featured-talks .talk-title small {
 
 #main-container.main-schedule {
   margin: 0 auto;
+  /* clip (not hidden) so sticky positioning inside is not broken. */
+  overflow-x: clip;
+  max-width: min(1600px, 100vw);
   #main-card {
     margin: 0 auto;
     main {
@@ -179,7 +191,6 @@ body.page-agenda .featured-page #featured-talks .talk-title small {
     }
   }
 
-  /* The container main now provides the 5px padding. We can set it to 0 or leave as minimal here. */
   pretalx-schedule[view="schedule"],
   #fahrplan {
     padding: 0 !important;
@@ -198,13 +209,24 @@ body.page-agenda .featured-page #featured-talks .talk-title small {
 }
 
 #main-container #fahrplan {
-  overflow: visible;
+  /* auto makes #fahrplan the Vue component's scroll parent (findScrollParent
+   * skips clip/hidden); browser scrollbar hidden because the component
+   * renders its own custom scroll thumb. */
+  overflow-x: auto;
+  overflow-y: visible;
+  scrollbar-width: none;
   width: 100%;
+  max-width: 100%;
   box-sizing: border-box;
+
+  &::-webkit-scrollbar {
+    display: none;
+  }
 
   pretalx-schedule {
     display: block;
     width: 100%;
+    max-width: 100%;
     --pretalx-sticky-top-offset: 40px;
   }
 }

--- a/app/eventyay/webapp/schedule/src/App.vue
+++ b/app/eventyay/webapp/schedule/src/App.vue
@@ -998,7 +998,8 @@ export default {
 		background: #fff
 		padding: 0
 		margin: 0
-		overflow: auto
+		overflow-y: auto
+		overflow-x: hidden
 		--pretalx-sticky-top-offset: 0px
 		> .c-schedule-toolbar
 			border-bottom: 1px solid $clr-dividers-light


### PR DESCRIPTION
## Summary

Fixes the horizontal scrollbar that appears on the schedule page at typical laptop resolutions (13–15 inch, e.g. 1366×768), and in fullscreen view.

## Root Cause

The Vue `pretalx-schedule` component calls `findScrollParent()` on mount to measure its container width. `findScrollParent()` (utils.js) only recognises `overflow: auto | scroll` — it skips `clip`, `hidden`, and `visible`. Without a recognised scroll parent, it falls back to `document.body.offsetWidth`, which can be inflated by overflowing content, producing a page-level scrollbar.

## Changes

**`app/eventyay/static/agenda/css/_agenda.css`**
- `#fahrplan { overflow-x: auto; scrollbar-width: none }` — registers `#fahrplan` as the Vue component's scroll parent so it                    measures the correct container width; browser scrollbar hidden because the component renders its own custom scroll thumb
- `body.page-agenda { overflow-x: clip }` and `#main-container.main-schedule` backstops to prevent any residual bleed to document level

**`app/eventyay/webapp/schedule/src/App.vue`**
- `.pretalx-schedule:fullscreen`: `overflow: auto` → `overflow-y: auto; overflow-x: hidden` to fix the scrollbar in fullscreen/full-page view

## Testing

Verified locally with Docker at 1366×768 viewport:
- `document.body.scrollWidth` (1337px) < `window.innerWidth` (1352px) 
- No horizontal scrollbar on the schedule page 
- No horizontal scrollbar in fullscreen mode 

Fixes #3274

## Summary by Sourcery

Prevent horizontal scrollbars on the schedule page and in fullscreen schedule view by constraining layout and adjusting scroll containers.

Bug Fixes:
- Eliminate page-level horizontal scrolling on agenda schedule pages at common laptop resolutions.
- Remove unwanted horizontal scrollbar when the schedule is viewed in fullscreen mode.

Enhancements:
- Constrain the main schedule container and schedule component to the viewport width while preserving sticky positioning behavior.

## Screenshots

### Before
> Horizontal scrollbar visible on schedule page and fullscreen view

### After – Schedule Page (No Horizontal Scrollbar)
<img width="1918" height="906" alt="schedule_page" src="https://github.com/user-attachments/assets/d49aa62a-9740-4ab6-af80-804ddc20662d" />


### After – Fullscreen View (No  Horizontal Scrollbar)
<img width="1919" height="1079" alt="full_screen_view" src="https://github.com/user-attachments/assets/63b9825e-e55d-4062-89d0-9267401ada3a" />
