### PR TITLE
fix: replace generic Exception with PermissionDenied in check_access_…

### DIFF
--- a/app/eventyay/base/models/organizer.py
+++ b/app/eventyay/base/models/organizer.py
@@ -6,7 +6,7 @@ from urllib.parse import urlencode
 from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
 
 from django.conf import settings
-from django.core.exceptions import PermissionDenied
+from werkzeug.exceptions import PermissionDenied
 from django.core.validators import MinLengthValidator, RegexValidator
 from django.db import models, transaction
 from django.db.models import Exists, OuterRef, Q

--- a/app/eventyay/base/models/organizer.py
+++ b/app/eventyay/base/models/organizer.py
@@ -6,7 +6,7 @@ from urllib.parse import urlencode
 from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
 
 from django.conf import settings
-from werkzeug.exceptions import PermissionDenied
+from django.core.exceptions import PermissionDenied
 from django.core.validators import MinLengthValidator, RegexValidator
 from django.db import models, transaction
 from django.db.models import Exists, OuterRef, Q

--- a/app/eventyay/base/models/organizer.py
+++ b/app/eventyay/base/models/organizer.py
@@ -47,7 +47,7 @@ def check_access_permissions(organizer):
     warnings = []
     teams = organizer.teams.all().annotate(member_count=models.Count('members')).filter(member_count__gt=0)
     if not [t for t in teams if t.can_change_teams]:
-        # TODO: Should use a concrete exception type
+        
         raise PermissionDenied(
             _(
                 'There must be at least one team with the permission to change teams, '
@@ -72,7 +72,6 @@ def check_access_permissions(organizer):
     for event in organizer.events.all():
         event_teams = teams.filter(models.Q(limit_events=event) | models.Q(all_events=True)).distinct()
         if not event_teams:
-            # TODO: Should use a concrete exception type
             raise PermissionDenied(
                 str(
                     _(

--- a/app/eventyay/base/models/organizer.py
+++ b/app/eventyay/base/models/organizer.py
@@ -47,7 +47,6 @@ def check_access_permissions(organizer):
     warnings = []
     teams = organizer.teams.all().annotate(member_count=models.Count('members')).filter(member_count__gt=0)
     if not [t for t in teams if t.can_change_teams]:
-        
         raise PermissionDenied(
             _(
                 'There must be at least one team with the permission to change teams, '

--- a/app/eventyay/base/models/organizer.py
+++ b/app/eventyay/base/models/organizer.py
@@ -6,6 +6,7 @@ from urllib.parse import urlencode
 from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
 
 from django.conf import settings
+from django.core.exceptions import PermissionDenied
 from django.core.validators import MinLengthValidator, RegexValidator
 from django.db import models, transaction
 from django.db.models import Exists, OuterRef, Q
@@ -47,7 +48,7 @@ def check_access_permissions(organizer):
     teams = organizer.teams.all().annotate(member_count=models.Count('members')).filter(member_count__gt=0)
     if not [t for t in teams if t.can_change_teams]:
         # TODO: Should use a concrete exception type
-        raise Exception(
+        raise PermissionDenied(
             _(
                 'There must be at least one team with the permission to change teams, '
                 'as otherwise nobody can create new teams or grant permissions to existing teams.'
@@ -72,7 +73,7 @@ def check_access_permissions(organizer):
         event_teams = teams.filter(models.Q(limit_events=event) | models.Q(all_events=True)).distinct()
         if not event_teams:
             # TODO: Should use a concrete exception type
-            raise Exception(
+            raise PermissionDenied(
                 str(
                     _(
                         'There must be at least one team with access to every event. '


### PR DESCRIPTION
Fixes #3353 

### Summary
Replaced generic Exception with PermissionDenied in check_access_permissions.

### Changes
- Added PermissionDenied import
- Replaced generic Exception with PermissionDenied in two places

### Notes
- Focused PR (single change)
- Follows existing TODO comment

## Summary by Sourcery

Use a concrete permission error when validating organizer access permissions.

Bug Fixes:
- Raise PermissionDenied instead of a generic Exception when no team can change teams for an organizer.
- Raise PermissionDenied instead of a generic Exception when no team has access to every event for an organizer.