### PR TITLE
Restore BBB server cost update command

### DIFF
--- a/app/eventyay/base/management/commands/bbb_update_cost.py
+++ b/app/eventyay/base/management/commands/bbb_update_cost.py
@@ -6,13 +6,14 @@ from django.core.management.base import BaseCommand
 from lxml import etree
 
 from eventyay.base.models import BBBServer
-from eventyay.core.services.bbb import get_url
+from eventyay.base.services.bbb import get_url
+
 
 logger = logging.getLogger(__name__)
 
 
 class Command(BaseCommand):
-    help = "Updated load balancing cost of BBB servers"
+    help = "Update load balancing costs of BBB servers"
 
     def _update_cost(self, server: BBBServer):
         try:
@@ -23,15 +24,10 @@ class Command(BaseCommand):
 
             root = etree.fromstring(r.text)
             if root.xpath("returncode")[0].text != "SUCCESS":
-                raise ValueError("Recordings could not be fetched: " + r.text)
+                raise ValueError("Meetings could not be fetched: " + r.text)
 
-            # Our naive cost calculation probably needs to adjusted at some point. For now, it works like this:
-            # Every meeting has a minimal cost of 10, which models that every running meeting requires resources (mostly
-            # RAM) on the server. Then, we model an additional cost of 10 * video_senders * video_recipients
-            # as well as a cost of 1 * audio_senders * audio_recipients. This follows the bandwidth estimation given
-            # at https://docs.bigbluebutton.org/support/faq.html#bandwidth-requirements and we hope that other resources
-            # (CPU) are roughly linear to the same values.
-
+            # Every meeting has a base cost of 10. Video cost is estimated as
+            # 10 * senders * recipients, and audio as senders * recipients.
             for meet in root.xpath("meetings/meeting"):
                 participants = int(meet.xpath("participantCount")[0].text)
                 voice_users = int(meet.xpath("voiceParticipantCount")[0].text)

--- a/app/eventyay/base/management/commands/bbb_update_cost.py
+++ b/app/eventyay/base/management/commands/bbb_update_cost.py
@@ -10,6 +10,7 @@ from eventyay.base.services.bbb import get_url
 
 
 logger = logging.getLogger(__name__)
+REQUEST_TIMEOUT = (5, 30)
 
 
 class Command(BaseCommand):
@@ -18,7 +19,7 @@ class Command(BaseCommand):
     def _update_cost(self, server: BBBServer):
         try:
             meetings_url = get_url("getMeetings", {}, server.url, server.secret)
-            r = requests.get(meetings_url)
+            r = requests.get(meetings_url, timeout=REQUEST_TIMEOUT)
             r.raise_for_status()
             cost = 0
 

