### PR TITLE
Add global Event Creation setting

### DIFF
--- a/app/eventyay/base/settings.py
+++ b/app/eventyay/base/settings.py
@@ -96,6 +96,9 @@ class GlobalSettingsObject(GlobalSettingsBase):
     slug = '_global'
 
 
+EVENT_SERIES_CREATION_ENABLED = 'event_series_creation_enabled'
+
+
 class SettingsSandbox:
     """
     Transparently proxied access to event settings, handling your prefixes for you.

--- a/app/eventyay/control/forms/event.py
+++ b/app/eventyay/control/forms/event.py
@@ -42,6 +42,7 @@ from eventyay.base.services.system_questions import (
     state_to_asked_required,
 )
 from eventyay.base.settings import (
+    EVENT_SERIES_CREATION_ENABLED,
     GlobalSettingsObject,
     PERSON_NAME_SCHEMES,
     PERSON_NAME_TITLE_GROUPS,
@@ -170,7 +171,7 @@ class EventWizardFoundationForm(forms.Form):
             })
 
         gs = GlobalSettingsObject()
-        series_enabled = gs.settings.get('event_series_creation_enabled', as_type=bool, default=True)
+        series_enabled = gs.settings.get(EVENT_SERIES_CREATION_ENABLED, as_type=bool, default=True)
         if not series_enabled and cleaned_data.get('has_subevents'):
             raise ValidationError({
                 'has_subevents': _('Event series creation is disabled by the administrator.')

--- a/app/eventyay/control/forms/event.py
+++ b/app/eventyay/control/forms/event.py
@@ -164,9 +164,7 @@ class EventWizardFoundationForm(forms.Form):
         locales = cleaned_data.get('locales', [])
         content_locales = cleaned_data.get('content_locales')
 
-        if not content_locales:
-            pass
-        elif set(content_locales) - set(locales):
+        if content_locales and set(content_locales) - set(locales):
             raise ValidationError({
                 'content_locales': _('Content languages must be a subset of the active languages.')
             })

--- a/app/eventyay/control/forms/event.py
+++ b/app/eventyay/control/forms/event.py
@@ -165,11 +165,17 @@ class EventWizardFoundationForm(forms.Form):
         content_locales = cleaned_data.get('content_locales')
 
         if not content_locales:
-            return cleaned_data
-
-        if set(content_locales) - set(locales):
+            pass
+        elif set(content_locales) - set(locales):
             raise ValidationError({
                 'content_locales': _('Content languages must be a subset of the active languages.')
+            })
+
+        gs = GlobalSettingsObject()
+        series_enabled = gs.settings.get('event_series_creation_enabled', as_type=bool, default=True)
+        if not series_enabled and cleaned_data.get('has_subevents'):
+            raise ValidationError({
+                'has_subevents': _('Event series creation is disabled by the administrator.')
             })
 
         return cleaned_data

--- a/app/eventyay/control/forms/global_settings.py
+++ b/app/eventyay/control/forms/global_settings.py
@@ -22,6 +22,8 @@ class GlobalSettingsForm(SettingsForm):
         global_settings = self.obj.settings
         if global_settings.get('billing_validation') is None:
             global_settings.set('billing_validation', True)
+        if global_settings.get('event_series_creation_enabled') is None:
+            global_settings.set('event_series_creation_enabled', True)
         if global_settings.get('smtp_port') is None or global_settings.get('smtp_port') == '':
             self.obj.settings.set('smtp_port', settings.EMAIL_PORT)
         if global_settings.get('smtp_host') is None or global_settings.get('smtp_host') == '':
@@ -55,6 +57,17 @@ class GlobalSettingsForm(SettingsForm):
                         help_text=_(
                             'Billing validation lets you require organizers to set up a billing method before they can create events. '
                             'When this option is enabled, no new event can be created until a valid billing method has been added.'
+                        ),
+                    ),
+                ),
+                (
+                    'event_series_creation_enabled',
+                    forms.BooleanField(
+                        required=False,
+                        label=_('Allow event series creation'),
+                        help_text=_(
+                            'When enabled, organizers can create event series or time slot bookings in addition to singular events. '
+                            'Disable this to restrict event creation to singular events and non-event shops only.'
                         ),
                     ),
                 ),
@@ -460,6 +473,9 @@ class GlobalSettingsForm(SettingsForm):
             ('organizers', _('Organizers'), [
                 'allow_all_users_create_organizer',
                 'allow_payment_users_create_organizer',
+            ]),
+            ('event_creation', _('Event Creation'), [
+                'event_series_creation_enabled',
             ]),
         ]
 

--- a/app/eventyay/control/forms/global_settings.py
+++ b/app/eventyay/control/forms/global_settings.py
@@ -8,7 +8,7 @@ from django.utils.translation import gettext_lazy as _
 from i18nfield.forms import I18nFormField, I18nTextarea, I18nTextInput
 
 from eventyay.base.forms import SecretKeySettingsField, SettingsForm
-from eventyay.base.settings import GlobalSettingsObject
+from eventyay.base.settings import EVENT_SERIES_CREATION_ENABLED, GlobalSettingsObject
 from eventyay.base.signals import register_global_settings
 
 
@@ -22,8 +22,8 @@ class GlobalSettingsForm(SettingsForm):
         global_settings = self.obj.settings
         if global_settings.get('billing_validation') is None:
             global_settings.set('billing_validation', True)
-        if global_settings.get('event_series_creation_enabled') is None:
-            global_settings.set('event_series_creation_enabled', True)
+        if global_settings.get(EVENT_SERIES_CREATION_ENABLED) is None:
+            global_settings.set(EVENT_SERIES_CREATION_ENABLED, True)
         if global_settings.get('smtp_port') is None or global_settings.get('smtp_port') == '':
             self.obj.settings.set('smtp_port', settings.EMAIL_PORT)
         if global_settings.get('smtp_host') is None or global_settings.get('smtp_host') == '':
@@ -61,7 +61,7 @@ class GlobalSettingsForm(SettingsForm):
                     ),
                 ),
                 (
-                    'event_series_creation_enabled',
+                    EVENT_SERIES_CREATION_ENABLED,
                     forms.BooleanField(
                         required=False,
                         label=_('Allow event series creation'),
@@ -475,7 +475,7 @@ class GlobalSettingsForm(SettingsForm):
                 'allow_payment_users_create_organizer',
             ]),
             ('event_creation', _('Event Creation'), [
-                'event_series_creation_enabled',
+                EVENT_SERIES_CREATION_ENABLED,
             ]),
         ]
 

--- a/app/eventyay/control/templates/pretixcontrol/global_settings.html
+++ b/app/eventyay/control/templates/pretixcontrol/global_settings.html
@@ -133,6 +133,28 @@
                                 {% endif %}
                             {% endfor %}
                         </fieldset>
+                    {% elif group_key == "event_creation" %}
+                        <fieldset>
+                            <legend>{{ group_label }}</legend>
+                            <div class="form-group">
+                                <label class="col-md-3 control-label">
+                                    <strong>{{ form.event_series_creation_enabled.label }}</strong>
+                                </label>
+                                <div class="col-md-9">
+                                    <div class="checkbox">
+                                        <label>
+                                            {{ form.event_series_creation_enabled }} {% trans "Enable" %}
+                                        </label>
+                                    </div>
+                                    {% if form.event_series_creation_enabled.help_text %}
+                                        <span class="help-block">{{ form.event_series_creation_enabled.help_text }}</span>
+                                    {% endif %}
+                                    {% if form.event_series_creation_enabled.errors %}
+                                        <div class="help-block">{{ form.event_series_creation_enabled.errors }}</div>
+                                    {% endif %}
+                                </div>
+                            </div>
+                        </fieldset>
                     {% elif group_key == "billing_validation" %}
                         <fieldset>
                             <legend>{{ group_label }}</legend>

--- a/app/eventyay/eventyay_common/templates/eventyay_common/events/create_foundation.html
+++ b/app/eventyay/eventyay_common/templates/eventyay_common/events/create_foundation.html
@@ -67,6 +67,7 @@
                         </div>
                     </label>
                 </div>
+                {% if event_series_creation_enabled %}
                 <div class="big-radio radio">
                     <label>
                         <input type="radio" value="on" name="{{ form.has_subevents.html_name }}" {% if form.has_subevents.avalue %}checked{% endif %}>
@@ -87,6 +88,7 @@
                         </div>
                     </label>
                 </div>
+                {% endif %}
             </div>
         </div>
     <fieldset>

--- a/app/eventyay/eventyay_common/views/event.py
+++ b/app/eventyay/eventyay_common/views/event.py
@@ -33,7 +33,7 @@ from eventyay.base.i18n import language
 from eventyay.base.models import Event, EventMetaValue, Organizer, Quota
 from eventyay.consts import DEFAULT_PLUGINS
 from eventyay.base.services import tickets
-from eventyay.base.settings import SETTINGS_AFFECTING_CSS
+from eventyay.base.settings import SETTINGS_AFFECTING_CSS, GlobalSettingsObject
 from eventyay.presale.style import regenerate_css
 from eventyay.base.services.quotas import QuotaAvailability
 from eventyay.control.forms.event import EventWizardBasicsForm, EventWizardFoundationForm
@@ -215,6 +215,10 @@ class EventCreateView(SafeSessionWizardView):
         if self.steps.current == 'basics':
             context['organizer'] = self.get_cleaned_data_for_step('foundation').get('organizer')
         context['event_creation_for_choice'] = {e.name: e.value for e in EventCreatedFor}
+        gs = GlobalSettingsObject()
+        context['event_series_creation_enabled'] = gs.settings.get(
+            'event_series_creation_enabled', as_type=bool, default=True
+        )
         return context
 
     def render(self, form=None, **kwargs):

--- a/app/eventyay/eventyay_common/views/event.py
+++ b/app/eventyay/eventyay_common/views/event.py
@@ -33,7 +33,7 @@ from eventyay.base.i18n import language
 from eventyay.base.models import Event, EventMetaValue, Organizer, Quota
 from eventyay.consts import DEFAULT_PLUGINS
 from eventyay.base.services import tickets
-from eventyay.base.settings import SETTINGS_AFFECTING_CSS, GlobalSettingsObject
+from eventyay.base.settings import EVENT_SERIES_CREATION_ENABLED, SETTINGS_AFFECTING_CSS, GlobalSettingsObject
 from eventyay.presale.style import regenerate_css
 from eventyay.base.services.quotas import QuotaAvailability
 from eventyay.control.forms.event import EventWizardBasicsForm, EventWizardFoundationForm
@@ -217,7 +217,7 @@ class EventCreateView(SafeSessionWizardView):
         context['event_creation_for_choice'] = {e.name: e.value for e in EventCreatedFor}
         gs = GlobalSettingsObject()
         context['event_series_creation_enabled'] = gs.settings.get(
-            'event_series_creation_enabled', as_type=bool, default=True
+            EVENT_SERIES_CREATION_ENABLED, as_type=bool, default=True
         )
         return context
 


### PR DESCRIPTION
fixes #3669 

Added a global "Event Creation" setting that lets admins enable or disable event series creation. the setting defaults to True (enabled), the form shows both options when enabled, hides the series option when disabled, and server-side validation prevents bypassing via direct form submission when disabled.


https://github.com/user-attachments/assets/63fa9e86-0cda-4ed9-9313-f8a19ce7ef2e

