### PR TITLE
fix(talk): restore schedule public/non-public toggle and presale nav

### DIFF
--- a/app/eventyay/api/views/event.py
+++ b/app/eventyay/api/views/event.py
@@ -44,7 +44,7 @@ from eventyay.api.serializers.event import (
 from eventyay.api.serializers.rooms import EventSerializer as RoomsEventSerializer
 from eventyay.api.utils import get_protocol
 from eventyay.api.views import ConditionalListView
-from eventyay.base.models import Device, SubEvent, TaxRule, TeamAPIToken, User
+from eventyay.base.models import Device, Organizer, SubEvent, TaxRule, TeamAPIToken, User
 from eventyay.base.models.event import Event
 from eventyay.base.payment import ManualPayment
 from eventyay.base.services.event import notify_event_change
@@ -510,7 +510,7 @@ def check_token_permission(token, permission_required):
     decoded_data = jwt.decode(token, settings.SECRET_KEY, algorithms=['HS256'])
     # Check if user existed
     User.objects.get(email=decoded_data['email'])
-    if decoded_data.get('has_perms') not in permission_required:
+    if decoded_data.get('has_perms') != permission_required:
         return False
     return True
 
@@ -519,27 +519,43 @@ def check_token_permission(token, permission_required):
 @require_POST
 @scopes_disabled()
 def talk_schedule_public(request, *args, **kwargs):
-    # Disabled because it uses pretix Organizer model
-    return JsonResponse({'status': 'disabled (pretix dependency)'}, status=501)
+    auth_header = request.headers.get('Authorization')
+    if not auth_header or not auth_header.startswith('Bearer '):
+        logger.error('Authorization header missing or invalid')
+        return JsonResponse({'status': 'Authorization header missing or invalid'}, status=403)
 
-
-# def talk_schedule_public(request, *args, **kwargs):
-#     auth_header = request.headers.get('Authorization')
-#     if auth_header and auth_header.startswith('Bearer '):
-#         token = auth_header.split(' ')[1]
-#         try:
-#             if not check_token_permission(token, 'orga.edit_schedule'):
-#                 return JsonResponse(
-#                     {'status': 'User does not have permission to show schedule on menu'},
-#                     status=403,
-#                 )
-#             organiser = get_object_or_404(Organizer, slug=kwargs['organizer'])
-#             event = get_object_or_404(Event, slug=kwargs['event'], organizer=organiser)
-#             request_data = json.loads(request.body)
-#             event.settings.talk_schedule_public = request_data.get('is_show_schedule') or False
-#             return JsonResponse({'status': 'success'}, status=200)
-#         except jwt.ExpiredSignatureError:
-#             ...
+    token = auth_header.split(' ')[1]
+    try:
+        if not check_token_permission(token, 'base.edit_schedule'):
+            return JsonResponse(
+                {'status': 'User does not have permission to show schedule on menu'},
+                status=403,
+            )
+        organizer = get_object_or_404(Organizer, slug=kwargs['organizer'])
+        event = get_object_or_404(Event, slug=kwargs['event'], organizer=organizer)
+        request_data = json.loads(request.body)
+        is_show_schedule = bool(request_data.get('is_show_schedule'))
+        flags = dict(event.feature_flags)
+        flags['show_schedule'] = is_show_schedule
+        event.feature_flags = flags
+        event.settings.talk_schedule_public = is_show_schedule
+        event.save(update_fields=['feature_flags'])
+        return JsonResponse({'status': 'success'}, status=200)
+    except jwt.ExpiredSignatureError:
+        logger.error('Token has expired')
+        return JsonResponse({'status': 'Token has expired'}, status=401)
+    except jwt.InvalidTokenError:
+        logger.error('Invalid token')
+        return JsonResponse({'status': 'Invalid token'}, status=401)
+    except User.DoesNotExist:
+        logger.error('User not found for schedule-public token')
+        return JsonResponse({'status': 'User not found'}, status=401)
+    except json.JSONDecodeError:
+        logger.error('Invalid JSON payload for schedule-public')
+        return JsonResponse({'status': 'Invalid JSON payload'}, status=400)
+    except Exception:
+        logger.exception('Internal server error in talk_schedule_public')
+        return JsonResponse({'status': 'Internal server error'}, status=500)
 
 
 class CustomerOrderCheckView(APIView):

--- a/app/eventyay/base/settings.py
+++ b/app/eventyay/base/settings.py
@@ -50,6 +50,7 @@ settings_hierarkey.add_default('venueless_issuer', '', str)
 settings_hierarkey.add_default('venueless_audience', '', str)
 settings_hierarkey.add_default('venueless_talk_schedule_url', '', str)
 settings_hierarkey.add_default('venueless_show_public_link', False, bool)
+settings_hierarkey.add_default('talk_schedule_public', None, bool)
 settings_hierarkey.add_default('create_for', 'all', str)
 
 # Telemetry settings for anonymous usage data collection

--- a/app/eventyay/common/templates/common/fragment_nav.html
+++ b/app/eventyay/common/templates/common/fragment_nav.html
@@ -26,7 +26,8 @@
         </a>
     {% endif %}
     {% if show_talks_tab %}
-        {% if schedule or current_event.has_schedule_content %}
+        {% can_list_schedule current_event as show_schedule_tab %}
+        {% if show_schedule_tab and current_event.has_schedule_content %}
             {% with schedule_url=current_event.talk_schedule_url|default:current_event.urls.schedule %}
                 <a href="{{ schedule_url }}" class="header-tab {% if '/schedule/' in path %}active{% endif %}">
                     <i class="fa fa-calendar"></i> {{ schedule_label }}

--- a/app/eventyay/common/templatetags/event_tags.py
+++ b/app/eventyay/common/templatetags/event_tags.py
@@ -3,6 +3,7 @@ from urllib.parse import quote, urlsplit
 
 from django.conf import settings
 from django import template
+from django.contrib.auth.models import AnonymousUser
 from django.http import QueryDict
 from django.urls import reverse
 
@@ -10,7 +11,7 @@ from django_scopes import scopes_disabled
 
 from eventyay.base.models import Order, OrderPosition
 from eventyay.common.urls import is_http_url
-from eventyay.common.permissions import user_has_cfp_submissions
+from eventyay.common.permissions import is_admin_mode_active, user_has_cfp_submissions
 from eventyay.talk_rules.submission import are_featured_submissions_visible
 
 register = template.Library()
@@ -171,6 +172,27 @@ def can_view_tickets(context, event=None):
     if not event:
         return False
     return event.user_can_view_tickets(getattr(request, 'user', None), request=request)
+
+
+@register.simple_tag(takes_context=True)
+def can_list_schedule(context, event=None):
+    """Whether schedule-related navigation should be shown on public pages."""
+    request = context.get('request')
+    event = event or getattr(request, 'event', None)
+    if not request or not event:
+        return False
+
+    user = getattr(request, 'user', None) or AnonymousUser()
+    if getattr(user, 'is_authenticated', False):
+        if is_admin_mode_active(request):
+            return True
+        return user.has_perm('base.list_schedule', event)
+
+    return bool(
+        event.talks_published
+        and event.get_feature_flag('show_schedule')
+        and event.current_schedule
+    )
 
 
 @register.simple_tag(takes_context=True)

--- a/app/eventyay/orga/forms/event.py
+++ b/app/eventyay/orga/forms/event.py
@@ -165,6 +165,8 @@ class EventForm(ReadOnlyFlag, I18nHelpText, JsonSubfieldMixin, I18nModelForm):
 
     def save(self, *args, **kwargs):
         result = super().save(*args, **kwargs)
+        if 'show_schedule' in self.cleaned_data:
+            self.instance.settings.talk_schedule_public = bool(self.cleaned_data['show_schedule'])
         css_text = self.cleaned_data.get('custom_css_text', '')
         if css_text and 'custom_css_text' in self.changed_data:
             self.instance.custom_css.save(self.instance.slug + '.css', ContentFile(css_text))

--- a/app/eventyay/orga/views/schedule.py
+++ b/app/eventyay/orga/views/schedule.py
@@ -169,17 +169,26 @@ class ScheduleResetView(EventPermissionRequired, View):
 class ScheduleToggleView(EventPermissionRequired, View):
     permission_required = 'base.update_event'
 
+    @staticmethod
+    def _set_schedule_public(event, is_public):
+        """Persist talk schedule visibility for agenda and presale navigation."""
+        flags = dict(event.feature_flags)
+        flags['show_schedule'] = is_public
+        event.feature_flags = flags
+        event.settings.talk_schedule_public = is_public
+        event.save(update_fields=['feature_flags'])
+
     def dispatch(self, request, event):
         super().dispatch(request, event)
-        self.request.event.feature_flags['show_schedule'] = not self.request.event.get_feature_flag('show_schedule')
-        self.request.event.save()
+        is_public = not self.request.event.get_feature_flag('show_schedule')
+        self._set_schedule_public(self.request.event, is_public)
         # Trigger tickets to hidden/unhidden schedule menu
         try:
             from eventyay.orga.tasks import trigger_public_schedule
 
             trigger_public_schedule.apply_async(
                 kwargs={
-                    'is_show_schedule': self.request.event.feature_flags['show_schedule'],
+                    'is_show_schedule': is_public,
                     'event_slug': self.request.event.slug,
                     'organiser_slug': self.request.event.organiser.slug,
                     'user_email': self.request.user.email,

--- a/app/eventyay/presale/templates/pretixpresale/event/fragment_nav.html
+++ b/app/eventyay/presale/templates/pretixpresale/event/fragment_nav.html
@@ -25,7 +25,8 @@
         {% endif %}
 
         {% if show_talks_tab %}
-            {% if schedule or request.event.has_schedule_content %}
+            {% can_list_schedule request.event as show_schedule_tab %}
+            {% if show_schedule_tab and request.event.has_schedule_content %}
                 <a href="{{ request.event.talk_schedule_url }}" class="header-tab ">
                     <i class="fa fa-calendar"></i> {% translate "Schedule" %}
                 </a>

--- a/app/tests/talk/common/test_common_templatetags.py
+++ b/app/tests/talk/common/test_common_templatetags.py
@@ -1,7 +1,8 @@
 import pytest
+from django.contrib.auth.models import AnonymousUser
 from django_scopes import scope
 
-from eventyay.common.templatetags.event_tags import can_view_featured_sessions_public
+from eventyay.common.templatetags.event_tags import can_list_schedule, can_view_featured_sessions_public
 from pretalx.common.templatetags.copyable import copyable
 from pretalx.common.templatetags.html_signal import html_signal
 from pretalx.common.templatetags.rich_text import rich_text
@@ -138,3 +139,25 @@ def test_can_view_featured_sessions_public_respects_never_with_staff_session(eve
     user.has_active_staff_session = always_active_staff_session
 
     assert can_view_featured_sessions_public({'request': request}, event=event) is False
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize(
+    'show_schedule,expected',
+    (
+        (True, True),
+        (False, False),
+    ),
+)
+def test_can_list_schedule_anonymous_respects_show_schedule(event, rf, show_schedule, expected):
+    with scope(event=event):
+        event.talks_published = True
+        event.feature_flags['show_schedule'] = show_schedule
+        event.save()
+        event.release_schedule('v1')
+
+    request = rf.get('/')
+    request.event = event
+    request.user = AnonymousUser()
+
+    assert can_list_schedule({'request': request}, event=event) is expected


### PR DESCRIPTION
…sync

Re-enable the schedule-public API, persist show_schedule reliably, and gate presale navigation on schedule visibility so hiding the schedule works again.