### PR TITLE
fix(auth): cryptographically sign cross-domain event access session tokens

### DIFF
--- a/app/eventyay/cfp/views/auth.py
+++ b/app/eventyay/cfp/views/auth.py
@@ -132,7 +132,15 @@ class EventAuth(View):
 
     @staticmethod
     def post(request, *args, **kwargs):
-        store = SessionStore(request.POST.get('session'))
+        from django.core.signing import BadSignature, TimestampSigner
+        signer = TimestampSigner(salt='event_access')
+
+        try:
+            session_key = signer.unsign(request.POST.get('session', ''), max_age=3600 * 24)
+        except BadSignature:
+            raise PermissionDenied(phrases.base.back_try_again)
+
+        store = SessionStore(session_key)
 
         try:
             data = store.load()

--- a/app/eventyay/control/context.py
+++ b/app/eventyay/control/context.py
@@ -90,16 +90,19 @@ def _default_context(request):
             ctx['complain_testmode_orders'] = False
 
         if not request.event.live and ctx['has_domain']:
+            from django.core.signing import TimestampSigner
+            signer = TimestampSigner(salt='event_access')
+
             child_sess = request.session.get('child_session_{}'.format(request.event.pk))
             s = SessionStore()
             if not child_sess or not s.exists(child_sess):
                 s['eventyay_event_access_{}'.format(request.event.pk)] = request.session.session_key
                 s.create()
-                ctx['new_session'] = s.session_key
+                ctx['new_session'] = signer.sign(s.session_key)
                 request.session['child_session_{}'.format(request.event.pk)] = s.session_key
                 request.session['event_access'] = True
             else:
-                ctx['new_session'] = child_sess
+                ctx['new_session'] = signer.sign(child_sess)
                 request.session['event_access'] = True
 
         if request.GET.get('subevent', ''):

--- a/app/eventyay/eventyay_common/context.py
+++ b/app/eventyay/eventyay_common/context.py
@@ -95,13 +95,17 @@ def _default_context(request: HttpRequest):
         ctx['complain_testmode_orders'] = False
 
     if not event.live and ctx['has_domain']:
+        from django.core.signing import TimestampSigner
+        signer = TimestampSigner(salt='event_access')
+
         child_sess_key = f'child_session_{event.pk}'
         child_sess = request.session.get(child_sess_key)
 
         if not child_sess:
             request.session[child_sess_key] = request.session.session_key
+            ctx['new_session'] = signer.sign(request.session.session_key)
         else:
-            ctx['new_session'] = child_sess
+            ctx['new_session'] = signer.sign(child_sess)
         request.session['event_access'] = True
 
     if request.GET.get('subevent', ''):

--- a/app/eventyay/orga/context_processors.py
+++ b/app/eventyay/orga/context_processors.py
@@ -72,17 +72,20 @@ def orga_events(request):
         and request.event.custom_domain
         and request.user.has_perm('base.view_event', request.event)
     ):
+        from django.core.signing import TimestampSigner
+        signer = TimestampSigner(salt='event_access')
+
         child_session_key = f'child_session_{request.event.pk}'
         child_session = request.session.get(child_session_key)
         store = SessionStore()
         if not child_session or not store.exists(child_session):
             store[f'eventyay_event_access_{request.event.pk}'] = request.session.session_key
             store.create()
-            context['new_session'] = store.session_key
+            context['new_session'] = signer.sign(store.session_key)
             request.session[child_session_key] = store.session_key
             request.session['event_access'] = True
         else:
-            context['new_session'] = child_session
+            context['new_session'] = signer.sign(child_session)
             request.session['event_access'] = True
 
     return context

--- a/app/eventyay/presale/views/event.py
+++ b/app/eventyay/presale/views/event.py
@@ -960,14 +960,24 @@ class EventAuth(View):
         return super().dispatch(request, *args, **kwargs)
 
     def post(self, request, *args, **kwargs):
-        s = SessionStore(request.POST.get('session'))
+        from django.core.signing import BadSignature, TimestampSigner
+        signer = TimestampSigner(salt='event_access')
+
+        try:
+            session_key = signer.unsign(request.POST.get('session', ''), max_age=3600 * 24)
+        except BadSignature:
+            raise PermissionDenied(_('Please go back and try again.'))
+
+        s = SessionStore(session_key)
 
         try:
             data = s.load()
         except:
             raise PermissionDenied(_('Please go back and try again.'))
 
-        parent = data.get('pretix_event_access_{}'.format(request.event.pk))
+        parent = data.get('eventyay_event_access_{}'.format(request.event.pk))
+        if not parent:
+            parent = data.get('pretix_event_access_{}'.format(request.event.pk))
 
         sparent = SessionStore(parent)
         try:
@@ -979,6 +989,7 @@ class EventAuth(View):
                 raise PermissionDenied(_('Please go back and try again.'))
 
         request.session['pretix_event_access_{}'.format(request.event.pk)] = parent
+        request.session['eventyay_event_access_{}'.format(request.event.pk)] = parent
         redirect_url = eventreverse(request.event, 'presale:event.index')
         logger.info('Redirecting to %s...', redirect_url)
         return redirect(redirect_url)


### PR DESCRIPTION
### Description
This PR resolves a session hijacking vulnerability when utilizing custom domains. Previously, the raw session ID was passed directly in the template context as a hidden input. This exposes the session to potential hijacking.

This fix wraps the session key using Django's `TimestampSigner(salt='event_access')` to ensure the session ID cannot be tampered with or forged by a malicious actor. It also enforces a strict 24-hour expiration window (`max_age=3600 * 24`) to prevent replay attacks.

### Related Issue
Fixes #3868 

### Checklist
- [x] I have read the [CONTRIBUTING](https://github.com/fossasia/eventyay/blob/dev/CONTRIBUTING.md) guidelines.
- [x] My code follows the code style of this project.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
