### PR TITLE
fix: replace break with continue to prevent dropped webhooks

### DIFF
--- a/app/eventyay/api/webhooks.py
+++ b/app/eventyay/api/webhooks.py
@@ -259,6 +259,39 @@ def register_default_webhook_events(sender, **kwargs):
     )
 
 
+# @app.task(base=TransactionAwareTask, max_retries=9, default_retry_delay=900, acks_late=True)
+# def notify_webhooks(logentry_ids: list):
+#     if not isinstance(logentry_ids, list):
+#         logentry_ids = [logentry_ids]
+#     qs = LogEntry.all.select_related('event', 'event__organizer').filter(id__in=logentry_ids)
+#     _org, _at, webhooks = None, None, None
+#     for logentry in qs:
+#         if not logentry.organizer:
+#             break  # We need to know the organizer
+
+#         notification_type = logentry.webhook_type
+
+#         if not notification_type:
+#             break  # Ignore, no webhooks for this event type
+
+#         if _org != logentry.organizer or _at != logentry.action_type or webhooks is None:
+#             _org = logentry.organizer
+#             _at = logentry.action_type
+
+#             # All webhooks that registered for this notification
+#             event_listener = WebHookEventListener.objects.filter(
+#                 webhook=OuterRef('pk'), action_type=notification_type.action_type
+#             )
+#             webhooks = WebHook.objects.annotate(has_el=Exists(event_listener)).filter(
+#                 organizer=logentry.organizer, has_el=True, enabled=True
+#             )
+#             if logentry.event_id:
+#                 webhooks = webhooks.filter(Q(all_events=True) | Q(limit_events__pk=logentry.event_id))
+
+#         for wh in webhooks:
+#             send_webhook.apply_async(args=(logentry.id, notification_type.action_type, wh.pk))
+
+
 @app.task(base=TransactionAwareTask, max_retries=9, default_retry_delay=900, acks_late=True)
 def notify_webhooks(logentry_ids: list):
     if not isinstance(logentry_ids, list):
@@ -267,12 +300,22 @@ def notify_webhooks(logentry_ids: list):
     _org, _at, webhooks = None, None, None
     for logentry in qs:
         if not logentry.organizer:
-            break  # We need to know the organizer
+            logger.debug(
+                'Skipping webhook notification for log entry %d: no organizer',
+                logentry.id,
+            )
+            continue  # We need to know the organizer, skip this entry
 
         notification_type = logentry.webhook_type
 
         if not notification_type:
-            break  # Ignore, no webhooks for this event type
+            logger.debug(
+                'Skipping webhook notification for log entry %d: '
+                'no matching webhook event type for %s',
+                logentry.id,
+                logentry.action_type,
+            )
+            continue  # Ignore, no webhooks for this event type
 
         if _org != logentry.organizer or _at != logentry.action_type or webhooks is None:
             _org = logentry.organizer
@@ -290,7 +333,6 @@ def notify_webhooks(logentry_ids: list):
 
         for wh in webhooks:
             send_webhook.apply_async(args=(logentry.id, notification_type.action_type, wh.pk))
-
 
 @app.task(base=ProfiledTask, bind=True, max_retries=9, acks_late=True)
 def send_webhook(self, logentry_id: int, action_type: str, webhook_id: int):


### PR DESCRIPTION
## Description
Fixed a critical bug in the `notify_webhooks` Celery task where early-exit conditions used `break` instead of `continue`. This behavior previously caused the loop to terminate prematurely, silently dropping all remaining webhook notifications in the batch if a single log entry was missing an organizer or webhook type.

This patch replaces `break` with `continue` and adds `logger.debug` statements to track skipped entries without aborting the entire dispatch process.

Fixes #3400

## Motivation and Context
This fix resolves a high-severity issue causing silent data loss in webhook notification delivery. It ensures that all valid log entries in a batch are processed and dispatched, even if one entry in the batch is invalid.

## How Has This Been Tested?
- Verified the Celery task loop logic to ensure `continue` correctly skips invalid entries and proceeds to the next `logentry` in `qs`.
- Confirmed that `logger.debug` statements utilize the properly initialized `logger` at the top of the file.
- Ensured no existing webhook logic was modified outside of the early-exit conditions.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code refactor or cleanup (changes to existing code for improved readability or performance)

## Summary by Sourcery

Ensure webhook dispatch continues processing all log entries instead of aborting the batch when an entry is invalid.

Bug Fixes:
- Prevent webhook batches from terminating early when a log entry lacks an organizer or webhook type, avoiding silent dropping of subsequent notifications.

Enhancements:
- Add debug logging for skipped webhook log entries to aid in diagnosing missing organizer or webhook type conditions.