### PR TITLE
fix: log.py duplicate import, bare except, and user.name bugs

### DIFF
--- a/app/eventyay/base/models/log.py
+++ b/app/eventyay/base/models/log.py
@@ -153,7 +153,7 @@ class LogEntry(models.Model):
                 return ''
 
             co = self.content_object
-        except Exception:
+        except Exception:Exception
             return ''
         a_map = None
         a_text = None

--- a/app/eventyay/base/models/log.py
+++ b/app/eventyay/base/models/log.py
@@ -11,7 +11,6 @@ from django.utils.functional import cached_property
 from django.utils.html import escape
 from django.utils.translation import gettext_lazy as _
 from django.utils.translation import pgettext_lazy
-from django_scopes import ScopedManager
 
 from eventyay.base.signals import logentry_object_link
 
@@ -76,7 +75,7 @@ class LogEntry(models.Model):
     def __str__(self):
         """Custom __str__ to help with debugging."""
         event = getattr(self.event, 'slug', 'None')
-        user = getattr(self.user, 'name', 'None')
+        user = getattr(self.user, 'email', 'None')
         return (
             f'LogEntry(event={event}, user={user}, content_object={self.content_object}, '
             f'action_type={self.action_type})'
@@ -154,7 +153,7 @@ class LogEntry(models.Model):
                 return ''
 
             co = self.content_object
-        except:
+        except Exception:
             return ''
         a_map = None
         a_text = None
@@ -338,7 +337,7 @@ class ActivityLog(models.Model):
     def __str__(self):
         """Custom __str__ to help with debugging."""
         event = getattr(self.event, 'slug', 'None')
-        person = getattr(self.person, 'name', 'None')
+        person = getattr(self.person, 'email', 'None')
         return (
             f'ActivityLog(event={event}, person={person}, content_object={self.content_object}, '
             f'action_type={self.action_type})'

--- a/app/eventyay/base/models/log.py
+++ b/app/eventyay/base/models/log.py
@@ -153,7 +153,7 @@ class LogEntry(models.Model):
                 return ''
 
             co = self.content_object
-        except Exception:Exception
+               except Exception:
             return ''
         a_map = None
         a_text = None


### PR DESCRIPTION
### Description


- Remove duplicate import of ScopedManager
- Change LogEntry.__str__ user.name to user.email
- Change ActivityLog.__str__ person.name to person.email
- Replace bare except in display_object with except Exception

## Summary by Sourcery

Improve logging models’ string representations and exception handling for safer debugging output.

Bug Fixes:
- Use user email instead of name in LogEntry string representation to avoid relying on a potentially missing name field.
- Use person email instead of name in ActivityLog string representation to avoid relying on a potentially missing name field.
- Replace a bare except in display_object with an explicit Exception handler to prevent unintended exception swallowing.