### PR TITLE
chore : view event doubled in UI talks

### DIFF
--- a/app/eventyay/static/common/css/_navbar.css
+++ b/app/eventyay/static/common/css/_navbar.css
@@ -418,6 +418,13 @@ nav.navbar.navbar-inverse #button-sudo:focus i,
   border-color: transparent;
 }
 
+@media (min-width: 768px) {
+  .navbar-header .mobile-navbar-view-link,
+  .navbar-header .mobile-navbar-view-form {
+    display: none;
+  }
+}
+
 .sr-only {
   position: absolute;
   width: 1px;


### PR DESCRIPTION
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/3a7ab4dc-e7a8-4d50-89cf-e6d3af34ab3b" />

<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/2deddaca-b5f3-465c-85eb-42362997d678" />


## Summary by Sourcery

Enhancements:
- Adjust responsive navbar CSS so mobile view links/forms are only shown below 768px width.