### PR TITLE
Resolve ticketing widget product list 500 errors

### DIFF
--- a/app/eventyay/agenda/urls.py
+++ b/app/eventyay/agenda/urls.py
@@ -61,6 +61,11 @@ def get_schedule_urls(regex_prefix, name_prefix=''):
 
 app_name = 'agenda'
 urlpatterns = [
+    re_path(
+        r'^widgets/(?P<filename>pretalx-schedule[-\w.]*\.js)$',
+        widget.widget_schedule_chunk,
+        name='widget.schedule.chunk',
+    ),
     path(
         'widgets/schedule.js',
         widget.widget_script,

--- a/app/eventyay/agenda/views/widget.py
+++ b/app/eventyay/agenda/views/widget.py
@@ -5,7 +5,7 @@ from urllib.parse import unquote
 from csp.decorators import csp_exempt
 from django.contrib.auth.models import AnonymousUser
 from django.contrib.staticfiles import finders
-from django.http import Http404, HttpResponse, JsonResponse
+from django.http import FileResponse, Http404, HttpResponse, JsonResponse
 from django.templatetags.static import static
 from django.views.decorators.gzip import gzip_page
 from django.views.decorators.http import condition
@@ -238,20 +238,18 @@ def widget_qrcodes(request, organizer=None, event=None, version=None, kind=None,
 
 
 @condition(etag_func=widget_js_etag)
-@gzip_page
 @csp_exempt()
 def widget_script(request, organizer=None, event=None, **kwargs):
     # Serve the ESM bundle directly so the response goes through Django's middleware
     # stack (CorsMiddleware adds Access-Control-Allow-Origin). Serving via a static-file
     # loader would bypass middleware and break cross-origin embeds because module scripts
     # always enforce CORS.
+    # The Access-Control-Allow-Origin header is applied by CorsMiddleware because this
+    # URL is matched by CORS_URLS_REGEX; no manual header is needed here.
     file_path = finders.find(WIDGET_PATH)
     if not file_path:
         raise Http404
-    with open(file_path, 'rb') as f:
-        content = f.read()
-    response = HttpResponse(content, content_type='application/javascript; charset=utf-8')
-    response['Access-Control-Allow-Origin'] = '*'
+    response = FileResponse(open(file_path, 'rb'), content_type='application/javascript; charset=utf-8')
     response['Cache-Control'] = 'public, max-age=86400'
     return response
 

--- a/app/eventyay/agenda/views/widget.py
+++ b/app/eventyay/agenda/views/widget.py
@@ -249,7 +249,11 @@ def widget_script(request, organizer=None, event=None, **kwargs):
     file_path = finders.find(WIDGET_PATH)
     if not file_path:
         raise Http404
-    response = FileResponse(open(file_path, 'rb'), content_type='application/javascript; charset=utf-8')
+    try:
+        f = open(file_path, 'rb')
+    except OSError:
+        raise Http404
+    response = FileResponse(f, content_type='application/javascript; charset=utf-8')
     response['Cache-Control'] = 'public, max-age=86400'
     return response
 

--- a/app/eventyay/agenda/views/widget.py
+++ b/app/eventyay/agenda/views/widget.py
@@ -5,7 +5,7 @@ from urllib.parse import unquote
 from csp.decorators import csp_exempt
 from django.contrib.auth.models import AnonymousUser
 from django.contrib.staticfiles import finders
-from django.http import FileResponse, Http404, HttpResponse, JsonResponse
+from django.http import Http404, HttpResponse, JsonResponse
 from django.templatetags.static import static
 from django.views.decorators.gzip import gzip_page
 from django.views.decorators.http import condition
@@ -238,22 +238,29 @@ def widget_qrcodes(request, organizer=None, event=None, version=None, kind=None,
 
 
 @condition(etag_func=widget_js_etag)
+@gzip_page
 @csp_exempt()
 def widget_script(request, organizer=None, event=None, **kwargs):
-    # Serve the ESM bundle directly so the response goes through Django's middleware
-    # stack (CorsMiddleware adds Access-Control-Allow-Origin). Serving via a static-file
-    # loader would bypass middleware and break cross-origin embeds because module scripts
-    # always enforce CORS.
-    # The Access-Control-Allow-Origin header is applied by CorsMiddleware because this
-    # URL is matched by CORS_URLS_REGEX; no manual header is needed here.
-    file_path = finders.find(WIDGET_PATH)
-    if not file_path:
-        raise Http404
-    try:
-        f = open(file_path, 'rb')
-    except OSError:
-        raise Http404
-    response = FileResponse(f, content_type='application/javascript; charset=utf-8')
+    # Keep this endpoint backwards-compatible for third-party embeds that use a classic
+    # <script src=".../widgets/schedule.js"></script> tag. We serve a tiny loader that
+    # injects the actual ESM widget bundle from the static URL.
+    # IMPORTANT: this endpoint is typically embedded cross-origin. A relative /static/ URL would
+    # resolve against the embedding page's origin, not ours. We therefore build an absolute URL
+    # based on the current script's URL at runtime.
+    module_src = static(WIDGET_PATH)
+    loader = (
+        "(function(){"
+        f"var staticPath={module_src!r};"
+        "var base=(document.currentScript&&document.currentScript.src)?document.currentScript.src:window.location.href;"
+        "var u=(function(){try{return new URL(staticPath, base).href;}catch(e){return staticPath;}})();"
+        "var s=document.createElement('script');"
+        "s.type='module';"
+        "s.crossOrigin='anonymous';"
+        "s.src=u;"
+        "(document.head||document.documentElement).appendChild(s);"
+        "})();"
+    )
+    response = HttpResponse(loader, content_type='text/javascript; charset=utf-8')
     response['Cache-Control'] = 'public, max-age=86400'
     return response
 

--- a/app/eventyay/agenda/views/widget.py
+++ b/app/eventyay/agenda/views/widget.py
@@ -5,7 +5,7 @@ from urllib.parse import unquote
 from csp.decorators import csp_exempt
 from django.contrib.auth.models import AnonymousUser
 from django.contrib.staticfiles import finders
-from django.http import Http404, HttpResponse, JsonResponse
+from django.http import Http404, HttpResponse, JsonResponse, FileResponse
 from django.templatetags.static import static
 from django.views.decorators.gzip import gzip_page
 from django.views.decorators.http import condition
@@ -247,7 +247,12 @@ def widget_script(request, organizer=None, event=None, **kwargs):
     # IMPORTANT: this endpoint is typically embedded cross-origin. A relative /static/ URL would
     # resolve against the embedding page's origin, not ours. We therefore build an absolute URL
     # based on the current script's URL at runtime.
-    module_src = static(WIDGET_PATH)
+    from django.urls import reverse
+    if request.event:
+        module_src = reverse('agenda:widget.schedule.chunk', kwargs={'organizer': request.organizer.slug, 'event': request.event.slug, 'filename': 'pretalx-schedule.js'})
+    else:
+        module_src = static(WIDGET_PATH)
+    
     loader = (
         "(function(){"
         f"var staticPath={module_src!r};"
@@ -262,6 +267,21 @@ def widget_script(request, organizer=None, event=None, **kwargs):
     )
     response = HttpResponse(loader, content_type='text/javascript; charset=utf-8')
     response['Cache-Control'] = 'public, max-age=86400'
+    return response
+
+
+@csp_exempt()
+def widget_schedule_chunk(request, organizer=None, event=None, filename=None, **kwargs):
+    file_path = finders.find(f'schedule/{filename}')
+    if not file_path:
+        raise Http404
+    try:
+        f = open(file_path, 'rb')
+    except OSError:
+        raise Http404
+    response = FileResponse(f, content_type='application/javascript; charset=utf-8')
+    response['Cache-Control'] = 'public, max-age=86400'
+    response['Access-Control-Allow-Origin'] = '*'
     return response
 
 

--- a/app/eventyay/agenda/views/widget.py
+++ b/app/eventyay/agenda/views/widget.py
@@ -238,7 +238,6 @@ def widget_qrcodes(request, organizer=None, event=None, version=None, kind=None,
 
 
 @condition(etag_func=widget_js_etag)
-@condition(etag_func=widget_js_etag)
 @gzip_page
 @csp_exempt()
 def widget_script(request, organizer=None, event=None, **kwargs):

--- a/app/eventyay/agenda/views/widget.py
+++ b/app/eventyay/agenda/views/widget.py
@@ -238,34 +238,21 @@ def widget_qrcodes(request, organizer=None, event=None, version=None, kind=None,
 
 
 @condition(etag_func=widget_js_etag)
+@condition(etag_func=widget_js_etag)
 @gzip_page
 @csp_exempt()
 def widget_script(request, organizer=None, event=None, **kwargs):
-    # This page basically just serves a static file under a known path (ideally, the
-    # administrators could and should even turn on gzip compression for the
-    # /<event>/widget/schedule.js path, as it cuts down the transferred data
-    # by about 80% for the schedule.js file, which is the largest file on the
-    # main schedule page).
-    # Keep this endpoint backwards-compatible for third-party embeds that use a classic
-    # <script src=".../widgets/schedule.js"></script> tag. We serve a tiny loader that
-    # injects the actual ESM widget bundle from the static URL.
-    # IMPORTANT: this endpoint is typically embedded cross-origin. A relative /static/ URL would
-    # resolve against the embedding page's origin, not ours. We therefore build an absolute URL
-    # based on the current script's URL at runtime.
-    module_src = static(WIDGET_PATH)
-    loader = (
-        "(function(){"
-        f"var staticPath={module_src!r};"
-        "var base=(document.currentScript&&document.currentScript.src)?document.currentScript.src:window.location.href;"
-        "var u=(function(){try{return new URL(staticPath, base).href;}catch(e){return staticPath;}})();"
-        "var s=document.createElement('script');"
-        "s.type='module';"
-        "s.crossOrigin='anonymous';"
-        "s.src=u;"
-        "(document.head||document.documentElement).appendChild(s);"
-        "})();"
-    )
-    response = HttpResponse(loader, content_type='text/javascript; charset=utf-8')
+    # Serve the ESM bundle directly so the response goes through Django's middleware
+    # stack (CorsMiddleware adds Access-Control-Allow-Origin). Serving via a static-file
+    # loader would bypass middleware and break cross-origin embeds because module scripts
+    # always enforce CORS.
+    file_path = finders.find(WIDGET_PATH)
+    if not file_path:
+        raise Http404
+    with open(file_path, 'rb') as f:
+        content = f.read()
+    response = HttpResponse(content, content_type='application/javascript; charset=utf-8')
+    response['Access-Control-Allow-Origin'] = '*'
     response['Cache-Control'] = 'public, max-age=86400'
     return response
 

--- a/app/eventyay/base/models/event.py
+++ b/app/eventyay/base/models/event.py
@@ -328,6 +328,8 @@ class EventMixin:
         setting. Times are not shown.
         """
         tz = tz or ZoneInfo(key=self.settings.timezone)
+        if isinstance(tz, str):
+            tz = ZoneInfo(key=tz)
         if (not self.settings.show_date_to and not force_show_end) or not self.date_to:
             return _date(self.date_from.astimezone(tz), 'DATE_FORMAT')
         return daterange(self.date_from.astimezone(tz), self.date_to.astimezone(tz))

--- a/app/eventyay/config/settings.py
+++ b/app/eventyay/config/settings.py
@@ -401,7 +401,14 @@ CORE_MODULES = (
 # CORS_URLS_REGEX restricts which URL paths receive the header — only widget and
 # event-CSS endpoints.
 CORS_ALLOW_ALL_ORIGINS = True
-CORS_URLS_REGEX = r'^(?:.*/widget[s]?/.*|.*/static/event\.css|.*/schedule/widget/.*)$'
+
+CORS_URLS_REGEX = (
+    r"^(?:"
+    r".*/widget[s]?/.*|"
+    r".*/schedule/widget/.*|"
+    r".*/static/event\.css"
+    r")$"
+)
 
 # TODO: This list is only for display. It should not be here.
 PLUGINS = []

--- a/app/eventyay/config/settings.py
+++ b/app/eventyay/config/settings.py
@@ -398,7 +398,7 @@ CORE_MODULES = (
 )
 
 # Restrict CORS to widget and event-CSS endpoints only
-CORS_URLS_REGEX = r'^.*/widget[s]?/|^.*/static/event\.css$|^.*/schedule/widget/'
+CORS_URLS_REGEX = r'^(?:.*/widget[s]?/.*|.*/static/event\.css|.*/schedule/widget/.*)$'
 
 # TODO: This list is only for display. It should not be here.
 PLUGINS = []

--- a/app/eventyay/config/settings.py
+++ b/app/eventyay/config/settings.py
@@ -397,6 +397,8 @@ CORE_MODULES = (
     )
 )
 
+CORS_ALLOW_ALL_ORIGINS = True
+
 # TODO: This list is only for display. It should not be here.
 PLUGINS = []
 for entry_point in entry_points(group='pretalx.plugin'):

--- a/app/eventyay/config/settings.py
+++ b/app/eventyay/config/settings.py
@@ -397,7 +397,8 @@ CORE_MODULES = (
     )
 )
 
-CORS_ALLOW_ALL_ORIGINS = True
+# Restrict CORS to widget and event-CSS endpoints only
+CORS_URLS_REGEX = r'^.*/widget[s]?/|^.*/static/event\.css$|^.*/schedule/widget/'
 
 # TODO: This list is only for display. It should not be here.
 PLUGINS = []

--- a/app/eventyay/config/settings.py
+++ b/app/eventyay/config/settings.py
@@ -406,7 +406,8 @@ CORS_URLS_REGEX = (
     r"^(?:"
     r".*/widget[s]?/.*|"
     r".*/schedule/widget/.*|"
-    r".*/static/event\.css"
+    r".*/static/event\.css|"
+    r".*/static/schedule/.*\.js"
     r")$"
 )
 

--- a/app/eventyay/config/settings.py
+++ b/app/eventyay/config/settings.py
@@ -397,7 +397,10 @@ CORE_MODULES = (
     )
 )
 
-# Restrict CORS to widget and event-CSS endpoints only
+# Widgets are public embeds served to any origin, so all origins must be allowed.
+# CORS_URLS_REGEX restricts which URL paths receive the header — only widget and
+# event-CSS endpoints.
+CORS_ALLOW_ALL_ORIGINS = True
 CORS_URLS_REGEX = r'^(?:.*/widget[s]?/.*|.*/static/event\.css|.*/schedule/widget/.*)$'
 
 # TODO: This list is only for display. It should not be here.

--- a/app/eventyay/presale/views/widget.py
+++ b/app/eventyay/presale/views/widget.py
@@ -210,8 +210,9 @@ def get_picture(event, picture):
 class WidgetAPIProductList(EventListMixin, View):
     def _get_products(self):
         qs = self.request.event.products
-        if 'products' in self.request.GET:
-            qs = qs.filter(pk__in=self.request.GET.get('products').split(','))
+        item_filter = self.request.GET.get('items') or self.request.GET.get('products')
+        if item_filter:
+            qs = qs.filter(pk__in=item_filter.split(','))
         if 'categories' in self.request.GET:
             qs = qs.filter(category__pk__in=self.request.GET.get('categories').split(','))
 

--- a/app/eventyay/presale/views/widget.py
+++ b/app/eventyay/presale/views/widget.py
@@ -4,6 +4,7 @@ import json
 import logging
 from collections import defaultdict
 from datetime import date, datetime, timedelta
+from zoneinfo import ZoneInfo
 from urllib.parse import urljoin
 
 import isoweek
@@ -228,7 +229,7 @@ class WidgetAPIProductList(EventListMixin, View):
                 {
                     'id': cat.pk if cat else None,
                     'name': str(cat.name) if cat else None,
-                    'description': str(rich_text(cat.description, safelinks=False))
+                    'description': str(rich_text(cat.description))
                     if cat and cat.description
                     else None,
                     'products': [
@@ -236,7 +237,7 @@ class WidgetAPIProductList(EventListMixin, View):
                             'id': product.pk,
                             'name': str(product.name),
                             'picture': get_picture(self.request.event, product.picture) if product.picture else None,
-                            'description': str(rich_text(product.description, safelinks=False))
+                            'description': str(rich_text(product.description))
                             if product.description
                             else None,
                             'has_variations': product.has_variations,
@@ -269,7 +270,7 @@ class WidgetAPIProductList(EventListMixin, View):
                                     'id': var.id,
                                     'value': str(var.value),
                                     'order_max': var.order_max,
-                                    'description': str(rich_text(var.description, safelinks=False))
+                                    'description': str(rich_text(var.description))
                                     if var.description
                                     else None,
                                     'price': price_dict(product, var.display_price),
@@ -399,6 +400,8 @@ class WidgetAPIProductList(EventListMixin, View):
 
     def _get_date_range(self, ev, event, tz=None):
         tz = tz or event.timezone
+        if isinstance(tz, str):
+            tz = ZoneInfo(key=tz)
         dr = ev.get_date_range_display(tz)
         if event.settings.show_times:
             dr += ' ' + date_format(ev.date_from.astimezone(tz), 'TIME_FORMAT')
@@ -465,7 +468,7 @@ class WidgetAPIProductList(EventListMixin, View):
 
         if hasattr(self.request, 'event'):
             data['name'] = str(request.event.name)
-            data['frontpage_text'] = str(rich_text(request.event.settings.frontpage_text, safelinks=False))
+            data['frontpage_text'] = str(rich_text(request.event.settings.frontpage_text))
 
         cache_key = ':'.join(
             [
@@ -722,9 +725,9 @@ class WidgetAPIProductList(EventListMixin, View):
         ev = self.subevent or request.event
         data['name'] = str(ev.name)
         if self.subevent:
-            data['frontpage_text'] = str(rich_text(self.subevent.frontpage_text, safelinks=False))
+            data['frontpage_text'] = str(rich_text(self.subevent.frontpage_text))
         else:
-            data['frontpage_text'] = str(rich_text(request.event.settings.frontpage_text, safelinks=False))
+            data['frontpage_text'] = str(rich_text(request.event.settings.frontpage_text))
         data['date_range'] = self._get_date_range(ev, request.event)
         fail = False
 

--- a/app/eventyay/presale/views/widget.py
+++ b/app/eventyay/presale/views/widget.py
@@ -230,7 +230,7 @@ class WidgetAPIProductList(EventListMixin, View):
                 {
                     'id': cat.pk if cat else None,
                     'name': str(cat.name) if cat else None,
-                    'description': str(rich_text(cat.description))
+                    'description': str(rich_text(cat.description, safelinks=False))
                     if cat and cat.description
                     else None,
                     'items': [
@@ -238,7 +238,7 @@ class WidgetAPIProductList(EventListMixin, View):
                             'id': product.pk,
                             'name': str(product.name),
                             'picture': get_picture(self.request.event, product.picture) if product.picture else None,
-                            'description': str(rich_text(product.description))
+                            'description': str(rich_text(product.description, safelinks=False))
                             if product.description
                             else None,
                             'has_variations': product.has_variations,
@@ -271,7 +271,7 @@ class WidgetAPIProductList(EventListMixin, View):
                                     'id': var.id,
                                     'value': str(var.value),
                                     'order_max': var.order_max,
-                                    'description': str(rich_text(var.description))
+                                    'description': str(rich_text(var.description, safelinks=False))
                                     if var.description
                                     else None,
                                     'price': price_dict(product, var.display_price),

--- a/app/eventyay/presale/views/widget.py
+++ b/app/eventyay/presale/views/widget.py
@@ -783,12 +783,12 @@ class WidgetAPIProductList(EventListMixin, View):
                 fail = True
 
         if not fail and (ev.presale_is_running or request.event.settings.show_products_outside_presale_period):
-            data['items_by_category'], data['display_add_to_cart'], data['productnum'] = self._get_products()
+            data['items_by_category'], data['display_add_to_cart'], data['itemnum'] = self._get_products()
             data['display_add_to_cart'] = data['display_add_to_cart'] and ev.presale_is_running
         else:
             data['items_by_category'] = []
             data['display_add_to_cart'] = False
-            data['productnum'] = 0
+            data['itemnum'] = 0
 
         data['has_seating_plan'] = ev.seating_plan is not None
 

--- a/app/eventyay/presale/views/widget.py
+++ b/app/eventyay/presale/views/widget.py
@@ -232,7 +232,7 @@ class WidgetAPIProductList(EventListMixin, View):
                     'description': str(rich_text(cat.description))
                     if cat and cat.description
                     else None,
-                    'products': [
+                    'items': [
                         {
                             'id': product.pk,
                             'name': str(product.name),
@@ -783,10 +783,10 @@ class WidgetAPIProductList(EventListMixin, View):
                 fail = True
 
         if not fail and (ev.presale_is_running or request.event.settings.show_products_outside_presale_period):
-            data['products_by_category'], data['display_add_to_cart'], data['productnum'] = self._get_products()
+            data['items_by_category'], data['display_add_to_cart'], data['productnum'] = self._get_products()
             data['display_add_to_cart'] = data['display_add_to_cart'] and ev.presale_is_running
         else:
-            data['products_by_category'] = []
+            data['items_by_category'] = []
             data['display_add_to_cart'] = False
             data['productnum'] = 0
 


### PR DESCRIPTION

  1. Fixed 500 errors from rich_text() call sites
  2. Fixed 500 errors from missing isinstance(tz, str) guard on timezone handling
  3. Fixed wrong JSON key names in product_list response
  4. Fixed schedule widget serving a module loader that created CORS-blocked static file fetches

<img width="950" height="422" alt="image" src="https://github.com/user-attachments/assets/12fac4af-4f3f-49c6-bbad-2befbfcb1a97" />


Fixes #3647 

