### PR TITLE
Auto-create tracks on session CSV import

### DIFF
--- a/app/eventyay/base/services/talkimport.py
+++ b/app/eventyay/base/services/talkimport.py
@@ -63,6 +63,21 @@ USER_CODE_MAX_LENGTH = User._meta.get_field('code').max_length or 16
 USER_FULLNAME_MAX_LENGTH = User._meta.get_field('fullname').max_length or 255
 SUBMISSION_CODE_MAX_LENGTH = Submission._meta.get_field('code').max_length or 16
 ROOM_NAME_MAX_LENGTH = Room._meta.get_field('name').max_length or 100
+TRACK_NAME_MAX_LENGTH = Track._meta.get_field('name').max_length or 200
+
+# A rotating palette of distinct colours used when auto-creating tracks during import.
+_TRACK_AUTO_COLORS = [
+    '#3498db',
+    '#2ecc71',
+    '#e67e22',
+    '#9b59b6',
+    '#e74c3c',
+    '#1abc9c',
+    '#f39c12',
+    '#2980b9',
+    '#27ae60',
+    '#8e44ad',
+]
 NORMALIZED_SPEAKER_SETTINGS = {
     key: f'csv:{key}'
     for key in (
@@ -1175,8 +1190,8 @@ def _import_submission_row(event, settings, record, acting_user, speaker_cache=N
     if not sub_type:
         raise ImportExecutionError(_('No session type found for this event.'))
 
-    # Resolve track (use pre-fetched cache)
-    track = _resolve_track(track_val, caches) if track_val and caches else None
+    # Resolve track (auto-create if not found)
+    track = _resolve_or_create_track(track_val, event, caches) if track_val else None
 
     # Resolve state (use pre-fetched valid_states set)
     valid_states = caches['valid_states'] if caches else {choice[0] for choice in SubmissionStates.get_choices()}
@@ -1386,6 +1401,33 @@ def _resolve_track(track_val: str, caches: dict) -> 'Track | None':
     except (ValueError, TypeError):
         pass
     return None
+
+
+def _resolve_or_create_track(
+    track_val: str,
+    event: Event,
+    caches: dict | None,
+) -> 'Track | None':
+    """Find an existing Track by name or pk, or create one when not found."""
+    normalized_name = track_val.strip() if track_val else ''
+    if not normalized_name:
+        return None
+    normalized_name = str(normalized_name)[:TRACK_NAME_MAX_LENGTH]
+
+    track = _resolve_track(normalized_name, caches) if caches else None
+    if not track:
+        track = Track.objects.filter(event=event, name__iexact=normalized_name).first()
+
+    if track:
+        return track
+
+    # Auto-create the track with a colour from the rotating palette.
+    existing_count = len(caches['tracks']) if caches else Track.objects.filter(event=event).count()
+    color = _TRACK_AUTO_COLORS[existing_count % len(_TRACK_AUTO_COLORS)]
+    track = Track.objects.create(event=event, name=normalized_name, color=color)
+    if caches is not None:
+        caches['tracks'].append(track)
+    return track
 
 
 def _resolve_room(room_val: str, caches: dict) -> 'Room | None':

--- a/app/eventyay/orga/forms/importers.py
+++ b/app/eventyay/orga/forms/importers.py
@@ -222,7 +222,7 @@ SESSION_IMPORT_FIELDS: list[ImportField] = [
     ImportField(
         identifier='track',
         label=_('Track'),
-        help_text=_('Must match an existing track name or ID.'),
+        help_text=_('Must match an existing track name or ID. A new track will be created automatically if no match is found.'),
         suggestions=['track', 'category'],
     ),
     ImportField(


### PR DESCRIPTION
needed for #3435 

Previously, if a CSV row referenced a track that did not exist, the track was silently skipped and the session was left unlinked. Rooms are already auto-created; this brings the same behaviour to tracks.

Changes:
- Add TRACK_NAME_MAX_LENGTH constant and _TRACK_AUTO_COLORS palette.
- Add _resolve_or_create_track(): finds an existing Track by exact/partial name or pk, and creates a new one (with a rotating default colour) when no match is found, mirroring _resolve_or_create_room().
- Update _import_submission_row() to call _resolve_or_create_track instead of the read-only _resolve_track.
- Update the Track help-text in SessionImportProcessForm to inform users that new tracks are created automatically.


<img width="5088" height="3352" alt="image" src="https://github.com/user-attachments/assets/76272276-1437-4212-ae81-1e947e79ca4f" />
<img width="5088" height="3352" alt="image" src="https://github.com/user-attachments/assets/0e14b7c9-ef00-45cf-ad6d-75e217e396b5" />
