### PR TITLE
fix: change_password AttributeError referencing nonexistent self.name

### DIFF
--- a/app/eventyay/base/models/auth.py
+++ b/app/eventyay/base/models/auth.py
@@ -763,8 +763,13 @@ the eventyay robot"""
         self.pw_reset_time = None
         self.save()
 
+        if not self.email:
+            # Cannot send confirmation without an email address
+            self.log_action(action='eventyay.user.password.changed', user=self)
+            return
+
         context = {
-            'name': self.name or '',
+            'name': self.fullname or '',
         }
         mail_text = _(
             """Hi {name},

--- a/app/tests/talk/person/test_user_model.py
+++ b/app/tests/talk/person/test_user_model.py
@@ -1,4 +1,5 @@
 import pytest
+from django.core import mail as djmail
 from django_scopes import scope, scopes_disabled
 
 from pretalx.person.models.user import User, avatar_path
@@ -117,3 +118,41 @@ def test_user_reset_password_without_text(orga_user, event):
         orga_user.reset_password(event)
         orga_user.refresh_from_db()
         assert orga_user.pw_reset_token
+
+
+@pytest.mark.django_db
+def test_user_change_password_sends_mail_and_logs_action(orga_user):
+    djmail.outbox = []
+    old_password = orga_user.password
+    old_log_count = orga_user.own_actions().filter(action_type='eventyay.user.password.changed').count()
+
+    orga_user.change_password('newsecurepassword123')
+    orga_user.refresh_from_db()
+
+    assert orga_user.password != old_password
+    assert orga_user.check_password('newsecurepassword123')
+    assert len(djmail.outbox) == 1
+    assert djmail.outbox[0].to == [orga_user.email]
+    assert (
+        orga_user.own_actions().filter(action_type='eventyay.user.password.changed').count()
+        == old_log_count + 1
+    )
+
+
+@pytest.mark.django_db
+def test_user_change_password_without_email_logs_and_skips_mail(orga_user):
+    orga_user.email = ''
+    orga_user.save(update_fields=['email'])
+
+    djmail.outbox = []
+    old_log_count = orga_user.own_actions().filter(action_type='eventyay.user.password.changed').count()
+
+    orga_user.change_password('newsecurepassword123')
+    orga_user.refresh_from_db()
+
+    assert orga_user.check_password('newsecurepassword123')
+    assert len(djmail.outbox) == 0
+    assert (
+        orga_user.own_actions().filter(action_type='eventyay.user.password.changed').count()
+        == old_log_count + 1
+    )


### PR DESCRIPTION
### Description

Closes : #3399

- Replaced self.name with self.fullname in User.change_password context
- Added early return for users lacking an email address (e.g. kiosk) to prevent failure when sending the confirmation email
- Fixes issue where password changes roll back due to AttributeError

## Summary by Sourcery

Fix password change flow for users without email and correct use of the user name field in confirmation emails.

Bug Fixes:
- Prevent password changes from rolling back due to accessing a nonexistent user name attribute in the confirmation email context.
- Avoid errors when sending password change confirmation for users without an email address by skipping the email and only logging the action.