### PR TITLE
Fix products pagination footer

### DIFF
--- a/app/eventyay/control/templates/pretixcontrol/items/index.html
+++ b/app/eventyay/control/templates/pretixcontrol/items/index.html
@@ -113,8 +113,8 @@
                             </td>
                             <td>{% if i.category %}{{ i.category.name }}{% endif %}</td>
                             <td>
-                                <a href="{% url "control:event.products.up" organizer=request.event.organizer.slug event=request.event.slug product=i.id %}" class="btn btn-default btn-sm {% if forloop.counter0 == 0 and is_paginated and not page_obj.has_previous %}disabled{% endif %}"><i class="fa fa-arrow-up"></i></a>
-                                <a href="{% url "control:event.products.down" organizer=request.event.organizer.slug event=request.event.slug product=i.id %}" class="btn btn-default btn-sm {% if forloop.revcounter0 == 0 and is_paginated and not page_obj.has_next %}disabled{% endif %}"><i class="fa fa-arrow-down"></i></a>
+                                <a href="{% url "control:event.products.up" organizer=request.event.organizer.slug event=request.event.slug product=i.id %}{% if request.GET %}?{{ request.GET.urlencode }}{% endif %}" class="btn btn-default btn-sm {% if forloop.counter0 == 0 and is_paginated and not page_obj.has_previous %}disabled{% endif %}"><i class="fa fa-arrow-up"></i></a>
+                                <a href="{% url "control:event.products.down" organizer=request.event.organizer.slug event=request.event.slug product=i.id %}{% if request.GET %}?{{ request.GET.urlencode }}{% endif %}" class="btn btn-default btn-sm {% if forloop.revcounter0 == 0 and is_paginated and not page_obj.has_next %}disabled{% endif %}"><i class="fa fa-arrow-down"></i></a>
                             </td>
                             <td class="text-right flip">
                                 <a href="{% url "control:event.product" organizer=request.event.organizer.slug event=request.event.slug product=i.id %}" class="btn btn-default btn-sm"><i class="fa fa-edit"></i></a>

--- a/app/eventyay/control/templates/pretixcontrol/items/index.html
+++ b/app/eventyay/control/templates/pretixcontrol/items/index.html
@@ -113,8 +113,8 @@
                             </td>
                             <td>{% if i.category %}{{ i.category.name }}{% endif %}</td>
                             <td>
-                                <a href="{% url "control:event.products.up" organizer=request.event.organizer.slug event=request.event.slug product=i.id %}{% if request.GET %}?{{ request.GET.urlencode }}{% endif %}" class="btn btn-default btn-sm {% if forloop.counter0 == 0 and is_paginated and not page_obj.has_previous %}disabled{% endif %}"><i class="fa fa-arrow-up"></i></a>
-                                <a href="{% url "control:event.products.down" organizer=request.event.organizer.slug event=request.event.slug product=i.id %}{% if request.GET %}?{{ request.GET.urlencode }}{% endif %}" class="btn btn-default btn-sm {% if forloop.revcounter0 == 0 and is_paginated and not page_obj.has_next %}disabled{% endif %}"><i class="fa fa-arrow-down"></i></a>
+                                <a href="{% url 'control:event.products.up' organizer=request.event.organizer.slug event=request.event.slug product=i.id %}{% if request.GET %}?{{ request.GET.urlencode }}{% endif %}" class="btn btn-default btn-sm {% if not i.can_move_up %}disabled{% endif %}"><i class="fa fa-arrow-up"></i></a>
+                                <a href="{% url 'control:event.products.down' organizer=request.event.organizer.slug event=request.event.slug product=i.id %}{% if request.GET %}?{{ request.GET.urlencode }}{% endif %}" class="btn btn-default btn-sm {% if not i.can_move_down %}disabled{% endif %}"><i class="fa fa-arrow-down"></i></a>
                             </td>
                             <td class="text-right flip">
                                 <a href="{% url "control:event.product" organizer=request.event.organizer.slug event=request.event.slug product=i.id %}" class="btn btn-default btn-sm"><i class="fa fa-edit"></i></a>

--- a/app/eventyay/control/templates/pretixcontrol/items/index.html
+++ b/app/eventyay/control/templates/pretixcontrol/items/index.html
@@ -127,6 +127,6 @@
                 </tbody>
             </table>
         </div>
