### PR TITLE
Fix admin user anonymize redirect

### DIFF
--- a/app/eventyay/control/views/users.py
+++ b/app/eventyay/control/views/users.py
@@ -179,6 +179,12 @@ class UserAnonymizeView(
         ctx['edit_user'] = get_object_or_404(User, pk=self.kwargs.get('id'))
         return ctx
 
+    def get_success_url(self):
+        return reverse('eventyay_admin:admin.users')
+
+    def get_error_url(self):
+        return reverse('eventyay_admin:admin.users.edit', kwargs=self.kwargs)
+
     def post(self, request, *args, **kwargs):
         self.object = get_object_or_404(User, pk=self.kwargs.get('id'))
         try:
@@ -201,10 +207,10 @@ class UserAnonymizeView(
         except DatabaseError:
             logger.exception('Failed to anonymize user %s from admin user page.', self.object.pk)
             messages.error(request, _('The user could not be anonymized. Please try again later.'))
-            return redirect(reverse('eventyay_admin:admin.users.edit', kwargs=self.kwargs))
+            return redirect(self.get_error_url())
         else:
             messages.success(request, _('User has been anonymized successfully.'))
-            return redirect(reverse('eventyay_admin:admin.users'))
+            return redirect(self.get_success_url())
 
 
 class UserImpersonateView(AdministratorPermissionRequiredMixin, RecentAuthenticationRequiredMixin, View):

--- a/app/eventyay/control/views/users.py
+++ b/app/eventyay/control/views/users.py
@@ -1,4 +1,5 @@
 import json
+import logging
 from contextlib import contextmanager
 
 from django.conf import settings
@@ -10,6 +11,7 @@ from django.contrib.auth import (
     login,
 )
 from django.contrib.auth.mixins import LoginRequiredMixin
+from django.db import transaction
 from django.http import JsonResponse
 from django.shortcuts import get_object_or_404, redirect
 from django.urls import reverse
@@ -33,6 +35,8 @@ from eventyay.control.forms.users import UserEditForm
 from eventyay.control.permissions import AdministratorPermissionRequiredMixin
 from eventyay.control.views import CreateView, UpdateView
 from eventyay.control.views.user import RecentAuthenticationRequiredMixin
+
+logger = logging.getLogger(__name__)
 
 
 def get_used_backend(request):
@@ -177,23 +181,30 @@ class UserAnonymizeView(
 
     def post(self, request, *args, **kwargs):
         self.object = get_object_or_404(User, pk=self.kwargs.get('id'))
-        self.object.log_action('eventyay.user.anonymized', user=request.user)
-        self.object.email = '{}@disabled.eventyay.com'.format(self.object.pk)
-        self.object.fullname = ''
-        self.object.is_active = False
-        self.object.notifications_send = False
-        self.object.save()
-        for le in self.object.all_logentries.filter(action_type='eventyay.user.settings.changed'):
-            d = le.parsed_data
-            if 'email' in d:
-                d['email'] = '█'
-            if 'fullname' in d:
-                d['fullname'] = '█'
-            le.data = json.dumps(d)
-            le.shredded = True
-            le.save(update_fields=['data', 'shredded'])
+        try:
+            with transaction.atomic():
+                self.object.log_action('eventyay.user.anonymized', user=request.user)
+                self.object.email = '{}@disabled.eventyay.com'.format(self.object.pk)
+                self.object.fullname = ''
+                self.object.is_active = False
+                self.object.notifications_send = False
+                self.object.save()
+                for le in self.object.all_logentries.filter(action_type='eventyay.user.settings.changed'):
+                    d = le.parsed_data
+                    if 'email' in d:
+                        d['email'] = '█'
+                    if 'fullname' in d:
+                        d['fullname'] = '█'
+                    le.data = json.dumps(d)
+                    le.shredded = True
+                    le.save(update_fields=['data', 'shredded'])
+        except Exception:
+            logger.exception('Failed to anonymize user %s from admin user page.', self.object.pk)
+            messages.error(request, _('The user could not be anonymized. Please try again later.'))
+        else:
+            messages.success(request, _('User has been anonymized successfully.'))
 
-        return redirect(reverse('eventyay_admin:admin.users.edit', kwargs=self.kwargs))
+        return redirect(reverse('eventyay_admin:admin.users'))
 
 
 class UserImpersonateView(AdministratorPermissionRequiredMixin, RecentAuthenticationRequiredMixin, View):

--- a/app/eventyay/control/views/users.py
+++ b/app/eventyay/control/views/users.py
@@ -11,7 +11,7 @@ from django.contrib.auth import (
     login,
 )
 from django.contrib.auth.mixins import LoginRequiredMixin
-from django.db import transaction
+from django.db import DatabaseError, transaction
 from django.http import JsonResponse
 from django.shortcuts import get_object_or_404, redirect
 from django.urls import reverse
@@ -198,13 +198,13 @@ class UserAnonymizeView(
                     le.data = json.dumps(d)
                     le.shredded = True
                     le.save(update_fields=['data', 'shredded'])
-        except Exception:
+        except DatabaseError:
             logger.exception('Failed to anonymize user %s from admin user page.', self.object.pk)
             messages.error(request, _('The user could not be anonymized. Please try again later.'))
+            return redirect(reverse('eventyay_admin:admin.users.edit', kwargs=self.kwargs))
         else:
             messages.success(request, _('User has been anonymized successfully.'))
-
-        return redirect(reverse('eventyay_admin:admin.users'))
+            return redirect(reverse('eventyay_admin:admin.users'))
 
 
 class UserImpersonateView(AdministratorPermissionRequiredMixin, RecentAuthenticationRequiredMixin, View):


### PR DESCRIPTION
Fixes #3699

  This PR fixes the admin user anonymization flow so admins are not shown an error page after anonymizing a user from the admin
  user page.

  ## Changes

  - Redirect admins to the admin users list after a successful anonymization.
  - Show a success message: `User has been anonymized successfully.`
  - Handle database failures during anonymization with a clear error message.
  - Redirect back to the user edit page if anonymization fails.
  - Add logging for anonymization failures from the admin user page.
  - Avoid trying to render the anonymized/deleted user detail page after successful anonymization.

  ## Testing

  - Verified that clicking `Anonymize` completes the anonymization flow.
  - Verified that the admin is redirected to the users list after success.
  - Verified that a success message is shown after anonymization.
  - Verified that database errors are logged and show a clear error message instead of a generic error page.

  ## Notes

  The anonymization action remains protected by the existing admin and recent-authentication permission checks.
  
  
  
https://github.com/user-attachments/assets/6f6c2790-fbe8-44d1-80da-473717b22d3d

