### PR TITLE
ci: simplify services and align config with TOML defaults

### DIFF
--- a/.github/workflows/video-backend-ci.yml
+++ b/.github/workflows/video-backend-ci.yml
@@ -18,11 +18,8 @@ env:
 jobs:
   python-uv-check:
     name: Backend validation (uv + Django checks)
-    # Pin to a specific Ubuntu LTS to reduce runner drift.
     runs-on: ubuntu-24.04
-    # Most config is read from eventyay.testing.toml via EVY_RUNNING_ENVIRONMENT=testing.
-    # Only the environment selector and secret key are set here; manage.py check does not
-    # connect to services so no database or Redis is needed for this job.
+    # manage.py check imports URL modules that touch the Redis cache backend at load time.
     env:
       EVY_RUNNING_ENVIRONMENT: testing
       EVY_SECRET_KEY: ci-test-secret-key
@@ -30,7 +27,10 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Install system packages
-        run: sudo apt-get update -qq && sudo apt-get install -y gettext
+        run: sudo apt-get update -qq && sudo apt-get install -y gettext redis-server
+
+      - name: Wait for Redis
+        run: timeout 30 bash -c 'until redis-cli ping >/dev/null 2>&1; do sleep 1; done'
 
       - uses: actions/setup-python@v5
         with:
@@ -111,12 +111,6 @@ jobs:
       - name: Run database migrations
         working-directory: app
         run: uv run python manage.py migrate --noinput
-
-      # tests/stable is a curated subset that passes reliably against the current
-      # codebase. The broader tests/ tree contains legacy suites with outstanding
-      # failures inherited from the project's history. The path forward is to fix
-      # those tests incrementally and re-enable them here, or quarantine them
-      # explicitly with pytest markers in a separate slow/legacy CI job.
       - name: Run pytest
         working-directory: app
         run: uv run pytest tests/stable -v --tb=short
@@ -169,9 +163,6 @@ jobs:
           echo $! > server.pid
 
       - name: Wait for server and verify healthcheck
-        # Use `localhost` (not 127.0.0.1) so MultiDomainMiddleware accepts the
-        # request: it compares the Host header against SITE_URL which defaults
-        # to http://localhost:8000.
         run: |
           for _ in {1..30}; do
             if curl -fsS http://localhost:8000/healthcheck/ >/dev/null 2>&1; then

--- a/.github/workflows/video-backend-ci.yml
+++ b/.github/workflows/video-backend-ci.yml
@@ -18,24 +18,19 @@ env:
 jobs:
   python-uv-check:
     name: Backend validation (uv + Django checks)
-    runs-on: ubuntu-latest
-    services:
-      redis:
-        image: redis:7
-        ports:
-          - 6379:6379
-        options: >-
-          --health-cmd="redis-cli ping"
-          --health-interval=10s
-          --health-timeout=5s
-          --health-retries=5
+    # Pin to a specific Ubuntu LTS to reduce runner drift.
+    runs-on: ubuntu-24.04
+    # Most config is read from eventyay.testing.toml via EVY_RUNNING_ENVIRONMENT=testing.
+    # Only the environment selector and secret key are set here; manage.py check does not
+    # connect to services so no database or Redis is needed for this job.
+    env:
+      EVY_RUNNING_ENVIRONMENT: testing
+      EVY_SECRET_KEY: ci-test-secret-key
     steps:
       - uses: actions/checkout@v4
 
-      - name: Install system packages (gettext)
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y gettext
+      - name: Install system packages
+        run: sudo apt-get update -qq && sudo apt-get install -y gettext
 
       - uses: actions/setup-python@v5
         with:
@@ -48,16 +43,12 @@ jobs:
         run: uv sync --directory app
 
       - name: Django system checks
-        env:
-          EVY_SECRET_KEY: ci-test-secret-key
-          EVY_DEBUG: "true"
-          EVY_REDIS_URL: redis://localhost:6379/0
         working-directory: app
         run: uv run python manage.py check
 
   video-build:
     name: Video build (Vite)
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     defaults:
       run:
         working-directory: app/eventyay/webapp/video
