### PR TITLE
Fix: Prevent duplicate badge options for add-on tickets

### DIFF
--- a/app/eventyay/plugins/badges/signals.py
+++ b/app/eventyay/plugins/badges/signals.py
@@ -112,6 +112,8 @@ def event_copy_data_receiver(sender, other, question_map, product_map, **kwargs)
 
 @receiver(question_form_fields, dispatch_uid='badges_question_form_fields')
 def badge_question_form_fields(sender, position, **kwargs):
+     if position.addon_to_id:
+        return {}
     layout = get_badge_layout_for_position(sender, position)
     if not layout or not layout.allow_customization:
         return {}


### PR DESCRIPTION
"This PR addresses issue #3141. The badge options field was duplicating because the signal triggered for every ticket position. I have added a check in signals.py to ensure it doesn't render for add-on tickets. Verified the logic in the codebase."

## Summary by Sourcery

Bug Fixes:
- Avoid duplicate badge options by skipping badge question form fields for add-on ticket positions.