### PR TITLE
Fix/bbb recordings server failure

### DIFF
--- a/app/eventyay/base/services/bbb.py
+++ b/app/eventyay/base/services/bbb.py
@@ -420,7 +420,14 @@ class BBBService:
 
                 server_recordings = []
                 tz = pytz.timezone(self.event.timezone)
-                for rec in root.xpath("recordings/recording"):
+                recordings_nodes = root.xpath("recordings")
+                if not recordings_nodes:
+                    logger.error(
+                        "BBB recordings response from server %s has no recordings container",
+                        server,
+                    )
+                    continue
+                for rec in recordings_nodes[0].xpath("recording"):
                     url_presentation = url_screenshare = url_video = url_notes = None
                     for f in rec.xpath("playback/format"):
                         if f.xpath("type")[0].text == "presentation":

--- a/app/eventyay/base/services/bbb.py
+++ b/app/eventyay/base/services/bbb.py
@@ -1,3 +1,4 @@
+import asyncio
 import hashlib
 import logging
 import random
@@ -394,19 +395,30 @@ class BBBService:
 
     async def get_recordings_for_room(self, room):
         recordings = []
-        for server in await self._get_possible_servers():
-            try:
-                call = await get_call_for_room(room)
-                recordings_url = get_url(
-                    "getRecordings",
-                    {"meetingID": call.meeting_id, "state": "any"},
-                    server.url,
-                    server.secret,
-                )
-                root = await self._get(recordings_url, timeout=10)
-                if root is False:
-                    return []
+        call = await get_call_for_room(room)
+        if not call:
+            return recordings
 
+        successful_request = False
+        servers = await self._get_possible_servers()
+        recording_urls = [
+            get_url(
+                "getRecordings",
+                {"meetingID": call.meeting_id, "state": "any"},
+                server.url,
+                server.secret,
+            )
+            for server in servers
+        ]
+        responses = await asyncio.gather(
+            *(self._get(url, timeout=10) for url in recording_urls)
+        )
+        for server, recordings_url, root in zip(servers, recording_urls, responses):
+            try:
+                if root is False:
+                    continue
+
+                successful_request = True
                 tz = pytz.timezone(self.event.timezone)
                 for rec in root.xpath("recordings/recording"):
                     url_presentation = url_screenshare = url_video = url_notes = None
@@ -463,5 +475,5 @@ class BBBService:
                         }
                     )
             except Exception:
-                logger.exception(f"Could not fetch recordings from server {server}")
-        return recordings
+                logger.exception("Could not fetch recordings from server %s", server)
+        return recordings if successful_request else None

--- a/app/eventyay/base/services/bbb.py
+++ b/app/eventyay/base/services/bbb.py
@@ -418,7 +418,7 @@ class BBBService:
                 if root is False:
                     continue
 
-                successful_request = True
+                server_recordings = []
                 tz = pytz.timezone(self.event.timezone)
                 for rec in root.xpath("recordings/recording"):
                     url_presentation = url_screenshare = url_video = url_notes = None
@@ -446,7 +446,7 @@ class BBBService:
                             and not url_notes
                         ):
                             continue
