### PR TITLE
chore: fix bugs on scheduling

### DIFF
--- a/app/eventyay/webapp/schedule/src/App.vue
+++ b/app/eventyay/webapp/schedule/src/App.vue
@@ -422,7 +422,7 @@ export default {
 				}
 				if (filteredTrackIds && !filteredTrackIds.has(session.track)) continue
 				if (filteredRoomIds && !filteredRoomIds.has(session.room)) continue
-				if (filteredTypeValues && !filteredTypeValues.has(session.session_type)) continue
+				if (filteredTypeValues && !filteredTypeValues.has(getSessionTypeLabel(session.session_type))) continue
 				if (langExact) {
 					const fallbackLocale = this.schedule?.content_locales?.[0] || null
 					const sessionLocale = session.content_locale || fallbackLocale

--- a/app/eventyay/webapp/schedule/src/components/GridScheduleWrapper.vue
+++ b/app/eventyay/webapp/schedule/src/components/GridScheduleWrapper.vue
@@ -90,8 +90,6 @@ export default {
 				sessions: new Set(dayToSessions.get(day)),
 				rooms: new Set(dayToSessions.get(day).map((session) => session.room)),
 			}));
-			const dayMap = new Map();
-			dayMap.set(initialGroups[0].days[0], initialGroups[0]);
 
 			// Second pass: merge consecutive groups if they share sessions or their set of rooms is exactly the same
 			const mergedGroups = [];

--- a/app/eventyay/webapp/schedule/src/components/SpeakerDetail.vue
+++ b/app/eventyay/webapp/schedule/src/components/SpeakerDetail.vue
@@ -130,7 +130,7 @@ export default {
 					const spk = s.speakers
 					if (!spk) continue
 					for (let j = 0; j < spk.length; j++) {
-						if (spk[j].code === id) {
+						if (spk[j] && spk[j].code === id) {
 							out.push(s)
 							break
 						}

--- a/app/eventyay/webapp/schedule/src/components/SpeakersList.vue
+++ b/app/eventyay/webapp/schedule/src/components/SpeakersList.vue
@@ -655,6 +655,8 @@ export default {
 			.dropdown-menu
 				left: auto
 				right: 0
+				width: max-content
+				min-width: unset
 			.dropdown-actions
 				border-top: 1px solid #eee
 				padding: 4px 8px

--- a/app/eventyay/webapp/video/src/App.vue
+++ b/app/eventyay/webapp/video/src/App.vue
@@ -72,6 +72,8 @@ export default {
 				timezone: localStorage.getItem('userTimezone') || moment.tz.guess(),
 				hasAmPm: new Intl.DateTimeFormat(undefined, {hour: 'numeric'}).resolvedOptions().hour12,
 				errorLoading: computed(() => this.$store.state.schedule?.errorLoading),
+				speakersLookup: computed(() => this.$store.getters['schedule/speakersLookup']),
+				sessionsBySpeaker: computed(() => this.$store.getters['schedule/sessionsBySpeaker']),
 			}),
 			scheduleFav: (id) => this.$store.dispatch('schedule/fav', id),
 			scheduleUnfav: (id) => this.$store.dispatch('schedule/unfav', id),

--- a/app/eventyay/webapp/video/src/store/schedule.js
+++ b/app/eventyay/webapp/video/src/store/schedule.js
@@ -114,7 +114,7 @@ export default {
 					url: session.url,
 					start: moment.tz(session.start, rootState.userTimezone),
 					end: moment.tz(session.end, rootState.userTimezone),
-					speakers: session.speakers?.map(s => getters.speakersLookup[s]),
+					speakers: (session.speakers || []).map(s => getters.speakersLookup[s] || { code: s }).filter(Boolean),
 					track: getters.tracksLookup[session.track],
 					room: getters.roomsLookup[session.room],
 					fav_count: session.fav_count,
@@ -141,6 +141,18 @@ export default {
 		sessionsLookup (state, getters) {
 			if (!state.schedule) return {}
 			return getters.sessions.reduce((acc, s) => { acc[s.id] = s; return acc }, {})
+		},
+		sessionsBySpeaker (state, getters) {
+			if (!getters.sessions) return {}
+			return getters.sessions.reduce((acc, session) => {
+				(session.speakers || []).forEach((speaker) => {
+					const code = typeof speaker === 'string' ? speaker : speaker?.code
+					if (!code) return
+					if (!acc[code]) acc[code] = []
+					acc[code].push(session)
+				})
+				return acc
+			}, {})
 		},
 		days (state, getters) {
 			if (!getters.sessions) return


### PR DESCRIPTION
Fixes #3598
Fixes #3599
<img width="1650" height="580" alt="Screenshot 2026-05-19 at 1 13 58 PM" src="https://github.com/user-attachments/assets/8662bbfa-61ca-4866-b3c1-0b78d99d5fcf" />
<img width="1703" height="858" alt="Screenshot 2026-05-19 at 1 14 16 PM" src="https://github.com/user-attachments/assets/2da785b6-33d8-4ecb-ac54-8d46636f4739" />


## Summary by Sourcery

Improve schedule and speaker handling across video and schedule webapps to fix filtering and speaker-session association issues.

Bug Fixes:
- Fix session type filtering to use the human-readable session type label instead of the raw code.
- Prevent crashes when speaker entries in a session are null or undefined in speaker detail views.
- Adjust speakers list dropdown styling so the menu width fits its content instead of being constrained.

Enhancements:
- Expose a sessions-by-speaker mapping and related lookups in the video app store to support speaker-centric views.
- Simplify grid schedule grouping logic by removing unused day mapping state.