### PR TITLE
Fix btn-default border disappearing when clicked

### DIFF
--- a/app/eventyay/static/pretixbase/scss/_theme.scss
+++ b/app/eventyay/static/pretixbase/scss/_theme.scss
@@ -194,7 +194,6 @@ button:focus:not(:focus-visible),
 summary:focus:not(:focus-visible),
 [role="button"]:focus:not(:focus-visible) {
     outline: none;
-    box-shadow: none;
 }
 
 @include table-row-variant('success', lighten($brand-success, 40%));


### PR DESCRIPTION
Fixes #3783

The `btn-default` style uses an inset `box-shadow` to show its border because shared button styles set the real border width to `0`.

A global focus rule was removing `box-shadow` on `:focus:not(:focus-visible)`. As a result, clicking `btn btn-default` buttons made their border disappear in places where these buttons are used.

This PR removes that `box-shadow: none` reset so the existing button border remains visible after focus.

### Testing

* Reproduced the issue locally.
* Verified the fix locally in **Event Settings -> Payment**.
* Confirmed that `btn btn-default` buttons retain their border after being clicked/focused.

https://github.com/user-attachments/assets/4a26df47-885a-41b2-acea-1061633cd776

## Summary by Sourcery

Bug Fixes:
- Prevent btn-default borders from disappearing when buttons are clicked or focused by keeping their box-shadow intact.