### PR TITLE
chore: add do not record and ui fixes to schedule and schedule-editor

### DIFF
--- a/app/eventyay/agenda/views/schedule.py
+++ b/app/eventyay/agenda/views/schedule.py
@@ -389,6 +389,7 @@ def schedule_messages(request, **kwargs):
         'featured_speakers': _('Featured Speakers'),
         'view_profile': _('View speaker profile'),
         'no_starred_sessions': _('No starred sessions.'),
+        'schedule_do_not_record': _('This session will not be recorded.'),
     }
     strings = {key: str(value) for key, value in strings.items()}
     return HttpResponse(

--- a/app/eventyay/webapp/schedule-editor/locales/en/translation.json
+++ b/app/eventyay/webapp/schedule-editor/locales/en/translation.json
@@ -12,5 +12,6 @@
   "New break": "",
   "Drag the box to the schedule to create a new break": "",
   "Hidden rooms": "",
-  "Pending proposal state": ""
+  "Pending proposal state": "",
+  "This session will not be recorded.": ""
 }

--- a/app/eventyay/webapp/schedule-editor/src/App.vue
+++ b/app/eventyay/webapp/schedule-editor/src/App.vue
@@ -142,6 +142,7 @@ interface Talk {
   submission?: Record<string, unknown>
   uncreated?: boolean
   availabilities?: AvailabilityEntry[]
+  do_not_record?: boolean
 }
 
 interface SessionData {
@@ -159,6 +160,7 @@ interface SessionData {
   deletedRoom?: boolean
   uncreated?: boolean
   availabilities?: AvailabilityEntry[]
+  do_not_record?: boolean
 }
 
 interface SortMethod {
@@ -299,6 +301,7 @@ const unscheduled = computed<SessionData[]>(() => {
       track: tracksLookup.value[lookupKey(session.track)],
       duration: session.duration,
       state: session.state,
+      do_not_record: session.do_not_record,
     } as SessionData)
   }
   if (unassignedFilterString.value.length) {
@@ -350,6 +353,7 @@ const deletedRoomSessions = computed<SessionData[]>(() => {
       track: tracksLookup.value[lookupKey(session.track)],
       state: session.state,
       deletedRoom: true,
+      do_not_record: session.do_not_record,
     }))
 })
 
@@ -380,6 +384,7 @@ const sessions = computed<SessionData[]>(() => {
     track: tracksLookup.value[lookupKey(session.track)],
     state: session.state,
     room: roomsLookup.value[lookupKey(session.room)],
+    do_not_record: session.do_not_record,
   }))
 
   sessionList.sort((a, b) => a.start!.diff(b.start!))

