### PR TITLE
fix(schedule): remove duplicate slides/downloads in TalkDetail

### DIFF
--- a/app/eventyay/webapp/schedule/src/components/TalkDetail.vue
+++ b/app/eventyay/webapp/schedule/src/components/TalkDetail.vue
@@ -24,11 +24,6 @@
 					h2.field-heading {{ answer.question }}
 					.field-content
 						markdown-content(:markdown="answer.answer")
-			.downloads(v-if="resolvedTalk.resources && resolvedTalk.resources.length > 0")
-				h2 {{ t.downloads }}
-				a.download(v-for="{resource, link, description} of resolvedTalk.resources", :href="getAbsoluteResourceUrl(resource || link)", target="_blank", rel="noopener noreferrer")
-					.mdi(:class="`mdi-${getIconByFileEnding(resource || link)}`")
-					.filename {{ description }}
 			.video-stream(v-if="resolvedTalk.stream_url && computedJoinRoomLink && isLive")
 				a.view-video-btn(:href="computedJoinRoomLink")
 					svg(viewBox="0 0 24 24", width="18", height="18", fill="currentColor")
@@ -405,13 +400,6 @@ export default {
 				.field-content
 					font-size: 16px
 					font-weight: 600
-		.downloads
-			border: border-separator()
-			border-radius: 4px
-			display: flex
-			flex-direction: column
-			font-size: 16px
-			font-weight: 600
 		.video-stream
 			margin-top: 16px
 			.view-video-btn


### PR DESCRIPTION
Fix: #3616

<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/e5768615-07a7-4b6b-bf70-91e44915026a" />

## Summary by Sourcery

Bug Fixes:
- Prevent duplicate display of talk resources/downloads in the talk detail page.