### PR TITLE
fix(video): add reset and update delete room options

### DIFF
--- a/app/eventyay/api/serializers/schedule.py
+++ b/app/eventyay/api/serializers/schedule.py
@@ -17,11 +17,11 @@ from eventyay.base.models.slot import TalkSlot
 
 @register_serializer()
 class ScheduleListSerializer(FlexFieldsSerializerMixin, PretalxSerializer):
-    version = CharField(source="version_with_fallback")
+    version = CharField(source='version_with_fallback')
 
     class Meta:
         model = Schedule
-        fields = ["id", "version", "published"]
+        fields = ['id', 'version', 'published']
 
 
 @register_serializer(versions=CURRENT_VERSIONS)
@@ -30,23 +30,23 @@ class ScheduleSerializer(ScheduleListSerializer):
 
     @extend_schema_field(list[int])
     def get_slots(self, obj):
-        only_visible_slots = self.context.get("only_visible_slots", True)
+        only_visible_slots = self.context.get('only_visible_slots', True)
         if only_visible_slots and not obj.version:
             # This should never happen, but better safe than sorry.
             return []
         qs = obj.talks.all()
         if only_visible_slots:
-            qs = qs.filter(is_visible=True)
-        if serializer := self.get_extra_flex_field("slots", qs):
+            qs = qs.filter(is_visible=True).exclude(room__deleted=True)
+        if serializer := self.get_extra_flex_field('slots', qs):
             return serializer.data
-        return qs.values_list("pk", flat=True)
+        return qs.values_list('pk', flat=True)
 
     class Meta(ScheduleListSerializer.Meta):
