### PR TITLE
fix: talks dashboard navigation buttons misaligned

### DIFF
--- a/app/eventyay/static/orga/css/_layout.css
+++ b/app/eventyay/static/orga/css/_layout.css
@@ -1781,6 +1781,7 @@ h2 .user-name-display img {
 
 .import-preview-table th {
   white-space: nowrap;
+}
 
 .avatar-license-text {
   overflow-wrap: anywhere;


### PR DESCRIPTION
The issue was due to a missing closing brace.

<img width="367" height="479" alt="Screenshot 2026-05-26 143321" src="https://github.com/user-attachments/assets/de5e6782-e189-4376-877c-ddc045fdb55b" />

Fixes #3658

## Summary by Sourcery

Bug Fixes:
- Correct a missing closing brace in the orga layout stylesheet that was breaking layout and misaligning talks dashboard navigation buttons.