### PR TITLE
Fix missing "Create a new event" label on Talk dashboard

### DIFF
--- a/app/eventyay/orga/templates/orga/event_list.html
+++ b/app/eventyay/orga/templates/orga/event_list.html
@@ -30,6 +30,7 @@
                 {% if can_create_event %}
                     <a class="dashboard-block symbol" href="{% url "eventyay_common:events.add" %}">
                         <i class="fa fa-plus-circle" title="{% translate "Create a new event" %}"></i>
+                        <div class="dashboard-description">{% translate "Create a new event" %}</div>
                     </a>
                 {% endif %}
             </div>

--- a/app/eventyay/orga/templates/orga/event_list.html
+++ b/app/eventyay/orga/templates/orga/event_list.html
@@ -28,9 +28,9 @@
                     {% include "orga/includes/dashboard_block_event.html" %}
                 {% endfor %}
                 {% if can_create_event %}
-                    <a class="dashboard-block symbol" href="{% url "eventyay_common:events.add" %}">
-                        <i class="fa fa-plus-circle" title="{% translate "Create a new event" %}"></i>
-                        <div class="dashboard-description">{% translate "Create a new event" %}</div>
+                    <a class="dashboard-block symbol" href="{% url 'eventyay_common:events.add' %}">
+                        <i class="fa fa-plus-circle" aria-hidden="true"></i>
+                        <div class="dashboard-description">{% translate 'Create a new event' %}</div>
                     </a>
                 {% endif %}
             </div>


### PR DESCRIPTION
Fixes #3340

<img width="800" height="600" alt="Screenshot 2026-04-20 235609" src="https://github.com/user-attachments/assets/6271b696-92b0-4dde-a627-6fb244942f71" />

## Summary by Sourcery

New Features:
- Display a descriptive "Create a new event" text label alongside the create-event icon on the dashboard.