### PR TITLE
fix duplicate migration slot occupancy

### DIFF
--- a/app/eventyay/base/migrations/0030_room_is_unscheduled_team_polls_questions.py
+++ b/app/eventyay/base/migrations/0030_room_is_unscheduled_team_polls_questions.py
@@ -6,7 +6,7 @@ from django.db import migrations, models
 class Migration(migrations.Migration):
 
     dependencies = [
-        ('base', '0028_product_free_price_max_product_free_price_min_and_more'),
+        ('base', '0029_organizerfollower'),
     ]
 
     operations = [


### PR DESCRIPTION
## Summary by Sourcery

Bug Fixes:
- Correct the migration dependency for the room unscheduled/team polls questions migration to avoid duplicate migration slot occupancy issues.