### PR TITLE
chore: cfp mandatory field disable removed

### DIFF
--- a/app/eventyay/base/models/cfp.py
+++ b/app/eventyay/base/models/cfp.py
@@ -109,7 +109,7 @@ def default_fields():
         'track': {'visibility': 'do_not_ask', 'public': False},
         'duration': {'visibility': 'do_not_ask', 'public': False},
         'slot_count': {'visibility': 'optional', 'public': False},
-        'content_locale': {'visibility': 'required', 'public': False},
+        'content_locale': {'visibility': 'required', 'public': False, 'public_label': None},
         'additional_speaker': {'visibility': 'optional', 'public': False},
         'fullname': {'visibility': 'required', 'public': True},
     }

--- a/app/eventyay/common/forms/mixins.py
+++ b/app/eventyay/common/forms/mixins.py
@@ -82,8 +82,13 @@ class RequestRequire:
         for key in self.Meta.request_require:
             visibility = self.event.cfp.fields.get(key, default_fields()[key])['visibility']
             if visibility == 'do_not_ask':
-                self.fields.pop(key, None)
-            elif field := self.fields.get(key):
+                if key == 'content_locale' and self.event.is_multilingual:
+                    visibility = 'required'
+                else:
+                    self.fields.pop(key, None)
+                    continue
+            field = self.fields.get(key)
+            if field:
                 field.required = visibility == 'required'
                 min_value = self.event.cfp.fields.get(key, {}).get('min_length')
                 max_value = self.event.cfp.fields.get(key, {}).get('max_length')

--- a/app/eventyay/orga/forms/cfp.py
+++ b/app/eventyay/orga/forms/cfp.py
@@ -267,7 +267,9 @@ class CfPSettingsForm(CfPGeneralSettingsForm):
                     value = 'required'
                 self.instance.cfp.fields[key]['visibility'] = value
                 if 'cfp_content_locale_public_label' in self.cleaned_data:
-                    public_label = self.cleaned_data.get('cfp_content_locale_public_label') or None
+                    public_label = self.cleaned_data.get('cfp_content_locale_public_label')
+                    if public_label is not None:
+                        public_label = public_label.strip() or None
                     self.instance.cfp.fields[key]['public_label'] = public_label
             else:
                 self.instance.cfp.fields[key]['visibility'] = self.cleaned_data.get(f'cfp_ask_{key}')

--- a/app/eventyay/orga/forms/cfp.py
+++ b/app/eventyay/orga/forms/cfp.py
@@ -182,6 +182,25 @@ class CfPSettingsForm(CfPGeneralSettingsForm):
                     ],
                     widget=forms.Select(attrs={'disabled': True, 'aria-readonly': 'true'}),
                 )