@@ -78,38 +69,34 @@ jobs:
 
   pytest-integration:
     name: Integration tests (pytest)
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     needs: python-uv-check
-    services:
-      postgres:
-        image: postgres:16
-        env:
-          POSTGRES_USER: eventyay
-          POSTGRES_PASSWORD: eventyay
-          POSTGRES_DB: eventyay-db
-        ports:
-          - 5432:5432
-        options: >-
-          --health-cmd="pg_isready -U eventyay -d eventyay-db"
-          --health-interval=10s
-          --health-timeout=5s
-          --health-retries=5
-      redis:
-        image: redis:7
-        ports:
-          - 6379:6379
-        options: >-
-          --health-cmd="redis-cli ping"
-          --health-interval=10s
-          --health-timeout=5s
-          --health-retries=5
+    # EVY_RUNNING_ENVIRONMENT loads eventyay.testing.toml (debug=true, email backend, etc.).
+    # DB connection details are CI-specific and kept out of eventyay.testing.toml so local
+    # developer runs continue to use their own peer-auth connection.
+    env:
+      EVY_RUNNING_ENVIRONMENT: testing
+      EVY_SECRET_KEY: ci-test-secret-key
+      EVY_POSTGRES_USER: eventyay
+      EVY_POSTGRES_PASSWORD: eventyay
+      EVY_POSTGRES_HOST: localhost
+      EVY_POSTGRES_PORT: "5432"
     steps:
       - uses: actions/checkout@v4
 
-      - name: Install system packages (gettext)
+      - name: Install system packages
+        run: sudo apt-get update -qq && sudo apt-get install -y gettext postgresql redis-server
+
+      - name: Set up PostgreSQL
         run: |
-          sudo apt-get update
-          sudo apt-get install -y gettext
+          # apt starts PostgreSQL automatically via systemd; wait for it to accept connections.
+          pg_isready -h localhost -t 30
+          sudo -u postgres createuser eventyay
+          sudo -u postgres psql -c "ALTER USER eventyay WITH PASSWORD 'eventyay';"
+          sudo -u postgres createdb -O eventyay "eventyay-db"
+
+      - name: Wait for Redis
+        run: timeout 30 bash -c 'until redis-cli ping >/dev/null 2>&1; do sleep 1; done'
 
       - uses: actions/setup-python@v5
         with:
@@ -118,73 +105,48 @@ jobs:
       - name: Install uv
         run: pip install uv
 
-      - name: Sync dependencies (including test group)
+      - name: Sync dependencies
         run: uv sync --directory app --group test
 
       - name: Run database migrations
-        env:
-          EVY_POSTGRES_USER: eventyay
-          EVY_POSTGRES_PASSWORD: eventyay
-          EVY_POSTGRES_DB: eventyay-db
-          EVY_POSTGRES_HOST: localhost
-          EVY_POSTGRES_PORT: "5432"
-          EVY_REDIS_URL: redis://localhost:6379/0
-          EVY_SECRET_KEY: ci-test-secret-key
-          EVY_DEBUG: "true"
         working-directory: app
         run: uv run python manage.py migrate --noinput
 
+      # tests/stable is a curated subset that passes reliably against the current
+      # codebase. The broader tests/ tree contains legacy suites with outstanding
+      # failures inherited from the project's history. The path forward is to fix
+      # those tests incrementally and re-enable them here, or quarantine them
+      # explicitly with pytest markers in a separate slow/legacy CI job.
       - name: Run pytest
-        env:
-          EVY_POSTGRES_USER: eventyay
-          EVY_POSTGRES_PASSWORD: eventyay
-          EVY_POSTGRES_DB: eventyay-db
-          EVY_POSTGRES_HOST: localhost
-          EVY_POSTGRES_PORT: "5432"
-          EVY_REDIS_URL: redis://localhost:6379/0
-          EVY_SECRET_KEY: ci-test-secret-key
-          EVY_DEBUG: "true"
-          EVY_RUNNING_ENVIRONMENT: testing
-          DJANGO_SETTINGS_MODULE: eventyay.config.settings
         working-directory: app
         run: uv run pytest tests/stable -v --tb=short
 
   backend-smoke:
     name: Backend smoke test (healthcheck)
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     needs: python-uv-check
-    services:
-      postgres:
-        image: postgres:16
-        env:
-          POSTGRES_USER: eventyay
-          POSTGRES_PASSWORD: eventyay
-          POSTGRES_DB: eventyay-db
-        ports:
-          - 5432:5432
-        options: >-
-          --health-cmd="pg_isready -U eventyay -d eventyay-db"
-          --health-interval=10s
-          --health-timeout=5s
-          --health-retries=5
-      redis:
-        image: redis:7
-        ports:
-          - 6379:6379
-        options: >-
-          --health-cmd="redis-cli ping"
-          --health-interval=10s
-          --health-timeout=5s
-          --health-retries=5
+    env:
+      EVY_RUNNING_ENVIRONMENT: testing
+      EVY_SECRET_KEY: ci-test-secret-key
+      EVY_POSTGRES_USER: eventyay
+      EVY_POSTGRES_PASSWORD: eventyay
+      EVY_POSTGRES_HOST: localhost
+      EVY_POSTGRES_PORT: "5432"
     steps:
       - uses: actions/checkout@v4
 
