### PR TITLE
chore: session information page custom question public visibility fix

### DIFF
--- a/app/eventyay/base/models/schedule.py
+++ b/app/eventyay/base/models/schedule.py
@@ -895,7 +895,7 @@ class Schedule(PretalxModel):
                     talk_data['answers'] = [
                         {
                             'question': str(answer.question.question),
-                            'answer': str(answer.answer),
+                            'answer': str(answer.answer_string),
                             'question_id': answer.question_id,
                             'options': [str(opt.answer) for opt in answer.options.all()],
                         }

--- a/app/eventyay/webapp/schedule/src/components/SessionModal.vue
+++ b/app/eventyay/webapp/schedule/src/components/SessionModal.vue
@@ -17,12 +17,23 @@ dialog.pretalx-modal#session-modal(ref="modal", @click.stop="close()")
 					export-dropdown.session-export-area(v-if="talkExportOptions.length", :options="talkExportOptions")
 				.text-content
 					.recording-embed(v-if="modalContent.contentObject.recording_iframe", v-html="modalContent.contentObject.recording_iframe")
-					.abstract(v-if="modalContent.contentObject.abstract", v-html="renderRichText(modalContent.contentObject.abstract)")
+					.field-section(v-if="modalContent.contentObject.abstract")
+						h4.field-heading Abstract
+						.field-content(v-html="renderRichText(modalContent.contentObject.abstract)")
 					template(v-if="modalContent.contentObject.isLoading")
 						bunt-progress-circular(size="big", :page="true")
 					template(v-else)
-						hr(v-if="(modalContent.contentObject.abstract?.length > 0) && (modalContent.contentObject.apiContent?.description?.length > 0)")
-						.description(v-if="modalContent.contentObject.apiContent?.description?.length > 0", v-html="renderRichText(modalContent.contentObject.apiContent.description)")
+						.field-section(v-if="modalContent.contentObject.apiContent?.description?.length > 0 || modalContent.contentObject.description?.length > 0")
+							h4.field-heading Description
+							.field-content(v-html="renderRichText(modalContent.contentObject.apiContent?.description || modalContent.contentObject.description)")
+						template(v-if="textAnswers.length > 0")
+							.field-section(v-for="answer in textAnswers", :key="answer.id || answer.question_id")
+								h4.field-heading {{ getLocalizedString(answer.question.question) }}
+								.field-content(v-html="renderRichText(answer.answer)")
+						template(v-if="publicScheduleAnswers.length > 0")
+							.field-section(v-for="answer in publicScheduleAnswers", :key="answer.question_id")
+								h4.field-heading {{ answer.question }}
+								.field-content(v-html="renderRichText(answer.answer)")
 						template(v-if="shortAnswers.length > 0 || iconAnswers.length > 0")
 							hr
 							.answers
@@ -210,14 +221,26 @@ export default {
 			const apiContent = this.modalContent.contentObject.apiContent
 			if (!apiContent || !apiContent.answers || !apiContent.answers.length) return []
 			return apiContent.answers.filter((answer) => {
-				// Exclude text answers and URL answers with icons (those go to iconAnswers)
-				return answer.question.variant !== 'text' && !(answer.question.variant === 'url' && answer.question.icon)
+				// Exclude text/string answers (those go to textAnswers) and URL answers with icons (iconAnswers)
+				return answer.question.variant !== 'text' && answer.question.variant !== 'string' && !(answer.question.variant === 'url' && answer.question.icon)
 			})
 		},
 		iconAnswers () {
 			const apiContent = this.modalContent.contentObject.apiContent
 			if (!apiContent || !apiContent.answers || !apiContent.answers.length) return []
 			return apiContent.answers.filter((answer) => answer.question.variant === 'url' && answer.question.icon)
+		},
+		textAnswers () {
+			const apiContent = this.modalContent.contentObject.apiContent
+			if (!apiContent || !apiContent.answers || !apiContent.answers.length) return []
+			return apiContent.answers.filter((answer) => answer.question.variant === 'text' || answer.question.variant === 'string')
+		},
+		publicScheduleAnswers () {
+			const apiContent = this.modalContent?.contentObject?.apiContent
+			if (apiContent && apiContent.answers && apiContent.answers.length > 0) return []
+			const answers = this.modalContent?.contentObject?.answers
+			if (!answers || !answers.length) return []
+			return answers
 		}
 	},
 	methods: {
@@ -338,8 +361,21 @@ export default {
 					aspect-ratio: 16 / 9
 					border: none
 					border-radius: 4px
-			.abstract
-				font-weight: bold
+			.field-section
+				margin-bottom: 12px
+				.field-heading
+					margin: 0 0 4px 0
+					font-size: 14px
+					font-weight: 700
+					color: $clr-grey-600
+				.field-content
+					padding: 8px 12px
+					p
+						margin: 0.25em 0
+						&:first-child
+							margin-top: 0
+						&:last-child
+							margin-bottom: 0
 			p
 				font-size: 16px
 			hr

--- a/app/eventyay/webapp/schedule/src/components/TalkDetail.vue
+++ b/app/eventyay/webapp/schedule/src/components/TalkDetail.vue
@@ -11,8 +11,19 @@
 			.info
 				span.info-main {{ datetime }} {{ roomName }}
 				span.session-language(v-if="sessionLanguageLabel")  · {{ t.session_language }}: {{ sessionLanguageLabel }}
-			markdown-content.abstract(v-if="resolvedTalk.abstract", :markdown="resolvedTalk.abstract")
-			markdown-content.description(v-if="resolvedTalk.description", :markdown="resolvedTalk.description")
+			.field-section.abstract-section(v-if="resolvedTalk.abstract")
+				h2.field-heading Abstract
+				.field-content
+					markdown-content(:markdown="resolvedTalk.abstract")
+			.field-section.description-section(v-if="resolvedTalk.description")
+				h2.field-heading Description
+				.field-content
+					markdown-content(:markdown="resolvedTalk.description")
+			.public-answers(v-if="resolvedTalk.answers && resolvedTalk.answers.length > 0")
+				.field-section(v-for="answer in resolvedTalk.answers", :key="answer.question_id")
+					h2.field-heading {{ answer.question }}
+					.field-content
+						markdown-content(:markdown="answer.answer")
 			.downloads(v-if="resolvedTalk.resources && resolvedTalk.resources.length > 0")
 				h2 {{ t.downloads }}
 				a.download(v-for="{resource, link, description} of resolvedTalk.resources", :href="getAbsoluteResourceUrl(resource || link)", target="_blank")
@@ -353,10 +364,27 @@ export default {
 			color: $clr-secondary-text-light
 			.session-language
 				white-space: nowrap
-		.abstract
+		.abstract, .description
+			margin: 0
+		.field-section
 			margin: 16px 0 0 0
-			font-size: 16px
-			font-weight: 600
+			.field-heading
+				margin: 0 0 6px 0
+				font-size: 14px
+				font-weight: 700
+				color: $clr-secondary-text-light
+			.field-content
+				padding: 8px 12px
+				p
+					margin: 0.25em 0
+					&:first-child
+						margin-top: 0
+					&:last-child
+						margin-bottom: 0
+			&.abstract-section
+				.field-content
+					font-size: 16px
+					font-weight: 600
 		.downloads
 			border: border-separator()
 			border-radius: 4px


### PR DESCRIPTION
<img width="1447" height="794" alt="Screenshot 2026-05-02 at 4 17 39 PM" src="https://github.com/user-attachments/assets/6619f45f-15f7-470e-9a0a-422b872a5f5f" />

## Summary by Sourcery

Improve display and exposure of session abstracts, descriptions, and custom question answers in the web schedule UI.

New Features:
- Expose public custom question answers for sessions and talks on the schedule and talk detail pages.

Bug Fixes:
- Ensure custom text/string question answers use the correct answer_string field when serializing schedule data.
- Prevent private API-only answers from leaking by limiting public schedule answers to non-API answer sets.

Enhancements:
- Refine session and talk detail layouts to group abstracts, descriptions, and answers into consistently styled field sections for better readability.