+            elif attribute == 'content_locale':
+                # Content locale must always be visible for multilingual events;
+                # only optional vs required is configurable.
+                stored = obj.cfp.fields.get(attribute, default_fields()[attribute])['visibility']
+                initial_value = stored if stored in ('optional', 'required') else 'required'
+                self.fields[field_name] = forms.ChoiceField(
+                    required=True,
+                    initial=initial_value,
+                    choices=[
+                        ('optional', _('Ask, but do not require input')),
+                        ('required', _('Ask and require input')),
+                    ],
+                )
+                self.fields['cfp_content_locale_public_label'] = forms.CharField(
+                    required=False,
+                    max_length=100,
+                    initial=obj.cfp.fields.get(attribute, default_fields()[attribute]).get('public_label') or '',
+                    label=_('Public label'),
+                )
             else:
                 self.fields[field_name] = forms.ChoiceField(
                     required=True,
@@ -224,6 +243,7 @@ class CfPSettingsForm(CfPGeneralSettingsForm):
 
         if not obj.is_multilingual:
             self.fields.pop('cfp_ask_content_locale', None)
+            self.fields.pop('cfp_content_locale_public_label', None)
 
     def save(self, *args, **kwargs):
         # Preserve fields_config (drag-drop order) before modifying settings
@@ -240,6 +260,15 @@ class CfPSettingsForm(CfPGeneralSettingsForm):
             # Full Name is always required and cannot be changed
             if key == 'fullname':
                 self.instance.cfp.fields[key]['visibility'] = 'required'
+            elif key == 'content_locale':
+                # Content locale can only be optional or required, never do_not_ask
+                value = self.cleaned_data.get('cfp_ask_content_locale')
+                if value not in ('optional', 'required'):
+                    value = 'required'
+                self.instance.cfp.fields[key]['visibility'] = value
+                if 'cfp_content_locale_public_label' in self.cleaned_data:
+                    public_label = self.cleaned_data.get('cfp_content_locale_public_label') or None
+                    self.instance.cfp.fields[key]['public_label'] = public_label
             else:
                 self.instance.cfp.fields[key]['visibility'] = self.cleaned_data.get(f'cfp_ask_{key}')
 

--- a/app/eventyay/orga/forms/submission.py
+++ b/app/eventyay/orga/forms/submission.py
@@ -120,6 +120,9 @@ class SubmissionForm(ReadOnlyFlag, RequestRequire, forms.ModelForm):
                 self.fields.pop('content_locale')
             else:
                 self.fields['content_locale'].choices = self.event.named_content_locales
+                custom_label = event.cfp.fields.get('content_locale', {}).get('public_label')
+                if custom_label:
+                    self.fields['content_locale'].label = custom_label
         # If duration is not required, point out that the default is the session type's duration,
         # but only if there is more than one session type, because otherwise users will be
         # confused what that is.

--- a/app/eventyay/orga/templates/orga/cfp/forms.html
+++ b/app/eventyay/orga/templates/orga/cfp/forms.html
@@ -109,21 +109,8 @@
                     <tbody dragsort-url="{% url 'orga:cfp.questions.list' event=request.event.slug %}">
                         <tr dragsort-id="title">
                             <th>{% translate "Title" %}</th>
-                            <td class="text-center">
-                                <label class="toggle-switch always-on" aria-label="{% translate 'Title is always active' %}">
-                                    <input type="checkbox" checked disabled aria-label="{% translate 'Title always active' %}">
-                                    <span class="toggle-slider"></span>
-                                </label>
-                            </td>
-                            <td class="text-center">
-                                <div class="required-status-wrapper" data-current="required">
-                                    <select class="required-status-dropdown" disabled aria-readonly="true"
-                                        aria-describedby="title-required-help" data-current="required">
-                                        <option value="required" selected>Required</option>
-                                    </select>
-                                </div>
-                                <span id="title-required-help" class="sr-only">{% translate "The title is always required and cannot be changed." %}</span>
-                            </td>
+                            <td class="text-center"></td>
+                            <td class="text-center"></td>
                             <td>{{ sform.cfp_title_min_length.as_field_group }}</td>
                             <td>{{ sform.cfp_title_max_length.as_field_group }}</td>
                             <td class="text-center">
@@ -380,12 +367,6 @@
                         <tr dragsort-id="content_locale">
                             <th>{% translate "Content Locale" %}</th>
                             <td class="text-center">
-                                <label class="toggle-switch" data-field-id="{{ field.auto_id }}"
-                                    aria-label="Toggle active state for Content Locale">
-                                    <input type="checkbox" {% if field.value != 'do_not_ask' %}checked{% endif %}
-                                        aria-label="Active toggle for Content Locale">
-                                    <span class="toggle-slider"></span>
-                                </label>
                                 <input type="hidden" name="{{ field.html_name }}" value="{{ field.value }}"
                                     id="{{ field.auto_id }}" data-is-question-field="true">
                             </td>
@@ -393,17 +374,28 @@
                                 <div class="required-status-wrapper" data-current="{% if field.value == 'required' %}required{% else %}optional{% endif %}">
                                     <select class="required-status-dropdown" data-field-id="{{ field.auto_id }}"
                                         data-current="{% if field.value == 'required' %}required{% else %}optional{% endif %}"
-                                        {% if field.value == 'do_not_ask' %}disabled{% endif %}
                                         aria-label="Required status for Content Locale">
-                                        <option value="optional" {% if field.value == 'optional' or field.value == 'do_not_ask' %}selected{% endif %}>Optional</option>
+                                        <option value="optional" {% if field.value == 'optional' %}selected{% endif %}>Optional</option>
                                         <option value="required" {% if field.value == 'required' %}selected{% endif %}>
                                             Required</option>
                                     </select>
                                 </div>
                             </td>
-                            <td></td>
-                            <td></td>
-                            <td></td>
+                            <td colspan="3">
+                                <input type="text"
+                                    name="{{ sform.cfp_content_locale_public_label.html_name }}"
+                                    id="{{ sform.cfp_content_locale_public_label.auto_id }}"
+                                    value="{{ sform.cfp_content_locale_public_label.value|default:'' }}"
+                                    maxlength="100"
+                                    placeholder="{% translate 'Public label (default: Language)' %}"
+                                    class="form-control form-control-sm{% if sform.cfp_content_locale_public_label.errors %} is-invalid{% endif %}"
+                                    aria-label="{{ sform.cfp_content_locale_public_label.label }}">
+                                {% if sform.cfp_content_locale_public_label.errors %}
+                                    <div class="invalid-feedback d-block">
+                                        {{ sform.cfp_content_locale_public_label.errors }}
+                                    </div>
+                                {% endif %}
+                            </td>
                             <td class="text-center">{{ field_counts.content_locale }}</td>
                             <td class="text-right">
                                 <button type="button" draggable="true" class="btn btn-sm btn-primary dragsort-button" title="{% translate 'Move item' %}">
@@ -640,22 +632,10 @@
                         <tr dragsort-id="fullname">
                             <th>{% translate "Full Name" %}</th>
                             <td class="text-center">
-                                <label class="toggle-switch always-on" aria-label="{% translate 'Full Name is always active' %}">
-                                    <input type="checkbox" checked disabled aria-label="{% translate 'Full Name always active' %}">
-                                    <span class="toggle-slider"></span>
-                                </label>
                                 <input type="hidden" name="{{ field.html_name }}" value="required"
                                     id="{{ field.auto_id }}">
                             </td>
-                            <td class="text-center">
-                                <div class="required-status-wrapper" data-current="required">
-                                    <select class="required-status-dropdown" disabled aria-readonly="true"
-                                        aria-describedby="fullname-required-help" data-current="required">
-                                        <option value="required" selected>Required</option>
-                                    </select>
-                                </div>
-                                <span id="fullname-required-help" class="sr-only">{% translate "Full Name is always required and cannot be changed." %}</span>
-                            </td>
+                            <td class="text-center"></td>
                             <td></td>
                             <td></td>
                             <td class="text-center">

--- a/app/eventyay/orga/templates/orga/submission/content.html
+++ b/app/eventyay/orga/templates/orga/submission/content.html
@@ -105,7 +105,11 @@
         {% endif %}
 
         <div class="form-group row">
-            <label class="col-md-3 col-form-label">{% translate "Language" %}</label>
+            <label class="col-md-3 col-form-label">
+                {% with custom_label=submission.event.cfp.fields.content_locale.public_label %}
+                    {% if custom_label %}{{ custom_label }}{% else %}{% translate "Language" %}{% endif %}
+                {% endwith %}
+            </label>
             <div class="col-md-9 mt-1">
                 {{ submission.get_content_locale_display }}
             </div>

--- a/app/eventyay/static/orga/js/questionToggles.js
+++ b/app/eventyay/static/orga/js/questionToggles.js
@@ -127,7 +127,24 @@ function initFormPageToggles() {
         const requiredDropdown = document.querySelector(`.required-status-dropdown[data-field-id="${escapedId}"]`);
         const toggleInput = document.querySelector(`.toggle-switch[data-field-id="${escapedId}"] input`);
 
-        if (!requiredDropdown || !toggleInput) return;
+        if (!requiredDropdown) return;
+
+        // Fields without a toggle are always visible; keep dropdown state in sync.
+        // Always-on toggles (disabled inputs) also fall through here.
+        if (!toggleInput || toggleInput.disabled) {
+            if (toggleInput) {
+                toggleInput.checked = true;
+            }
+            requiredDropdown.disabled = false;
+            requiredDropdown.style.opacity = '1';
+            if (value && value !== 'do_not_ask') {
+                requiredDropdown.value = value;
+                requiredDropdown.dataset.current = value;
+                const wrapper = requiredDropdown.closest('.required-status-wrapper');
+                if (wrapper) wrapper.dataset.current = value;
+            }
+            return;
+        }
 
         if (value === 'do_not_ask') {
             toggleInput.checked = false;
@@ -141,7 +158,7 @@ function initFormPageToggles() {
             // Update dropdown value and data-current attribute for color
             requiredDropdown.value = value;
             requiredDropdown.dataset.current = value;
-            
+
             // Update wrapper data-current for Font Awesome icon color
             const wrapper = requiredDropdown.closest('.required-status-wrapper');
             if (wrapper) {
@@ -162,7 +179,7 @@ function initFormPageToggles() {
             const escapedId = fieldId.replace(/(["\\])/g, '\\$1');
             const checkbox = document.querySelector(`.toggle-switch[data-field-id="${escapedId}"] input`);
 
-            if (!hiddenInput || !checkbox.checked) {
+            if (!hiddenInput || (checkbox && !checkbox.checked)) {
                 return; // Can't change if inactive
             }
 

--- a/app/eventyay/submission/forms/submission.py
+++ b/app/eventyay/submission/forms/submission.py
@@ -179,6 +179,9 @@ class InfoForm(
                 self.fields.pop('content_locale')
             else:
                 self.fields['content_locale'].choices = self.event.named_content_locales
+                custom_label = self.event.cfp.fields.get('content_locale', {}).get('public_label')
+                if custom_label:
+                    self.fields['content_locale'].label = custom_label
 
     def _set_slot_count(self, instance=None):
         if not self.event.get_feature_flag('present_multiple_times'):


### PR DESCRIPTION
Fixes #3541 
<img width="2056" height="1329" alt="Screenshot 2026-05-11 at 10 23 34 PM" src="https://github.com/user-attachments/assets/14490df9-877b-453d-b3e6-2a9b256761d0" />

## Summary by Sourcery

Relax CFP mandatory field controls and improve content locale handling.

New Features:
- Allow configuring content locale visibility only between optional and required while keeping it always visible for multilingual events.
- Introduce a customizable public label for the content locale field that is shown in submission forms and details.

Bug Fixes:
- Ensure always-on CFP fields keep their required dropdown enabled and synced in the UI.
- Prevent content locale from being set to 'do_not_ask' in CFP settings while preserving correct visibility in forms.

Enhancements:
- Simplify the CFP UI by removing non-interactive mandatory toggles for title and full name.
- Propagate content locale visibility and labeling consistently across organizer and public submission forms.