### PR TITLE
fixes: remove duplicate and fix rtl

### DIFF
--- a/app/eventyay/static/common/js/formTools.js
+++ b/app/eventyay/static/common/js/formTools.js
@@ -226,13 +226,37 @@ const initToastUiMarkdownTextarea = (textarea) => {
     textarea.__eventyayToastUiEditor = editor
     mount.__eventyayToastUiEditor = editor
 
-    const fieldLang = textarea.getAttribute('lang') || textarea.lang
-    if (fieldLang) {
-        const ww = mount.querySelector?.('.toastui-editor-ww-container')
-        if (ww) ww.setAttribute('lang', fieldLang)
-        const md = mount.querySelector?.('.toastui-editor-md-container')
-        if (md) md.setAttribute('lang', fieldLang)
+    const applyLanguageDirection = () => {
+        const fieldLang = textarea.getAttribute('lang') || textarea.lang
+        const fieldDir = textarea.getAttribute('dir') || textarea.dir
+
+        const flagTargets = mount.querySelectorAll?.([
+            '.toastui-editor-ww-container',
+            '.toastui-editor-md-container',
+        ].join(',')) || []
+
+        flagTargets.forEach((element) => {
+            if (fieldLang) element.setAttribute('lang', fieldLang)
+            if (fieldDir) element.setAttribute('dir', fieldDir)
+        })
+
+        if (!fieldDir) return
+
+        const editorTargets = mount.querySelectorAll?.([
+            '.toastui-editor-contents',
+            '.ProseMirror',
+            '.toastui-editor-md-preview',
+            '.toastui-editor-md-code',
+            '.cm-editor',
+            '.cm-content',
+        ].join(',')) || []
+
+        editorTargets.forEach((element) => {
+            element.setAttribute('dir', fieldDir)
+        })
     }
+    applyLanguageDirection()
+    requestAnimationFrame(applyLanguageDirection)
 
     const installAbsoluteLinkOnlyValidation = () => {
         if (!window.MutationObserver) return () => { }
@@ -427,6 +451,8 @@ const initToastUiMarkdownTextarea = (textarea) => {
             if (typeof editor.changeMode === 'function') {
                 editor.changeMode(isMarkdownMode ? 'markdown' : 'wysiwyg', true)
             }
+
+            requestAnimationFrame(applyLanguageDirection)
 
             syncToTextarea()
         })

--- a/app/eventyay/webapp/schedule/src/components/TalkDetail.vue
+++ b/app/eventyay/webapp/schedule/src/components/TalkDetail.vue
@@ -19,8 +19,8 @@
 				h2.field-heading Description
 				.field-content
 					markdown-content(:markdown="resolvedTalk.description")
-			.public-answers(v-if="resolvedTalk.answers && resolvedTalk.answers.length > 0")
-				.field-section(v-for="answer in resolvedTalk.answers", :key="answer.question_id")
+			.public-answers(v-if="visibleAnswers.length > 0")
+				.field-section(v-for="answer in visibleAnswers", :key="answer.question_id")
 					h2.field-heading {{ answer.question }}
 					.field-content
 						markdown-content(:markdown="answer.answer")
@@ -210,6 +210,13 @@ export default {
 				return null
 			}
 			return null
+		},
+		visibleAnswers() {
+			const answers = this.resolvedTalk?.answers || []
+			if (!this.resolvedTalk?.resources?.length) return answers
+
+			const downloadsLabel = (this.t.downloads || '').trim().toLowerCase()
+			return answers.filter((answer) => (answer.question || '').trim().toLowerCase() !== downloadsLabel)
 		},
 		computedJoinRoomLink() {
 			if (!this.resolvedTalk) return ''


### PR DESCRIPTION
This PR fixes two issues:

1. Removes the duplicated downloads section from session page for slides
<img width="1818" height="1180" alt="image" src="https://github.com/user-attachments/assets/54fa5051-766a-43cd-963b-e37002fe1c29" />

2. Fixes RTL language in the message Box
<img width="1818" height="1180" alt="image" src="https://github.com/user-attachments/assets/28939f0b-0bb5-4c96-927d-d6d9033ce5fe" />
