### PR TITLE
chore: featured session never default and video join button fixes

### DIFF
--- a/app/eventyay/agenda/views/featured.py
+++ b/app/eventyay/agenda/views/featured.py
@@ -1,10 +1,9 @@
 from django.contrib.auth.models import AnonymousUser
-from django.http import HttpResponsePermanentRedirect, HttpResponseRedirect
+from django.http import HttpResponsePermanentRedirect
 from django.utils.functional import cached_property
 from django.views.generic import TemplateView
 from django_context_decorator import context
 
-from eventyay.common.permissions import is_admin_mode_active
 from eventyay.common.views.mixins import EventPermissionRequired
 from eventyay.base.models.submission import SubmissionStates
 from eventyay.talk_rules.submission import are_featured_submissions_visible
@@ -21,8 +20,6 @@ class FeaturedView(EventPermissionRequired, TemplateView):
     def has_permission(self):
         """Gate on org "show featured" + schedule rules, not ``list_featured`` (orga always passes that)."""
         request = self.request
-        if is_admin_mode_active(request):
-            return True
         user = getattr(request, 'user', None)
         if user is None:
             return False
@@ -49,11 +46,3 @@ class FeaturedView(EventPermissionRequired, TemplateView):
     @cached_property
     def hide_visibility_warning(self):
         return are_featured_submissions_visible(AnonymousUser(), self.request.event)
-
-    def dispatch(self, request, *args, **kwargs):
-        can_see_featured = self.has_permission()
-        can_schedule = request.user.has_perm('base.list_schedule', request.event)
-
-        if not can_see_featured and can_schedule:
-            return HttpResponseRedirect(request.event.urls.schedule)
-        return super().dispatch(request, *args, **kwargs)

