### PR TITLE
Add redirect for old style event /e/ to /ev/

### DIFF
--- a/deployment/nginx/enext-direct
+++ b/deployment/nginx/enext-direct
@@ -57,7 +57,11 @@ server {
 		proxy_read_timeout 86400;
 	}
 
-    # Regular HTTP requests - route to gunicorn
+	location ~ ^/e/(.*)$ {
+		return 301 /ev/$1;
+	}
+
+	# Regular HTTP requests - route to gunicorn
 	location / {
 		add_header Referrer-Policy same-origin always;
 


### PR DESCRIPTION
## Summary by Sourcery

New Features:
- Introduce a redirect from /e/ URLs to /ev/ in the enext-direct Nginx deployment config.