### PR TITLE
fix: Resolve LSP violation in Sig1TicketSecretGenerator

### DIFF
--- a/app/eventyay/base/secrets.py
+++ b/app/eventyay/base/secrets.py
@@ -109,7 +109,7 @@ class RandomTicketSecretGenerator(BaseTicketSecretGenerator):
         attendee_name: str = None,
         current_secret: str = None,
         force_invalidate=False,
-    ):
+    ) -> str:
         if current_secret and not force_invalidate:
             return current_secret
         return get_random_string(
@@ -190,9 +190,10 @@ class Sig1TicketSecretGenerator(BaseTicketSecretGenerator):
         product: Product,
         variation: ProductVariation = None,
         subevent: SubEvent = None,
+        attendee_name: str = None,
         current_secret: str = None,
         force_invalidate=False,
-    ):
+    ) -> str:
         if current_secret and not force_invalidate:
             ticket = self._parse(current_secret)
             if ticket:


### PR DESCRIPTION
**Describe the bug**
The base class `BaseTicketSecretGenerator` defines `generate_secret` with the parameter `attendee_name: str = None`. However, the subclass `Sig1TicketSecretGenerator` overrides this method but completely omits the `attendee_name` parameter from its signature.

This violates the Liskov Substitution Principle (LSP) and causes a `TypeError` at runtime if a caller invokes `generate_secret` on a `Sig1TicketSecretGenerator` instance while passing the `attendee_name` parameter.

Closes #3871 

**Expected behavior**
Subclasses overriding `generate_secret` must maintain signature compatibility with the base class.

**Screenshots**
N/A

**Additional context**
Added `attendee_name: str = None` to the signature of `Sig1TicketSecretGenerator.generate_secret` in `app/eventyay/base/secrets.py` to match the base class.

## Summary by Sourcery

Bug Fixes:
- Add the attendee_name parameter to Sig1TicketSecretGenerator.generate_secret to match the BaseTicketSecretGenerator signature and avoid TypeError when called with attendee_name.