### PR TITLE
bug: add truncation to session pill

### DIFF
--- a/app/eventyay/webapp/schedule-editor/src/components/Session.vue
+++ b/app/eventyay/webapp/schedule-editor/src/components/Session.vue
@@ -158,6 +158,30 @@ function onPointerDown(event: PointerEvent): void {
 </script>
 
 <style lang="stylus">
+sessionTextClamp(lines)
+	min-width: 0
+	display: -webkit-box
+	-webkit-line-clamp: lines
+	line-clamp: lines
+	-webkit-box-orient: vertical
+	overflow: hidden
+	overflow-wrap: break-word
+	overflow-wrap: anywhere
+	word-break: break-word
+	text-overflow: ellipsis
+
+sessionTextExpand()
+	display: block
+	-webkit-line-clamp: unset
+	line-clamp: unset
+	-webkit-box-orient: unset
+	overflow: hidden
+	white-space: normal
+	overflow-wrap: break-word
+	overflow-wrap: anywhere
+	word-break: break-word
+	text-overflow: clip
+
 .c-linear-schedule-session
 	display: flex
 	min-width: 300px
@@ -251,14 +275,17 @@ function onPointerDown(event: PointerEvent): void {
 		min-width: 0
 		.title
 			font-weight: 500
+			sessionTextClamp(2)
 		.speakers
 			color: $clr-secondary-text-light
+			sessionTextClamp(1)
 		.bottom-info
 			flex: auto
 			display: flex
 			align-items: flex-end
 			.track
 				flex: 1
+				min-width: 0
 				color: var(--track-color)
 				ellipsis()
 				margin-right: 4px
@@ -276,6 +303,10 @@ function onPointerDown(event: PointerEvent): void {
 		font-size: 16px
 		.warning-icon span
 			padding-right: 4px
+	@media (hover: hover) and (pointer: fine)
+		&:hover:not(.dragging):not(.clone)
+			.title, .speakers
+				sessionTextExpand()
 @media print
 	.c-linear-schedule-session.isbreak
 		border: 2px solid $clr-grey-300 !important

--- a/app/eventyay/webapp/schedule/src/components/Session.vue
+++ b/app/eventyay/webapp/schedule/src/components/Session.vue
@@ -197,6 +197,30 @@ export default {
 }
 </script>
 <style lang="stylus">
+sessionTextClamp(lines)
+	min-width: 0
+	display: -webkit-box
+	-webkit-line-clamp: lines
+	line-clamp: lines
+	-webkit-box-orient: vertical
+	overflow: hidden
+	overflow-wrap: break-word
+	overflow-wrap: anywhere
+	word-break: break-word
+	text-overflow: ellipsis
+
+sessionTextExpand()
+	display: block
+	-webkit-line-clamp: unset
+	line-clamp: unset
+	-webkit-box-orient: unset
+	overflow: hidden
+	white-space: normal
+	overflow-wrap: break-word
+	overflow-wrap: anywhere
+	word-break: break-word
+	text-overflow: clip
+
 .c-linear-schedule-session, .break
 	z-index: 10
 	display: flex
@@ -279,9 +303,11 @@ export default {
 			font-weight: 500
 			margin-bottom: 4px
 			margin-right: 0
+			sessionTextClamp(2)
 		.speakers
 			color: $clr-secondary-text-light
 			display: flex
+			min-width: 0
 			.avatars
 				flex: none
 				> *:not(:first-child)
@@ -295,24 +321,25 @@ export default {
 					object-fit: cover
 			.names
 				line-height: 24px
+				flex: 1
+				sessionTextClamp(1)
 		.abstract
 			margin: 8px 0 12px 0
 			// TODO make this take up more space if available?
-			display: -webkit-box
-			-webkit-line-clamp: 3
-			-webkit-box-orient: vertical
-			overflow: hidden
+			sessionTextClamp(3)
 		.bottom-info
 			flex: auto
 			display: flex
 			align-items: flex-end
 			.track
 				flex: 1
+				min-width: 0
 				color: var(--track-color)
 				ellipsis()
 				margin-right: 4px
 			.room
 				flex: 1
+				min-width: 0
 				text-align: right
 				color: $clr-secondary-text-light
 				ellipsis()
@@ -385,6 +412,10 @@ export default {
 			border-left: none
 			.title
 				color: var(--pretalx-clr-primary)
+	@media (hover: hover) and (pointer: fine)
+		&:hover
+			.title, .speakers .names
+				sessionTextExpand()
 @media(hover: none)
 	.c-linear-schedule-session .session-icons .btn-fav-container
 		display: inline-flex
@@ -411,6 +442,7 @@ export default {
 				font-size: 14px
 			.abstract
 				-webkit-line-clamp: 2
+				line-clamp: 2
 			.bottom-info
 				font-size: 12px
 	.c-linear-schedule-session.has-date

--- a/app/eventyay/webapp/schedule/src/components/Session.vue
+++ b/app/eventyay/webapp/schedule/src/components/Session.vue
@@ -441,8 +441,7 @@ sessionTextExpand()
 			.title
 				font-size: 14px
 			.abstract
-				-webkit-line-clamp: 2
-				line-clamp: 2
+				sessionTextClamp(2)
 			.bottom-info
 				font-size: 12px
 	.c-linear-schedule-session.has-date


### PR DESCRIPTION
## Summary by Sourcery

Improve truncation and hover expansion behavior for session titles and metadata in schedule and schedule-editor views.

Bug Fixes:
- Prevent session titles, speaker names, and related metadata from overflowing their pill container by clamping text to a limited number of lines.

Enhancements:
- Add shared text clamping and expansion helpers for session content, enabling multi-line ellipsis with hover-based expansion on pointer devices in both schedule and schedule-editor session components.