### PR TITLE
Fix BBB room move source server handling

### DIFF
--- a/app/eventyay/control/views/admin_views.py
+++ b/app/eventyay/control/views/admin_views.py
@@ -761,12 +761,13 @@ class BBBMoveRoom(AdminBase, FormView):
         except BBBCall.DoesNotExist:
             messages.error(self.request, _("No BBB session found for this room."))
             return HttpResponseRedirect(self.request.path)
+        source_server = c.server
         try:
             u = get_url(
                 "end",
                 {"meetingID": c.meeting_id, "password": c.moderator_pw},
-                server.url,
-                server.secret,
+                source_server.url,
+                source_server.secret,
             )
             r = requests.get(u, timeout=15)
             r.raise_for_status()

--- a/app/tests/stable/test_bbb_move_room.py
+++ b/app/tests/stable/test_bbb_move_room.py
@@ -1,0 +1,47 @@
+from unittest.mock import Mock
+
+import pytest
+from django.urls import reverse
+
+from eventyay.base.models import BBBCall, BBBServer, Room
+
+
+@pytest.mark.django_db
+def test_move_bbb_room_ends_meeting_on_source_server(
+    event, staff_client, mocker
+):
+    source_server = BBBServer.objects.create(
+        url="https://source.example.com/bigbluebutton/",
+        secret="source-secret",
+    )
+    target_server = BBBServer.objects.create(
+        url="https://target.example.com/bigbluebutton/",
+        secret="target-secret",
+    )
+    room = Room.objects.create(event=event, name="BBB room")
+    call = BBBCall.objects.create(event=event, room=room, server=source_server)
+    get_url = mocker.patch(
+        "eventyay.control.views.admin_views.get_url",
+        return_value="https://source.example.com/end",
+    )
+    response = Mock()
+    request = mocker.patch(
+        "eventyay.control.views.admin_views.requests.get", return_value=response
+    )
+
+    result = staff_client.post(
+        reverse("eventyay_admin:video_admin:bbbserver.moveroom"),
+        {"room": room.pk, "server": target_server.pk},
+    )
+
+    assert result.status_code == 302
+    call.refresh_from_db()
+    assert call.server == target_server
+    get_url.assert_called_once_with(
+        "end",
+        {"meetingID": call.meeting_id, "password": call.moderator_pw},
+        source_server.url,
+        source_server.secret,
+    )
+    request.assert_called_once_with("https://source.example.com/end", timeout=15)
+    response.raise_for_status.assert_called_once_with()


### PR DESCRIPTION
Fixes #3876 
## Description

  Fixes the BBB room move operation to terminate the meeting on its current source server before assigning the room to the selected target server.

  Previously, the termination request incorrectly used the target server’s URL and secret. This could leave existing attendees connected to the source meeting while new attendees
  joined the target server.

  ## Changes

  - Use the source BBB server URL and secret when ending the existing meeting.
  - Reassign the BBBCall to the target server afterward.
  - Add a regression test verifying the source server receives the termination request.
  
  

https://github.com/user-attachments/assets/d1a92030-8987-4cf5-828e-09a007b16174

