### PR TITLE
fix: remove imprint URL from event creation form

### DIFF
--- a/app/eventyay/control/forms/event.py
+++ b/app/eventyay/control/forms/event.py
@@ -198,13 +198,6 @@ class EventWizardBasicsForm(I18nModelForm):
         ),
         required=False,
     )
-    imprint_url = forms.URLField(
-        label=_('Imprint URL'),
-        help_text=_('This should point e.g. to a part of your website '
-                    'that has your contact details and legal information.'),
-        required=False,
-    )
-
     team = forms.ModelChoiceField(
         label=_('Grant access to team'),
         help_text=_(

--- a/app/eventyay/control/forms/event.py
+++ b/app/eventyay/control/forms/event.py
@@ -545,10 +545,6 @@ class EventUpdateForm(I18nModelForm):
         kwargs.setdefault('initial', {})
         self.instance = kwargs['instance']
         super().__init__(*args, **kwargs)
-        self.fields['location'].widget.attrs['rows'] = '3'
-        self.fields['location'].widget.attrs['placeholder'] = _('Sample Conference Center\nHeidelberg, Germany')
-        self.fields['geo_lat'].widget.attrs['placeholder'] = _('Latitude, e.g. 40.7128')
-        self.fields['geo_lon'].widget.attrs['placeholder'] = _('Longitude, e.g. -74.0060')
         self.fields['sales_channels'] = forms.MultipleChoiceField(
             label=self.fields['sales_channels'].label,
             help_text=self.fields['sales_channels'].help_text,
@@ -571,9 +567,6 @@ class EventUpdateForm(I18nModelForm):
         localized_fields = '__all__'
         fields = [
             'currency',
-            'location',
-            'geo_lat',
-            'geo_lon',
             'presale_start',
             'presale_end',
             'sales_channels',

--- a/app/eventyay/control/forms/event.py
+++ b/app/eventyay/control/forms/event.py
@@ -545,6 +545,10 @@ class EventUpdateForm(I18nModelForm):
         kwargs.setdefault('initial', {})
         self.instance = kwargs['instance']
         super().__init__(*args, **kwargs)
+        self.fields['location'].widget.attrs['rows'] = '3'
+        self.fields['location'].widget.attrs['placeholder'] = _('Sample Conference Center\nHeidelberg, Germany')
+        self.fields['geo_lat'].widget.attrs['placeholder'] = _('Latitude, e.g. 40.7128')
+        self.fields['geo_lon'].widget.attrs['placeholder'] = _('Longitude, e.g. -74.0060')
         self.fields['sales_channels'] = forms.MultipleChoiceField(
             label=self.fields['sales_channels'].label,
             help_text=self.fields['sales_channels'].help_text,
@@ -567,6 +571,9 @@ class EventUpdateForm(I18nModelForm):
         localized_fields = '__all__'
         fields = [
             'currency',
+            'location',
+            'geo_lat',
+            'geo_lon',
             'presale_start',
             'presale_end',
             'sales_channels',

--- a/app/eventyay/eventyay_common/templates/eventyay_common/events/create_basics.html
+++ b/app/eventyay/eventyay_common/templates/eventyay_common/events/create_basics.html
@@ -50,6 +50,5 @@
     <fieldset>
         <legend>{% trans "Getting in touch" %}</legend>
         {% bootstrap_field form.email layout="control" %}
-        {% bootstrap_field form.imprint_url layout="control" %}
     </fieldset>
 {% endblock %}

--- a/app/eventyay/eventyay_common/views/event.py
+++ b/app/eventyay/eventyay_common/views/event.py
@@ -296,7 +296,7 @@ class EventCreateView(SafeSessionWizardView):
             # Persist timezone on the event model as well so downstream consumers see the updated value
             event.timezone = basics_data['timezone']
             event.save(update_fields=['timezone'])
-            
+
             # Use the selected create_for option, but ensure smart defaults work for all
             create_for = self.storage.extra_data.get('create_for', EventCreatedFor.BOTH)
             event.settings.set('create_for', create_for)

--- a/app/eventyay/eventyay_common/views/event.py
+++ b/app/eventyay/eventyay_common/views/event.py
@@ -297,10 +297,6 @@ class EventCreateView(SafeSessionWizardView):
             event.timezone = basics_data['timezone']
             event.save(update_fields=['timezone'])
             
-            # Save imprint_url to settings (consistent with EventCommonSettingsForm)
-            if basics_data.get('imprint_url'):
-                event.settings.set('imprint_url', basics_data['imprint_url'])
-
             # Use the selected create_for option, but ensure smart defaults work for all
             create_for = self.storage.extra_data.get('create_for', EventCreatedFor.BOTH)
             event.settings.set('create_for', create_for)


### PR DESCRIPTION
Fixes #3671 

Removes the Imprint URL field from the event creation wizard. This field is not essential during initial event creation and adds unnecessary friction. Organisers can still configure the Imprint URL later in the event settings.

**Changes:**
- Remove `imprint_url` field from [EventWizardBasicsForm] in [control/forms/event.py]
- Remove `imprint_url` field from [create_basics.html] template
- Clean up stale `imprint_url` handling in wizard's [done()] method

**Impact:**
- Event creation now focuses on essential fields only
- Imprint URL remains fully editable via event settings (API and UI)
- Existing events with an Imprint URL are unaffected
- No data model changes required (stored in `event.settings` JSON)


https://github.com/user-attachments/assets/4a29e95a-192f-452f-9c84-d98f510704ff



## Summary by Sourcery

Streamline the event creation wizard by removing the non-essential Imprint URL field from the basics step while keeping imprint management in event settings.

Enhancements:
- Remove the Imprint URL field from the event creation basics form and template to reduce friction during initial event setup.
- Drop obsolete imprint URL handling from the event creation wizard completion logic, relying on existing event settings management instead.