### PR TITLE
Fix BBB hide presentation setting

### DIFF
--- a/app/eventyay/base/services/bbb.py
+++ b/app/eventyay/base/services/bbb.py
@@ -303,8 +303,7 @@ class BBBService:
                 "userdata-bbb_skip_video_preview": (
                     "true" if config.get("auto_camera", False) else "false"
                 ),
-                # For some reason, bbb_auto_swap_layout does what you expect from bbb_hide_presentation
-                "userdata-bbb_auto_swap_layout": (
+                "userdata-bbb_hide_presentation_on_join": (
                     "true" if config.get("hide_presentation", False) else "false"
                 ),
             },

--- a/app/tests/video/live/test_bigbluebutton.py
+++ b/app/tests/video/live/test_bigbluebutton.py
@@ -1,6 +1,7 @@
 import re
 import uuid
 from contextlib import asynccontextmanager
+from urllib.parse import parse_qs, urlparse
 
 import pytest
 from aiohttp.http_exceptions import HttpProcessingError
@@ -188,6 +189,9 @@ async def test_bbb_xml_error(bbb_room):
 @pytest.mark.asyncio
 @pytest.mark.django_db
 async def test_successful_url(bbb_room):
+    bbb_room.module_config[0]["config"]["hide_presentation"] = True
+    await database_sync_to_async(bbb_room.save)(update_fields=["module_config"])
+
     with aioresponses() as m:
         async with world_communicator(named=True) as c:
             await c.send_json_to(["bbb.room_url", 123, {"room": str(bbb_room.pk)}])
@@ -218,6 +222,9 @@ This conference was already in existence and may currently be in progress.
             response = await c.receive_json_from()
             assert response[0] == "success"
             assert "/join?" in response[2]["url"]
+            query = parse_qs(urlparse(response[2]["url"]).query)
+            assert query["userdata-bbb_hide_presentation_on_join"] == ["true"]
+            assert "userdata-bbb_auto_swap_layout" not in query
 
             @database_sync_to_async
             def get_call():


### PR DESCRIPTION
Fixes #3787 
## Description

  Fixes the BBB hide-presentation setting by using the correct
  userdata-bbb_hide_presentation_on_join parameter. Adds a
  regression test to verify the generated join URL uses the
  correct parameter.
  
  

https://github.com/user-attachments/assets/04b8a0f4-9119-46be-9007-aa856b6a056b

## Summary by Sourcery

Fix BigBlueButton join URL handling of the hide-presentation setting and add a regression test to validate the generated URL parameters.

Bug Fixes:
- Correct the BigBlueButton join URL to use the userdata-bbb_hide_presentation_on_join parameter when hide_presentation is enabled.

Tests:
- Add a regression test ensuring the BigBlueButton join URL includes userdata-bbb_hide_presentation_on_join and omits userdata-bbb_auto_swap_layout when hide_presentation is enabled.