-        fields = ScheduleListSerializer.Meta.fields + ["comment", "slots"]
+        fields = ScheduleListSerializer.Meta.fields + ['comment', 'slots']
         extra_expandable_fields = {
-            "slots": (
-                "eventyay.api.serializers.schedule.TalkSlotSerializer",
-                {"read_only": True, "many": True, "omit": ("schedule",)},
+            'slots': (
+                'eventyay.api.serializers.schedule.TalkSlotSerializer',
+                {'read_only': True, 'many': True, 'omit': ('schedule',)},
             )
         }
 
@@ -58,47 +58,45 @@ class ScheduleReleaseSerializer(PretalxSerializer):
 
     class Meta:
         model = Schedule
-        fields = ("version", "comment")
+        fields = ('version', 'comment')
 
     def validate_version(self, value):
-        event = self.context["request"].event
+        event = self.context['request'].event
         if event.schedules.filter(version=value).exists():
-            raise ValidationError(
-                f"A schedule with the version '{value}' already exists for this event."
-            )
+            raise ValidationError(f"A schedule with the version '{value}' already exists for this event.")
         return value
 
 
 @register_serializer(versions=CURRENT_VERSIONS)
 class TalkSlotSerializer(FlexFieldsSerializerMixin, PretalxSerializer):
-    submission = SlugRelatedField(slug_field="code", read_only=True)
-    end = DateTimeField(source="local_end")
+    submission = SlugRelatedField(slug_field='code', read_only=True)
+    end = DateTimeField(source='local_end')
 
     class Meta:
         model = TalkSlot
         fields = [
-            "id",
-            "room",
-            "start",
-            "end",
-            "submission",
-            "schedule",
-            "description",
-            "duration",
+            'id',
+            'room',
+            'start',
+            'end',
+            'submission',
+            'schedule',
+            'description',
+            'duration',
         ]
-        read_only_fields = ["submission", "schedule"]
+        read_only_fields = ['submission', 'schedule']
         expandable_fields = {
-            "submission": (
-                "eventyay.api.serializers.submission.SubmissionSerializer",
-                {"read_only": True, "omit": ("slots",)},
+            'submission': (
+                'eventyay.api.serializers.submission.SubmissionSerializer',
+                {'read_only': True, 'omit': ('slots',)},
             ),
-            "schedule": (
-                "eventyay.api.serializers.schedule.ScheduleSerializer",
-                {"read_only": True, "omit": ("slots", "speakers")},
+            'schedule': (
+                'eventyay.api.serializers.schedule.ScheduleSerializer',
+                {'read_only': True, 'omit': ('slots', 'speakers')},
             ),
-            "room": (
-                "eventyay.api.serializers.room.RoomSerializer",
-                {"read_only": True},
+            'room': (
+                'eventyay.api.serializers.room.RoomSerializer',
+                {'read_only': True},
             ),
         }
 
@@ -106,20 +104,22 @@ class TalkSlotSerializer(FlexFieldsSerializerMixin, PretalxSerializer):
 @register_serializer(versions=CURRENT_VERSIONS)
 class TalkSlotOrgaSerializer(TalkSlotSerializer):
     class Meta(TalkSlotSerializer.Meta):
-        fields = TalkSlotSerializer.Meta.fields + ["is_visible"]
-        read_only_fields = TalkSlotSerializer.Meta.read_only_fields + ["is_visible"]
+        fields = TalkSlotSerializer.Meta.fields + ['is_visible']
+        read_only_fields = TalkSlotSerializer.Meta.read_only_fields + ['is_visible']
         expandable_fields = TalkSlotSerializer.Meta.expandable_fields
 
     def validate_end(self, value):
         if self.instance and self.instance.submission:
             raise ValidationError(
-                "End can only be edited if there is no submission associated with the slot. Otherwise, update the submission duration."
+                'End can only be edited if there is no submission associated with the slot. '
+                'Otherwise, update the submission duration.'
             )
         return value
 
     def validate_description(self, value):
         if self.instance and self.instance.submission:
             raise ValidationError(
-                "Description can only be edited if there is no submission associated with the slot. Otherwise, update the submission abstract."
+                'Description can only be edited if there is no submission associated with the slot. '
+                'Otherwise, update the submission abstract.'
             )
         return value

--- a/app/eventyay/api/views/schedule.py
+++ b/app/eventyay/api/views/schedule.py
@@ -30,28 +30,29 @@ from eventyay.base.models.slot import TalkSlot
 
 @extend_schema_view(
     list=extend_schema(
-        summary="List Schedules",
+        summary='List Schedules',
         description=(
-            "This endpoint returns a list of schedules. "
-            "As schedule data can get very complex when expanded, the list endpoint only contains metadata. "
-            "Please refer to the detail endpoint documentation to see how to retrieve slots, submissions and speakers."
+            'This endpoint returns a list of schedules. '
+            'As schedule data can get very complex when expanded, the list endpoint only contains metadata. '
+            'Please refer to the detail endpoint documentation to see how to retrieve slots, submissions and speakers.'
         ),
-        parameters=[build_search_docs("version")],
+        parameters=[build_search_docs('version')],
     ),
     retrieve=extend_schema(
-        summary="Show Schedule",
+        summary='Show Schedule',
         description=(
-            "In addition to the standard lookup by ID, you can also use the special /wip/ and /latest/ URL paths to access the unpublished and latest published schedules. "
-            "To receive most schedule data, query the endpoint with ``?expand=room,slots.submission.speakers``."
+            'In addition to the standard lookup by ID, you can also use the special /wip/ and /latest/ '
+            'URL paths to access the unpublished and latest published schedules. '
+            'To receive most schedule data, query the endpoint with ``?expand=room,slots.submission.speakers``.'
         ),
         parameters=[
             build_expand_docs(
-                "slots",
-                "slots.room",
-                "slots.submission",
-                "slots.submission.speakers",
-                "slots.submission.track",
-                "slots.submission.submission_type",
+                'slots',
+                'slots.room',
+                'slots.submission',
+                'slots.submission.speakers',
+                'slots.submission.track',
+                'slots.submission.submission_type',
             ),
         ],
     ),
@@ -59,61 +60,60 @@ from eventyay.base.models.slot import TalkSlot
 class ScheduleViewSet(PretalxViewSetMixin, viewsets.ReadOnlyModelViewSet):
     serializer_class = LegacyScheduleSerializer
     queryset = Schedule.objects.none()
-    endpoint = "schedules"
-    search_fields = ("version",)
+    endpoint = 'schedules'
+    search_fields = ('version',)
     # We look up schedules by IDs, but we permit the special names "wip" and "latest"
-    lookup_value_regex = "[^/]+"
+    lookup_value_regex = '[^/]+'
     permission_map = {
-        "redirect_version": "schedule.list_schedule",
-        "get_exporter": "schedule.list_schedule",
+        'redirect_version': 'schedule.list_schedule',
+        'get_exporter': 'schedule.list_schedule',
     }
 
     def get_unversioned_serializer_class(self):
-        if self.action == "list":
+        if self.action == 'list':
             return ScheduleListSerializer
-        if self.action == "release":
+        if self.action == 'release':
             return ScheduleReleaseSerializer
         return ScheduleSerializer
 
     def get_serializer_context(self):
         context = super().get_serializer_context()
-        context["only_visible_slots"] = self.event and not self.has_perm("orga_view")
+        context['only_visible_slots'] = self.event and not self.has_perm('orga_view')
         return context
 
     def get_queryset(self):
         if not self.event:
             return self.queryset
-        current_schedule = (
-            self.event.current_schedule.pk if self.event.current_schedule else None
-        )
-        if self.has_perm("release", self.event):
+        current_schedule = self.event.current_schedule.pk if self.event.current_schedule else None
+        if self.has_perm('release', self.event):
             return self.event.schedules.all()
         return self.event.schedules.filter(pk=current_schedule)
 
     def get_object(self):
         identifier = self.kwargs.get(self.lookup_field)
-        if identifier == "wip":
+        if identifier == 'wip':
             queryset = self.get_queryset()
             obj = get_object_or_404(queryset, version=None)
             self.check_object_permissions(self.request, obj)
             return obj
-        if identifier == "latest":
+        if identifier == 'latest':
             if not self.event or not self.event.current_schedule:
                 raise Http404
-            obj = get_object_or_404(
-                self.get_queryset(), pk=self.event.current_schedule.pk
-            )
+            obj = get_object_or_404(self.get_queryset(), pk=self.event.current_schedule.pk)
             self.check_object_permissions(self.request, obj)
             return obj
 
         return super().get_object()
 
     @extend_schema(
-        summary="Redirect to a schedule by its version",
-        description="This endpoint redirects to a specific schedule using its version name (e.g., '1.0', 'My Release') instead of its numeric ID.",
+        summary='Redirect to a schedule by its version',
+        description=(
+            'This endpoint redirects to a specific schedule using its version name '
+            "(e.g., '1.0', 'My Release') instead of its numeric ID."
+        ),
         parameters=[
             OpenApiParameter(
-                name="version",
+                name='version',
                 type=str,
                 location=OpenApiParameter.QUERY,
                 required=True,
@@ -125,42 +125,40 @@ class ScheduleViewSet(PretalxViewSetMixin, viewsets.ReadOnlyModelViewSet):
             404: OpenApiResponse(),
         },
     )
-    @action(detail=False, url_path="by-version")
+    @action(detail=False, url_path='by-version')
     def redirect_version(self, request, event, organizer=None):
-        version = request.query_params.get("version")
+        version = request.query_params.get('version')
         schedule = get_object_or_404(self.event.schedules, version=version)
-        if not self.has_perm("view", schedule):
+        if not self.has_perm('view', schedule):
             raise Http404
-        redirect_url = reverse(
-            "api:schedule-detail", kwargs={"event": event, "pk": schedule.pk}
-        )
+        redirect_url = reverse('api:schedule-detail', kwargs={'event': event, 'pk': schedule.pk})
         return HttpResponseRedirect(redirect_url)
 
     @extend_schema(
-        summary="Release a new schedule version",
-        description="Freezes the current Work-in-Progress (WIP) schedule, creating a new named version. This makes the WIP schedule available under the given version name and creates a new empty WIP schedule.",
+        summary='Release a new schedule version',
+        description=(
+            'Freezes the current Work-in-Progress (WIP) schedule, creating a new named version. '
+            'This makes the WIP schedule available under the given version name and creates a new empty WIP '
+            'schedule.'
+        ),
         request=ScheduleReleaseSerializer,
         responses={
             201: OpenApiResponse(
-                description="Schedule released successfully.",
+                description='Schedule released successfully.',
                 response=ScheduleSerializer,
             ),
-            400: OpenApiResponse(
-                description="Invalid data provided (e.g., version name already exists)."
-            ),
-            403: OpenApiResponse(description="Permission denied."),
+            400: OpenApiResponse(description='Invalid data provided (e.g., version name already exists).'),
+            403: OpenApiResponse(description='Permission denied.'),
         },
     )
-    @action(detail=False, methods=["POST"])
+    @action(detail=False, methods=['POST'])
     def release(self, request, event, organizer=None):
         wip_schedule = request.event.wip_schedule
-        serializer = ScheduleReleaseSerializer(
-            data=request.data, context=self.get_serializer_context()
-        )
+        serializer = ScheduleReleaseSerializer(data=request.data, context=self.get_serializer_context())
         serializer.is_valid(raise_exception=True)
 
-        version_name = serializer.validated_data.get("version")
-        comment = serializer.validated_data.get("comment")
+        version_name = serializer.validated_data.get('version')
+        comment = serializer.validated_data.get('comment')
 
         schedule, _ = wip_schedule.freeze(
             name=version_name,
@@ -169,36 +167,34 @@ class ScheduleViewSet(PretalxViewSetMixin, viewsets.ReadOnlyModelViewSet):
             comment=comment,
         )
 
-        response_serializer = ScheduleSerializer(
-            schedule, context=self.get_serializer_context()
-        )
+        response_serializer = ScheduleSerializer(schedule, context=self.get_serializer_context())
         return Response(response_serializer.data, status=status.HTTP_201_CREATED)
 
     @extend_schema(
-        summary="Get Exporter Content",
-        description="Retrieve the content of a specific schedule exporter by name.",
+        summary='Get Exporter Content',
+        description='Retrieve the content of a specific schedule exporter by name.',
         parameters=[
             OpenApiParameter(
-                name="name",
+                name='name',
                 type=str,
                 location=OpenApiParameter.PATH,
                 required=True,
-                description="The name of the exporter.",
+                description='The name of the exporter.',
             ),
             OpenApiParameter(
-                name="lang",
+                name='lang',
                 type=str,
                 location=OpenApiParameter.QUERY,
                 required=False,
-                description="Language code for the export content.",
+                description='Language code for the export content.',
             ),
         ],
         responses={
-            200: OpenApiResponse(description="Format depends on the chosen exporter."),
-            404: OpenApiResponse(description="Exporter or schedule not found."),
+            200: OpenApiResponse(description='Format depends on the chosen exporter.'),
+            404: OpenApiResponse(description='Exporter or schedule not found.'),
         },
     )
-    @action(detail=True, methods=["get"], url_path="exporters/(?P<name>[^/]+)")
+    @action(detail=True, methods=['get'], url_path='exporters/(?P<name>[^/]+)')
     def get_exporter(self, request, event, organizer=None, pk=None, name=None):
         schedule = self.get_object()
         response = get_schedule_exporter_content(request, name, schedule)
@@ -209,48 +205,57 @@ class ScheduleViewSet(PretalxViewSetMixin, viewsets.ReadOnlyModelViewSet):
 
 @extend_schema_view(
     list=extend_schema(
-        summary="List Talk Slots",
-        description="This endpoint always returns a filtered list. If you don’t provide any filters of your own, it will be filtered to show only talk slots in the latest published schedule.",
+        summary='List Talk Slots',
+        description=(
+            'This endpoint always returns a filtered list. If you don’t provide any filters of your own, '
+            'it will be filtered to show only talk slots in the latest published schedule.'
+        ),
         parameters=[
-            build_search_docs("submission.title", "submission.speakers.fullname"),
+            build_search_docs('submission.title', 'submission.speakers.fullname'),
             build_expand_docs(
-                "room",
-                "schedule",
-                "submission",
-                "submission.speakers",
-                "submission.track",
-                "submission.submission_type",
-                "submission.answers",
-                "submission.answers.question",
-                "submission.resources",
+                'room',
+                'schedule',
+                'submission',
+                'submission.speakers',
+                'submission.track',
+                'submission.submission_type',
+                'submission.answers',
+                'submission.answers.question',
+                'submission.resources',
             ),
         ],
     ),
     retrieve=extend_schema(
-        summary="Show Talk Slot",
+        summary='Show Talk Slot',
         parameters=[
             build_expand_docs(
-                "room",
-                "schedule",
-                "submission",
-                "submission.speakers",
-                "submission.track",
-                "submission.submission_type",
-                "submission.answers",
-                "submission.answers.question",
-                "submission.resources",
+                'room',
+                'schedule',
+                'submission',
+                'submission.speakers',
+                'submission.track',
+                'submission.submission_type',
+                'submission.answers',
+                'submission.answers.question',
+                'submission.resources',
             )
         ],
     ),
     update=extend_schema(
-        summary="Update Talk Slot",
-        description="Only talk slots in the WIP schedule can be changed – once a schedule version is frozen, its talk slots can’t be modified anymore.",
+        summary='Update Talk Slot',
+        description=(
+            'Only talk slots in the WIP schedule can be changed – once a schedule version is frozen, '
+            'its talk slots can’t be modified anymore.'
+        ),
     ),
     partial_update=extend_schema(
-        summary="Update Talk Slot (Partial Update)",
-        description="Only talk slots in the WIP schedule can be changed – once a schedule version is frozen, its talk slots can’t be modified anymore.",
+        summary='Update Talk Slot (Partial Update)',
+        description=(
+            'Only talk slots in the WIP schedule can be changed – once a schedule version is frozen, '
+            'its talk slots can’t be modified anymore.'
+        ),
     ),
-    ical=extend_schema(summary="Export Talk Slot as iCalendar file"),
+    ical=extend_schema(summary='Export Talk Slot as iCalendar file'),
 )
 class TalkSlotViewSet(
     PretalxViewSetMixin,
@@ -261,16 +266,14 @@ class TalkSlotViewSet(
 ):
     serializer_class = TalkSlotSerializer
     queryset = TalkSlot.objects.none()
-    endpoint = "slots"
-    search_fields = ("submission__title", "submission__speakers__fullname")
+    endpoint = 'slots'
+    search_fields = ('submission__title', 'submission__speakers__fullname')
     filterset_class = TalkSlotFilter
-    permission_map = {"ical": "schedule.view_talkslot"}
+    permission_map = {'ical': 'schedule.view_talkslot'}
 
     @cached_property
     def is_orga(self):
-        return self.event and self.request.user.has_perm(
-            "base.orga_view_schedule", self.event
-        )
+        return self.event and self.request.user.has_perm('base.orga_view_schedule', self.event)
 
     def get_unversioned_serializer_class(self):
         if self.is_orga:
@@ -281,53 +284,43 @@ class TalkSlotViewSet(
         if not self.event:
             return self.queryset
 
-        queryset = TalkSlot.objects.filter(schedule__event=self.event).select_related(
-            "submission", "room", "schedule"
-        )
+        queryset = TalkSlot.objects.filter(schedule__event=self.event).select_related('submission', 'room', 'schedule')
         if not self.is_orga:
-            queryset = queryset.filter(is_visible=True).exclude(
-                schedule__version__isnull=True
+            queryset = (
+                queryset.filter(is_visible=True).exclude(room__deleted=True).exclude(schedule__version__isnull=True)
             )
 
         if fields := self.check_expanded_fields(
-            "submission.speakers",
-            "submission.resources",
-            "submission.answers",
-            "submission.question",
+            'submission.speakers',
+            'submission.resources',
+            'submission.answers',
+            'submission.question',
         ):
-            queryset = queryset.prefetch_related(
-                *[f.replace(".", "__") for f in fields]
-            )
-        if fields := self.check_expanded_fields(
-            "submission.track", "submission.submission_type"
-        ):
-            queryset = queryset.select_related(*[f.replace(".", "__") for f in fields])
+            queryset = queryset.prefetch_related(*[f.replace('.', '__') for f in fields])
+        if fields := self.check_expanded_fields('submission.track', 'submission.submission_type'):
+            queryset = queryset.select_related(*[f.replace('.', '__') for f in fields])
 
-        if self.action != "list":
+        if self.action != 'list':
             return queryset
 
         # In the list view, fall back to filtering by current schedule if there is no
         # other filter present.
         # If there is no current schedule, that means an empty response.
         filter_params = self.filterset_class.get_fields().keys()
-        is_any_filter_active = any(
-            param in self.request.query_params for param in filter_params
-        )
+        is_any_filter_active = any(param in self.request.query_params for param in filter_params)
 
         if not is_any_filter_active:
             queryset = queryset.filter(schedule=self.event.current_schedule)
 
         return queryset
 
-    @action(detail=True, methods=["get"])
+    @action(detail=True, methods=['get'])
     def ical(self, request, event, pk=None):
         """Export a single talk slot as an iCalendar file."""
         slot = self.get_object()
         if not slot.submission:
             raise Http404
         calendar_data = slot.full_ical()
-        response = HttpResponse(calendar_data.serialize(), content_type="text/calendar")
-        response["Content-Disposition"] = (
-            f'attachment; filename="{request.event.slug}-{slot.submission.code}.ics"'
-        )
+        response = HttpResponse(calendar_data.serialize(), content_type='text/calendar')
+        response['Content-Disposition'] = f'attachment; filename="{request.event.slug}-{slot.submission.code}.ics"'
         return response

--- a/app/eventyay/base/models/schedule.py
+++ b/app/eventyay/base/models/schedule.py
@@ -221,6 +221,7 @@ class Schedule(PretalxModel):
             .prefetch_related('submission__speakers')
             .filter(
                 room__isnull=False,
+                room__deleted=False,
                 start__isnull=False,
                 is_visible=True,
                 submission__isnull=False,
@@ -230,7 +231,7 @@ class Schedule(PretalxModel):
 
     @cached_property
     def breaks(self):
-        return self.talks.select_related('room').filter(submission__isnull=True)
+        return self.talks.select_related('room').filter(submission__isnull=True, room__deleted=False)
 
     @cached_property
     def slots(self):
@@ -335,7 +336,9 @@ class Schedule(PretalxModel):
                 result['canceled_talks'] += old_by_submission[entry.submission]
             else:
                 new, canceled, moved = self._handle_submission_move(
-                    entry.submission, old_slots, new_slots,
+                    entry.submission,
+                    old_slots,
+                    new_slots,
                     all_old_slots=old_by_submission.get(entry.submission, []),
                     all_new_slots=new_by_submission.get(entry.submission, []),
                 )
@@ -350,7 +353,9 @@ class Schedule(PretalxModel):
                 result['new_talks'] += new_by_submission[entry.submission]
             else:
                 new, canceled, moved = self._handle_submission_move(
-                    entry.submission, old_slots, new_slots,
+                    entry.submission,
+                    old_slots,
+                    new_slots,
                     all_old_slots=old_by_submission.get(entry.submission, []),
                     all_new_slots=new_by_submission.get(entry.submission, []),
                 )
@@ -486,7 +491,12 @@ class Schedule(PretalxModel):
 
     def get_all_talk_warnings(self, ids=None, filter_updated=None):
         talks = (
-            self.talks.filter(submission__isnull=False, start__isnull=False, room__isnull=False)
+            self.talks.filter(
+                submission__isnull=False,
+                start__isnull=False,
+                room__isnull=False,
+                room__deleted=False,
+            )
             .select_related(
                 'submission',
                 'room',
@@ -528,7 +538,7 @@ class Schedule(PretalxModel):
             # room_overlap warning — matching the per-talk ``.exists()`` query
             # at get_talk_warnings() which scans all TalkSlots in the room.
             extra_slots_qs = (
-                self.talks.filter(start__isnull=False, room__isnull=False)
+                self.talks.filter(start__isnull=False, room__isnull=False, room__deleted=False)
                 .select_related('submission')
                 .prefetch_related('submission__speakers')
             )
@@ -759,6 +769,8 @@ class Schedule(PretalxModel):
         talks = self.talks.all()
         if not all_talks:
             talks = self.talks.filter(is_visible=True)
+        if respect_public_visibility:
+            talks = talks.filter(room__isnull=False).exclude(room__deleted=True)
         if filter_updated:
             talks = talks.filter(updated__gte=filter_updated)
         talks = talks.select_related(
@@ -820,11 +832,13 @@ class Schedule(PretalxModel):
                 ss_start = timezone.make_aware(ss_start, timezone.get_current_timezone())
             if timezone.is_naive(ss_end):
                 ss_end = timezone.make_aware(ss_end, timezone.get_current_timezone())
-            stream_schedules_by_room[ss.room_id].append((
-                ss_start.astimezone(UTC),
-                ss_end.astimezone(UTC),
-                ss,
-            ))
+            stream_schedules_by_room[ss.room_id].append(
+                (
+                    ss_start.astimezone(UTC),
+                    ss_end.astimezone(UTC),
+                    ss,
+                )
+            )
         rooms: set[Room] = set(self.event.rooms.filter(deleted=False)) if all_rooms else set()
         tracks: set[Track] = set()
         speakers: set[User] = set()

--- a/app/eventyay/base/services/room.py
+++ b/app/eventyay/base/services/room.py
@@ -9,9 +9,8 @@ from django.utils.timezone import now
 from django_scopes import scopes_disabled
 
 from eventyay.base.models import AuditLog, Channel, User
-from eventyay.base.models.room import Room
 from eventyay.base.models.event import Event
-from eventyay.base.models.room import RoomConfigSerializer, RoomView
+from eventyay.base.models.room import Room, RoomConfigSerializer, RoomView
 from eventyay.base.services.user import get_public_users
 from eventyay.base.signals import periodic_task
 from eventyay.features.live.channels import GROUP_ROOM
@@ -50,12 +49,7 @@ def end_view(view: RoomView, delete=False):
         view.end = now()
         view.save()
     c = RoomView.objects.filter(room_id=view.room_id, end__isnull=True).count()
-    is_last = (
-        RoomView.objects.filter(
-            room_id=view.room_id, end__isnull=True, user=view.user
-        ).count()
-        == 0
-    )
+    is_last = RoomView.objects.filter(room_id=view.room_id, end__isnull=True, user=view.user).count() == 0
     return c, is_last
 
 
@@ -63,12 +57,10 @@ async def get_viewers(event: Event, room: Room):
     users = await get_public_users(
         # We're doing an ORM query in an async method, but it's okay, since it is not going to be evaluated but
         # lazily passed to get_public_users which will use it as a subquery :)
-        ids=RoomView.objects.filter(room=room, end__isnull=True).values_list(
-            "user_id", flat=True
-        ),
+        ids=RoomView.objects.filter(room=room, end__isnull=True).values_list('user_id', flat=True),
         event_id=event.pk,
         include_banned=False,
-        trait_badges_map=event.config.get("trait_badges_map"),
+        trait_badges_map=event.config.get('trait_badges_map'),
         require_show_publicly=True,
     )
     return users
@@ -83,15 +75,15 @@ def save_room(event, room, update_fields, old_data, by_user):
     AuditLog.objects.create(
         event_id=event.id,
         user=by_user,
-        type="event.room.updated",
+        type='event.room.updated',
         data={
-            "object": str(room.id),
-            "old": old_data,
-            "new": new,
+            'object': str(room.id),
+            'old': old_data,
+            'new': new,
         },
     )
 
-    if "chat.native" in {m["type"] for m in room.module_config}:
+    if 'chat.native' in {m['type'] for m in room.module_config}:
         Channel.objects.get_or_create(event_id=event.pk, room=room)
     return new
 
@@ -100,16 +92,16 @@ def save_room(event, room, update_fields, old_data, by_user):
 @atomic
 def delete_room(event, room, by_user):
     room.deleted = True
-    room.save(update_fields=["deleted"])
+    room.save(update_fields=['deleted'])
     old = RoomConfigSerializer(room).data
 
     AuditLog.objects.create(
         event_id=event.id,
         user=by_user,
-        type="event.room.deleted",
+        type='event.room.deleted',
         data={
-            "object": str(room.id),
-            "old": old,
+            'object': str(room.id),
+            'old': old,
         },
     )
 
@@ -123,9 +115,7 @@ def reorder_rooms(event, id_list, by_user):
         except Exception:
             return sys.maxsize, r.sorting_priority, r.name
 
-    all_rooms = list(
-        event.rooms.filter(deleted=False).only("id", "name", "sorting_priority")
-    )
+    all_rooms = list(event.rooms.filter(deleted=False).only('id', 'name', 'sorting_priority'))
     all_rooms.sort(key=key)
     to_update = []
 
@@ -134,14 +124,14 @@ def reorder_rooms(event, id_list, by_user):
             r.sorting_priority = i + 1
             to_update.append(r)
 
-    Room.objects.bulk_update(to_update, fields=["sorting_priority"])
+    Room.objects.bulk_update(to_update, fields=['sorting_priority'])
 
     AuditLog.objects.create(
         event_id=event.id,
         user=by_user,
-        type="event.room.reorder",
+        type='event.room.reorder',
         data={
-            "id_list": id_list,
+            'id_list': id_list,
         },
     )
 
@@ -157,9 +147,9 @@ async def broadcast_stream_change(room_id, stream_schedule, reload=False):
     await get_channel_layer().group_send(
         GROUP_ROOM.format(id=room_id),
         {
-            "type": "stream.change",
-            "stream": data,
-            "reload": reload,
+            'type': 'stream.change',
+            'stream': data,
+            'reload': reload,
         },
     )
 
@@ -172,11 +162,7 @@ def check_stream_schedule_changes(sender, **kwargs):
     # Keep the last broadcast marker stable across periodic runs to avoid repeated rebroadcasts.
     cache_timeout = None
 
-    rooms = (
-        Room.objects.filter(deleted=False, stream_schedules__isnull=False)
-        .select_related('event')
-        .distinct()
-    )
+    rooms = Room.objects.filter(deleted=False, stream_schedules__isnull=False).select_related('event').distinct()
 
     for room in rooms:
         current_stream = room.get_current_stream()
@@ -187,6 +173,4 @@ def check_stream_schedule_changes(sender, **kwargs):
 
         if current_stream_id != last_broadcast_id:
             cache.set(cache_key, current_stream_id, cache_timeout)
-            async_to_sync(broadcast_stream_change)(
-                room.pk, current_stream, reload=current_stream_id is None
-            )
+            async_to_sync(broadcast_stream_change)(room.pk, current_stream, reload=current_stream_id is None)

--- a/app/eventyay/features/live/modules/room.py
+++ b/app/eventyay/features/live/modules/room.py
@@ -12,7 +12,12 @@ from django.utils.timezone import now
 from sentry_sdk import add_breadcrumb, configure_scope
 
 from eventyay.base.models.room import AnonymousInvite, RoomConfigSerializer
-from eventyay.core.permissions import Permission
+from eventyay.base.services.event import (
+    create_room,
+    get_room_config_for_user,
+    get_rooms,
+    notify_event_change,
+)
 from eventyay.base.services.poll import get_polls, get_voted_polls
 from eventyay.base.services.reactions import store_reaction
 from eventyay.base.services.room import (
@@ -23,14 +28,10 @@ from eventyay.base.services.room import (
     save_room,
     start_view,
 )
-from eventyay.base.services.event import (
-    create_room,
-    get_room_config_for_user,
-    get_rooms,
-    notify_event_change,
-)
+from eventyay.core.permissions import Permission
 from eventyay.core.utils.redis import aredis
 from eventyay.features.live.channels import (
+    GROUP_EVENT,
     GROUP_ROOM,
     GROUP_ROOM_POLL_ALL_RESULTS,
     GROUP_ROOM_POLL_MANAGE,
@@ -39,7 +40,6 @@ from eventyay.features.live.channels import (
     GROUP_ROOM_QUESTION_MODERATE,
     GROUP_ROOM_QUESTION_READ,
     GROUP_ROOM_VIEWERS,
-    GROUP_EVENT,
 )
 from eventyay.features.live.decorators import (
     command,
@@ -49,6 +49,7 @@ from eventyay.features.live.decorators import (
 )
 from eventyay.features.live.exceptions import ConsumerException
 from eventyay.features.live.modules.base import BaseModule
+
 
 logger = logging.getLogger(__name__)
 
@@ -420,13 +421,13 @@ class RoomModule(BaseModule):
     @command("delete")
     @room_action(permission_required=Permission.ROOM_DELETE)
     async def delete(self, body):
-        self.room.deleted = True
         await delete_room(self.consumer.event, self.room, by_user=self.consumer.user)
         await self.consumer.send_success()
         await get_channel_layer().group_send(
             f"event.{self.consumer.event.id}",
             {"type": "room.delete", "room": str(self.room.id)},
         )
+        await notify_event_change(self.consumer.event.id)
 
     @event("delete")
     async def push_room_delete(self, body):

--- a/app/eventyay/schedule/exporters.py
+++ b/app/eventyay/schedule/exporters.py
@@ -106,7 +106,7 @@ class ScheduleData(BaseExporter):
         }
 
         for talk in talks:
-            if not talk.start or not talk.room or (not talk.submission and not self.with_breaks):
+            if not talk.start or not talk.room or talk.room.deleted or (not talk.submission and not self.with_breaks):
                 continue
             talk_date = talk.local_start.date()
             if talk.local_start.hour < 3 and talk_date != event.date_from:
@@ -135,7 +135,7 @@ class ScheduleData(BaseExporter):
         for day in data.values():
             day['rooms'] = sorted(
                 day['rooms'].values(),
-                key=lambda room: (room['position'] if room['position'] is not None else room['id']),
+                key=lambda room: room['position'] if room['position'] is not None else room['id'],
             )
         return tuple(data.values())
 
@@ -230,7 +230,12 @@ class FrabJsonExporter(ScheduleData):
                 for talk in room['talks']:
                     if not talk.submission_id:
                         continue
-                    if self.favs_retrieve and self.talk_ids and talk.submission and talk.submission.code not in self.talk_ids:
+                    if (
+                        self.favs_retrieve
+                        and self.talk_ids
+                        and talk.submission
+                        and talk.submission.code not in self.talk_ids
+                    ):
                         continue
                     submission_ids.add(talk.submission_id)
 
@@ -253,8 +258,9 @@ class FrabJsonExporter(ScheduleData):
 
         return {
             profile.user_id: profile
-            for profile in SpeakerProfile.objects.filter(event=self.event, user_id__in=speaker_ids)
-            .select_related('user', 'event')
+            for profile in SpeakerProfile.objects.filter(event=self.event, user_id__in=speaker_ids).select_related(
+                'user', 'event'
+            )
         }
 
     def get_speaker_profile(self, person):
@@ -269,10 +275,10 @@ class FrabJsonExporter(ScheduleData):
         return {
             'url': self.metadata['url'],
             'version': schedule.version,
-                'base_url': self.metadata['base_url'],
-                'conference': {
-                    'acronym': self.event.slug,
-                    'title': localize_event_text(self.event.name),
+            'base_url': self.metadata['base_url'],
+            'conference': {
+                'acronym': self.event.slug,
+                'title': localize_event_text(self.event.name),
                 'start': self.event.date_from.strftime('%Y-%m-%d'),
                 'end': self.event.date_to.strftime('%Y-%m-%d'),
                 'daysCount': self.event.duration,
@@ -324,15 +330,17 @@ class FrabJsonExporter(ScheduleData):
         persons = []
         for person in talk.submission.speakers.all():
             profile = self.get_speaker_profile(person)
-            persons.append({
-                'code': person.code,
-                'name': person.get_display_name(),
-                'avatar': person.get_avatar_url(self.event) or None,
-                'biography': localize_event_text(profile.biography),
-                'public_name': person.get_display_name(),  # deprecated
-                'guid': person.guid,
-                'url': profile.urls.public.full(),
-            })
+            persons.append(
+                {
+                    'code': person.code,
+                    'name': person.get_display_name(),
+                    'avatar': person.get_avatar_url(self.event) or None,
+                    'biography': localize_event_text(profile.biography),
+                    'public_name': person.get_display_name(),  # deprecated
+                    'guid': person.guid,
+                    'url': profile.urls.public.full(),
+                }
+            )
         return {
             'guid': talk.uuid,
             'code': talk.submission.code,
@@ -346,11 +354,7 @@ class FrabJsonExporter(ScheduleData):
             'url': talk.submission.urls.public.full(),
             'title': localize_event_text(talk.submission.title),
             'subtitle': '',
-            'track': (
-                localize_event_text(talk.submission.track.name)
-                if talk.submission.track
-                else None
-            ),
+            'track': (localize_event_text(talk.submission.track.name) if talk.submission.track else None),
             'type': localize_event_text(talk.submission.submission_type.name),
             'language': talk.submission.content_locale,
             'abstract': localize_event_text(talk.submission.abstract),

--- a/app/eventyay/webapp/schedule-editor/src/App.vue
+++ b/app/eventyay/webapp/schedule-editor/src/App.vue
@@ -25,6 +25,10 @@
 							i.fa.fa-sort-amount-desc(v-if="unassignedSort === method.name && unassignedSortDirection === -1")
 				session.new-break(:session="{title: '+ ' + translations.newBreak}", :isDragged="false", @startDragging="startNewBreak", @click="showNewBreakHint", v-tooltip.fixed="{text: newBreakTooltip, show: newBreakTooltip}", @pointerleave="removeNewBreakHint")
 				session(v-for="un in unscheduled", :key="un.id", :session="un", @startDragging="startDragging", :isDragged="draggedSession && un.id === draggedSession.id")
+				.deleted-room-sessions(v-if="deletedRoomSessions.length")
+					h3 {{ $t('Deleted Room Sessions') }}
+					p {{ $t('These sessions were assigned to a room that has been deleted. Drag them into another room to restore them to the schedule.') }}
+					session(v-for="session in deletedRoomSessions", :key="session.id", :session="session", @startDragging="startDragging", :isDragged="draggedSession && session.id === draggedSession.id")
 			#schedule-wrapper(v-scrollbar.x.y="")
 				.schedule-controls
 					bunt-tabs.days(v-if="days", :modelValue="currentDay.format()", ref="tabs" :class="['grid-tabs']")
@@ -107,12 +111,12 @@ interface Speaker {
 }
 
 interface Track {
-  id: string
+  id: string | number
   name: Record<string, string> // localized names
 }
 
 interface Room {
-  id: string
+  id: string | number
   name: Record<string, string>
 }
 
@@ -126,8 +130,8 @@ interface Talk {
   title: Record<string, string>
   abstract?: string
   speakers?: string[]
-  track?: string
-  room?: string
+  track?: string | number
+  room?: string | number
   duration: number
   start?: string | null
   end?: string | null
@@ -150,6 +154,7 @@ interface SessionData {
   end?: Moment
   state?: string
   room?: Room
+  deletedRoom?: boolean
   uncreated?: boolean
   availabilities?: AvailabilityEntry[]
 }
@@ -227,11 +232,15 @@ const translations = reactive({
   newBreak: $t('New break'),
 })
 
+function lookupKey(value?: string | number | null): string {
+  return value == null ? '' : String(value)
+}
+
 // Lookups
 const roomsLookup = computed<Record<string, Room>>(() => {
   if (!schedule.value) return {}
   return schedule.value.rooms.reduce((acc, room) => {
-    acc[room.id] = room
+    acc[lookupKey(room.id)] = room
     return acc
   }, {} as Record<string, Room>)
 })
@@ -239,7 +248,7 @@ const roomsLookup = computed<Record<string, Room>>(() => {
 const tracksLookup = computed<Record<string, Track>>(() => {
   if (!schedule.value) return {}
   return schedule.value.tracks.reduce((acc, track) => {
-    acc[track.id] = track
+    acc[lookupKey(track.id)] = track
     return acc
   }, {} as Record<string, Track>)
 })
@@ -274,18 +283,18 @@ const unassignedSortMethods = computed<SortMethod[]>(() => {
   return sortMethods
 })
 
-// Sessions without start or room (unassigned)
+// Sessions without start (unassigned)
 const unscheduled = computed<SessionData[]>(() => {
   if (!schedule.value) return []
   let sessions: SessionData[] = []
-  for (const session of schedule.value.talks.filter((s) => !s.start || !s.room)) {
+  for (const session of schedule.value.talks.filter((s) => !s.start)) {
     sessions.push({
       id: session.id,
       code: session.code,
       title: session.title,
       abstract: session.abstract,
       speakers: resolveSessionSpeakers(session.speakers),
-      track: tracksLookup.value[session.track ?? ''],
+      track: tracksLookup.value[lookupKey(session.track)],
       duration: session.duration,
       state: session.state,
     } as SessionData)
@@ -323,6 +332,25 @@ const unscheduled = computed<SessionData[]>(() => {
   return sessions
 })
 
+const deletedRoomSessions = computed<SessionData[]>(() => {
+  if (!schedule.value) return []
+  return schedule.value.talks
+    .filter((session) => session.start && (!session.room || !roomsLookup.value[lookupKey(session.room)]))
+    .map((session) => ({
+      id: session.id,
+      code: session.code,
+      title: session.title,
+      abstract: session.abstract,
+      start: moment(session.start),
+      end: moment(session.end),
+      duration: session.end ? moment(session.end).diff(moment(session.start), 'minutes') : session.duration,
+      speakers: resolveSessionSpeakers(session.speakers),
+      track: tracksLookup.value[lookupKey(session.track)],
+      state: session.state,
+      deletedRoom: true,
+    }))
+})
+
 const sessions = computed<SessionData[]>(() => {
   if (!schedule.value) return []
   const dayStart = days.value[0]
@@ -332,6 +360,8 @@ const sessions = computed<SessionData[]>(() => {
   const filteredSessions = schedule.value.talks.filter(
     (s) =>
       s.start &&
+      s.room &&
+      roomsLookup.value[lookupKey(s.room)] &&
       moment(s.start).isSameOrAfter(dayStart) &&
       moment(s.start).isSameOrBefore(dayEnd),
   )
@@ -345,9 +375,9 @@ const sessions = computed<SessionData[]>(() => {
     end: moment(session.end),
     duration: moment(session.end).diff(moment(session.start), 'minutes'),
     speakers: resolveSessionSpeakers(session.speakers),
-    track: tracksLookup.value[session.track ?? ''],
+    track: tracksLookup.value[lookupKey(session.track)],
     state: session.state,
-    room: roomsLookup.value[session.room ?? ''],
+    room: roomsLookup.value[lookupKey(session.room)],
   }))
 
   sessionList.sort((a, b) => a.start!.diff(b.start!))
@@ -565,7 +595,7 @@ function startDragging({ event, session }: DragStartEvent) {
 async function stopDragging(): Promise<void> {
   try {
     if (isUnassigning.value && draggedSession.value) {
-      if (draggedSession.value.code) {
+      if (draggedSession.value.code && !draggedSession.value.deletedRoom) {
         const movedSession = schedule.value?.talks.find((s) => s.id === draggedSession.value!.id)
         if (movedSession) {
           movedSession.start = null
@@ -866,6 +896,20 @@ onUnmounted(() => {
 				align-items: center
 				&:hover
 					background-color: $clr-dividers-light
+		.deleted-room-sessions
+			margin: 24px 12px 0 8px
+			padding-top: 16px
+			border-top: 4px solid $clr-danger
+			h3
+				margin: 0 0 8px
+				font-size: 18px
+				font-weight: 600
+				color: $clr-danger
+			p
+				margin: 0 8px 8px 0
+				font-size: 13px
+				line-height: 18px
+				color: $clr-secondary-text-light
 	.schedule-controls
 		display: flex
 		align-items: center

--- a/app/eventyay/webapp/video/src/components/RoomEditPrompt.vue
+++ b/app/eventyay/webapp/video/src/components/RoomEditPrompt.vue
@@ -9,6 +9,19 @@ prompt.c-room-edit-prompt(:scrollable="false", @close="$emit('close')")
 			bunt-button(@click="fetchConfig") Retry
 		template(v-else-if="config")
 			.edit-body(v-scrollbar.y="")
+				.reset-section(v-if="wasConfigured")
+					.section-header
+						h3 Reset Room
+						bunt-button.btn-reset(
+							v-if="!confirmingReset",
+							@click="confirmingReset = true",
+						) Reset
+					p Return this room to the unconfigured state. The room itself and assigned sessions stay in place.
+					.confirmation(v-if="confirmingReset")
+						p Are you sure you want to reset this room to the unconfigured state?
+						.confirmation-actions
+							bunt-button.btn-cancel(@click="confirmingReset = false") Cancel
+							bunt-button.btn-reset(@click="resetRoom", :loading="resetting", :error-message="resetError") Confirm reset
 				.type-section
 					h3 Room Type
 					.current-type(v-if="inferredType")
@@ -35,6 +48,16 @@ prompt.c-room-edit-prompt(:scrollable="false", @close="$emit('close')")
 					:config="config",
 					:modules="modules"
 				)
+				.danger-zone(v-if="wasConfigured && hasPermission('room:delete')")
+					h3 Danger Zone
+					p #[b Deleting this room will remove it from the schedule, but the sessions will remain safe.] Sessions assigned to this room will no longer have a room assigned.
+					bunt-button.btn-delete-room(v-if="!confirmingDelete", @click="confirmingDelete = true") Delete
+					.delete-confirmation(v-else)
+						p Please type #[b {{ localizedRoomName }}] to confirm deletion.
+						bunt-input(name="deletingRoomName", label="Room name", v-model="deletingRoomName", @keypress.enter="deleteRoom")
+						.confirmation-actions
+							bunt-button.btn-cancel(@click="cancelDelete") Cancel
+							bunt-button.btn-delete-room(icon="delete", :disabled="deletingRoomName !== localizedRoomName", @click="deleteRoom", :loading="deleting", :error-message="deleteError") Delete this room
 			.edit-actions
 				bunt-button.btn-cancel(@click="$emit('close')") Cancel
 				bunt-button.btn-save(@click="save", :loading="saving", :error-message="saveError") Save
@@ -64,14 +87,22 @@ export default {
 			required: true
 		}
 	},
-	emits: ['close'],
+	emits: ['close', 'deleted'],
 	data () {
 		return {
 			loading: true,
 			error: null,
 			config: null,
+			wasConfigured: false,
 			saving: false,
 			saveError: null,
+			confirmingReset: false,
+			resetting: false,
+			resetError: null,
+			confirmingDelete: false,
+			deletingRoomName: '',
+			deleting: false,
+			deleteError: null,
 			allRoomTypes: ROOM_TYPES,
 			typeComponents: markRaw({
 				stage: Stage,
@@ -117,6 +148,9 @@ export default {
 			set (value) {
 				this.config.description = value
 			}
+		},
+		localizedRoomName () {
+			return this.$localize(this.config?.name)
 		}
 	},
 	async created () {
@@ -128,6 +162,7 @@ export default {
 			this.error = null
 			try {
 				this.config = await api.call('room.config.get', { room: this.room.id })
+				this.wasConfigured = !!inferType(this.config)
 			} catch (err) {
 				this.error = err.code === 'protocol.denied'
 					? 'You do not have permission to edit this room.'
@@ -139,6 +174,41 @@ export default {
 		changeType (type) {
 			if (this.inferredType && this.inferredType.id === type.id) return
 			this.config.module_config = [{ type: type.startingModule, config: {} }]
+		},
+		async resetRoom () {
+			this.resetError = null
+			this.resetting = true
+			try {
+				await api.call('room.config.patch', {
+					room: this.config.id,
+					module_config: []
+				})
+				this.$emit('close')
+			} catch (err) {
+				console.error('Failed to reset room: %o', err)
+				this.resetError = err.message || String(err)
+			} finally {
+				this.resetting = false
+			}
+		},
+		cancelDelete () {
+			this.confirmingDelete = false
+			this.deletingRoomName = ''
+			this.deleteError = null
+		},
+		async deleteRoom () {
+			if (this.deletingRoomName !== this.localizedRoomName) return
+			this.deleteError = null
+			this.deleting = true
+			try {
+				await api.call('room.delete', { room: this.config.id })
+				this.$emit('deleted')
+			} catch (err) {
+				console.error('Failed to delete room: %o', err)
+				this.deleteError = err.message || String(err)
+			} finally {
+				this.deleting = false
+			}
 		},
 		async save () {
 			this.saveError = null
@@ -191,6 +261,36 @@ export default {
 		display: flex
 		flex-direction: column
 		gap: 16px
+	.reset-section
+		padding: 12px
+		border: border-separator()
+		border-radius: 4px
+		background-color: $clr-grey-50
+		p
+			margin: 0
+			font-size: 13px
+			line-height: 18px
+			color: $clr-secondary-text-light
+	.section-header
+		display: flex
+		align-items: center
+		justify-content: space-between
+		gap: 12px
+		h3
+			margin: 0
+			font-size: 16px
+			font-weight: 500
+	.confirmation
+		margin-top: 12px
+		padding-top: 12px
+		border-top: border-separator()
+	.confirmation-actions
+		display: flex
+		justify-content: flex-end
+		gap: 8px
+		margin-top: 12px
+	.btn-reset
+		button-style(color: $clr-orange)
 	.type-section
 		h3
 			margin: 0 0 8px
@@ -245,6 +345,26 @@ export default {
 		gap: 8px
 	.type-settings
 		margin-top: 8px
+	.danger-zone
+		padding: 12px
+		border: 1px solid $clr-danger
+		border-radius: 4px
+		background-color: rgba($clr-danger, 0.05)
+		h3
+			margin: 0 0 8px
+			font-size: 16px
+			font-weight: 600
+			color: $clr-danger
+		p
+			margin: 0 0 12px
+			font-size: 13px
+			line-height: 18px
+	.delete-confirmation
+		margin-top: 12px
+		padding-top: 12px
+		border-top: border-separator()
+	.btn-delete-room
+		button-style(color: $clr-danger)
 	.edit-actions
 		display: flex
 		justify-content: flex-end

--- a/app/eventyay/webapp/video/src/views/admin/rooms/item.vue
+++ b/app/eventyay/webapp/video/src/views/admin/rooms/item.vue
@@ -19,36 +19,26 @@
 					span.room-name(v-html="$emojify($localize(config.name))")
 				.actions
 					bunt-button(v-if="hasPermission('room:update')", @click="showRoomEditPrompt = true") Edit
-					bunt-button.btn-delete-room(@click="showDeletePrompt = true") delete
 			edit-form(:config="config")
 	bunt-progress-circular(v-else, size="huge")
 	transition(name="prompt")
 		RoomEditPrompt(
 			v-if="showRoomEditPrompt && config",
 			:room="{id: config.id}",
-			@close="closeRoomEditPrompt"
+			@close="closeRoomEditPrompt",
+			@deleted="roomDeleted"
 		)
-		prompt.delete-prompt(v-if="showDeletePrompt", @close="showDeletePrompt = false")
-			.content
-				.prompt-header
-					h3 Are you ABSOLUTELY sure?
-				p This action #[b CANNOT] be undone. This will permanently delete the room
-				.room-name {{ $localize(config.name) }}
-				p Please type in the name of the room to confirm.
-				bunt-input(name="deletingRoomName", label="Room name", v-model="deletingRoomName", @keypress.enter="deleteRoom")
-				bunt-button.delete-room(icon="delete", :disabled="deletingRoomName !== $localize(config.name)", @click="deleteRoom", :loading="deleting", :error-message="deleteError") delete this room
 </template>
 <script>
 import { mapGetters } from 'vuex'
 import api from 'lib/api'
-import Prompt from 'components/Prompt'
 import RoomEditPrompt from 'components/RoomEditPrompt'
 import { inferType } from 'lib/room-types'
 import EditForm from './EditForm'
 
 export default {
 	name: 'AdminRoom',
-	components: { EditForm, Prompt, RoomEditPrompt },
+	components: { EditForm, RoomEditPrompt },
 	props: {
 		roomId: String
 	},
@@ -58,10 +48,6 @@ export default {
 			errorCode: null,
 			config: null,
 			showRoomEditPrompt: false,
-			showDeletePrompt: false,
-			deletingRoomName: '',
-			deleting: false,
-			deleteError: null,
 			_unwatchConnected: null
 		}
 	},
@@ -69,9 +55,6 @@ export default {
 		...mapGetters(['hasPermission']),
 		inferredType() {
 			return inferType(this.config)
-		},
-		localizedRoomName() {
-			return this.$localize(this.config?.name)
 		}
 	},
 	async created() {
@@ -106,21 +89,12 @@ export default {
 				console.error(error)
 			}
 		},
-		async deleteRoom() {
-			if (this.deletingRoomName !== this.localizedRoomName) return
-			this.deleting = true
-			this.deleteError = null
-			try {
-				await api.call('room.delete', {room: this.config.id})
-				this.$router.replace({name: 'admin:rooms:index'})
-			} catch (error) {
-				this.deleteError = this.$t(`error:${error.code}`)
-			}
-			this.deleting = false
-		},
 		closeRoomEditPrompt() {
 			this.showRoomEditPrompt = false
 			this.fetchConfig()
+		},
+		roomDeleted() {
+			this.$router.replace({name: 'admin:rooms:index'})
 		}
 	}
 }
@@ -162,8 +136,6 @@ export default {
 			flex: none
 			.bunt-button:not(:last-child)
 				margin-right: 16px
-			.btn-delete-room
-				button-style(color: $clr-danger)
 	.mystery-room
 		flex: auto
 		display: flex
@@ -176,26 +148,4 @@ export default {
 			margin: 0
 			font-size: 16px
 			color: $clr-secondary-text-light
-
-	.delete-prompt
-		.content
-			display: flex
-			flex-direction: column
-			padding: 16px
-		.question-box-header
-			margin-top: -10px
-			margin-bottom: 15px
-			align-items: center
-			display: flex
-			justify-content: space-between
-		.room-name
-			font-family: monospace
-			font-size: 16px
-			border: border-separator()
-			border-radius: 4px
-			padding: 4px 8px
-			background-color: $clr-grey-100
-			align-self: center
-		.delete-room
-			button-style(color: $clr-danger)
 </style>


### PR DESCRIPTION
This PR adds the following changes:

- Adds an option to reset a room in video back to an unconfigured state.
- Adds a danger zone and moves the option to delete the room inside the edit pop-up
- Once a room is deleted the sessions assigned to that room will be preserved.

Screenshots:

Reset Room:
<img width="1818" height="1180" alt="image" src="https://github.com/user-attachments/assets/69df35dc-b943-44ab-92b3-753f5717316b" />
<img width="1818" height="1180" alt="image" src="https://github.com/user-attachments/assets/805bd199-4410-4e86-87ff-a30b72de3735" />

Delete Danger Zone:
<img width="1818" height="1180" alt="image" src="https://github.com/user-attachments/assets/818610d5-68df-427c-88d4-eb788018b406" />
<img width="1818" height="1180" alt="image" src="https://github.com/user-attachments/assets/9edd8062-d2bb-413a-ba98-422245c78e95" />

Sessions of deleted Room:
<img width="1818" height="1180" alt="image" src="https://github.com/user-attachments/assets/e9a74d8c-7502-4e27-be1e-fcc077c3afa6" />

> sorry for including the syntax changes in this PR :(