### PR TITLE
 Fix Save button layout shift in Organizer settings

### DIFF
--- a/app/eventyay/control/templates/pretixcontrol/organizers/edit.html
+++ b/app/eventyay/control/templates/pretixcontrol/organizers/edit.html
@@ -88,6 +88,11 @@
                         {% bootstrap_field sform.privacy_policy layout="control" %}
                     </fieldset>
                 </div>
+                <div class="form-group submit-group">
+                    <button type="submit" class="btn btn-primary btn-save">
+                        {% trans "Save" %}
+                    </button>
+                </div>
             </div>
             <div class="col-xs-12 col-lg-2">
                 <div class="panel panel-default">
@@ -99,11 +104,6 @@
                     {% include "pretixcontrol/includes/logs.html" with obj=organizer %}
                 </div>
             </div>
-        </div>
-        <div class="form-group submit-group">
-            <button type="submit" class="btn btn-primary btn-save">
-                {% trans "Save" %}
-            </button>
         </div>
     </form>
 {% endblock %}


### PR DESCRIPTION
## Fixes #3892

### What does this PR do?

This PR fixes the Save button position on the Organizer Settings page.

Previously, the Save button was placed outside the main settings column, causing its position to be affected by the length of the Change History sidebar.

This change moves the Save button into the main settings column so it stays aligned with the form and behaves consistently with other settings pages.


https://github.com/user-attachments/assets/6783d4a3-6f1b-477c-9c31-7e050fcd9563


https://github.com/user-attachments/assets/a6051f2e-acb9-45ff-a6d2-0865b2b64552

## Summary by Sourcery

Enhancements:
- Move the Organizer settings Save button into the main settings column for consistent placement with other settings pages.