### PR TITLE
fix: error 500 on tickets common due to PR 3560(map integration)

### DIFF
--- a/app/eventyay/control/forms/event.py
+++ b/app/eventyay/control/forms/event.py
@@ -552,6 +552,10 @@ class EventUpdateForm(I18nModelForm):
         kwargs.setdefault('initial', {})
         self.instance = kwargs['instance']
         super().__init__(*args, **kwargs)
+        self.fields['location'].widget.attrs['rows'] = '3'
+        self.fields['location'].widget.attrs['placeholder'] = _('Sample Conference Center\nHeidelberg, Germany')
+        self.fields['geo_lat'].widget.attrs['placeholder'] = _('Latitude, e.g. 40.7128')
+        self.fields['geo_lon'].widget.attrs['placeholder'] = _('Longitude, e.g. -74.0060')
         self.fields['sales_channels'] = forms.MultipleChoiceField(
             label=self.fields['sales_channels'].label,
             help_text=self.fields['sales_channels'].help_text,
@@ -574,6 +578,9 @@ class EventUpdateForm(I18nModelForm):
         localized_fields = '__all__'
         fields = [
             'currency',
+            'location',
+            'geo_lat',
+            'geo_lon',
             'presale_start',
             'presale_end',
             'sales_channels',


### PR DESCRIPTION
Fixes ticket common settings error 500 stemming from pr #3560

## Summary by Sourcery

Fix event settings form to include and properly configure location and geocoordinate fields.

Bug Fixes:
- Resolve server error when accessing ticket common settings by ensuring location and geocoordinate fields are present on the event form.

Enhancements:
- Improve the event form UX by adding placeholders and sizing for location and geocoordinate inputs.