-        {% include "pretixcontrol/pagination.html" %}
     {% endif %}
+    {% include "pretixcontrol/pagination.html" %}
 {% endblock %}

--- a/app/eventyay/control/views/product.py
+++ b/app/eventyay/control/views/product.py
@@ -136,24 +136,30 @@ def product_move(request, product, up=True):
     messages.success(request, _('The order of products has been updated.'))
 
 
+def product_list_redirect(request):
+    url = reverse(
+        'control:event.products',
+        kwargs={
+            'organizer': request.event.organizer.slug,
+            'event': request.event.slug,
+        },
+    )
+    query = request.GET.urlencode()
+    if query:
+        url = f'{url}?{query}'
+    return HttpResponseRedirect(url)
+
+
 @event_permission_required('can_change_items')
 def product_move_up(request, organizer, event, product):
     product_move(request, product, up=True)
-    return redirect(
-        'control:event.products',
-        organizer=request.event.organizer.slug,
-        event=request.event.slug,
-    )
+    return product_list_redirect(request)
 
 
 @event_permission_required('can_change_items')
 def product_move_down(request, organizer, event, product):
     product_move(request, product, up=False)
-    return redirect(
-        'control:event.products',
-        organizer=request.event.organizer.slug,
-        event=request.event.slug,
-    )
+    return product_list_redirect(request)
 
 
 class CategoryDelete(EventPermissionRequiredMixin, DeleteView):

--- a/app/eventyay/control/views/product.py
+++ b/app/eventyay/control/views/product.py
@@ -107,6 +107,39 @@ class ProductList(PaginationMixin, ListView):
 
     def get_context_data(self, **kwargs):
         ctx = super().get_context_data(**kwargs)
+        products = list(ctx['products'])
+        category_ids = {product.category_id for product in products}
+        category_filter = Q()
+        non_empty_category_ids = {category_id for category_id in category_ids if category_id is not None}
+        if non_empty_category_ids:
+            category_filter |= Q(category_id__in=non_empty_category_ids)
+        if None in category_ids:
+            category_filter |= Q(category__isnull=True)
+
+        products_by_category = {}
+        if category_filter:
+            for product_id, category_id in (
+                self.request.event.products.filter(category_filter)
+                .order_by('category_id', 'position')
+                .values_list('id', 'category_id')
+            ):
+                products_by_category.setdefault(category_id, []).append(product_id)
+
+        move_states = {}
+        for category_products in products_by_category.values():
+            last_index = len(category_products) - 1
+            for index, product_id in enumerate(category_products):
+                move_states[product_id] = {
+                    'can_move_up': index > 0,
+                    'can_move_down': index < last_index,
+                }
+
+        for product in products:
+            state = move_states.get(product.pk, {})
+            product.can_move_up = state.get('can_move_up', False)
+            product.can_move_down = state.get('can_move_down', False)
+
+        ctx['products'] = products
         ctx['sales_channels'] = get_all_sales_channels()
         return ctx
 

--- a/app/eventyay/control/views/product.py
+++ b/app/eventyay/control/views/product.py
@@ -92,12 +92,9 @@ from . import ChartContainingView, CreateView, PaginationMixin, UpdateView
 logger = logging.getLogger(__name__)
 
 
-class ProductList(ListView):
+class ProductList(PaginationMixin, ListView):
     model = Product
     context_object_name = 'products'
-    # paginate_by = 30
-    # Pagination is disabled as it is very unlikely to be necessary
-    # here and could cause problems with the "reorder-within-category" feature
     template_name = 'pretixcontrol/items/index.html'
 
     def get_queryset(self):


### PR DESCRIPTION
Fixes #3744 

## Summary
  - Enable the shared pagination footer on the Products list page
  - Move the Products pagination include outside the non-empty table branch
  - Align Products footer behavior with Quotas and other Products module pages
  
 

https://github.com/user-attachments/assets/d79f6e99-d1cf-4202-b940-795287b36921

## Summary by Sourcery

Enable standard pagination support on the Products list page and ensure the pagination footer is always rendered consistently with other pages.

Enhancements:
- Add pagination mixin to the Products list view to support shared pagination behavior.
- Adjust the Products list template so the shared pagination footer is rendered outside the non-empty table condition.