### PR TITLE
Fix HLS playback termination when schedule ends

### DIFF
--- a/app/eventyay/webapp/video/src/components/Livestream.vue
+++ b/app/eventyay/webapp/video/src/components/Livestream.vue
@@ -371,14 +371,14 @@ export default {
 			if (this.$refs.video.paused) {
 				this.playbackRequested = true
 				this.$refs.video.play()
-				this.player.startLoad()
+				this.player?.startLoad()
 				// force live edge after unpausing
 				// TODO make this less yarring
 				this.$refs.video.currentTime = this.$refs.video.buffered.end(this.$refs.video.buffered.length - 1)
 			} else {
 				this.playbackRequested = false
 				this.$refs.video.pause()
-				this.player.stopLoad()
+				this.player?.stopLoad()
 			}
 		},
 		chooseLevel(level) {

--- a/app/eventyay/webapp/video/src/components/Livestream.vue
+++ b/app/eventyay/webapp/video/src/components/Livestream.vue
@@ -65,6 +65,22 @@ const HLS_DEFAULT_CONFIG = {
 	manifestLoadingMaxRetryTimeout: 5000
 }
 
+const createPlayerState = (buffering = true) => ({
+	isLive: null,
+	buffering,
+	seeking: false,
+	currentTime: 0,
+	duration: 0,
+	bufferedRanges: null,
+	hoveredProgress: null,
+	levels: null,
+	autoLevel: null,
+	manualLevel: null,
+	showLevelChooser: false,
+	textTracks: [],
+	showCaptionsChooser: false
+})
+
 export default {
 	components: {},
 	props: {
@@ -88,28 +104,14 @@ export default {
 	data() {
 		return {
 			theme,
-			isLive: null,
 			playing: true,
 			playbackRequested: true,
-			buffering: true,
-			seeking: false,
 			offline: false,
 			fullscreen: false,
 			volume: 1,
 			muted: false,
 			automuted: false,
-			currentTime: 0,
-			duration: 0,
-			bufferedRanges: null,
-			hoveredProgress: null,
-			// Quality levels
-			levels: null,
-			autoLevel: null,
-			manualLevel: null,
-			showLevelChooser: false,
-			// Captions
-			textTracks: [],
-			showCaptionsChooser: false,
+			...createPlayerState(),
 			// Alternative sources
 			showSourceChooser: false,
 			chosenAlternative: null,
@@ -231,20 +233,7 @@ export default {
 				video.load()
 			}
 			this.nativeMetadataHandler = null
-
-			this.isLive = null
-			this.buffering = false
-			this.seeking = false
-			this.currentTime = 0
-			this.duration = 0
-			this.bufferedRanges = null
-			this.hoveredProgress = null
-			this.levels = null
-			this.autoLevel = null
-			this.manualLevel = null
-			this.showLevelChooser = false
-			this.textTracks = []
-			this.showCaptionsChooser = false
+			Object.assign(this, createPlayerState(false))
 		},
 		scheduleRetry(player, callback, delay) {
 			const timer = setTimeout(() => {
@@ -306,7 +295,7 @@ export default {
 				player.on(Hls.Events.LEVEL_LOADED, (event, data) => {
 					this.isLive = data.details.live
 					if (!data.details.live && this.onlyLive) {
-						this.player?.destroy()
+						this.destroyPlayer()
 						this.offline = true
 					}
 				})

--- a/app/eventyay/webapp/video/src/components/Livestream.vue
+++ b/app/eventyay/webapp/video/src/components/Livestream.vue
@@ -90,6 +90,7 @@ export default {
 			theme,
 			isLive: null,
 			playing: true,
+			playbackRequested: true,
 			buffering: true,
 			seeking: false,
 			offline: false,
@@ -111,7 +112,9 @@ export default {
 			showCaptionsChooser: false,
 			// Alternative sources
 			showSourceChooser: false,
-			chosenAlternative: null
+			chosenAlternative: null,
+			nativeMetadataHandler: null,
+			retryTimers: new Set()
 		}
 	},
 	computed: {
@@ -182,6 +185,7 @@ export default {
 	},
 	created() {
 		this.playing = this.autoplay
+		this.playbackRequested = this.autoplay
 		if (localStorage[`livestream.native.alternative:${this.room.id}`]) {
 			this.chosenAlternative = localStorage[`livestream.native.alternative:${this.room.id}`]
 		}
@@ -201,27 +205,71 @@ export default {
 		this.initializePlayer()
 	},
 	beforeUnmount() {
-		this.player?.destroy()
+		this.destroyPlayer()
 		document.removeEventListener('fullscreenchange', this.onFullscreenchange)
 		this.$refs.video.textTracks.removeEventListener('addtrack', this.onTextTracksChanged)
 		this.$refs.video.textTracks.removeEventListener('change', this.onTextTracksChanged)
 		this.$refs.video.textTracks.removeEventListener('removetrack', this.onTextTracksChanged)
 	},
 	methods: {
+		destroyPlayer() {
+			for (const timer of this.retryTimers) {
+				clearTimeout(timer)
+			}
+			this.retryTimers.clear()
+			const player = this.player
+			this.player = null
+			player?.destroy()
+
+			const video = this.$refs.video
+			if (video) {
+				if (this.nativeMetadataHandler) {
+					video.removeEventListener('loadedmetadata', this.nativeMetadataHandler)
+				}
+				video.pause()
+				video.removeAttribute('src')
+				video.load()
+			}
+			this.nativeMetadataHandler = null
+
+			this.isLive = null
+			this.buffering = false
+			this.seeking = false
+			this.currentTime = 0
+			this.duration = 0
+			this.bufferedRanges = null
+			this.hoveredProgress = null
+			this.levels = null
+			this.autoLevel = null
+			this.manualLevel = null
+			this.showLevelChooser = false
+			this.textTracks = []
+			this.showCaptionsChooser = false
+		},
+		scheduleRetry(player, callback, delay) {
+			const timer = setTimeout(() => {
+				this.retryTimers.delete(timer)
+				if (this.player === player) {
+					callback()
+				}
+			}, delay)
+			this.retryTimers.add(timer)
+		},
 		initializePlayer() {
 			const url = this.hlsUrl
+			const shouldPlay = this.playbackRequested
+			this.destroyPlayer()
+			const video = this.$refs.video
+
 			if (!url || (typeof url === 'string' && url.trim() === '')) {
 				this.offline = true
-				this.buffering = false
 				return
 			}
-			this.player?.destroy()
 			this.buffering = true
-			const video = this.$refs.video
 			const start = async() => {
 				this.offline = false
 				this.buffering = false
-				if (!this.playing) return
+				if (!shouldPlay) return
 				try {
 					await video.play()
 				} catch (e) {
@@ -233,7 +281,7 @@ export default {
 			}
 			if (Hls.isSupported()) {
 				const hlsConfig = Object.assign({}, HLS_DEFAULT_CONFIG, config.video_player?.['hls.js'], {
-					autoStartLoad: this.playing
+					autoStartLoad: shouldPlay
 				})
 				const player = new Hls(hlsConfig)
 				let started = false
@@ -274,13 +322,13 @@ export default {
 					} else if ([Hls.ErrorDetails.MANIFEST_LOAD_ERROR, Hls.ErrorDetails.LEVEL_LOAD_ERROR].includes(data.details)) {
 						if (!started) {
 							this.offline = true
-							setTimeout(load, RETRY_INTERVAL)
+							this.scheduleRetry(player, load, RETRY_INTERVAL)
 						} else if (data.response.code === 404) {
 							this.initializePlayer()
 						}
 					} else if (data.type === Hls.ErrorTypes.NETWORK_ERROR) {
 						this.buffering = true
-						setTimeout(() => player.startLoad(), 250)
+						this.scheduleRetry(player, () => player.startLoad(), 250)
 					}
 				})
 
@@ -290,9 +338,10 @@ export default {
 			} else if (video.canPlayType('application/vnd.apple.mpegurl')) {
 				if (this.hlsUrl) {
 					video.src = this.hlsUrl
-					video.addEventListener('loadedmetadata', function() {
+					this.nativeMetadataHandler = () => {
 						start()
-					})
+					}
+					video.addEventListener('loadedmetadata', this.nativeMetadataHandler, {once: true})
 				}
 			}
 			if (this.$features.enabled('muxdata') && (this.module.config.mux_env_key || config.mux?.env_key)) {
@@ -320,12 +369,14 @@ export default {
 				if (!this.$refs.video.paused) return
 			}
 			if (this.$refs.video.paused) {
+				this.playbackRequested = true
 				this.$refs.video.play()
 				this.player.startLoad()
 				// force live edge after unpausing
 				// TODO make this less yarring
 				this.$refs.video.currentTime = this.$refs.video.buffered.end(this.$refs.video.buffered.length - 1)
 			} else {
+				this.playbackRequested = false
 				this.$refs.video.pause()
 				this.player.stopLoad()
 			}
@@ -432,7 +483,7 @@ export default {
 			this.seeking = false
 		},
 		onEnded() {
-			this.player?.destroy()
+			this.destroyPlayer()
 			this.offline = true
 		},
 		onFullscreenchange() {


### PR DESCRIPTION
Fixes #3920 

## Summary

Fix HLS playback continuing after the active stream URL becomes empty or changes.

  ## Changes

  - Destroy the existing hls.js player before evaluating the next URL.
  - Pause and unload the video element when playback ends.
  - Cancel retry timers and native HLS metadata handlers from the previous source.
  - Reset stale playback and quality state.
  - Preserve the user's play/pause intent during player teardown.
  
  

https://github.com/user-attachments/assets/440f6117-f6b3-4c8d-8776-a64d7aff2e5a


