### PR TITLE
allow localhost values in SITE_URL

### DIFF
--- a/app/eventyay/config/settings.py
+++ b/app/eventyay/config/settings.py
@@ -1488,5 +1488,6 @@ if IS_DEVELOPMENT:
         ALLOWED_HOSTS = list(dict.fromkeys([*ALLOWED_HOSTS, '10.0.2.2', '10.0.3.2']))
     # Trust standard local and emulator origins for CSRF
     CSRF_TRUSTED_ORIGINS += ['http://localhost:8000', 'http://127.0.0.1:8000', 'http://10.0.2.2:8000', 'http://10.0.3.2:8000']
-    # Use relative URLs to remain host-agnostic
-    if 'localhost' in TALK_HOSTNAME: TALK_HOSTNAME = ''
+    # Use a relative talk hostname locally to keep talk links host-agnostic
+    if 'localhost' in TALK_HOSTNAME:
+        TALK_HOSTNAME = ''

--- a/app/eventyay/config/settings.py
+++ b/app/eventyay/config/settings.py
@@ -1488,6 +1488,3 @@ if IS_DEVELOPMENT:
         ALLOWED_HOSTS = list(dict.fromkeys([*ALLOWED_HOSTS, '10.0.2.2', '10.0.3.2']))
     # Trust standard local and emulator origins for CSRF
     CSRF_TRUSTED_ORIGINS += ['http://localhost:8000', 'http://127.0.0.1:8000', 'http://10.0.2.2:8000', 'http://10.0.3.2:8000']
-    # Use a relative talk hostname locally to keep talk links host-agnostic
-    if 'localhost' in TALK_HOSTNAME:
-        TALK_HOSTNAME = ''

--- a/app/eventyay/config/settings.py
+++ b/app/eventyay/config/settings.py
@@ -1489,5 +1489,4 @@ if IS_DEVELOPMENT:
     # Trust standard local and emulator origins for CSRF
     CSRF_TRUSTED_ORIGINS += ['http://localhost:8000', 'http://127.0.0.1:8000', 'http://10.0.2.2:8000', 'http://10.0.3.2:8000']
     # Use relative URLs to remain host-agnostic
-    if 'localhost' in SITE_URL: SITE_URL = ''
     if 'localhost' in TALK_HOSTNAME: TALK_HOSTNAME = ''


### PR DESCRIPTION
by deleting the condition that emptied SITE_URL when it contained localhost

## Summary by Sourcery

Adjust local development settings related to host configuration.

Bug Fixes:
- Preserve SITE_URL even when it contains localhost instead of forcibly clearing it.

Enhancements:
- Retain TALK_HOSTNAME reset behavior for localhost while no longer altering SITE_URL.