### PR TITLE
fix: correct incorrect HTTP status codes in event and submission views

### DIFF
--- a/app/eventyay/api/views/event.py
+++ b/app/eventyay/api/views/event.py
@@ -595,7 +595,7 @@ class EventThemeView(APIView):
             )
             return Response(
                 'error happened when trying to get theme data of event: ' + kwargs['event_id'],
-                status=404,
+                status=HTTP_404_NOT_FOUND,
             )
 
 

--- a/app/eventyay/api/views/event.py
+++ b/app/eventyay/api/views/event.py
@@ -595,7 +595,7 @@ class EventThemeView(APIView):
             )
             return Response(
                 'error happened when trying to get theme data of event: ' + kwargs['event_id'],
-                status=503,
+                status=404,
             )
 
 

--- a/app/eventyay/api/views/submission.py
+++ b/app/eventyay/api/views/submission.py
@@ -579,7 +579,7 @@ class SubmissionFavouriteDeprecatedView(View):
             return JsonResponse(
                 {'error': str(e)},
                 safe=False,
-                status=status.HTTP_503_SERVICE_UNAVAILABLE,
+                status=status.HTTP_500_INTERNAL_SERVER_ERROR,
             )
 
     @staticmethod
@@ -626,7 +626,7 @@ class SubmissionFavouriteDeprecatedView(View):
             return JsonResponse(
                 {'error': str(e)},
                 safe=False,
-                status=status.HTTP_503_SERVICE_UNAVAILABLE,
+                status=status.HTTP_500_INTERNAL_SERVER_ERROR,
             )
 
     @staticmethod


### PR DESCRIPTION
**## Description**

This PR replaces semantically incorrect HTTP 503 responses in `event.py` and `submission.py`.

**### Changes**

* Changed `503 Service Unavailable` → `404 Not Found` in `EventThemeView` when the requested theme configuration is missing.
* Changed `503 Service Unavailable` → `500 Internal Server Error` in deprecated submission favourite handlers for unexpected internal exceptions.

**### Why**

HTTP 503 indicates temporary service unavailability or infrastructure failure. These branches instead represent:

* missing resources/configuration (`404`)
* unexpected internal application errors (`500`)

I intentionally did not modify the `order.py` `SendMailException` branch because it may represent a temporary downstream mail-service failure, for which `503 Service Unavailable` can still be semantically appropriate.

Fixes #3290

## Summary by Sourcery

Correct HTTP status codes returned by event theme and submission favourite views to better reflect missing resources and internal errors.

Bug Fixes:
- Return 500 Internal Server Error instead of 503 Service Unavailable for unexpected exceptions in deprecated submission favourite handlers.
- Return 404 Not Found instead of 503 Service Unavailable when an event's theme configuration is missing.