### PR TITLE
fix: resolve PDF editor toolbox control wrapping and contrast notice overlapping

### DIFF
--- a/app/eventyay/control/templates/pretixcontrol/pdf/index.html
+++ b/app/eventyay/control/templates/pretixcontrol/pdf/index.html
@@ -258,13 +258,15 @@
                         </div>
                     </div>
                     <div class="row control-group text">
-                        <div class="col-sm-6">
+                        <div class="col-sm-12">
                             <label>{% trans "Font size (pt)" %}</label><br>
                             <input type="number" value="13" class="input-block-level form-control" step="0.1"
                                     id="toolbox-fontsize">
                         </div>
-                        <div class="col-sm-6">
-                            <label>&nbsp;</label><br>
+                    </div>
+                    <div class="row control-group text">
+                        <div class="col-sm-12">
+                            <label>{% trans "Font style" %}</label><br>
                             <div class="btn-group btn-group-justified" role="group">
                                 <div class="btn-group" role="group">
                                     <button type="button" class="btn btn-default toggling" data-action="bold">
@@ -285,14 +287,16 @@
                             </div>
                         </div>
                     </div>
-                    <div class="row control-group text">
-                        <div class="col-sm-6">
+                    <div class="row control-group text form-group">
+                        <div class="col-xs-12">
                             <label>{% trans "Text color" %}</label><br>
                             <input type="text" value="#000000" class="input-block-level form-control colorpickerfield"
                                     id="toolbox-col">
                         </div>
-                        <div class="col-sm-6">
-                            <label>&nbsp;</label><br>
+                    </div>
+                    <div class="row control-group text">
+                        <div class="col-sm-12">
+                            <label>{% trans "Alignment" %}</label><br>
                             <div class="btn-group btn-group-justified" id="toolbox-align">
                                 <div class="btn-group" role="group">
                                     <button type="button" class="btn btn-default option toggling" data-action="left">


### PR DESCRIPTION
This PR resolves the layout breakage and overlapping controls inside the PDF/badge editor's toolbox sidebar.

Previously, several controls were placed side-by-side inside narrow `col-sm-6` columns, causing buttons to wrap awkwardly and layout boxes to overflow the panel. Additionally, because the text color input lacked standard Bootstrap form group markup, the dynamically appended contrast notice was squeezed next to the input inside a flex wrapper, stretching the layout height.


| Before | After |
|--------|-------|
| <img width="300" alt="before" src="https://github.com/user-attachments/assets/7ac2d7ec-6f76-47c4-90c8-17db543501f3" /> | <img width="300" alt="after" src="https://github.com/user-attachments/assets/c7208e10-0b84-4328-839c-e0d187f313e4" /> |



### Changes Made
- **Grid Realignment**: Isolated the **Font size**, **Font style** (Bold/Italic/Downward), **Text color**, and **Alignment** controls into separate full-width rows to provide sufficient horizontal breathing room.
- **Dynamic Contrast Notice Fix**: Configured the **Text color** markup with `form-group` and `col-xs-12` wrapper classes. This allows the global `getColorFieldHost` utility to correctly identify the column block as the host container, ensuring the contrast alert text stacks vertically **below** the input field instead of stretching the flex container.
- **Added Labels**: Introduced localized `<label>` tags for the isolated **Font style** and **Alignment** blocks.


- Closes : #3758 