### PR TITLE
quickfix: html tags fix on signup

### DIFF
--- a/app/eventyay/jinja-templates/account/signup.jinja
+++ b/app/eventyay/jinja-templates/account/signup.jinja
@@ -42,7 +42,7 @@
           </div>
         {% endif %}
         {% if form.password1.help_text %}
-          <div class='field-help'>{{ form.password1.help_text }}</div>
+          <div class='field-help'>{{ form.password1.help_text|safe }}</div>
         {% endif %}
       </div>
 

--- a/app/eventyay/person/forms/user.py
+++ b/app/eventyay/person/forms/user.py
@@ -40,7 +40,7 @@ class UserForm(CfPFormMixin, forms.Form):
         required=False,
     )
     register_password_repeat = NewPasswordConfirmationField(
-        label=_('Password (again)'),
+        label=_('Confirm Password'),
         required=False,
         confirm_with='register_password',
         widget=forms.PasswordInput(attrs={'autocomplete': 'new-password'}),

--- a/app/eventyay/static/common/css/allauth.css
+++ b/app/eventyay/static/common/css/allauth.css
@@ -136,6 +136,25 @@
   line-height: 1.4;
 }
 
+.field-help ul {
+  padding-left: 0;
+  margin: 0;
+  list-style: none;
+}
+
+.field-help li {
+  margin: 0.25rem 0;
+  padding-left: 1.2rem;
+  position: relative;
+}
+
+.field-help li:before {
+  content: "•";
+  position: absolute;
+  left: 0;
+  color: #7f8c8d;
+}
+
 /* Description and message text */
 .description,
 .password-reset-done-container p,


### PR DESCRIPTION
## Summary by Sourcery

Improve signup password help display and field labeling for clarity.

Bug Fixes:
- Render password help text as safe HTML so list formatting displays correctly on the signup page.

Enhancements:
- Add list styling for password help items to display as a clean, unbulleted list with custom bullet indicators.
- Rename the repeat password field label to 'Confirm Password' for clearer wording on the signup form.