### PR TITLE
Fix overflow in event logs for long actor and object names

### DIFF
--- a/app/eventyay/control/templates/pretixcontrol/event/logs.html
+++ b/app/eventyay/control/templates/pretixcontrol/event/logs.html
@@ -50,7 +50,7 @@
                             </span>
                         {% endif %}
                     </div>
-                    <div class="col-lg-2 col-sm-6 col-xs-12">
+                    <div class="col-lg-2 col-sm-6 col-xs-12 log-break-word">
                         {% if log.user %}
                             {% if log.user.is_staff %}
                                 <span class="fa fa-id-card fa-danger fa-fw"
@@ -73,7 +73,7 @@
                             {{ log.api_token.name }}
                         {% endif %}
                     </div>
-                    <div class="col-lg-2 col-sm-12 col-xs-12">
+                    <div class="col-lg-2 col-sm-12 col-xs-12 log-break-word">
                         {% if log.display_object %}
                             <span class="fa fa-flag"></span> {{ log.display_object|safe }}
                         {% endif %}

--- a/app/eventyay/static/pretixcontrol/scss/main.scss
+++ b/app/eventyay/static/pretixcontrol/scss/main.scss
@@ -1197,3 +1197,7 @@ h1 .label {
         background-image: url(static('leaflet/images/marker-icon.png'));
     }
 }
+.log-break-word {
+    overflow-wrap: break-word;
+    word-break: break-all;
+}


### PR DESCRIPTION
<img width="1377" height="701" alt="Screenshot 2026-06-14 at 8 38 18 PM" src="https://github.com/user-attachments/assets/4cbbb23c-15c7-41fc-a0f5-95e464a6c4c2" />


This PR fixes the layout overflow issue in the Event Logs page when very long actor names, email addresses, or object names are displayed.

### Changes Made

* Replaced Bootstrap `text-break` utility classes with a custom CSS class.
* Added `log-break-word` styling to ensure long strings wrap correctly within their columns.
* Prevented long product names and email addresses from overflowing into adjacent columns.

### Testing

1. Created an event with an extremely long product name.
2. Opened Event Logs page.
3. Verified that long names wrap within their respective columns.
4. Confirmed that the log table layout remains intact and readable.



Before:

* Long product names overflowed into adjacent columns.

After:

* Long product names wrap correctly inside the assigned column without breaking the layout.

## Summary by Sourcery

Improve event log table layout to handle very long actor and object names without overflowing adjacent columns.

Enhancements:
- Apply a custom log-break-word CSS class to actor and object columns in the event logs table so long values wrap within their cells.
- Define a reusable log-break-word style in the main stylesheet to enforce safe word wrapping for long strings.