--- a/app/eventyay/base/models/event.py
+++ b/app/eventyay/base/models/event.py
@@ -192,7 +192,7 @@ FEATURE_FLAGS = [
 def default_feature_flags():
     return {
         'show_schedule': True,
-        'show_featured': 'after_schedule',
+        'show_featured': 'never',
         'show_widget_if_not_public': False,
         'session_popularity_enabled': False,
         'session_popularity_show_on_calendar': True,

--- a/app/eventyay/common/templates/common/base_public.html
+++ b/app/eventyay/common/templates/common/base_public.html
@@ -163,7 +163,7 @@
                             {% endif %}
                         </div>
                         {% if show_online_video_link %}
-                            <div class="header-join-video-floating-mobile d-md-none">
+                            <div class="header-join-video-floating-mobile">
                                     <a href="{% if request.resolver_match.namespace == 'agenda' %}{% url 'agenda:event.onlinevideo.join' organizer=current_event.organizer.slug event=current_event.slug %}{% else %}{% eventurl current_event 'presale:event.onlinevideo.join' %}{% endif %}" class="btn btn-primary btn-join-video-icon-only join-video-link d-flex align-items-center justify-content-center" title="{% translate "Join online video" %}">
                                         <i class="fa fa-video-camera" aria-hidden="true"></i>
                                         <span class="join-video-text">{% translate "Join online video" %}</span>

--- a/app/eventyay/common/templates/common/base_public.html
+++ b/app/eventyay/common/templates/common/base_public.html
@@ -169,7 +169,7 @@
                                 {% eventurl current_event 'presale:event.onlinevideo.join' as join_event_url %}
                             {% endif %}
                             <div class="header-join-video-floating-mobile">
-                                    <a href="{{ join_event_url }}" class="btn btn-primary btn-join-video-icon-only join-video-link d-flex align-items-center justify-content-center" title="{% translate "Join online video" %}">
+                                    <a href="{{ join_event_url }}" class="btn btn-primary btn-join-video-icon-only join-video-link d-flex align-items-center justify-content-center" title="{% translate 'Join online video' %}" aria-label="{% translate 'Join online video' %}">
                                         <i class="fa fa-video-camera" aria-hidden="true"></i>
                                         <span class="join-video-text">{% translate "Join online video" %}</span>
                                     </a>

--- a/app/eventyay/common/templates/common/base_public.html
+++ b/app/eventyay/common/templates/common/base_public.html
@@ -163,8 +163,13 @@
                             {% endif %}
                         </div>
                         {% if show_online_video_link %}
+                            {% if request.resolver_match.namespace == 'agenda' %}
+                                {% url 'agenda:event.onlinevideo.join' organizer=current_event.organizer.slug event=current_event.slug as join_event_url %}
+                            {% else %}
+                                {% eventurl current_event 'presale:event.onlinevideo.join' as join_event_url %}
+                            {% endif %}
                             <div class="header-join-video-floating-mobile">
-                                    <a href="{% if request.resolver_match.namespace == 'agenda' %}{% url 'agenda:event.onlinevideo.join' organizer=current_event.organizer.slug event=current_event.slug %}{% else %}{% eventurl current_event 'presale:event.onlinevideo.join' %}{% endif %}" class="btn btn-primary btn-join-video-icon-only join-video-link d-flex align-items-center justify-content-center" title="{% translate "Join online video" %}">
+                                    <a href="{{ join_event_url }}" class="btn btn-primary btn-join-video-icon-only join-video-link d-flex align-items-center justify-content-center" title="{% translate "Join online video" %}">
                                         <i class="fa fa-video-camera" aria-hidden="true"></i>
                                         <span class="join-video-text">{% translate "Join online video" %}</span>
                                     </a>

--- a/app/eventyay/common/templatetags/event_tags.py
+++ b/app/eventyay/common/templatetags/event_tags.py
@@ -7,7 +7,6 @@ from django.urls import reverse
 from django_scopes import scopes_disabled
 
 from eventyay.base.models import Order, OrderPosition
-from eventyay.common.permissions import is_admin_mode_active
 from eventyay.talk_rules.submission import are_featured_submissions_visible
 
 register = template.Library()
@@ -165,8 +164,6 @@ def can_view_featured_sessions_public(context, event=None):
     event = event or getattr(request, 'event', None)
     if not request or not event:
         return False
-    if is_admin_mode_active(request):
-        return True
     user = getattr(request, 'user', None)
     if user is None:
         return False

--- a/app/eventyay/static/cfp/css/_layout.css
+++ b/app/eventyay/static/cfp/css/_layout.css
@@ -309,7 +309,7 @@ header {
   min-width: 0;
   border-radius: 6px;
   box-shadow: 0 3px 8px rgba(0, 0, 0, 0.18);
-  background-color: var(--Color-primary, var(--color-primary));
+  background-color: var(--color-primary);
   color: white;
   border: none;
   font-size: 0.82rem;

--- a/app/eventyay/static/cfp/css/_layout.css
+++ b/app/eventyay/static/cfp/css/_layout.css
@@ -284,6 +284,81 @@ header {
   display: inline-flex;
   border-radius: 14px;
   background: transparent;
+  position: relative;
+}
+
+/* Join online video: button on the event hero (all breakpoints). Nav tab duplicate is hidden. */
+#header-tabs .join-video-link {
+  display: none;
+}
+
+.header-join-video-floating-mobile {
+  position: absolute;
+  bottom: -27.5px;
+  right: 7.5px;
+  z-index: 1050;
+}
+
+.header-join-video-floating-mobile .btn-join-video-icon-only {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 6px;
+  padding: 2px 6px;
+  height: 28px;
+  min-width: 0;
+  border-radius: 6px;
+  box-shadow: 0 3px 8px rgba(0, 0, 0, 0.18);
+  background-color: var(--Color-primary, var(--color-primary));
+  color: white;
+  border: none;
+  font-size: 0.82rem;
+  font-weight: 500;
+  line-height: 1;
+}
+
+@media (max-width: 319px) {
+  .header-join-video-floating-mobile .btn-join-video-icon-only {
+    width: 32px;
+    height: 32px;
+    padding: 0;
+    border-radius: 50%;
+    border: none;
+  }
+
+  .header-join-video-floating-mobile .btn-join-video-icon-only .join-video-text {
+    display: none;
+  }
+
+  .header-join-video-floating-mobile .btn-join-video-icon-only i {
+    font-size: 0.95rem;
+  }
+}
+
+.header-join-video-floating-mobile .btn-join-video-icon-only .join-video-text {
+  display: inline-block;
+}
+
+.header-join-video-floating-mobile .btn-join-video-icon-only:hover,
+.header-join-video-floating-mobile .btn-join-video-icon-only:focus {
+  transform: scale(1.02);
+  box-shadow: 0 6px 18px rgba(0, 0, 0, 0.22);
+  color: white !important;
+  background-color: var(--color-primary);
+  filter: none;
+}
+
+@media (min-width: 769px) {
+  body.page-agenda .event-hero-overlay {
+    display: flex;
+    width: 100%;
+    padding-left: 0;
+    padding-right: 0;
+  }
+
+  body.page-agenda .header-join-video-floating-mobile {
+    right: 0;
+  }
 }
 
 .event-hero-text {
@@ -658,67 +733,6 @@ footer {
     font-size: 0.9rem;
   }
 
-  /* Hide the navbar join link on mobile, as it is now floating below the hero */
-  #header-tabs .join-video-link {
-    display: none !important;
-  }
-
-  .header-join-video-floating-mobile {
-    position: absolute;
-    bottom: -27.5px;
-    right: 7.5px;
-    z-index: 1050;
-    
-    /* Button for mobile/tablet: compact with icon + text */
-    .btn-join-video-icon-only {
-      display: inline-flex;
-      align-items: center;
-      justify-content: center;
-      gap: 6px;
-      padding: 2px 6px;
-      height: 28px;
-      min-width: 0;
-      border-radius: 6px;
-      box-shadow: 0 3px 8px rgba(0,0,0,0.18);
-      background-color: var(--Color-primary, var(--color-primary));
-      color: white;
-      border: none;
-      font-size: 0.82rem;
-      font-weight: 500;
-      line-height: 1;
-    }
-
-    /* Very small screens (phones): make it a compact circular icon-only button */
-    /* Restrict the icon-only behavior to < 320px so 320px devices show the text */
-    @media (max-width: 319px) {
-      .btn-join-video-icon-only {
-        width: 32px;
-        height: 32px;
-        padding: 0;
-        border-radius: 50%;
-        border: none;
-      }
-      .btn-join-video-icon-only .join-video-text {
-        display: none;
-      }
-      .btn-join-video-icon-only i {
-        font-size: 0.95rem;
-      }
-    }
-
-    .btn-join-video-icon-only .join-video-text {
-      display: inline-block;
-    }
-
-    .btn-join-video-icon-only:hover, .btn-join-video-icon-only:focus {
-      transform: scale(1.02);
-      box-shadow: 0 6px 18px rgba(0,0,0,0.22);
-      color: white !important;
-      background-color: var(--color-primary);
-      filter: none;
-    }
-  }
-
   .event-hero-overlay {
     position: relative;
     display: flex;
@@ -762,7 +776,7 @@ footer {
 
   #main-container {
     padding: 0;
-    padding-top: 20px;
+    padding-top: 24px;
     width: 100%;
     margin-top: 1.5rem;
 
@@ -858,13 +872,12 @@ footer {
   }
 }
 
-/* Hide mobile-only navbar icons, CfS short text, and floating join button on desktop */
-.nav-icon-mobile, .cfs-short, .header-join-video-floating-mobile {
+.nav-icon-mobile, .cfs-short {
   display: none;
 }
 
 @media (max-width: 768px) {
-  .nav-icon-mobile, .header-join-video-floating-mobile {
+  .nav-icon-mobile {
     display: block;
   }
   .nav-icon-mobile {

--- a/app/eventyay/static/common/css/base.css
+++ b/app/eventyay/static/common/css/base.css
@@ -56,6 +56,12 @@ legend {
   object-fit: contain;
 }
 
+@media (min-width: 769px) {
+  #main-container.presale-container #event-logo {
+    padding-left: 1rem;
+  }
+}
+
 button,
 [role="button"],
 a.btn,

--- a/app/eventyay/static/pretixpresale/scss/custom.css
+++ b/app/eventyay/static/pretixpresale/scss/custom.css
@@ -219,6 +219,19 @@ header .header-row-right {
     display: none;
 }
 
+@media (min-width: 769px) {
+    .event-hero-overlay {
+        display: flex;
+        width: 100%;
+        padding-left: 0;
+        padding-right: 0;
+    }
+
+    .header-join-video-floating-mobile {
+        right: 0;
+    }
+}
+
 @media (max-width: 768px) {
     .presale-sticky-tabs {
         flex-direction: row;
@@ -295,25 +308,6 @@ header .header-row-right {
         display: inline;
     }
 
-    .join-video-link {
-        display: block;
-        width: 100%;
-        text-align: center;
-        padding: 8px 12px;
-        margin: 4px 0 0;
-        background: var(--color-primary);
-        color: white !important;
-        border-radius: var(--size-border-radius, 4px);
-        border-bottom: none !important;
-        font-size: 0.88rem;
-        font-weight: 500;
-    }
-
-    .join-video-link:hover {
-        background: var(--color-primary-dark, var(--color-primary));
-        text-decoration: none;
-        opacity: 0.9;
-    }
 
     .login-link {
         display: flex;

--- a/app/eventyay/static/pretixpresale/scss/custom.scss
+++ b/app/eventyay/static/pretixpresale/scss/custom.scss
@@ -184,15 +184,23 @@
     display: none;
 }
 
-/* Align the hero title/logo horizontal edge with the content text below */
-.event-hero-overlay {
-    padding-left: 1rem;
-    padding-right: 1rem;
-}
-
 /* Desktop: hide mobile-only CfS abbreviation */
 .cfs-short {
     display: none;
+}
+
+/* Desktop: keep hero overlay full-width so floating Join Video aligns to page edge. */
+@media (min-width: 769px) {
+    .event-hero-overlay {
+        display: flex;
+        width: 100%;
+        padding-left: 0;
+        padding-right: 0;
+    }
+
+    .header-join-video-floating-mobile {
+        right: 0;
+    }
 }
 
 @media (max-width: 768px) {
@@ -280,26 +288,6 @@
         display: inline;
     }
 
-    /* "Join online video" as a full-width button below the nav row */
-    .join-video-link {
-        display: block;
-        width: 100%;
-        text-align: center;
-        padding: 8px 12px;
-        margin: 4px 0 0;
-        background: var(--color-primary);
-        color: white !important;
-        border-radius: var(--size-border-radius, 4px);
-        border-bottom: none !important;
-        font-size: 0.88rem;
-        font-weight: 500;
-    }
-
-    .join-video-link:hover {
-        background: var(--color-primary-dark, var(--color-primary));
-        text-decoration: none;
-        opacity: 0.9;
-    }
 
     /* Logged-out login link: icon-only on mobile, like the icon dropdowns */
     .login-link {

--- a/app/eventyay/talk_rules/submission.py
+++ b/app/eventyay/talk_rules/submission.py
@@ -56,7 +56,7 @@ def _show_featured_setting(event):
     if 'show_featured' in flags and flags['show_featured'] is not None:
         raw = flags['show_featured']
     else:
-        raw = defaults.get('show_featured', 'after_schedule')
+        raw = defaults.get('show_featured', 'never')
     if isinstance(raw, bool):
         return 'always' if raw else 'never'
     if isinstance(raw, str):
@@ -66,7 +66,7 @@ def _show_featured_setting(event):
         # Migrate legacy value saved before rename.
         if normalized == 'pre_schedule':
             return 'after_schedule'
-    return defaults.get('show_featured', 'after_schedule')
+    return defaults.get('show_featured', 'never')
 
 
 def _event_has_published_schedule(event):

--- a/app/tests/talk/agenda/views/test_agenda_featured.py
+++ b/app/tests/talk/agenda/views/test_agenda_featured.py
@@ -25,6 +25,20 @@ def test_featured_invisible_because_setting(
         assert response.url == event.urls.featured
 
 
+@pytest.mark.django_db
+def test_featured_invisible_when_setting_unset(
+    client, django_assert_max_num_queries, event, confirmed_submission
+):
+    with scope(event=event):
+        event.feature_flags.pop("show_featured", None)
+        event.save()
+        confirmed_submission.is_featured = True
+        confirmed_submission.save()
+    with django_assert_max_num_queries(9):
+        response = client.get(event.urls.featured, follow=True)
+    assert response.status_code == 404
+
+
 @pytest.mark.parametrize("featured", ("always", "never", "after_schedule"))
 @pytest.mark.django_db
 def test_featured_invisible_because_schedule(

--- a/app/tests/talk/agenda/views/test_agenda_featured.py
+++ b/app/tests/talk/agenda/views/test_agenda_featured.py
@@ -51,13 +51,10 @@ def test_featured_invisible_because_schedule(
     with django_assert_max_num_queries(8):
         response = client.get(event.urls.featured)
 
-    if featured != "always":
-        # there might be multiple redirects to correct trailing slashes, so the
-        # one we're looking for is not always the last one.
-        assert response.status_code == 302
-        assert response.url == event.urls.schedule
-    else:
+    if featured == "always":
         assert response.status_code == 200
+    else:
+        assert response.status_code == 404
 
 
 @pytest.mark.django_db
@@ -96,3 +93,18 @@ def test_featured_talk_list(
     content = response.text
     assert confirmed_submission.title in content
     assert other_confirmed_submission.title not in content
+
+
+@pytest.mark.django_db
+def test_featured_never_blocks_admin_mode_direct_url(client, event, administrator, confirmed_submission, monkeypatch):
+    with scope(event=event):
+        event.feature_flags['show_featured'] = 'never'
+        event.save()
+        confirmed_submission.is_featured = True
+        confirmed_submission.save()
+
+    monkeypatch.setattr(type(administrator), 'has_active_staff_session', lambda self, session_key: True)
+    client.force_login(administrator)
+
+    response = client.get(event.urls.featured)
+    assert response.status_code == 404

--- a/app/tests/talk/agenda/views/test_agenda_schedule.py
+++ b/app/tests/talk/agenda/views/test_agenda_schedule.py
@@ -79,6 +79,18 @@ def test_cannot_see_schedule_by_setting(client, user, event, featured):
 
 @pytest.mark.django_db
 @pytest.mark.usefixtures('slot', 'other_slot')
+def test_cannot_see_schedule_by_default_featured_setting(client, user, event):
+    with scope(event=event):
+        event.feature_flags['show_schedule'] = False
+        event.feature_flags.pop('show_featured', None)
+        event.save()
+        assert not user.has_perm('schedule.list_schedule', event)
+    response = client.get(event.urls.schedule, HTTP_ACCEPT='text/html')
+    assert response.status_code == 404
+
+
+@pytest.mark.django_db
+@pytest.mark.usefixtures('slot', 'other_slot')
 @pytest.mark.parametrize('featured', ('always', 'never', 'after_schedule'))
 def test_cannot_see_no_schedule(client, user, event, featured):
     with scope(event=event):

--- a/app/tests/talk/common/test_common_templatetags.py
+++ b/app/tests/talk/common/test_common_templatetags.py
@@ -1,6 +1,7 @@
 import pytest
 from django_scopes import scope
 
+from eventyay.common.templatetags.event_tags import can_view_featured_sessions_public
 from pretalx.common.templatetags.copyable import copyable
 from pretalx.common.templatetags.html_signal import html_signal
 from pretalx.common.templatetags.rich_text import rich_text
@@ -114,3 +115,26 @@ class MockEncodeDict(dict):
 class FakeRequest:
     def __init__(self, get):
         self.GET = MockEncodeDict(get)
+
+
+@pytest.mark.django_db
+def test_can_view_featured_sessions_public_respects_never_with_staff_session(event, user, rf):
+    with scope(event=event):
+        event.feature_flags['show_featured'] = 'never'
+        event.save()
+
+    request = rf.get('/')
+    request.event = event
+    request.user = user
+
+    class FakeSession:
+        session_key = 'staff-session'
+
+    request.session = FakeSession()
+
+    def always_active_staff_session(session_key):
+        return session_key == 'staff-session'
+
+    user.has_active_staff_session = always_active_staff_session
+
+    assert can_view_featured_sessions_public({'request': request}, event=event) is False


### PR DESCRIPTION
<img width="1454" height="709" alt="Screenshot 2026-04-18 at 9 25 04 PM" src="https://github.com/user-attachments/assets/e2d790e6-baac-4ab3-a22d-35b48db2ae93" />

## Summary by Sourcery

Adjust online video join button placement across breakpoints and change featured sessions to be hidden by default.

Bug Fixes:
- Ensure the floating 'Join online video' button is visible and correctly aligned across agenda and presale views instead of relying on a mobile-only navbar link.

Enhancements:
- Unify hero overlay layout on desktop so floating action buttons align with page edges.
- Tweak main container padding for better spacing beneath the event hero.

Chores:
- Change the default feature flag so featured sessions are not shown unless explicitly enabled, and update the corresponding flag resolution logic.