### PR TITLE
fix(schedule): prevent page-level horizontal scrollbar on laptop viewports

### DIFF
--- a/app/eventyay/static/agenda/css/_agenda.css
+++ b/app/eventyay/static/agenda/css/_agenda.css
@@ -171,6 +171,7 @@ body.page-agenda .featured-page #featured-talks .talk-title small {
 
 #main-container.main-schedule {
   margin: 0 auto;
+  overflow-x: clip;
   #main-card {
     margin: 0 auto;
     main {
@@ -205,6 +206,7 @@ body.page-agenda .featured-page #featured-talks .talk-title small {
   pretalx-schedule {
     display: block;
     width: 100%;
+    max-width: 100%;
     --pretalx-sticky-top-offset: 40px;
   }
 }

--- a/app/eventyay/webapp/schedule/src/App.vue
+++ b/app/eventyay/webapp/schedule/src/App.vue
@@ -1013,6 +1013,9 @@ export default {
 			border-bottom: 1px solid $clr-dividers-light
 	&.grid-schedule
 		margin: 0 auto
+		min-width: 0
+		width: 100%
+		overflow-x: clip
 	&.list-schedule
 		min-width: 0
 	&.speaker-view

--- a/app/eventyay/webapp/schedule/src/components/GridSchedule.vue
+++ b/app/eventyay/webapp/schedule/src/components/GridSchedule.vue
@@ -586,8 +586,9 @@ export default {
 <style lang="stylus">
 .c-grid-schedule
 	flex: auto
+	min-width: 0
 	background-color: $clr-grey-50
-	--room-col-min: 320px
+	--room-col-min: 280px
 	.sticky-header
 		position: sticky
 		top: calc(var(--pretalx-sticky-top-offset, 0px) + var(--pretalx-toolbar-height, 30px) + var(--pretalx-version-warning-height, 0px) - 1px)
@@ -772,9 +773,9 @@ export default {
 	.rooms-inner
 		grid-template-columns: 96px repeat(var(--total-rooms), minmax(var(--room-col-min), 1fr)) auto
 
-@media (max-width: 600px)
+@media (max-width: 768px)
 	.c-grid-schedule
-		--room-col-min: 240px
+		--room-col-min: 200px
 
 @media print
 	.c-grid-schedule


### PR DESCRIPTION
Fixes #3274

## What changed

- **`GridSchedule.vue`**: Reduced `--room-col-min` from `320px` to `280px` (desktop) and `200px` on screens <=768px. This allows typical 3-4 room schedules to fit natively within 1280-1366px laptop viewports without triggering a page-level scrollbar. Added `min-width: 0` and `overflow-x: clip` to `.c-grid-schedule` to bound the flex container. `width: 100%` was omitted since `flex: auto` already fills available space. `overflow-x: clip` is used rather than `hidden` because `hidden` would make `.sticky-header` stick relative to this non-scrolling ancestor instead of the viewport.
- **`App.vue`**: Added `min-width: 0`, `width: 100%`, and `overflow-x: clip` to `.pretalx-schedule.grid-schedule` to bound the web component root. `clip` is used rather than `hidden` to preserve `position: sticky` on the toolbar and timeslice labels.
- **`_agenda.css`**: Added `overflow-x: clip` to `#main-container.main-schedule` and `max-width: 100%` to the `pretalx-schedule` custom element to contain the full-page schedule view, which was also showing a spurious scrollbar.

## Why this approach

The grid schedule already has its own custom in-component horizontal scrollbar for when room count genuinely exceeds viewport width. The page-level scrollbar was caused by flex children not being bounded by `min-width: 0`. `overflow-x: clip` is used throughout rather than `hidden` because `hidden` creates a scroll container that silently breaks `position: sticky` on descendant elements (the rooms bar, toolbar).

## Verified

- No horizontal scrollbar at 1280px and 1366px viewport widths with 3-4 rooms
- Internal custom scrollbar still activates correctly when many rooms are present
- `position: sticky` toolbar and timeslice labels remain functional
- Full-page view (`/schedule/`) no longer shows a spurious bottom scrollbar
- Print layout unaffected


## Screenshots
<img width="1607" height="954" alt="Screenshot 2026-04-17 at 01-28-49 " src="https://github.com/user-attachments/assets/0d5567bb-2a36-484f-97dd-df6bd23af025" />

## Summary by Sourcery

Adjust schedule layout styles to prevent unwanted page-level horizontal scrollbars while preserving the internal grid scrollbar and sticky headers.

Bug Fixes:
- Prevent horizontal page scrollbars on laptop and full-page schedule views by constraining the grid schedule and main schedule containers.

Enhancements:
- Reduce minimum room column widths and adjust responsive breakpoint so typical schedules fit within common laptop viewport widths without overflow.
- Ensure schedule containers take full available width while remaining bounded via min-width and max-width constraints.

## Summary by Sourcery

Adjust schedule layout styling to prevent unwanted horizontal page scrollbars while preserving the internal grid scroll behavior and sticky headers.

Bug Fixes:
- Eliminate unintended horizontal page-level scrollbars on laptop viewports for embedded and full-page schedule views by constraining schedule containers.

Enhancements:
- Reduce minimum room column widths and adjust the responsive breakpoint so typical multi-room schedules fit within common laptop viewport widths without overflowing.
- Constrain schedule root and grid containers with min/max width and horizontal clipping to keep layout within the viewport while maintaining sticky header behavior.