### PR TITLE
urgent recovery

### DIFF
--- a/app/eventyay/base/models/room.py
+++ b/app/eventyay/base/models/room.py
@@ -237,12 +237,14 @@ class Room(VersionedModel, OrderedModel, PretalxModel):
             'create': can_change_event_settings,
             'update': can_change_event_settings,
             'delete': can_change_event_settings,
+            'recover': can_change_event_settings,
         }
 
     class urls(EventUrls):
         """URL patterns for room views."""
         settings_base = edit = '{self.event.orga_urls.room_settings}{self.pk}/'
         delete = '{settings_base}delete/'
+        recover = '{settings_base}recover/'
 
     def __str__(self) -> str:
         return str(self.name)

--- a/app/eventyay/common/views/generic.py
+++ b/app/eventyay/common/views/generic.py
@@ -147,6 +147,7 @@ CRUDHandlerMap = {
     'create': {'get': 'form_view', 'post': 'form_handler'},
     'update': {'get': 'form_view', 'post': 'form_handler'},
     'delete': {'get': 'delete_view', 'post': 'delete_handler'},
+    'recover': {'get': 'recover_handler', 'post': 'recover_handler'},
 }
 
 
@@ -304,7 +305,7 @@ class CRUDView(PaginationMixin, Filterable, View):
     def get_success_url(self):
         if next_url := get_next_url(self.request):
             return next_url
-        if self.action == 'delete' or self.detail_is_update:
+        if self.action in ('delete', 'recover') or self.detail_is_update:
             return self.reverse('list')
         return self.reverse('detail', instance=self.object)
 
@@ -448,6 +449,8 @@ class CRUDView(PaginationMixin, Filterable, View):
             return f'{url_base}/edit/'
         if action == 'delete':
             return f'{url_base}/delete/'
+        if action == 'recover':
+            return f'{url_base}/recover/'
 
     @classonlymethod
     def get_urls(cls, url_base, url_name, namespace=None, actions=None):

--- a/app/eventyay/orga/templates/orga/schedule/room/list.html
+++ b/app/eventyay/orga/templates/orga/schedule/room/list.html
@@ -30,24 +30,34 @@
             </thead>
             <tbody dragsort-url="{{ request.event.orga_urls.room_settings }}">
                 {% for room in room_list %}
-                    <tr dragsort-id="{{ room.pk }}">
+                    <tr dragsort-id="{{ room.pk }}" {% if room.deleted %}class="text-muted"{% endif %}>
                         <td>
-                            <a href="{{ room.urls.edit }}">{{ room.name }}</a>
+                            {% if room.deleted %}
+                                <span>{{ room.name }}</span>
+                            {% else %}
+                                <a href="{{ room.urls.edit }}">{{ room.name }}</a>
+                            {% endif %}
                         </td>
                         <td class="numeric">
                             {% if room.capacity %}{{ room.capacity }}{% endif %}
                         </td>
                         <td class="text-right">
-                            <button draggable="true" class="btn btn-sm btn-primary mr-1 dragsort-button" title="{% translate "Move item" %}">
-                                <i class="fa fa-arrows"></i>
-                            </button>
-
-                            <a href="{{ room.urls.edit }}" class="btn btn-sm btn-info">
-                                <i class="fa fa-edit"></i>
-                            </a>
-                            <a href="{{ room.urls.delete }}" class="btn btn-sm btn-danger">
-                                <i class="fa fa-trash"></i>
-                            </a>
+                            {% if room.deleted %}
+                                <a href="{{ room.urls.recover }}" class="btn btn-sm btn-success">
+                                    <i class="fa fa-undo"></i> {% translate "Recover" %}
+                                </a>
+                            {% else %}
+                                <button draggable="true" class="btn btn-sm btn-primary mr-1 dragsort-button" title="{% translate "Move item" %}">
+                                    <i class="fa fa-arrows"></i>
+                                </button>
+    
+                                <a href="{{ room.urls.edit }}" class="btn btn-sm btn-info">
+                                    <i class="fa fa-edit"></i>
+                                </a>
+                                <a href="{{ room.urls.delete }}" class="btn btn-sm btn-danger">
+                                    <i class="fa fa-trash"></i>
+                                </a>
+                            {% endif %}
                         </td>
                     </tr>
                 {% empty %}

--- a/app/eventyay/orga/views/schedule.py
+++ b/app/eventyay/orga/views/schedule.py
@@ -501,7 +501,10 @@ class RoomView(OrderActionMixin, OrgaCRUDView):
     template_namespace = 'orga/schedule'
 
     def get_queryset(self):
-        # Filter out soft-deleted rooms to sync with video component
+        # Filter out soft-deleted rooms to sync with video component,
+        # but allow them for recovery and listing
+        if self.action in ('list', 'recover'):
+            return self.request.event.rooms.all()
         return self.request.event.rooms.filter(deleted=False)
 
     def get_permission_required(self):
@@ -522,4 +525,12 @@ class RoomView(OrderActionMixin, OrgaCRUDView):
         obj.deleted = True
         obj.save(update_fields=['deleted'])
         messages.success(request, _('The selected room has been deleted.'))
+        return redirect(self.get_success_url())
+
+    def recover_handler(self, request, *args, **kwargs):
+        # Use soft delete recovery to sync with video component
+        obj = self.get_object()
+        obj.deleted = False
+        obj.save(update_fields=['deleted'])
+        messages.success(request, _('The selected room has been recovered.'))
         return redirect(self.get_success_url())


### PR DESCRIPTION
## Summary by Sourcery

Add support for soft-deleted room recovery in the organizer schedule views and routing, and expose recovery actions in the room list UI.

New Features:
- Allow organizers to recover soft-deleted rooms via a dedicated recover handler and URL pattern.
- Display soft-deleted rooms in the schedule room list with a visual distinction and a recover action instead of edit/delete controls.

Enhancements:
- Adjust generic CRUD routing and success URL handling to support the new recover action while keeping list and detail navigation consistent.