### PR TITLE
Fix signed ticket secret generator interface

### DIFF
--- a/app/eventyay/base/secrets.py
+++ b/app/eventyay/base/secrets.py
@@ -190,6 +190,7 @@ class Sig1TicketSecretGenerator(BaseTicketSecretGenerator):
         product: Product,
         variation: ProductVariation = None,
         subevent: SubEvent = None,
+        attendee_name: str = None,
         current_secret: str = None,
         force_invalidate=False,
     ):
@@ -197,7 +198,7 @@ class Sig1TicketSecretGenerator(BaseTicketSecretGenerator):
             ticket = self._parse(current_secret)
             if ticket:
                 unchanged = (
-                    ticket.product == product.pk
+                    ticket.item == product.pk
                     and ticket.variation == (variation.pk if variation else 0)
                     and ticket.subevent == (subevent.pk if subevent else 0)
                 )
@@ -206,7 +207,7 @@ class Sig1TicketSecretGenerator(BaseTicketSecretGenerator):
 
         t = pretix_sig1_pb2.Ticket()
         t.seed = get_random_string(9)
-        t.product = product.pk
+        t.item = product.pk
         t.variation = variation.pk if variation else 0
         t.subevent = subevent.pk if subevent else 0
         payload = t.SerializeToString()

--- a/app/tests/tickets/base/test_secrets.py
+++ b/app/tests/tickets/base/test_secrets.py
@@ -1,5 +1,6 @@
 import base64
 import struct
+from types import SimpleNamespace
 import pytest
 from django.utils.timezone import now
 from django_scopes import scope
@@ -33,7 +34,7 @@ def event():
 @pytest.mark.django_db
 @pytest.mark.parametrize('scheme', schemes)
 def test_force_invalidate(event, scheme):
-    item = event.items.create(name='Foo', default_price=0)
+    item = event.products.create(name='Foo', default_price=0)
     generator, input_dependent = scheme
     g = generator(event)
 
@@ -46,7 +47,7 @@ def test_force_invalidate(event, scheme):
 @pytest.mark.django_db
 @pytest.mark.parametrize('scheme', schemes)
 def test_keep_same(event, scheme):
-    item = event.items.create(name='Foo', default_price=0)
+    item = event.products.create(name='Foo', default_price=0)
     generator, input_dependent = scheme
     g = generator(event)
 
@@ -59,8 +60,8 @@ def test_keep_same(event, scheme):
 @pytest.mark.django_db
 @pytest.mark.parametrize('scheme', schemes)
 def test_change_if_required(event, scheme):
-    item = event.items.create(name='Foo', default_price=0)
-    item2 = event.items.create(name='Bar', default_price=0)
+    item = event.products.create(name='Foo', default_price=0)
+    item2 = event.products.create(name='Bar', default_price=0)
     generator, input_dependent = scheme
     g = generator(event)
 
@@ -76,7 +77,7 @@ def test_change_if_required(event, scheme):
 @pytest.mark.django_db
 @pytest.mark.parametrize('scheme', schemes)
 def test_change_if_invalid(event, scheme):
-    item = event.items.create(name='Foo', default_price=0)
+    item = event.products.create(name='Foo', default_price=0)
     generator, input_dependent = scheme
     g = generator(event)
 
@@ -84,6 +85,37 @@ def test_change_if_invalid(event, scheme):
     second = g.generate_secret(item, None, None, current_secret=first, force_invalidate=False)
     if input_dependent:
         assert first != second
+
+
+def test_sig1_generate_secret_accepts_attendee_name():
+    event = SimpleNamespace(
+        settings=SimpleNamespace(
+            ticket_secrets_pretix_sig1_privkey='',
+            ticket_secrets_pretix_sig1_pubkey='',
+        )
+    )
+    product = SimpleNamespace(pk=1)
+    generator = Sig1TicketSecretGenerator(event)
+
+    first = generator.generate_secret(
+        product,
+        None,
+        None,
+        attendee_name='Ada Lovelace',
+        current_secret=None,
+        force_invalidate=False,
+    )
+    assert first
+
+    second = generator.generate_secret(
+        product,
+        None,
+        None,
+        'Ada Lovelace',
+        current_secret=first,
+        force_invalidate=False,
+    )
+    assert second == first
 
 
 @pytest.mark.django_db


### PR DESCRIPTION
## Summary
- Align `Sig1TicketSecretGenerator.generate_secret` with the base generator interface by accepting `attendee_name`.
- Use the `item` protobuf field when generating and comparing signed ticket secrets.
- Add a focused regression test for keyword and positional `attendee_name` calls.

Fixes #3871

## Testing
- `PATH=/opt/homebrew/opt/gettext/bin:$PATH .venv/bin/pytest tests/tickets/base/test_secrets.py::test_sig1_generate_secret_accepts_attendee_name`
- `.venv/bin/ruff check eventyay/base/secrets.py tests/tickets/base/test_secrets.py`

Full `tests/tickets/base/test_secrets.py` was not completed locally because this workstation does not have the expected Eventyay PostgreSQL test database credentials available.
