### PR TITLE
Fix quota availability waiting list count

### DIFF
--- a/app/eventyay/api/views/product.py
+++ b/app/eventyay/api/views/product.py
@@ -612,7 +612,7 @@ class QuotaViewSet(ConditionalListView, viewsets.ModelViewSet):
             'exited_orders': qa.count_exited_orders[quota],
             'blocking_vouchers': qa.count_vouchers[quota],
             'cart_positions': qa.count_cart[quota],
-            'waiting_list': qa.count_pending_orders[quota],
+            'waiting_list': qa.count_waitinglist[quota],
             'available_number': avail[1],
             'available': avail[0] == Quota.AVAILABILITY_OK,
             'total_size': quota.size,

--- a/app/tests/tickets/api/test_items.py
+++ b/app/tests/tickets/api/test_items.py
@@ -1828,6 +1828,19 @@ def test_quota_availability(token_client, organizer, event, quota, item):
     } == resp.data
 
 
+@pytest.mark.django_db
+def test_quota_availability_counts_waiting_list_entries(token_client, organizer, event, quota, item):
+    event.waitinglistentries.create(item=item, email='waiting@example.com')
+
+    resp = token_client.get(
+        '/api/v1/organizers/{}/events/{}/quotas/{}/availability/'.format(organizer.slug, event.slug, quota.pk)
+    )
+
+    assert resp.status_code == 200
+    assert resp.data['pending_orders'] == 0
+    assert resp.data['waiting_list'] == 1
+
+
 @pytest.fixture
 def question(event, item):
     q = event.questions.create(


### PR DESCRIPTION
## Summary

- Fix quota availability API `waiting_list` to use the computed waiting-list count instead of the pending-order count.
- Add a regression test covering a quota with one waiting-list entry and no pending orders.

Closes #3883.

## Verification

- `git diff --check`
- `.venv/bin/ruff check --select F,E9 eventyay/api/views/product.py tests/tickets/api/test_items.py`
- `PYTHONPYCACHEPREFIX=.pycache-check .venv/bin/python -m py_compile eventyay/api/views/product.py tests/tickets/api/test_items.py`

I also attempted:

- `PATH=/opt/homebrew/opt/gettext/bin:$PATH .venv/bin/pytest tests/tickets/api/test_items.py::test_quota_availability_counts_waiting_list_entries`

but the local checkout currently fails during test collection before reaching this test because the ticket API test suite imports `pretix.*` modules and the local environment does not provide a `pretix` compatibility package.
