### PR TITLE
fix(api): return HTTP 400 on CheckInError in check-in redeem endpoint

### DIFF
--- a/app/eventyay/api/views/checkin.py
+++ b/app/eventyay/api/views/checkin.py
@@ -700,13 +700,14 @@ def _redeem_process(
 
             return Response(
                 {
-                    'status': 'redeemed',
-                    'reason': 'Already checked in',
+                    'status': 'error',
+                    'reason': e.code,
+                    'reason_explanation': None,
                     'require_attention': op.require_checkin_attention,
                     'position': position_data,
                     'list': MiniCheckinListSerializer(list_by_event[op.order.event_id]).data,
                 },
-                status=201,
+                status=400,
             )
         else:
             serializer_context = _setup_context(request, expand, op.order.event, pdf_data, user, auth)


### PR DESCRIPTION
Fixes #3503

## What this PR does

The `_redeem_process` function in `api/views/checkin.py` caught `CheckInError` and returned **HTTP 201** with `'status': 'redeemed'` Fixes #3503 
## What this PR does

The `_redeem_process` function in `api/views/checkin.py` caught `CheckInError` and returned **HTTP 201** with `'status': 'redeemed'` - both of which are semantically wrong for an error response. This fix brings the `CheckInError` branch in line with the other error branches in the same function.

## Changes

**`app/eventyay/api/views/checkin.py`**

| Field | Before | After |
|---|---|---|
| HTTP status | `201` | `400` |
| `status` field | `'redeemed'` | `'error'` |
| `reason` field | `'Already checked in'` (hardcoded) | `e.code` (from exception) |
| `reason_explanation` | missing | `None` (matches other error branches) |

## Why this matters

HTTP 201 means "resource created successfully". Returning it on a check-in error means any client that checks `response.status_code` will incorrectly treat a failed or duplicate check-in as a success. The `_handle_ambiguous_candidates` helper in the same file already returns `400` correctly - this was an inconsistency.

## Testing

- Trigger a duplicate check-in (scan the same ticket twice) via the API.
- - First scan -> `HTTP 201`, `"status": "ok"` (unchanged, still correct).
- - Second scan -> now returns `HTTP 400`, `"status": "error"`, `"reason": "already_redeemed"` (was `HTTP 201`, `"status": "redeemed"` before this fix).

## Summary by Sourcery

Bug Fixes:
- Change the check-in redeem endpoint to return HTTP 400 with an error status and structured reason details when a CheckInError occurs instead of incorrectly returning a 201 success response.