### PR TITLE
fix: resolve duplicate import, bare except, and user.name bugs in log.py

### DIFF
--- a/app/eventyay/base/models/log.py
+++ b/app/eventyay/base/models/log.py
@@ -11,7 +11,6 @@ from django.utils.functional import cached_property
 from django.utils.html import escape
 from django.utils.translation import gettext_lazy as _
 from django.utils.translation import pgettext_lazy
-from django_scopes import ScopedManager
 
 from eventyay.base.signals import logentry_object_link
 
@@ -76,7 +75,7 @@ class LogEntry(models.Model):
     def __str__(self):
         """Custom __str__ to help with debugging."""
         event = getattr(self.event, 'slug', 'None')
-        user = getattr(self.user, 'name', 'None')
+        user = str(self.user) if self.user else 'None'
         return (
             f'LogEntry(event={event}, user={user}, content_object={self.content_object}, '
             f'action_type={self.action_type})'
@@ -154,7 +153,7 @@ class LogEntry(models.Model):
                 return ''
 
             co = self.content_object
-        except:
+        except Exception:
             return ''
         a_map = None
         a_text = None
@@ -338,7 +337,7 @@ class ActivityLog(models.Model):
     def __str__(self):
         """Custom __str__ to help with debugging."""
         event = getattr(self.event, 'slug', 'None')
-        person = getattr(self.person, 'name', 'None')
+        person = str(self.person) if self.person else 'None'
         return (
             f'ActivityLog(event={event}, person={person}, content_object={self.content_object}, '
             f'action_type={self.action_type})'


### PR DESCRIPTION
Fixes #3401

- Remove duplicate ScopedManager import (line 5 and line 14)

- Replace bare except: with except Exception: to prevent silently catching SystemExit/KeyboardInterrupt

- Fix getattr(self.user, 'name', 'None') to str(self.user) if self.user else 'None' in LogEntry.__str__

- Fix getattr(self.person, 'name', 'None') to str(self.person) if self.person else 'None' in ActivityLog.__str__

## Summary by Sourcery

Refine logging models to improve robustness and accuracy of debug output.

Bug Fixes:
- Avoid accessing a non-existent name attribute in LogEntry.__str__ by consistently stringifying the related user object.
- Avoid accessing a non-existent name attribute in ActivityLog.__str__ by consistently stringifying the related person object.
- Prevent the log display_object helper from swallowing system-level exceptions by replacing a bare except with an explicit Exception handler.