### PR TITLE
cfp: hide avatar source/license when disabled

### DIFF
--- a/app/eventyay/person/forms/profile.py
+++ b/app/eventyay/person/forms/profile.py
@@ -138,13 +138,14 @@ class SpeakerProfileForm(
                     self.fields[field_name].widget.is_required = True
 
         cfp_defaults = default_fields()
-        count_chars = self.event.cfp.settings['count_length_in'] == 'chars'
-        count_length_in = self.event.cfp.settings['count_length_in']
+        count_length_in = self.event.cfp.settings.get('count_length_in', 'chars')
+        count_chars = count_length_in == 'chars'
         for key in ('avatar_source', 'avatar_license'):
             if key not in self.fields:
                 continue
-            config = self.event.cfp.fields.get(key, cfp_defaults[key])
-            visibility = config['visibility']
+            default_config = cfp_defaults.get(key, {})
+            config = self.event.cfp.fields.get(key, default_config)
+            visibility = config.get('visibility', default_config.get('visibility', 'optional'))
             if visibility == 'do_not_ask':
                 self.fields.pop(key, None)
                 continue
@@ -167,9 +168,11 @@ class SpeakerProfileForm(
                         count_in=count_length_in,
                     )
                 )
-                field.original_help_text = getattr(field, 'original_help_text', '')
+                field.original_help_text = getattr(field, 'original_help_text', field.help_text)
                 field.added_help_text = self.get_help_text('', min_value, max_value, count_length_in)
-                field.help_text = field.original_help_text + ' ' + field.added_help_text
+                field.help_text = ' '.join(
+                    part for part in (field.original_help_text, field.added_help_text) if part
+                )
 
         if not self.event.cfp.request_avatar:
             self.fields.pop('avatar', None)

--- a/app/eventyay/person/forms/profile.py
+++ b/app/eventyay/person/forms/profile.py
@@ -137,18 +137,23 @@ class SpeakerProfileForm(
                 if hasattr(self.fields[field_name].widget, 'is_required'):
                     self.fields[field_name].widget.is_required = True
 
+        cfp_defaults = default_fields()
         count_chars = self.event.cfp.settings['count_length_in'] == 'chars'
+        count_length_in = self.event.cfp.settings['count_length_in']
         for key in ('avatar_source', 'avatar_license'):
             if key not in self.fields:
                 continue
-            visibility = self.event.cfp.fields.get(key, default_fields()[key])['visibility']
+            config = self.event.cfp.fields.get(key, cfp_defaults[key])
+            visibility = config['visibility']
             if visibility == 'do_not_ask':
                 self.fields.pop(key, None)
                 continue
             field = self.fields[key]
             field.required = visibility == 'required'
-            min_value = self.event.cfp.fields.get(key, {}).get('min_length')
-            max_value = self.event.cfp.fields.get(key, {}).get('max_length')
+            if hasattr(field.widget, 'is_required'):
+                field.widget.is_required = field.required
+            min_value = config.get('min_length')
+            max_value = config.get('max_length')
             if min_value or max_value:
                 if min_value and count_chars:
                     field.widget.attrs['minlength'] = min_value
@@ -159,9 +164,12 @@ class SpeakerProfileForm(
                         self.validate_field_length,
                         min_length=min_value,
                         max_length=max_value,
-                        count_in=self.event.cfp.settings['count_length_in'],
+                        count_in=count_length_in,
                     )
                 )
+                field.original_help_text = getattr(field, 'original_help_text', '')
+                field.added_help_text = self.get_help_text('', min_value, max_value, count_length_in)
+                field.help_text = field.original_help_text + ' ' + field.added_help_text
 
         if not self.event.cfp.request_avatar:
             self.fields.pop('avatar', None)
@@ -294,7 +302,7 @@ class SpeakerProfileForm(
         field_classes = {
             'avatar': ImageField,
         }
-        request_require = {'biography', 'availabilities', 'avatar_source', 'avatar_license'}
+        request_require = {'biography', 'availabilities'}
 
 
 class OrgaProfileForm(forms.ModelForm):

--- a/app/eventyay/person/forms/profile.py
+++ b/app/eventyay/person/forms/profile.py
@@ -1,3 +1,5 @@
+from functools import partial
+
 from django import forms
 from django.conf import settings
 from django.contrib.auth.hashers import check_password
@@ -9,6 +11,7 @@ from django_scopes.forms import SafeModelChoiceField, SafeModelMultipleChoiceFie
 from i18nfield.forms import I18nModelForm
 
 from eventyay.base.models import Event, SpeakerProfile, TalkQuestion, TalkQuestionTarget, User
+from eventyay.base.models.cfp import default_fields
 from eventyay.base.models.information import SpeakerInformation
 from eventyay.base.models.submission import SubmissionStates
 from eventyay.cfp.forms.cfp import CfPFormMixin
@@ -133,6 +136,32 @@ class SpeakerProfileForm(
                 self.fields[field_name].required = True
                 if hasattr(self.fields[field_name].widget, 'is_required'):
                     self.fields[field_name].widget.is_required = True
+
+        count_chars = self.event.cfp.settings['count_length_in'] == 'chars'
+        for key in ('avatar_source', 'avatar_license'):
+            if key not in self.fields:
+                continue
+            visibility = self.event.cfp.fields.get(key, default_fields()[key])['visibility']
+            if visibility == 'do_not_ask':
+                self.fields.pop(key, None)
+                continue
+            field = self.fields[key]
+            field.required = visibility == 'required'
+            min_value = self.event.cfp.fields.get(key, {}).get('min_length')
+            max_value = self.event.cfp.fields.get(key, {}).get('max_length')
+            if min_value or max_value:
+                if min_value and count_chars:
+                    field.widget.attrs['minlength'] = min_value
+                if max_value and count_chars:
+                    field.widget.attrs['maxlength'] = max_value
+                field.validators.append(
+                    partial(
+                        self.validate_field_length,
+                        min_length=min_value,
+                        max_length=max_value,
+                        count_in=self.event.cfp.settings['count_length_in'],
+                    )
+                )
 
         if not self.event.cfp.request_avatar:
             self.fields.pop('avatar', None)
@@ -265,7 +294,7 @@ class SpeakerProfileForm(
         field_classes = {
             'avatar': ImageField,
         }
-        request_require = {'biography', 'availabilities'}
+        request_require = {'biography', 'availabilities', 'avatar_source', 'avatar_license'}
 
 
 class OrgaProfileForm(forms.ModelForm):


### PR DESCRIPTION
Closes : #3666 

<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/817641f7-63b2-400d-80fc-ffaa10638cef" />

<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/236b1ca9-e39d-4097-9d56-63966b92c783" />

What changed: Updated SpeakerProfileForm in app/eventyay/person/forms/profile.py to apply CfP form visibility rules to avatar_source and avatar_license after those fields are dynamically created.
Why: These fields were being added after the normal form init chain, so the standard RequestRequire mixin never removed them when organizers set them to Do not ask. This caused the fields to keep showing up in both the editor preview and the public speaker profile step even when disabled in CfP → Forms → Speaker Information.

## Summary by Sourcery

Align speaker profile avatar metadata fields with CfP visibility and validation settings.

Bug Fixes:
- Ensure avatar_source and avatar_license fields are hidden when configured as Do not ask in CfP settings.
- Respect required/optional and length constraints for avatar_source and avatar_license based on CfP configuration.

Enhancements:
- Extend request_require handling to cover avatar_source and avatar_license so they follow standard CfP form visibility rules.