--- a/app/eventyay/webapp/schedule-editor/src/components/GridSchedule.vue
+++ b/app/eventyay/webapp/schedule-editor/src/components/GridSchedule.vue
@@ -778,6 +778,11 @@ onUnmounted(() => {
 		.c-linear-schedule-session
 			z-index: 10
 			transition: padding 0.2s ease, font-size 0.2s ease
+	.grid-viewport .grid
+		.c-linear-schedule-session, .break
+			margin: 6px
+			min-width: 0
+			box-sizing: border-box
 	.timeslice
 		color: $clr-secondary-text-light
 		padding: 8px 10px 0 10px
@@ -810,8 +815,12 @@ onUnmounted(() => {
 		.timeslice
 			padding: 4px 6px 0 6px
 			font-size: 12px
+		.grid-viewport .grid
+			.c-linear-schedule-session, .break
+				margin: 4px 3px
+				min-height: 48px
+				font-size: 12px
 		.c-linear-schedule-session
-			margin: 4px 3px
 			min-height: 48px
 			font-size: 12px
 			.time-box
@@ -838,8 +847,12 @@ onUnmounted(() => {
 		.timeslice
 			padding: 12px 14px 0 14px
 			font-size: 15px
+		.grid-viewport .grid
+			.c-linear-schedule-session, .break
+				margin: 12px 9px
+				min-height: 120px
+				font-size: 15px
 		.c-linear-schedule-session
-			margin: 12px 9px
 			min-height: 120px
 			font-size: 15px
 			.time-box

--- a/app/eventyay/webapp/schedule-editor/src/components/Session.vue
+++ b/app/eventyay/webapp/schedule-editor/src/components/Session.vue
@@ -11,8 +11,14 @@
 		.pending-line(v-if="session.state === 'pending'")
 			i.fa.fa-exclamation-circle
 			span {{ $t('Pending proposal state') }}
-		.bottom-info(v-if="!isBreak")
+		.bottom-info(v-if="!isBreak && (session.track || session.do_not_record)")
 			.track(v-if="session.track") {{ getLocalizedString(session.track.name) }}
+			.do_not_record.no-print(v-if="session.do_not_record", :title="$t('This session will not be recorded.')", :aria-label="$t('This session will not be recorded.')")
+				svg(viewBox="0 0 116.59076 116.59076", width="24px", height="24px", fill="none", xmlns="http://www.w3.org/2000/svg", aria-hidden="true")
+					g(transform="translate(-9.3465481,-5.441411)")
+						rect(style="fill:#000000;fill-opacity;stroke:none;stroke-width:11.2589;stroke-linecap:round;stroke-dasharray:none;stroke-opacity:1;paint-order:markers stroke fill", width="52.753284", height="39.619537", x="35.496307", y="43.927021", rx="5.5179553", ry="7.573648")
+						path(style="fill:#000000;fill-opacity:1;stroke:none;stroke-width:18.7997;stroke-linecap:round;stroke-dasharray:none;stroke-opacity:1;paint-order:markers stroke fill", d="M 99.787546,47.04792 V 80.425654 L 77.727407,63.736793 Z")
+						path(style="fill:none;stroke:#b23e65;stroke-width:12;stroke-linecap:round;stroke-dasharray:none;stroke-opacity:1;paint-order:markers stroke fill", d="m 35.553146,95.825578 64.177559,-64.17757 m 16.294055,32.08879 A 48.382828,48.382828 0 0 1 67.641925,112.11961 48.382828,48.382828 0 0 1 19.259099,63.736798 48.382828,48.382828 0 0 1 67.641925,15.353968 48.382828,48.382828 0 0 1 116.02476,63.736798 Z")
 	.warning.no-print(v-if="warnings?.length")
 		.warning-icon.text-danger
 			span(v-if="warnings.length > 1") {{ warnings.length }}
@@ -49,6 +55,7 @@ interface Session {
   duration: number
   abstract?: string
   room?: string | number
+  do_not_record?: boolean
   [key: string]: string | number | boolean | Record<string, string> | Speaker[] | Track | Moment | null | undefined
 }
 
@@ -257,11 +264,17 @@ function onPointerDown(event: PointerEvent): void {
 			flex: auto
 			display: flex
 			align-items: flex-end
+			gap: 4px
+			min-width: 0
 			.track
 				flex: 1
 				color: var(--track-color)
 				ellipsis()
-				margin-right: 4px
+			.do_not_record
+				flex: none
+				display: flex
+				align-items: center
+				line-height: 0
 	.pending-line
 		color: $clr-warning
 		.fa

--- a/app/eventyay/webapp/schedule-editor/src/schemas.ts
+++ b/app/eventyay/webapp/schedule-editor/src/schemas.ts
@@ -86,7 +86,8 @@ export const TalkSchema = z.object({
   updated: z.string().optional(),
   uncreated: z.boolean().optional(),
   availabilities: z.array(AvailabilityEntrySchema).optional().default([]),
-  duration: z.number().optional()
+  duration: z.number().optional(),
+  do_not_record: z.boolean().optional(),
 });
 
 export const WarningSchema = z.object({

--- a/app/eventyay/webapp/schedule-editor/src/schemas.ts
+++ b/app/eventyay/webapp/schedule-editor/src/schemas.ts
@@ -87,7 +87,7 @@ export const TalkSchema = z.object({
   uncreated: z.boolean().optional(),
   availabilities: z.array(AvailabilityEntrySchema).optional().default([]),
   duration: z.number().optional(),
-  do_not_record: z.boolean().optional(),
+  do_not_record: z.union([z.boolean(), z.null()]).optional().transform(val => val === true).default(false),
 });
 
 export const WarningSchema = z.object({

--- a/app/eventyay/webapp/schedule/src/components/GridSchedule.vue
+++ b/app/eventyay/webapp/schedule/src/components/GridSchedule.vue
@@ -712,6 +712,10 @@ export default {
 			grid-template-columns: 78px repeat(var(--total-rooms), minmax(var(--room-col-min), 1fr)) auto
 			position: relative
 			min-width: max(min-content, calc(78px + (var(--total-rooms) * var(--room-col-min)) + 60px))
+			.c-linear-schedule-session, .break
+				margin: 6px
+				min-width: 0
+				box-sizing: border-box
 		.break
 			.time-box
 				background-color: $clr-grey-500
@@ -802,6 +806,11 @@ export default {
 	.rooms-bar .rooms-inner > .room
 		font-size: 14px
 		padding: 4px 2px
+	.grid-viewport .grid
+		.c-linear-schedule-session, .break
+			margin: 4px 3px
+			min-height: 48px
+			font-size: 12px
 	.grid
 		grid-template-columns: 60px repeat(var(--total-rooms), minmax(var(--room-col-min), 1fr)) auto
 	.rooms-inner
@@ -814,6 +823,11 @@ export default {
 	.rooms-bar .rooms-inner > .room
 		font-size: 20px
 		padding: 12px 6px
+	.grid-viewport .grid
+		.c-linear-schedule-session, .break
+			margin: 12px 9px
+			min-height: 120px
+			font-size: 15px
 	.grid
 		grid-template-columns: 96px repeat(var(--total-rooms), minmax(var(--room-col-min), 1fr)) auto
 	.rooms-inner

--- a/app/eventyay/webapp/schedule/src/components/Session.vue
+++ b/app/eventyay/webapp/schedule/src/components/Session.vue
@@ -17,25 +17,25 @@ a.c-linear-schedule-session(:class="{faved, 'has-date': showDate}", :style="styl
 					img(v-else-if="speaker.avatar_thumbnail_default", :src="speaker.avatar_thumbnail_default")
 					img(v-else-if="speaker.avatar || speaker.avatar_url", :src="speaker.avatar || speaker.avatar_url")
 			.names {{ session.speakers.map(s => s.name).join(', ') }}
-		.do_not_record(v-if="session.do_not_record")
-			svg(viewBox="0 0 116.59076 116.59076", width="24px", height="24px", fill="none", xmlns="http://www.w3.org/2000/svg")
-				g(transform="translate(-9.3465481,-5.441411)")
-					rect(style="fill:#000000;fill-opacity;stroke:none;stroke-width:11.2589;stroke-linecap:round;stroke-dasharray:none;stroke-opacity:1;paint-order:markers stroke fill", width="52.753284", height="39.619537", x="35.496307", y="43.927021", rx="5.5179553", ry="7.573648")
-					path(style="fill:#000000;fill-opacity:1;stroke:none;stroke-width:18.7997;stroke-linecap:round;stroke-dasharray:none;stroke-opacity:1;paint-order:markers stroke fill", d="M 99.787546,47.04792 V 80.425654 L 77.727407,63.736793 Z")
-					path(style="fill:none;stroke:#b23e65;stroke-width:12;stroke-linecap:round;stroke-dasharray:none;stroke-opacity:1;paint-order:markers stroke fill", d="m 35.553146,95.825578 64.177559,-64.17757 m 16.294055,32.08879 A 48.382828,48.382828 0 0 1 67.641925,112.11961 48.382828,48.382828 0 0 1 19.259099,63.736798 48.382828,48.382828 0 0 1 67.641925,15.353968 48.382828,48.382828 0 0 1 116.02476,63.736798 Z")
 		.tags-box(v-if="showTags && session.tags && session.tags.length")
 			.tags(v-for="tag_item of session.tags")
 				.tag-item(:style="{'background-color': tag_item.color, 'color': getContrastColor(tag_item.color)}") {{ tag_item.tag }}
 		.abstract(v-if="showAbstract", v-html="abstractText")
 		.bottom-info
 			.track(v-if="session.track") {{ getLocalizedString(session.track.name) }}
+			.do_not_record(v-if="session.do_not_record", :title="doNotRecordTooltip", :aria-label="doNotRecordTooltip")
+				svg(viewBox="0 0 116.59076 116.59076", width="24px", height="24px", fill="none", xmlns="http://www.w3.org/2000/svg", aria-hidden="true")
+					g(transform="translate(-9.3465481,-5.441411)")
+						rect(style="fill:#000000;fill-opacity;stroke:none;stroke-width:11.2589;stroke-linecap:round;stroke-dasharray:none;stroke-opacity:1;paint-order:markers stroke fill", width="52.753284", height="39.619537", x="35.496307", y="43.927021", rx="5.5179553", ry="7.573648")
+						path(style="fill:#000000;fill-opacity:1;stroke:none;stroke-width:18.7997;stroke-linecap:round;stroke-dasharray:none;stroke-opacity:1;paint-order:markers stroke fill", d="M 99.787546,47.04792 V 80.425654 L 77.727407,63.736793 Z")
+						path(style="fill:none;stroke:#b23e65;stroke-width:12;stroke-linecap:round;stroke-dasharray:none;stroke-opacity:1;paint-order:markers stroke fill", d="m 35.553146,95.825578 64.177559,-64.17757 m 16.294055,32.08879 A 48.382828,48.382828 0 0 1 67.641925,112.11961 48.382828,48.382828 0 0 1 19.259099,63.736798 48.382828,48.382828 0 0 1 67.641925,15.353968 48.382828,48.382828 0 0 1 116.02476,63.736798 Z")
 			.room(v-if="showRoom && session.room") {{ getLocalizedString(session.room.name) }}
 		.fav-count(v-if="loggedIn && showFavCount && session.fav_count > 0") {{ session.fav_count > 99 ? "99+" : session.fav_count }}
 	.stream-indicator(v-if="canOpenStream", :class="{live: isLive}", :title="streamTooltip", @click.prevent.stop="openStream")
 		svg(viewBox="0 0 24 24", width="20", height="20", fill="currentColor", xmlns="http://www.w3.org/2000/svg")
 			path(d="M17 10.5V7c0-.55-.45-1-1-1H4c-.55 0-1 .45-1 1v10c0 .55.45 1 1 1h12c.55 0 1-.45 1-1v-3.5l4 4v-11l-4 4z")
-	.session-icons
-		fav-button(v-if="loggedIn", @toggleFav="toggleFav")
+	.session-icons(v-if="loggedIn")
+		fav-button(@toggleFav="toggleFav")
 
 </template>
 <script>
@@ -174,6 +174,10 @@ export default {
 		hasFavCount () {
 			return this.loggedIn && this.showFavCount && this.session.fav_count > 0
 		},
+		doNotRecordTooltip () {
+			const m = this.translationMessages || {}
+			return m.schedule_do_not_record || m.do_not_record || 'This session will not be recorded.'
+		},
 		hasAnyRightIcons () {
 			return this.loggedIn || this.canOpenStream
 		}
@@ -306,11 +310,17 @@ export default {
 			flex: auto
 			display: flex
 			align-items: flex-end
+			gap: 4px
+			min-width: 0
 			.track
 				flex: 1
 				color: var(--track-color)
 				ellipsis()
-				margin-right: 4px
+			.do_not_record
+				flex: none
+				display: flex
+				align-items: center
+				line-height: 0
 			.room
 				flex: 1
 				text-align: right
@@ -330,8 +340,6 @@ export default {
 			text-align: center
 			background-color: var(--track-color)
 			color: $clr-primary-text-dark
-	.do_not_record
-		margin: 10px 0px
 	.tags-box
 		display: flex
 		flex-wrap: wrap
@@ -370,8 +378,6 @@ export default {
 		top: 2px
 		right: 2px
 		display: flex
-		.do-not-record
-			padding: 6px 6px 6px 0
 		.btn-fav-container
 			margin-top: 2px
 			display: inline-flex

--- a/app/eventyay/webapp/schedule/src/components/Session.vue
+++ b/app/eventyay/webapp/schedule/src/components/Session.vue
@@ -23,13 +23,13 @@ a.c-linear-schedule-session(:class="{faved, 'has-date': showDate}", :style="styl
 		.abstract(v-if="showAbstract", v-html="abstractText")
 		.bottom-info
 			.track(v-if="session.track") {{ getLocalizedString(session.track.name) }}
-			.do_not_record(v-if="session.do_not_record", :title="doNotRecordTooltip", :aria-label="doNotRecordTooltip")
-				svg(viewBox="0 0 116.59076 116.59076", width="24px", height="24px", fill="none", xmlns="http://www.w3.org/2000/svg", aria-hidden="true")
-					g(transform="translate(-9.3465481,-5.441411)")
-						rect(style="fill:#000000;fill-opacity;stroke:none;stroke-width:11.2589;stroke-linecap:round;stroke-dasharray:none;stroke-opacity:1;paint-order:markers stroke fill", width="52.753284", height="39.619537", x="35.496307", y="43.927021", rx="5.5179553", ry="7.573648")
-						path(style="fill:#000000;fill-opacity:1;stroke:none;stroke-width:18.7997;stroke-linecap:round;stroke-dasharray:none;stroke-opacity:1;paint-order:markers stroke fill", d="M 99.787546,47.04792 V 80.425654 L 77.727407,63.736793 Z")
-						path(style="fill:none;stroke:#b23e65;stroke-width:12;stroke-linecap:round;stroke-dasharray:none;stroke-opacity:1;paint-order:markers stroke fill", d="m 35.553146,95.825578 64.177559,-64.17757 m 16.294055,32.08879 A 48.382828,48.382828 0 0 1 67.641925,112.11961 48.382828,48.382828 0 0 1 19.259099,63.736798 48.382828,48.382828 0 0 1 67.641925,15.353968 48.382828,48.382828 0 0 1 116.02476,63.736798 Z")
 			.room(v-if="showRoom && session.room") {{ getLocalizedString(session.room.name) }}
+		.do_not_record(v-if="session.do_not_record", :title="doNotRecordTooltip", :aria-label="doNotRecordTooltip")
+			svg(viewBox="0 0 116.59076 116.59076", width="24px", height="24px", fill="none", xmlns="http://www.w3.org/2000/svg", aria-hidden="true")
+				g(transform="translate(-9.3465481,-5.441411)")
+					rect(style="fill:#000000;fill-opacity;stroke:none;stroke-width:11.2589;stroke-linecap:round;stroke-dasharray:none;stroke-opacity:1;paint-order:markers stroke fill", width="52.753284", height="39.619537", x="35.496307", y="43.927021", rx="5.5179553", ry="7.573648")
+					path(style="fill:#000000;fill-opacity:1;stroke:none;stroke-width:18.7997;stroke-linecap:round;stroke-dasharray:none;stroke-opacity:1;paint-order:markers stroke fill", d="M 99.787546,47.04792 V 80.425654 L 77.727407,63.736793 Z")
+					path(style="fill:none;stroke:#b23e65;stroke-width:12;stroke-linecap:round;stroke-dasharray:none;stroke-opacity:1;paint-order:markers stroke fill", d="m 35.553146,95.825578 64.177559,-64.17757 m 16.294055,32.08879 A 48.382828,48.382828 0 0 1 67.641925,112.11961 48.382828,48.382828 0 0 1 19.259099,63.736798 48.382828,48.382828 0 0 1 67.641925,15.353968 48.382828,48.382828 0 0 1 116.02476,63.736798 Z")
 		.fav-count(v-if="loggedIn && showFavCount && session.fav_count > 0") {{ session.fav_count > 99 ? "99+" : session.fav_count }}
 	.stream-indicator(v-if="canOpenStream", :class="{live: isLive}", :title="streamTooltip", @click.prevent.stop="openStream")
 		svg(viewBox="0 0 24 24", width="20", height="20", fill="currentColor", xmlns="http://www.w3.org/2000/svg")
@@ -176,10 +176,10 @@ export default {
 		},
 		doNotRecordTooltip () {
 			const m = this.translationMessages || {}
-			return m.schedule_do_not_record || m.do_not_record || 'This session will not be recorded.'
+			return m.schedule_do_not_record || 'This session will not be recorded.'
 		},
 		hasAnyRightIcons () {
-			return this.loggedIn || this.canOpenStream
+			return this.loggedIn || this.canOpenStream || this.session.do_not_record
 		}
 	},
 	methods: {
@@ -204,6 +204,7 @@ export default {
 .c-linear-schedule-session, .break
 	z-index: 10
 	display: flex
+	align-items: stretch
 	min-width: 300px
 	min-height: 96px
 	margin: 8px 0
@@ -264,6 +265,7 @@ export default {
 		.time-box
 			width: 88px
 	.info
+		position: relative
 		flex: auto
 		display: flex
 		flex-direction: column
@@ -316,16 +318,22 @@ export default {
 				flex: 1
 				color: var(--track-color)
 				ellipsis()
-			.do_not_record
-				flex: none
-				display: flex
-				align-items: center
-				line-height: 0
 			.room
 				flex: 1
 				text-align: right
 				color: $clr-secondary-text-light
 				ellipsis()
+		.do_not_record
+			position: absolute
+			bottom: 2px
+			right: 2px
+			width: 32px
+			height: 32px
+			display: flex
+			justify-content: center
+			align-items: center
+			line-height: 0
+			z-index: 5
 		.fav-count
 			border: 1px solid
 			border-radius: 50%


### PR DESCRIPTION
## Summary by Sourcery

Improve display and propagation of the "do not record" flag across the public schedule and schedule editor.

New Features:
- Show a do-not-record indicator with accessible tooltip for sessions on both the public schedule and schedule editor views.
- Include the do_not_record flag in schedule-editor data models, schemas, and computed session lists so it is preserved across editing workflows.

Enhancements:
- Adjust layout and spacing of session cards and breaks in grid views for better responsiveness and readability.
- Refine bottom-info section layout and favorite button visibility so icons only render when relevant.