### PR TITLE
add slot count and slides to builtin

### DIFF
--- a/app/eventyay/base/models/cfp.py
+++ b/app/eventyay/base/models/cfp.py
@@ -25,7 +25,7 @@ def default_settings():
 # Every other module should import these instead of hard-coding field names.
 BUILTIN_SESSION_FIELDS = (
     'title', 'abstract', 'description', 'notes', 'track',
-    'duration', 'content_locale', 'image', 'do_not_record',
+    'duration', 'slot_count', 'content_locale', 'image', 'slides', 'do_not_record',
 )
 BUILTIN_SPEAKER_FIELDS = (
     'fullname', 'biography', 'avatar', 'avatar_source',


### PR DESCRIPTION
New custom fields created should be now added to the bottom 

https://github.com/user-attachments/assets/fecd177a-1d29-4106-85bb-684628ee65ae




## Summary by Sourcery

Include slot count and slides as builtin session fields for call-for-papers configuration.

New Features:
- Expose slot_count as a builtin session field in CFP configuration.
- Expose slides as a builtin session field in CFP configuration.