### PR TITLE
Fix powered-by PDF asset failure

### DIFF
--- a/app/eventyay/base/pdf.py
+++ b/app/eventyay/base/pdf.py
@@ -749,12 +749,12 @@ class Renderer:
             content = 'dark'
         img = finders.find('pretixpresale/pdf/powered_by_eventyay_{}.png'.format(content))
 
-        ir = ThumbnailingImageReader(img)
         try:
+            ir = ThumbnailingImageReader(img)
             width, height = ir.resize(None, float(o['size']) * mm, 300)
         except Exception:
             logger.exception('Can not resize image')
-            pass
+            return
         canvas.drawImage(
             ir,
             float(o['left']) * mm,

--- a/app/tests/tickets/base/test_pdf.py
+++ b/app/tests/tickets/base/test_pdf.py
@@ -1,0 +1,58 @@
+from eventyay.base import pdf
+from eventyay.base.pdf import Renderer
+
+
+class CanvasSpy:
+    def __init__(self):
+        self.draw_calls = []
+
+    def drawImage(self, *args, **kwargs):
+        self.draw_calls.append((args, kwargs))
+
+
+class FailingImageReader:
+    def __init__(self, image):
+        self.image = image
+
+    def resize(self, width, height, dpi):
+        raise OSError('broken image')
+
+
+class ResizingImageReader:
+    def __init__(self, image):
+        self.image = image
+
+    def resize(self, width, height, dpi):
+        return 12, 34
+
+
+def test_draw_poweredby_skips_image_when_resize_fails(monkeypatch):
+    monkeypatch.setattr(pdf.finders, 'find', lambda path: 'broken.png')
+    monkeypatch.setattr(pdf, 'ThumbnailingImageReader', FailingImageReader)
+    canvas = CanvasSpy()
+
+    Renderer.__new__(Renderer)._draw_poweredby(
+        canvas,
+        None,
+        {'content': 'dark', 'size': '10', 'left': '0', 'bottom': '0'},
+    )
+
+    assert canvas.draw_calls == []
+
+
+def test_draw_poweredby_draws_resized_image(monkeypatch):
+    monkeypatch.setattr(pdf.finders, 'find', lambda path: 'powered-by.png')
+    monkeypatch.setattr(pdf, 'ThumbnailingImageReader', ResizingImageReader)
+    canvas = CanvasSpy()
+
+    Renderer.__new__(Renderer)._draw_poweredby(
+        canvas,
+        None,
+        {'content': 'dark', 'size': '10', 'left': '0', 'bottom': '0'},
+    )
+
+    assert len(canvas.draw_calls) == 1
+    args, kwargs = canvas.draw_calls[0]
+    assert isinstance(args[0], ResizingImageReader)
+    assert kwargs['width'] == 12
+    assert kwargs['height'] == 34


### PR DESCRIPTION
Fixes #3896

## Summary
- Skip drawing the optional powered-by image when image loading or resizing fails.
- Add regression coverage for the failing resize path and the successful resize/draw path.

## Verification
- From `app/`: `UV_CACHE_DIR=/tmp/uv-cache-eventyay-3896 DJANGO_SETTINGS_MODULE=eventyay.config.settings EVY_RUNNING_ENVIRONMENT=testing uv run python -m pytest tests/tickets/base/test_pdf.py -q`
- From `app/`: `UV_CACHE_DIR=/tmp/uv-cache-eventyay-3896 uv run ruff check tests/tickets/base/test_pdf.py`
- From `app/`: `UV_CACHE_DIR=/tmp/uv-cache-eventyay-3896 uv run ruff format --check tests/tickets/base/test_pdf.py`