-      - name: Install system packages (gettext + redis-tools)
+      - name: Install system packages
+        run: sudo apt-get update -qq && sudo apt-get install -y gettext postgresql redis-server curl
+
+      - name: Set up PostgreSQL
         run: |
-          sudo apt-get update
-          # redis-cli is provided by redis-tools; curl is needed for the HTTP healthcheck.
-          # postgresql-client provides pg_isready on ubuntu-latest (often already present, but keep it explicit).
-          sudo apt-get install -y gettext redis-tools curl postgresql-client
+          pg_isready -h localhost -t 30
+          sudo -u postgres createuser eventyay
+          sudo -u postgres psql -c "ALTER USER eventyay WITH PASSWORD 'eventyay';"
+          sudo -u postgres createdb -O eventyay "eventyay-db"
+
+      - name: Wait for Redis
+        run: timeout 30 bash -c 'until redis-cli ping >/dev/null 2>&1; do sleep 1; done'
 
       - uses: actions/setup-python@v5
         with:
@@ -196,74 +158,35 @@ jobs:
       - name: Sync dependencies
         run: uv sync --directory app
 
-      - name: Wait for services and run migrations
-        env:
-          EVY_POSTGRES_USER: eventyay
-          EVY_POSTGRES_PASSWORD: eventyay
-          EVY_POSTGRES_DB: eventyay-db
-          EVY_POSTGRES_HOST: localhost
-          EVY_POSTGRES_PORT: "5432"
-          EVY_REDIS_URL: redis://localhost:6379/0
-          EVY_SECRET_KEY: ci-test-secret-key
-          EVY_DEBUG: "true"
-        run: |
-          # Wait for Postgres
-          for _ in {1..30}; do
-            if pg_isready -h localhost -p 5432 -U eventyay -d eventyay-db >/dev/null 2>&1; then
-              echo "Postgres is up"
-              break
-            fi
-            sleep 2
-          done
-          pg_isready -h localhost -p 5432 -U eventyay -d eventyay-db
-
-          # Wait for Redis
-          for _ in {1..30}; do
-            if redis-cli -h localhost -p 6379 ping >/dev/null 2>&1; then
-              echo "Redis is up"
-              break
-            fi
-            sleep 2
-          done
-          redis-cli -h localhost -p 6379 ping
-
-          cd app
-          uv run python manage.py migrate --noinput
+      - name: Run migrations
+        working-directory: app
+        run: uv run python manage.py migrate --noinput
 
       - name: Start development server
-        env:
-          EVY_POSTGRES_USER: eventyay
-          EVY_POSTGRES_PASSWORD: eventyay
-          EVY_POSTGRES_DB: eventyay-db
-          EVY_POSTGRES_HOST: localhost
-          EVY_POSTGRES_PORT: "5432"
-          EVY_REDIS_URL: redis://localhost:6379/0
-          EVY_SECRET_KEY: ci-test-secret-key
-          EVY_DEBUG: "true"
         run: |
-          set -e
           cd app
           uv run python manage.py runserver 0.0.0.0:8000 &
           echo $! > server.pid
-          # Wait for server to be ready
+
+      - name: Wait for server and verify healthcheck
+        # Use `localhost` (not 127.0.0.1) so MultiDomainMiddleware accepts the
+        # request: it compares the Host header against SITE_URL which defaults
+        # to http://localhost:8000.
+        run: |
           for _ in {1..30}; do
