### PR TITLE
fix(ui): standardize header icon spacing for user and language controls

### DIFF
--- a/app/eventyay/static/cfp/css/_layout.css
+++ b/app/eventyay/static/cfp/css/_layout.css
@@ -11,10 +11,6 @@
   cursor: pointer;
 }
 
-/* Icon/text spacing is handled by shared rules in common/css/_dropdown.css */
-.presale-sticky-tabs .header-row-right details.dropdown summary .mobile-hide-text {
-  padding-right: 6px;
-}
 body {
   background: var(--color-grey-lightest);
 }

--- a/app/eventyay/static/cfp/css/_layout.css
+++ b/app/eventyay/static/cfp/css/_layout.css
@@ -11,9 +11,8 @@
   cursor: pointer;
 }
 
-/* Add padding to username for visual match */
+/* Icon/text spacing is handled by shared rules in common/css/_dropdown.css */
 .presale-sticky-tabs .header-row-right details.dropdown summary .mobile-hide-text {
-  padding-left: 6px;
   padding-right: 6px;
 }
 body {

--- a/app/eventyay/static/common/css/_dropdown.css
+++ b/app/eventyay/static/common/css/_dropdown.css
@@ -18,17 +18,16 @@ details.dropdown summary {
 #language-dropdown > summary,
 #user-dropdown-label > summary,
 #locale-dropdown-label > summary,
-.header-row-right details.dropdown > summary,
-.presale-sticky-tabs .header-row-right details.dropdown > summary {
+.header-row-right details.dropdown > summary {
   display: inline-flex;
   align-items: center;
-  gap: var(--header-icon-text-gap, 6px);
+  gap: var(--header-icon-text-gap, 0.375rem);
 }
 
 .header-row-right a.login-link {
   display: inline-flex;
   align-items: center;
-  gap: var(--header-icon-text-gap, 6px);
+  gap: var(--header-icon-text-gap, 0.375rem);
 }
 
 details.dropdown summary::before,

--- a/app/eventyay/static/common/css/_dropdown.css
+++ b/app/eventyay/static/common/css/_dropdown.css
@@ -13,6 +13,22 @@ details.dropdown summary {
   color: inherit;
 }
 
+/* Consistent spacing between user/language icons and labels (public + private headers) */
+#profile-dropdown > summary,
+#language-dropdown > summary,
+#user-dropdown-label > summary,
+#locale-dropdown-label > summary,
+.header-row-right details.dropdown > summary,
+.presale-sticky-tabs .header-row-right details.dropdown > summary,
+a.login-link {
+  align-items: center;
+  gap: 6px;
+}
+
+a.login-link {
+  display: inline-flex;
+}
+
 details.dropdown summary::before,
 details.dropdown summary::marker {
   display: none;
@@ -671,18 +687,6 @@ details.dropdown .dropdown-content-se::after {
 .navbar-inverse #language-dropdown > summary i,
 .navbar #language-dropdown > summary i {
   color: var(--navbar-link-color, #f8f9fa);
-}
-
-.navbar-top-links #profile-dropdown > summary i.fa-user,
-.navbar-inverse #profile-dropdown > summary i.fa-user,
-.navbar #profile-dropdown > summary i.fa-user {
-  margin-right: 5px;
-}
-
-.navbar-top-links #language-dropdown > summary i.fa-globe,
-.navbar-inverse #language-dropdown > summary i.fa-globe,
-.navbar #language-dropdown > summary i.fa-globe {
-  margin-right: 5px;
 }
 
 .navbar-top-links #profile-dropdown > summary i.fa-caret-down,

--- a/app/eventyay/static/common/css/_dropdown.css
+++ b/app/eventyay/static/common/css/_dropdown.css
@@ -13,20 +13,22 @@ details.dropdown summary {
   color: inherit;
 }
 
-/* Consistent spacing between user/language icons and labels (public + private headers) */
+/* User/language header triggers (scoped by id or header containers) */
 #profile-dropdown > summary,
 #language-dropdown > summary,
 #user-dropdown-label > summary,
 #locale-dropdown-label > summary,
 .header-row-right details.dropdown > summary,
-.presale-sticky-tabs .header-row-right details.dropdown > summary,
-a.login-link {
+.presale-sticky-tabs .header-row-right details.dropdown > summary {
+  display: inline-flex;
   align-items: center;
-  gap: 6px;
+  gap: var(--header-icon-text-gap, 6px);
 }
 
-a.login-link {
+.header-row-right a.login-link {
   display: inline-flex;
+  align-items: center;
+  gap: var(--header-icon-text-gap, 6px);
 }
 
 details.dropdown summary::before,

--- a/app/eventyay/static/common/css/_variables.css
+++ b/app/eventyay/static/common/css/_variables.css
@@ -66,7 +66,7 @@
 
   --size-border-radius: 0.25rem;
   --size-spacer: 1rem;
-  --header-icon-text-gap: 6px;
+  --header-icon-text-gap: 0.375rem;
 
   --shadow-lightest: 0 1px 2px rgb(0 0 0 / 0.24);
   --shadow-lighter: 0 1px 3px rgb(0 0 0 / 0.12), var(--shadow-lightest);

--- a/app/eventyay/static/common/css/_variables.css
+++ b/app/eventyay/static/common/css/_variables.css
@@ -66,6 +66,7 @@
 
   --size-border-radius: 0.25rem;
   --size-spacer: 1rem;
+  --header-icon-text-gap: 6px;
 
   --shadow-lightest: 0 1px 2px rgb(0 0 0 / 0.24);
   --shadow-lighter: 0 1px 3px rgb(0 0 0 / 0.12), var(--shadow-lightest);


### PR DESCRIPTION
Closes : #3657

https://github.com/user-attachments/assets/2de90438-a1eb-4a76-a9b1-9921da2a6a97

## Summary by Sourcery

Standardize spacing and alignment of header dropdown icons and labels across public and private views.

Enhancements:
- Apply shared flex alignment and consistent gap between user, language, and login controls in header dropdowns.
- Remove header-specific icon margin overrides in favor of common spacing rules.
- Clarify presale header spacing comment and rely on shared dropdown styles instead of per-element padding.