-                    recordings.append(
+                    server_recordings.append(
                         {
                             "start": (
                                 # BBB outputs timestamps in server time, not UTC :( Let's assume the BBB server time
@@ -474,6 +474,8 @@ class BBBService:
                             "url_notes": url_notes,
                         }
                     )
+                recordings.extend(server_recordings)
+                successful_request = True
             except Exception:
                 logger.exception("Could not fetch recordings from server %s", server)
         return recordings if successful_request else None

--- a/app/eventyay/features/live/modules/bbb.py
+++ b/app/eventyay/features/live/modules/bbb.py
@@ -68,4 +68,6 @@ class BBBModule(BaseModule):
         recordings = await service.get_recordings_for_room(
             self.room,
         )
+        if recordings is None:
+            raise ConsumerException("bbb.failed")
         await self.consumer.send_success({"results": recordings})

--- a/app/eventyay/webapp/video/src/components/RecordingsPrompt.vue
+++ b/app/eventyay/webapp/video/src/components/RecordingsPrompt.vue
@@ -4,9 +4,10 @@ prompt.c-recordings-prompt(@close="$emit('close')")
 		bunt-icon-button#btn-close(@click="$emit('close')") close
 		h1 {{ $t('RecordingsPrompt:headline:text') }}
 		p {{ $t('RecordingsPrompt:info:text') }}
-		bunt-progress-circular(v-if="recordings == null && error == null")
-		p(v-if="error != null") {{ $t('RecordingsPrompt:error:text') }}
-		.recordings(v-if="recordings != null")
+		bunt-progress-circular(v-if="loading")
+		p(v-else-if="error != null") {{ $t('RecordingsPrompt:error:text') }}
+		p(v-else-if="recordings.length === 0") {{ $t('RecordingsPrompt:empty:text') }}
+		.recordings(v-else)
 			.recording(v-for="r in recordings")
 				.recording-dates {{ moment(r.start).format('l, LT') }} – {{ moment(r.end).format('LT') }}
 				a.link.bunt-button(v-if="r.url && (r.state == 'published' || r.state == 'available')", :href="r.url", target="_blank") {{ $t('RecordingsPrompt:view:label') }}
@@ -28,19 +29,23 @@ export default {
 	emits: ['close'],
 	data() {
 		return {
-			recordings: null,
+			recordings: [],
 			error: null,
+			loading: true,
 		}
 	},
 	computed: {},
 	async created() {
 		try {
-			this.recordings = (await api.call('bbb.recordings', {room: this.room.id}, {timeout: 150000})).results
+			const response = await api.call('bbb.recordings', {room: this.room.id})
+			this.recordings = Array.isArray(response?.results) ? response.results : []
 			this.error = null
 		} catch (error) {
 			this.error = error
-			this.recordings = null
+			this.recordings = []
 			console.error(error)
+		} finally {
+			this.loading = false
 		}
 	},
 	methods: {

--- a/app/eventyay/webapp/video/src/locales/ar.json
+++ b/app/eventyay/webapp/video/src/locales/ar.json
@@ -302,6 +302,7 @@
 	"Questions:deactivated-placeholder": "الأسئلة معطلة حاليًا.",
 	"Questions:empty-placeholder": "لا توجد أسئلة حتى الآن، لماذا لا تطرح سؤالًا؟",
 	"Questions:moderator-actions:archive-all:label": "أرشفة الكل",
+	"RecordingsPrompt:empty:text": "لا توجد تسجيلات متاحة.",
 	"RecordingsPrompt:error:text": "فشل تحميل التسجيلات من الخادم.",
 	"RecordingsPrompt:headline:text": "التسجيلات",
 	"RecordingsPrompt:info:text": "يرجى ملاحظة أن التسجيلات تبدأ في المعالجة والظهور هنا بعد بضع دقائق من انتهاء الاجتماع (عادةً، إذا كانت الغرفة فارغة لفترة).",

--- a/app/eventyay/webapp/video/src/locales/de.json
+++ b/app/eventyay/webapp/video/src/locales/de.json
@@ -303,6 +303,7 @@
 	"Questions:deactivated-placeholder": "Fragen sind derzeit deaktiviert.",
 	"Questions:empty-placeholder": "Noch keine Fragen, warum stellen Sie nicht eine?",
 	"Questions:moderator-actions:archive-all:label": "Alle archivieren",
+	"RecordingsPrompt:empty:text": "Es sind keine Aufzeichnungen verfügbar.",
 	"RecordingsPrompt:error:text": "Fehler beim Laden der Aufzeichnungen vom Server.",
 	"RecordingsPrompt:headline:text": "Aufzeichnungen",
 	"RecordingsPrompt:info:text": "Bitte beachten Sie, dass Aufzeichnungen erst einige Minuten nach dem Ende des Meetings verarbeitet werden und hier erscheinen (in der Regel, wenn der Raum eine Weile leer war).",

--- a/app/eventyay/webapp/video/src/locales/en.json
+++ b/app/eventyay/webapp/video/src/locales/en.json
@@ -306,6 +306,7 @@
 	"Questions:deactivated-placeholder": "Questions are currently disabled.",
 	"Questions:empty-placeholder": "No questions yet, why not ask one?",
 	"Questions:moderator-actions:archive-all:label": "Archive All",
+	"RecordingsPrompt:empty:text": "No recordings are available.",
 	"RecordingsPrompt:error:text": "Failed to load recordings from the server.",
 	"RecordingsPrompt:headline:text": "Recordings",
 	"RecordingsPrompt:info:text": "Please note that recordings start processing and showing up here only a few minutes after the meeting has ended (usually, if the room was empty for a while).",

--- a/app/eventyay/webapp/video/src/locales/es.json
+++ b/app/eventyay/webapp/video/src/locales/es.json
@@ -302,6 +302,7 @@
 	"Questions:deactivated-placeholder": "Las preguntas están desactivadas en este momento.",
 	"Questions:empty-placeholder": "Aún no hay preguntas, ¿por qué no hacer una?",
 	"Questions:moderator-actions:archive-all:label": "Archivar todo",
+	"RecordingsPrompt:empty:text": "No hay grabaciones disponibles.",
 	"RecordingsPrompt:error:text": "Error al cargar grabaciones desde el servidor.",
 	"RecordingsPrompt:headline:text": "Grabaciones",
 	"RecordingsPrompt:info:text": "Tenga en cuenta que las grabaciones comienzan a procesarse y aparecen aquí solo unos minutos después de que la reunión haya finalizado (por lo general, si la sala ha estado vacía durante un tiempo).",

--- a/app/eventyay/webapp/video/src/locales/fr.json
+++ b/app/eventyay/webapp/video/src/locales/fr.json
@@ -302,6 +302,7 @@
 	"Questions:deactivated-placeholder": "Les questions sont actuellement désactivées.",
 	"Questions:empty-placeholder": "Pas encore de questions, pourquoi ne pas en poser une?",
 	"Questions:moderator-actions:archive-all:label": "Tout archiver",
+	"RecordingsPrompt:empty:text": "Aucun enregistrement n’est disponible.",
 	"RecordingsPrompt:error:text": "Échec du chargement des enregistrements depuis le serveur.",
 	"RecordingsPrompt:headline:text": "Enregistrements",
 	"RecordingsPrompt:info:text": "Veuillez noter que les enregistrements commencent à être traités et à apparaître ici seulement quelques minutes après la fin de la réunion (généralement, si la salle est restée vide pendant un certain temps).",

--- a/app/eventyay/webapp/video/src/locales/pt_BR.json
+++ b/app/eventyay/webapp/video/src/locales/pt_BR.json
@@ -303,6 +303,7 @@
 	"Questions:deactivated-placeholder": "Perguntas estão desativadas no momento.",
 	"Questions:empty-placeholder": "Ainda não há perguntas, por que não fazer uma?",
 	"Questions:moderator-actions:archive-all:label": "Arquivar tudo",
+	"RecordingsPrompt:empty:text": "Nenhuma gravação está disponível.",
 	"RecordingsPrompt:error:text": "Falha ao carregar gravações do servidor.",
 	"RecordingsPrompt:headline:text": "Gravações",
 	"RecordingsPrompt:info:text": "Observe que as gravações começam a ser processadas e aparecem aqui apenas alguns minutos após o término da reunião (normalmente, se a sala esteve vazia por um tempo).",

--- a/app/eventyay/webapp/video/src/locales/ru.json
+++ b/app/eventyay/webapp/video/src/locales/ru.json
@@ -302,6 +302,7 @@
 	"Questions:deactivated-placeholder": "Вопросы в данный момент отключены.",
 	"Questions:empty-placeholder": "Пока нет вопросов, почему бы не задать один?",
 	"Questions:moderator-actions:archive-all:label": "Архивировать все",
+	"RecordingsPrompt:empty:text": "Нет доступных записей.",
 	"RecordingsPrompt:error:text": "Не удалось загрузить записи с сервера.",
 	"RecordingsPrompt:headline:text": "Записи",
 	"RecordingsPrompt:info:text": "Пожалуйста, обратите внимание, что записи начинают обрабатываться и появляться здесь через несколько минут после окончания собрания (обычно, если комната оставалась пустой некоторое время).",

--- a/app/eventyay/webapp/video/src/locales/uk.json
+++ b/app/eventyay/webapp/video/src/locales/uk.json
@@ -302,6 +302,7 @@
 	"Questions:deactivated-placeholder": "Питання наразі вимкнені.",
 	"Questions:empty-placeholder": "Поки немає питань, чому б не задати одне?",
 	"Questions:moderator-actions:archive-all:label": "Архівувати все",
+	"RecordingsPrompt:empty:text": "Немає доступних записів.",
 	"RecordingsPrompt:error:text": "Не вдалося завантажити записи з сервера.",
 	"RecordingsPrompt:headline:text": "Записи",
 	"RecordingsPrompt:info:text": "Будь ласка, зверніть увагу, що записи починають оброблятися і з'являються тут через кілька хвилин після завершення зустрічі (зазвичай, якщо кімната залишалася порожньою деякий час).",

--- a/app/tests/video/live/test_bigbluebutton.py
+++ b/app/tests/video/live/test_bigbluebutton.py
@@ -349,6 +349,32 @@ async def test_recordings_bbb_error_response(bbb_room):
 
 @pytest.mark.asyncio
 @pytest.mark.django_db
+async def test_recordings_malformed_success_response(bbb_room):
+    server = await database_sync_to_async(BBBServer.objects.get)()
+    await database_sync_to_async(BBBCall.objects.create)(
+        room=bbb_room,
+        event=bbb_room.event,
+        server=server,
+    )
+
+    with aioresponses() as m:
+        m.get(
+            re.compile(r"^https://video1.pretix.eu/bigbluebutton.*$"),
+            body="""<response>
+<returncode>SUCCESS</returncode>
+<recordings><recording /></recordings>
+</response>""",
+        )
+
+        async with world_communicator(named=True) as c:
+            await c.send_json_to(["bbb.recordings", 123, {"room": str(bbb_room.pk)}])
+
+            response = await c.receive_json_from()
+            assert response == ["error", 123, {"code": "bbb.failed"}]
+
+
+@pytest.mark.asyncio
+@pytest.mark.django_db
 async def test_recordings_partial_server_failure(bbb_room):
     first_server = await database_sync_to_async(BBBServer.objects.get)()
     await database_sync_to_async(BBBCall.objects.create)(

--- a/app/tests/video/live/test_bigbluebutton.py
+++ b/app/tests/video/live/test_bigbluebutton.py
@@ -349,6 +349,31 @@ async def test_recordings_bbb_error_response(bbb_room):
 
 @pytest.mark.asyncio
 @pytest.mark.django_db
+async def test_recordings_missing_container(bbb_room):
+    server = await database_sync_to_async(BBBServer.objects.get)()
+    await database_sync_to_async(BBBCall.objects.create)(
+        room=bbb_room,
+        event=bbb_room.event,
+        server=server,
+    )
+
+    with aioresponses() as m:
+        m.get(
+            re.compile(r"^https://video1.pretix.eu/bigbluebutton.*$"),
+            body="""<response>
+<returncode>SUCCESS</returncode>
+</response>""",
+        )
+
+        async with world_communicator(named=True) as c:
+            await c.send_json_to(["bbb.recordings", 123, {"room": str(bbb_room.pk)}])
+
+            response = await c.receive_json_from()
+            assert response == ["error", 123, {"code": "bbb.failed"}]
+
+
+@pytest.mark.asyncio
+@pytest.mark.django_db
 async def test_recordings_malformed_success_response(bbb_room):
     server = await database_sync_to_async(BBBServer.objects.get)()
     await database_sync_to_async(BBBCall.objects.create)(

--- a/app/tests/video/live/test_bigbluebutton.py
+++ b/app/tests/video/live/test_bigbluebutton.py
@@ -274,6 +274,116 @@ async def test_bbb_xml_error(bbb_room):
 
 @pytest.mark.asyncio
 @pytest.mark.django_db
+async def test_recordings_empty_result(bbb_room):
+    server = await database_sync_to_async(BBBServer.objects.get)()
+    await database_sync_to_async(BBBCall.objects.create)(
+        room=bbb_room,
+        event=bbb_room.event,
+        server=server,
+    )
+
+    with aioresponses() as m:
+        m.get(
+            re.compile(r"^https://video1.pretix.eu/bigbluebutton.*$"),
+            body="""<response>
+<returncode>SUCCESS</returncode>
+<recordings />
+</response>""",
+        )
+
+        async with world_communicator(named=True) as c:
+            await c.send_json_to(["bbb.recordings", 123, {"room": str(bbb_room.pk)}])
+
+            response = await c.receive_json_from()
+            assert response == ["success", 123, {"results": []}]
+
+
+@pytest.mark.asyncio
+@pytest.mark.django_db
+async def test_recordings_all_servers_unavailable(bbb_room):
+    server = await database_sync_to_async(BBBServer.objects.get)()
+    await database_sync_to_async(BBBCall.objects.create)(
+        room=bbb_room,
+        event=bbb_room.event,
+        server=server,
+    )
+
+    with aioresponses() as m:
+        m.get(
+            re.compile(r"^https://video1.pretix.eu/bigbluebutton.*$"),
+            status=500,
+        )
+
+        async with world_communicator(named=True) as c:
+            await c.send_json_to(["bbb.recordings", 123, {"room": str(bbb_room.pk)}])
+
+            response = await c.receive_json_from()
+            assert response == ["error", 123, {"code": "bbb.failed"}]
+
+
+@pytest.mark.asyncio
+@pytest.mark.django_db
+async def test_recordings_bbb_error_response(bbb_room):
+    server = await database_sync_to_async(BBBServer.objects.get)()
+    await database_sync_to_async(BBBCall.objects.create)(
+        room=bbb_room,
+        event=bbb_room.event,
+        server=server,
+    )
+
+    with aioresponses() as m:
+        m.get(
+            re.compile(r"^https://video1.pretix.eu/bigbluebutton.*$"),
+            body="""<response>
+<returncode>FAILED</returncode>
+<messageKey>checksumError</messageKey>
+</response>""",
+        )
+
+        async with world_communicator(named=True) as c:
+            await c.send_json_to(["bbb.recordings", 123, {"room": str(bbb_room.pk)}])
+
+            response = await c.receive_json_from()
+            assert response == ["error", 123, {"code": "bbb.failed"}]
+
+
+@pytest.mark.asyncio
+@pytest.mark.django_db
+async def test_recordings_partial_server_failure(bbb_room):
+    first_server = await database_sync_to_async(BBBServer.objects.get)()
+    await database_sync_to_async(BBBCall.objects.create)(
+        room=bbb_room,
+        event=bbb_room.event,
+        server=first_server,
+    )
+    await database_sync_to_async(BBBServer.objects.create)(
+        url="https://video2.pretix.eu/bigbluebutton/",
+        secret="bogussecret",
+        active=True,
+    )
+
+    with aioresponses() as m:
+        m.get(
+            re.compile(r"^https://video1.pretix.eu/bigbluebutton.*$"),
+            status=500,
+        )
+        m.get(
+            re.compile(r"^https://video2.pretix.eu/bigbluebutton.*$"),
+            body="""<response>
+<returncode>SUCCESS</returncode>
+<recordings />
+</response>""",
+        )
+
+        async with world_communicator(named=True) as c:
+            await c.send_json_to(["bbb.recordings", 123, {"room": str(bbb_room.pk)}])
+
+            response = await c.receive_json_from()
+            assert response == ["success", 123, {"results": []}]
+
+
+@pytest.mark.asyncio
+@pytest.mark.django_db
 async def test_successful_url(bbb_room):
     bbb_room.module_config[0]["config"]["hide_presentation"] = True
     await database_sync_to_async(bbb_room.save)(update_fields=["module_config"])


### PR DESCRIPTION
## Description

Fixes the BBB recordings flow so the UI distinguishes between rooms with no recordings and failures while fetching recordings.

  Closes #3889 

  ## Changes

  - Fetch recordings from eligible BBB servers concurrently.
  - Return results when at least one BBB server responds successfully.
  - Reuse the existing bbb.failed error when every server fails or returns malformed data.
  - Display “No recordings are available.” for successful empty responses.
  - Prevent the recordings popup from spinning indefinitely or rendering blank.
  - Add focused tests for empty results, server failures, malformed responses, and partial server failures.

https://github.com/user-attachments/assets/74a4abff-b486-421f-9107-871d5b808b96

