### PR TITLE
fix: resolve incorrect language flags in event settings

### DIFF
--- a/app/eventyay/static/orga/css/_flags.css
+++ b/app/eventyay/static/orga/css/_flags.css
@@ -153,7 +153,7 @@ textarea[lang="bm"] {
 div[lang="bn"],
 input[lang="bn"],
 textarea[lang="bn"] {
-  background-image: url("/static/vendored/flags/bn.png");
+  background-image: url("/static/vendored/flags/bd.png");
 }
 div[lang="bo"],
 input[lang="bo"],
@@ -198,7 +198,7 @@ textarea[lang="bz"] {
 div[lang="ca"],
 input[lang="ca"],
 textarea[lang="ca"] {
-  background-image: url("/static/vendored/flags/ca.png");
+  background-image: url("/static/vendored/flags/ad.png");
 }
 div[lang="cc"],
 input[lang="cc"],
@@ -719,7 +719,7 @@ textarea[lang="mk"] {
 div[lang="ml"],
 input[lang="ml"],
 textarea[lang="ml"] {
-  background-image: url("/static/vendored/flags/ml.png");
+  background-image: url("/static/vendored/flags/in.png");
 }
 div[lang="mm"],
 input[lang="mm"],
@@ -749,12 +749,12 @@ textarea[lang="mq"] {
 div[lang="mr"],
 input[lang="mr"],
 textarea[lang="mr"] {
-  background-image: url("/static/vendored/flags/mr.png");
+  background-image: url("/static/vendored/flags/in.png");
 }
 div[lang="ms"],
 input[lang="ms"],
 textarea[lang="ms"] {
-  background-image: url("/static/vendored/flags/ms.png");
+  background-image: url("/static/vendored/flags/my.png");
 }
 div[lang="mt"],
 input[lang="mt"],
@@ -999,7 +999,7 @@ textarea[lang="sh"] {
 div[lang="si"],
 input[lang="si"],
 textarea[lang="si"] {
-  background-image: url("/static/vendored/flags/si.png");
+  background-image: url("/static/vendored/flags/lk.png");
 }
 div[lang="sj"],
 input[lang="sj"],
@@ -1014,7 +1014,7 @@ textarea[lang="sk"] {
 div[lang="sl"],
 input[lang="sl"],
 textarea[lang="sl"] {
-  background-image: url("/static/vendored/flags/sl.png");
+  background-image: url("/static/vendored/flags/si.png");
 }
 div[lang="sm"],
 input[lang="sm"],

--- a/app/eventyay/static/pretixcontrol/scss/_flags.scss
+++ b/app/eventyay/static/pretixcontrol/scss/_flags.scss
@@ -52,7 +52,7 @@ pre[lang=bh], input[lang=bh], textarea[lang=bh], div[lang=bh] { background-image
 pre[lang=bi], input[lang=bi], textarea[lang=bi], div[lang=bi] { background-image: url(static('pretixbase/img/flags/bi.png')); }
 pre[lang=bj], input[lang=bj], textarea[lang=bj], div[lang=bj] { background-image: url(static('pretixbase/img/flags/bj.png')); }
 pre[lang=bm], input[lang=bm], textarea[lang=bm], div[lang=bm] { background-image: url(static('pretixbase/img/flags/bm.png')); }
-pre[lang=bn], input[lang=bn], textarea[lang=bn], div[lang=bn] { background-image: url(static('pretixbase/img/flags/bn.png')); }
+pre[lang=bn], input[lang=bn], textarea[lang=bn], div[lang=bn] { background-image: url(static('pretixbase/img/flags/bd.png')); }
 pre[lang=bo], input[lang=bo], textarea[lang=bo], div[lang=bo] { background-image: url(static('pretixbase/img/flags/bo.png')); }
 pre[lang=br], input[lang=br], textarea[lang=br], div[lang=br] { background-image: url(static('pretixbase/img/flags/br.png')); }
 pre[lang=pt-br], input[lang=pt-br], textarea[lang=pt-br], div[lang=pt-br] { background-image: url(static('pretixbase/img/flags/br.png')); }
@@ -62,7 +62,7 @@ pre[lang=bv], input[lang=bv], textarea[lang=bv], div[lang=bv] { background-image
 pre[lang=bw], input[lang=bw], textarea[lang=bw], div[lang=bw] { background-image: url(static('pretixbase/img/flags/bw.png')); }
 pre[lang=by], input[lang=by], textarea[lang=by], div[lang=by] { background-image: url(static('pretixbase/img/flags/by.png')); }
 pre[lang=bz], input[lang=bz], textarea[lang=bz], div[lang=bz] { background-image: url(static('pretixbase/img/flags/bz.png')); }
-pre[lang=ca], input[lang=ca], textarea[lang=ca], div[lang=ca] { background-image: url(static('pretixbase/img/flags/ca.png')); }
+pre[lang=ca], input[lang=ca], textarea[lang=ca], div[lang=ca] { background-image: url(static('pretixbase/img/flags/ad.png')); }
 pre[lang=cc], input[lang=cc], textarea[lang=cc], div[lang=cc] { background-image: url(static('pretixbase/img/flags/cc.png')); }
 pre[lang=cd], input[lang=cd], textarea[lang=cd], div[lang=cd] { background-image: url(static('pretixbase/img/flags/cd.png')); }
 pre[lang=cf], input[lang=cf], textarea[lang=cf], div[lang=cf] { background-image: url(static('pretixbase/img/flags/cf.png')); }
@@ -170,14 +170,14 @@ pre[lang=me], input[lang=me], textarea[lang=me], div[lang=me] { background-image
 pre[lang=mg], input[lang=mg], textarea[lang=mg], div[lang=mg] { background-image: url(static('pretixbase/img/flags/mg.png')); }
 pre[lang=mh], input[lang=mh], textarea[lang=mh], div[lang=mh] { background-image: url(static('pretixbase/img/flags/mh.png')); }
 pre[lang=mk], input[lang=mk], textarea[lang=mk], div[lang=mk] { background-image: url(static('pretixbase/img/flags/mk.png')); }
-pre[lang=ml], input[lang=ml], textarea[lang=ml], div[lang=ml] { background-image: url(static('pretixbase/img/flags/ml.png')); }
+pre[lang=ml], input[lang=ml], textarea[lang=ml], div[lang=ml] { background-image: url(static('pretixbase/img/flags/in.png')); }
 pre[lang=mm], input[lang=mm], textarea[lang=mm], div[lang=mm] { background-image: url(static('pretixbase/img/flags/mm.png')); }
 pre[lang=mn], input[lang=mn], textarea[lang=mn], div[lang=mn] { background-image: url(static('pretixbase/img/flags/mn.png')); }
 pre[lang=mo], input[lang=mo], textarea[lang=mo], div[lang=mo] { background-image: url(static('pretixbase/img/flags/mo.png')); }
 pre[lang=mp], input[lang=mp], textarea[lang=mp], div[lang=mp] { background-image: url(static('pretixbase/img/flags/mp.png')); }
 pre[lang=mq], input[lang=mq], textarea[lang=mq], div[lang=mq] { background-image: url(static('pretixbase/img/flags/mq.png')); }
 pre[lang=mr], input[lang=mr], textarea[lang=mr], div[lang=mr] { background-image: url(static('pretixbase/img/flags/in.png')); }
-pre[lang=ms], input[lang=ms], textarea[lang=ms], div[lang=ms] { background-image: url(static('pretixbase/img/flags/ms.png')); }
+pre[lang=ms], input[lang=ms], textarea[lang=ms], div[lang=ms] { background-image: url(static('pretixbase/img/flags/my.png')); }
 pre[lang=mt], input[lang=mt], textarea[lang=mt], div[lang=mt] { background-image: url(static('pretixbase/img/flags/mt.png')); }
 pre[lang=mu], input[lang=mu], textarea[lang=mu], div[lang=mu] { background-image: url(static('pretixbase/img/flags/mu.png')); }
 pre[lang=mv], input[lang=mv], textarea[lang=mv], div[lang=mv] { background-image: url(static('pretixbase/img/flags/mv.png')); }
@@ -227,10 +227,10 @@ pre[lang=sd], input[lang=sd], textarea[lang=sd], div[lang=sd] { background-image
 pre[lang=se], input[lang=se], textarea[lang=se], div[lang=se] { background-image: url(static('pretixbase/img/flags/se.png')); }
 pre[lang=sg], input[lang=sg], textarea[lang=sg], div[lang=sg] { background-image: url(static('pretixbase/img/flags/sg.png')); }
 pre[lang=sh], input[lang=sh], textarea[lang=sh], div[lang=sh] { background-image: url(static('pretixbase/img/flags/sh.png')); }
-pre[lang=si], input[lang=si], textarea[lang=si], div[lang=si] { background-image: url(static('pretixbase/img/flags/si.png')); }
+pre[lang=si], input[lang=si], textarea[lang=si], div[lang=si] { background-image: url(static('pretixbase/img/flags/lk.png')); }
 pre[lang=sj], input[lang=sj], textarea[lang=sj], div[lang=sj] { background-image: url(static('pretixbase/img/flags/sj.png')); }
 pre[lang=sk], input[lang=sk], textarea[lang=sk], div[lang=sk] { background-image: url(static('pretixbase/img/flags/sk.png')); }
-pre[lang=sl], input[lang=sl], textarea[lang=sl], div[lang=sl] { background-image: url(static('pretixbase/img/flags/sl.png')); }
+pre[lang=sl], input[lang=sl], textarea[lang=sl], div[lang=sl] { background-image: url(static('pretixbase/img/flags/si.png')); }
 pre[lang=sm], input[lang=sm], textarea[lang=sm], div[lang=sm] { background-image: url(static('pretixbase/img/flags/sm.png')); }
 pre[lang=sn], input[lang=sn], textarea[lang=sn], div[lang=sn] { background-image: url(static('pretixbase/img/flags/sn.png')); }
 pre[lang=so], input[lang=so], textarea[lang=so], div[lang=so] { background-image: url(static('pretixbase/img/flags/so.png')); }


### PR DESCRIPTION
### Description
This PR resolves issue #3775 by correcting the language-to-flag icon associations in both `_flags.scss` and `_flags.css`. 

Several language codes were incorrectly matched to flags (e.g., Catalan `ca` displaying the flag of Canada instead of Andorra).

### Mappings Fixed
The following language-to-flag file associations have been corrected:
- **Catalan (ca)**: Changed from `ca.png` (Canada) to `ad.png` (Andorra).
- **Bengali (bn)**: Changed from `bn.png` (Brunei) to `bd.png` (Bangladesh).
- **Malay (ms)**: Changed from `ms.png` (Montserrat) to `my.png` (Malaysia).
- **Malayalam (ml)**: Changed from `ml.png` (Mali) to `in.png` (India).
- **Marathi (mr)**: Changed from `mr.png` (Mauritania) to `in.png` (India).
- **Sinhala (si)**: Changed from `si.png` (Slovenia) to `lk.png` (Sri Lanka).
- **Slovenian (sl)**: Changed from `sl.png` (Sierra Leone) to `si.png` (Slovenia).

### Verification
Verified both via local build checks and manually inside the development environment. The UI now displays correct flags corresponding to each selected language.

Closes #3775
<img width="1002" height="743" alt="corrected_flags_1780935370058" src="https://github.com/user-attachments/assets/1adeca19-e030-483c-8be8-e66f2cf8a719" />

## Summary by Sourcery

Bug Fixes:
- Fix incorrect flag icons shown for Bengali, Catalan, Malayalam, Marathi, Malay, Sinhala, and Slovenian language codes in both CSS and SCSS flag mappings.