### PR TITLE
fix(presale): move presale-ended alert to ticket section

### DIFF
--- a/app/eventyay/presale/templates/pretixpresale/event/index.html
+++ b/app/eventyay/presale/templates/pretixpresale/event/index.html
@@ -214,27 +214,6 @@
     {% endif %}
 
     {% if subevent or not event.has_subevents %}
-        {% if not ev.presale_is_running %}
-            <div class="alert alert-info">
-                {% if ev.presale_has_ended %}
-                    {% if event.settings.presale_has_ended_text %}
-                        {{ event.settings.presale_has_ended_text|event_localize|rich_text }}
-                    {% else %}
-                        {% blocktrans trimmed %}
-                            The presale period for this event is over.
-                        {% endblocktrans %}
-                    {% endif %}
-                {% elif event.settings.presale_start_show_date %}
-                    {% blocktrans trimmed with date=ev.effective_presale_start|date:"SHORT_DATE_FORMAT" time=ev.effective_presale_start|time:"TIME_FORMAT" %}
-                        The presale for this event will start on {{ date }} at {{ time }}.
-                    {% endblocktrans %}
-                {% else %}
-                    {% blocktrans trimmed %}
-                        The presale for this event has not yet started.
-                    {% endblocktrans %}
-                {% endif %}
-            </div>
-        {% endif %}
         {% if not cart_namespace or subevent %}
             <div>
                 {% if ev.location %}
@@ -303,6 +282,27 @@
     {% if subevent or not event.has_subevents %}
         {% include "pretixpresale/event/fragment_testmode_alert.html" %}
         <div id="tickets"></div>
+        {% if not ev.presale_is_running %}
+            <div class="alert alert-info">
+                {% if ev.presale_has_ended %}
+                    {% if event.settings.presale_has_ended_text %}
+                        {{ event.settings.presale_has_ended_text|event_localize|rich_text }}
+                    {% else %}
+                        {% blocktrans trimmed %}
+                            The presale period for this event is over.
+                        {% endblocktrans %}
+                    {% endif %}
+                {% elif event.settings.presale_start_show_date %}
+                    {% blocktrans trimmed with date=ev.effective_presale_start|date:"SHORT_DATE_FORMAT" time=ev.effective_presale_start|time:"TIME_FORMAT" %}
+                        The presale for this event will start on {{ date }} at {{ time }}.
+                    {% endblocktrans %}
+                {% else %}
+                    {% blocktrans trimmed %}
+                        The presale for this event has not yet started.
+                    {% endblocktrans %}
+                {% endif %}
+            </div>
+        {% endif %}
         {% if can_view_tickets %}
             {% if request.event.live or is_organiser %}
                 {% if ev.presale_is_running or event.settings.show_products_outside_presale_period %}


### PR DESCRIPTION
Fixes #3686 

The presale-ended alert was rendered in Block A (event info block), appearing before the location and date info rows - visually misaligned from where users expect ticket-related messaging.

The alert now renders:

- Below the event date/location info (Block A renders first)
- In the ticket section at the #tickets anchor (same nesting level as the form)
- Same container alignment - both alert and form are at identical indentation inside `<main>`, no CSS changes needed

 

https://github.com/user-attachments/assets/90819282-eaeb-47a8-8b85-3ee63f0d8d74


