### PR TITLE
Fix: Resolve TODO - Make 'Join online event' label translatable

### DIFF
--- a/app/eventyay/base/email.py
+++ b/app/eventyay/base/email.py
@@ -482,8 +482,8 @@ def base_placeholders(sender: Event, **kwargs):
     )
     def render_video_join_link(event: Event, order) -> str:
         url = build_join_video_url(event, order)
-        # TODO: Make the label translatable.
-        return f'<a href="{url}" class="button">Join online event</a>'
+
+        return f'<a href="{url}" class="button">{_("Join online event")}</a>'
     ph = [
         SimpleFunctionalMailTextPlaceholder('event', ['event'], lambda event: event.name, lambda event: event.name),
         SimpleFunctionalMailTextPlaceholder(


### PR DESCRIPTION
## Description

This PR resolves a TODO comment found at `app/eventyay/base/email.py` line 485:

# TODO: Make the label translatable.

## Changes

- Removed the `# TODO: Make the label translatable` comment
- Wrapped the hardcoded string `'Join online event'` with Django's `gettext_lazy` translation function `_()`

## Before

```python
# TODO: Make the label translatable.
return f'<a href="{url}" class="button">Join online event</a>'
```

## After

```python
return f'<a href="{url}" class="button">{_("Join online event")}</a>'
```

## Notes

- `gettext_lazy` was already imported as `_` in the file, so no new imports were needed.
- This ensures the button label can be translated into other languages via Django's i18n system.

## Summary by Sourcery

Bug Fixes:
- Allow the "Join online event" button text in email templates to be localized via Django's i18n system.