### PR TITLE
fix sendmail log to eventyay instead of pretalx

### DIFF
--- a/app/eventyay/base/models/mail.py
+++ b/app/eventyay/base/models/mail.py
@@ -473,7 +473,7 @@ class QueuedMail(PretalxModel):
 
         if self.pk:
             self.log_action(
-                'pretalx.mail.sent',
+                'eventyay.mail.sent',
                 person=requestor,
                 orga=orga,
                 data={'to_users': [(user.pk, user.email) for user in self.to_users.all()]},


### PR DESCRIPTION
Before:
<img width="1470" height="283" alt="Screenshot 2026-05-07 at 2 15 55 PM" src="https://github.com/user-attachments/assets/e72b9c4c-c5bd-4835-9b82-0cc79eef4791" />



After:
<img width="1469" height="502" alt="Screenshot 2026-05-07 at 2 15 43 PM" src="https://github.com/user-attachments/assets/0654290f-1057-4ed7-841c-1ad462044e9b" />

## Summary by Sourcery

Bug Fixes:
- Correct mail send action log identifier to use the eventyay namespace, ensuring logs are attributed to the right system.