### PR TITLE
Fix responsive search bar overflow on mobile devices

### DIFF
--- a/app/eventyay/static/orga/css/_layout.css
+++ b/app/eventyay/static/orga/css/_layout.css
@@ -1741,6 +1741,11 @@ h2 .user-name-display img {
     white-space: normal;
   }
 
+  .search-form > .form-group {
+    width: 100% !important;
+    margin-right: 0 !important;
+  }
+
   .dashboard-history .list-group .logentry {
     flex-direction: column;
     border-bottom: 1px solid var(--color-grey-light);

--- a/app/eventyay/static/orga/css/_layout.css
+++ b/app/eventyay/static/orga/css/_layout.css
@@ -1742,8 +1742,8 @@ h2 .user-name-display img {
   }
 
   .search-form > .form-group {
-    width: 100% !important;
-    margin-right: 0 !important;
+    width: 100%;
+    margin-right: 0;
   }
 
   .dashboard-history .list-group .logentry {


### PR DESCRIPTION


<img width="499" height="953" alt="image" src="https://github.com/user-attachments/assets/4e7a6c38-15e1-4900-991b-398ac5fc0b92" />


https://github.com/user-attachments/assets/5211b2e5-d07d-4737-a567-7e7d5e0d8f64



## Related Issue
Closes #3027

## Description
This PR fixes the responsive layout issues for the search bar component on mobile viewports.

Previously, the search form input group had a fixed width of `300px`, which caused overflow and overlap issues on smaller screens.

This update adds a mobile-specific override to ensure the input group expands to full width on devices with a viewport width of `768px` or smaller.

## Changes Made
- Modified: `app/eventyay/static/orga/css/_layout.css`
- Added responsive override inside the existing `@media (max-width: 768px)` block
- Set `.search-form > .form-group` width to `100%`
- Removed extra right margin to prevent overflow on mobile devices

## Result
The search bar now fits properly within mobile screen bounds without overlapping or horizontal scrolling.