--- a/app/tests/stable/test_bbb_update_cost.py
+++ b/app/tests/stable/test_bbb_update_cost.py
@@ -1,0 +1,129 @@
+from unittest.mock import Mock
+
+import pytest
+import requests
+from django.core.management import call_command
+
+from eventyay.base.models import BBBServer
+
+
+SUCCESS_NO_MEETINGS = """
+<response>
+  <returncode>SUCCESS</returncode>
+  <meetings />
+</response>
+"""
+
+SUCCESS_WITH_MEETING = """
+<response>
+  <returncode>SUCCESS</returncode>
+  <meetings>
+    <meeting>
+      <participantCount>4</participantCount>
+      <voiceParticipantCount>2</voiceParticipantCount>
+      <videoCount>1</videoCount>
+    </meeting>
+  </meetings>
+</response>
+"""
+
+
+class InlinePool:
+    def __init__(self, processes):
+        self.processes = processes
+
+    def map(self, function, servers):
+        return [function(server) for server in servers]
+
+
+def response_with(text):
+    response = Mock(text=text)
+    response.raise_for_status.return_value = None
+    return response
+
+
+@pytest.mark.django_db
+def test_bbb_update_cost_resets_idle_server_cost(mocker):
+    server = BBBServer.objects.create(
+        url="https://idle.example.com/bigbluebutton/",
+        secret="secret",
+        cost=99,
+    )
+    mocker.patch(
+        "eventyay.base.management.commands.bbb_update_cost.pool.ThreadPool",
+        InlinePool,
+    )
+    mocker.patch(
+        "eventyay.base.management.commands.bbb_update_cost.requests.get",
+        return_value=response_with(SUCCESS_NO_MEETINGS),
+    )
+
+    call_command("bbb_update_cost")
+
+    server.refresh_from_db()
+    assert server.cost == 0
+
+
+@pytest.mark.django_db
+def test_bbb_update_cost_calculates_meeting_cost(mocker):
+    server = BBBServer.objects.create(
+        url="https://busy.example.com/bigbluebutton/",
+        secret="secret",
+    )
+    mocker.patch(
+        "eventyay.base.management.commands.bbb_update_cost.pool.ThreadPool",
+        InlinePool,
+    )
+    mocker.patch(
+        "eventyay.base.management.commands.bbb_update_cost.requests.get",
+        return_value=response_with(SUCCESS_WITH_MEETING),
+    )
+
+    call_command("bbb_update_cost")
+
+    server.refresh_from_db()
+    assert server.cost == 58
+
+
+@pytest.mark.django_db
+def test_bbb_update_cost_ignores_inactive_and_continues_after_failure(mocker):
+    failed = BBBServer.objects.create(
+        url="https://failed.example.com/bigbluebutton/",
+        secret="secret",
+        cost=12,
+    )
+    healthy = BBBServer.objects.create(
+        url="https://healthy.example.com/bigbluebutton/",
+        secret="secret",
+        cost=12,
+    )
+    inactive = BBBServer.objects.create(
+        url="https://inactive.example.com/bigbluebutton/",
+        secret="secret",
+        active=False,
+        cost=12,
+    )
+
+    def get(url):
+        if "failed.example.com" in url:
+            raise requests.ConnectionError
+        return response_with(SUCCESS_NO_MEETINGS)
+
+    mocker.patch(
+        "eventyay.base.management.commands.bbb_update_cost.pool.ThreadPool",
+        InlinePool,
+    )
+    request = mocker.patch(
+        "eventyay.base.management.commands.bbb_update_cost.requests.get",
+        side_effect=get,
+    )
+
+    call_command("bbb_update_cost")
+
+    failed.refresh_from_db()
+    healthy.refresh_from_db()
+    inactive.refresh_from_db()
+    assert failed.cost == 12
+    assert healthy.cost == 0
+    assert inactive.cost == 12
+    assert request.call_count == 2

--- a/app/tests/stable/test_bbb_update_cost.py
+++ b/app/tests/stable/test_bbb_update_cost.py
@@ -4,6 +4,7 @@ import pytest
 import requests
 from django.core.management import call_command
 
+from eventyay.base.management.commands.bbb_update_cost import REQUEST_TIMEOUT
 from eventyay.base.models import BBBServer
 
 
@@ -53,7 +54,7 @@ def test_bbb_update_cost_resets_idle_server_cost(mocker):
         "eventyay.base.management.commands.bbb_update_cost.pool.ThreadPool",
         InlinePool,
     )
-    mocker.patch(
+    request = mocker.patch(
         "eventyay.base.management.commands.bbb_update_cost.requests.get",
         return_value=response_with(SUCCESS_NO_MEETINGS),
     )
@@ -62,6 +63,8 @@ def test_bbb_update_cost_resets_idle_server_cost(mocker):
 
     server.refresh_from_db()
     assert server.cost == 0
+    request.assert_called_once()
+    assert request.call_args.kwargs["timeout"] == REQUEST_TIMEOUT
 
 
 @pytest.mark.django_db
@@ -104,7 +107,8 @@ def test_bbb_update_cost_ignores_inactive_and_continues_after_failure(mocker):
         cost=12,
     )
 
-    def get(url):
+    def get(url, timeout):
+        assert timeout == REQUEST_TIMEOUT
         if "failed.example.com" in url:
             raise requests.ConnectionError
         return response_with(SUCCESS_NO_MEETINGS)


### PR DESCRIPTION
Fixes #3881 

## Description

  Fixes the unavailable bbb_update_cost management command.

  The command was located under eventyay.core, which is not an installed Django application, so Django could not discover it. It also imported the BBB URL helper from a removed
  module.

  ## Changes

  - Move bbb_update_cost into the installed eventyay.base application.
  - Import get_url from eventyay.base.services.bbb.
  - Correct command help and error messages.
  - Add tests covering:
      - Idle-server cost reset.
      - Running-meeting cost calculation.
      - Inactive-server filtering.
      - Continuing updates when one server is unavailable.