### PR TITLE
fix: replace incorrect HTTP 503 with correct status codes

### DIFF
--- a/app/eventyay/api/views/event.py
+++ b/app/eventyay/api/views/event.py
@@ -468,9 +468,8 @@ class EventThemeView(APIView):
                 kwargs["event_id"],
             )
             return Response(
-                "error happened when trying to get theme data of event: "
-                + kwargs["event_id"],
-                status=503,
+                {"detail": "Theme configuration not found for this event."},
+                status=404,
             )
 
 

--- a/app/eventyay/api/views/order.py
+++ b/app/eventyay/api/views/order.py
@@ -555,7 +555,8 @@ class OrderViewSet(viewsets.ModelViewSet):
         except SendMailException:
             return Response(
                 {'detail': _('There was an error sending the mail. Please try again later.')},
-                status=status.HTTP_503_SERVICE_UNAVAILABLE,
+                # ✅ FIXED
+                status=status.HTTP_500_INTERNAL_SERVER_ERROR,       
             )
 
         return Response(status=status.HTTP_204_NO_CONTENT)

--- a/app/eventyay/api/views/submission.py
+++ b/app/eventyay/api/views/submission.py
@@ -525,7 +525,7 @@ class SubmissionFavouriteDeprecatedView(View):
             return JsonResponse(
                 {"error": str(e)},
                 safe=False,
-                status=status.HTTP_503_SERVICE_UNAVAILABLE,
+                status=status.HTTP_500_INTERNAL_SERVER_ERROR,
             )
 
     @staticmethod
@@ -578,7 +578,7 @@ class SubmissionFavouriteDeprecatedView(View):
             return JsonResponse(
                 {"error": str(e)},
                 safe=False,
-                status=status.HTTP_503_SERVICE_UNAVAILABLE,
+                status=status.HTTP_500_INTERNAL_SERVER_ERROR,
             )
 
     @staticmethod


### PR DESCRIPTION
## What this PR does
Fixes 4 places where HTTP 503 (Service Unavailable) was incorrectly 
used for non-infrastructure errors.

## Changes
| File | Line | Before | After |
|------|------|--------|-------|
| api/views/event.py | 473 | 503 | 404 |
| api/views/order.py | 558 | 503 | 500 |
| api/views/submission.py | 528 | 503 | 500 |
| api/views/submission.py | 581 | 503 | 500 |

Closes #ISSUE_NUMBER

## Summary by Sourcery

Correct HTTP status codes and error responses for event theme retrieval, order resend link, and submission endpoints.

Bug Fixes:
- Return 404 with a structured error payload when an event theme configuration is missing instead of an unstructured 503 response.
- Use HTTP 500 instead of 503 for errors when resending order links fails due to mail-sending issues.
- Use HTTP 500 instead of 503 for unexpected errors in submission GET and POST handlers.