-            if curl -fsS http://127.0.0.1:8000/healthcheck/ >/dev/null; then
+            if curl -fsS http://localhost:8000/healthcheck/ >/dev/null 2>&1; then
               echo "Server is healthy"
               break
             fi
             sleep 2
           done
-          curl -fsS http://127.0.0.1:8000/healthcheck/ >/dev/null
-
-      - name: Verify healthcheck endpoint
-        run: |
-          response=$(curl -sS -w "\n%{http_code}" http://127.0.0.1:8000/healthcheck/)
+          response=$(curl -sS -w "\n%{http_code}" http://localhost:8000/healthcheck/)
           status_code=$(echo "$response" | tail -n1)
           if [ "$status_code" != "200" ]; then
-            echo "Healthcheck failed with status code: $status_code"
+            echo "Healthcheck failed with status: $status_code"
             exit 1
           fi
-          echo "Healthcheck passed with status code: $status_code"
+          echo "Healthcheck passed with status: $status_code"
 
       - name: Stop server
         if: always()

--- a/app/eventyay/config/eventyay.testing.toml
+++ b/app/eventyay/config/eventyay.testing.toml
@@ -3,3 +3,10 @@
 email_backend = 'django.core.mail.backends.locmem.EmailBackend'
 
 celery_always_eager = true
+debug = true
+
+# PostgreSQL connection settings are intentionally absent here.
+# Local test runs use the default peer-auth connection (postgres_user / postgres_host /
+# postgres_port are None by default, which triggers peer auth).
+# CI jobs supply their own connection details via EVY_POSTGRES_* env vars at the job
+# level in the workflow, keeping this shared TOML file developer-friendly.

--- a/app/tests/stable/__init__.py
+++ b/app/tests/stable/__init__.py
@@ -1,1 +1,20 @@
-# Empty file to make this a Python package
+# tests/stable — curated integration tests that run in CI
+#
+# This package contains a subset of the full test suite that passes reliably
+# against the current codebase. It is the scope executed by the CI workflow
+# (video-backend-ci.yml) via `pytest tests/stable`.
+#
+# Why not the full tests/ tree?
+# The broader tests/ directory includes legacy test suites inherited from the
+# project's history (pretix, pretalx, venueless). Many of those contain
+# outdated imports and assumptions that do not match the unified eventyay layout.
+# Running them all in CI would produce a high false-failure rate that masks real
+# regressions.
+#
+# Path forward (tracked here so this does not become permanent technical debt):
+#   1. Fix legacy tests incrementally, module by module.
+#   2. Once a module's tests are green, move or symlink them into this package
+#      (or remove this restriction and widen the pytest path in the workflow).
+#   3. Tests that cannot reasonably be fixed should be explicitly quarantined
+#      using a `@pytest.mark.legacy` marker and collected in a separate
+#      non-blocking CI job.


### PR DESCRIPTION
Fixes : #2314
Follow-up to PR closed #2963—Simplifies `video-backend-ci.yml` while keeping CI deterministic and aligned with the project’s TOML-first configuration.
- **Native services instead of Docker:** PostgreSQL and Redis are installed via apt on `ubuntu-24.04`. Apt/systemd starts them automatically; readiness uses bounded checks (`pg_isready -t 30`, `timeout 30` for Redis) instead of verbose Docker health options and manual wait loops.
- **Less env duplication:** Jobs set `EVY_RUNNING_ENVIRONMENT=testing` and only CI-specific values (`EVY_SECRET_KEY`, `EVY_POSTGRES_*`). Removed duplicates already covered by defaults or `eventyay.testing.toml` (`EVY_DEBUG`, `EVY_REDIS_URL`, `EVY_POSTGRES_DB`, per-step `DJANGO_SETTINGS_MODULE`).
- **TOML:** `debug = true` moved into `eventyay.testing.toml`, with a short comment on why Postgres settings stay out of that file (local peer-auth vs CI overrides).
- **Test scope:** Documented in `tests/stable/__init__.py` and workflow comment why CI runs `tests/stable` only and how to broaden coverage over time.
## Test plan
- [ ] `python-uv-check` passes (`manage.py check` with testing env)
- [ ] `pytest-integration` passes (`pytest tests/stable`)
- [ ] `backend-smoke` healthcheck returns 200 via `http://localhost:8000/healthcheck/`
- [ ] `video-build` still succeeds