### PR TITLE
feature: wip support added wip talks and speakers support added disabled useless wip features

### DIFF
--- a/app/eventyay/agenda/templates/agenda/base.html
+++ b/app/eventyay/agenda/templates/agenda/base.html
@@ -9,6 +9,8 @@
 {% load safelink %}
 
 {% load presale_locale %}
+{% load nav_tags %}
+{% load static %}
 {% block custom_header %}
     {% block alternate_link %}
         <link rel="alternate" type="application/atom+xml" title="{{ request.event.name|event_localize }} Schedule Versions" href="{{ request.event.urls.feed }}" />
@@ -52,3 +54,28 @@
     {% endif %}
     {% block agenda_content %}{% endblock agenda_content %}
 {% endblock content %}
+
+{% block body_bottom %}
+    {{ block.super }}
+    {% is_wip_agenda_preview request as wip_preview %}
+    {% if wip_preview %}
+        <dialog id="agenda-wip-preview-leave-dialog" class="agenda-wip-preview-leave-dialog" aria-labelledby="agenda-wip-preview-leave-title" aria-describedby="agenda-wip-preview-leave-message">
+            <div class="agenda-wip-preview-leave-dialog__card">
+                <p class="agenda-wip-preview-leave-dialog__icon" aria-hidden="true">
+                    <i class="fa fa-eye-slash"></i>
+                </p>
+                <h3 id="agenda-wip-preview-leave-title">{% translate "Leave schedule preview?" %}</h3>
+                <p id="agenda-wip-preview-leave-message" class="agenda-wip-preview-leave-dialog__message">
+                    {% blocktranslate trimmed %}
+                        You are moving away from schedule preview mode. This will move you to the public view. You will only be able to see the schedule if it is public and released.
+                    {% endblocktranslate %}
+                </p>
+                <div class="agenda-wip-preview-leave-dialog__actions">
+                    <button type="button" class="btn btn-default" data-wip-preview-action="stay">{% translate "Stay in preview" %}</button>
+                    <button type="button" class="btn btn-primary" data-wip-preview-action="leave">{% translate "Go to public view" %}</button>
+                </div>
+            </div>
+        </dialog>
+        <script type="module" src="{% static 'agenda/js/wip-preview-guard.js' %}"></script>
+    {% endif %}
+{% endblock body_bottom %}

--- a/app/eventyay/agenda/templates/agenda/schedule.html
+++ b/app/eventyay/agenda/templates/agenda/schedule.html
@@ -24,7 +24,7 @@
     {% vite_app_scripts 'schedule' 'src/main-wc.js' fallback='schedule/pretalx-schedule.js' %}
 
     {% with event_tz=request.event.settings.timezone|default:request.event.timezone %}
-    <pretalx-schedule event-url="{{ request.event.urls.base }}" version="{{ schedule.url_version }}" locale="{{ request.LANGUAGE_CODE }}" timezone="{{ event_tz }}" enrich-data {% if is_sessions_page %}view="sessions"{% elif show_talk_list %}format="list"{% endif %} {% if request.event.is_video_creation %}join-room-base-url="{{ request.event.urls.video_base }}rooms/"{% endif %} style="--pretalx-clr-primary: {{ request.event.visible_primary_color }}" disable-auto-scroll></pretalx-schedule>
+    <pretalx-schedule event-url="{{ request.event.urls.base }}" version="{{ schedule_page_version|default:schedule.url_version }}" locale="{{ request.LANGUAGE_CODE }}" timezone="{{ event_tz }}" enrich-data {% if is_sessions_page %}view="sessions"{% elif show_talk_list %}format="list"{% endif %} {% if request.event.is_video_creation %}join-room-base-url="{{ request.event.urls.video_base }}rooms/"{% endif %} style="--pretalx-clr-primary: {{ request.event.visible_primary_color }}" disable-auto-scroll></pretalx-schedule>
     {% endwith %}
     <noscript class="d-block">
         <div class="alert alert-info m-4">

--- a/app/eventyay/agenda/templates/agenda/speaker.html
+++ b/app/eventyay/agenda/templates/agenda/speaker.html
@@ -30,7 +30,7 @@
 <div>
     {% vite_app_scripts 'schedule' 'src/main-wc.js' fallback='schedule/pretalx-schedule.js' %}
     {% with event_tz=request.event.settings.timezone|default:request.event.timezone %}
-    <pretalx-schedule event-url="{{ request.event.urls.base }}" locale="{{ request.LANGUAGE_CODE }}" view="speaker" speaker-code="{{ profile.user.code }}" enrich-data style="--pretalx-clr-primary: {{ request.event.visible_primary_color }}"></pretalx-schedule>
+    <pretalx-schedule event-url="{{ request.event.urls.base }}" locale="{{ request.LANGUAGE_CODE }}" view="speaker" speaker-code="{{ profile.user.code }}" enrich-data {% if schedule_version %}version="{{ schedule_version }}"{% endif %} style="--pretalx-clr-primary: {{ request.event.visible_primary_color }}"></pretalx-schedule>
     {% endwith %}
     <noscript>
         <h1>{{ profile.user.get_display_name }}</h1>

--- a/app/eventyay/agenda/templates/agenda/speakers.html
+++ b/app/eventyay/agenda/templates/agenda/speakers.html
@@ -16,7 +16,7 @@
 <div>
     {% vite_app_scripts 'schedule' 'src/main-wc.js' fallback='schedule/pretalx-schedule.js' %}
     {% with event_tz=request.event.settings.timezone|default:request.event.timezone %}
-    <pretalx-schedule event-url="{{ request.event.urls.base }}" locale="{{ request.LANGUAGE_CODE }}" view="speakers" style="--pretalx-clr-primary: {{ request.event.visible_primary_color }}"></pretalx-schedule>
+    <pretalx-schedule event-url="{{ request.event.urls.base }}" locale="{{ request.LANGUAGE_CODE }}" view="speakers" {% if schedule_version %}version="{{ schedule_version }}"{% endif %} style="--pretalx-clr-primary: {{ request.event.visible_primary_color }}"></pretalx-schedule>
     {% endwith %}
 </div>
 {% html_signal "eventyay.agenda.signals.html_below_speakers_list" sender=request.event request=request %}

--- a/app/eventyay/agenda/templates/agenda/talk.html
+++ b/app/eventyay/agenda/templates/agenda/talk.html
@@ -31,7 +31,7 @@
     <script id="pretalx-schedule-data" type="application/json">{{ schedule_json|safe }}</script>
     {% vite_app_scripts 'schedule' 'src/main-wc.js' fallback='schedule/pretalx-schedule.js' %}
     {% with event_tz=request.event.settings.timezone|default:request.event.timezone %}
-    <pretalx-schedule event-url="{{ request.event.urls.base }}" locale="{{ request.LANGUAGE_CODE }}" view="talk" talk-code="{{ submission.code }}" {% if request.event.is_video_creation %}join-room-base-url="{{ request.event.urls.video_base }}rooms/"{% endif %} style="--pretalx-clr-primary: {{ request.event.visible_primary_color }}"></pretalx-schedule>
+    <pretalx-schedule event-url="{{ request.event.urls.base }}" locale="{{ request.LANGUAGE_CODE }}" view="talk" talk-code="{{ submission.code }}" {% if schedule_version %}version="{{ schedule_version }}"{% endif %} {% if request.event.is_video_creation %}join-room-base-url="{{ request.event.urls.video_base }}rooms/"{% endif %} style="--pretalx-clr-primary: {{ request.event.visible_primary_color }}"></pretalx-schedule>
     {% endwith %}
     <noscript>
         <h1>{{ submission.title|event_localize }}</h1>

--- a/app/eventyay/agenda/urls.py
+++ b/app/eventyay/agenda/urls.py
@@ -92,6 +92,9 @@ urlpatterns = [
     ),
     *get_schedule_urls('schedule'),
     *get_schedule_urls('schedule/v/<version>', 'versioned-'),
+    path('schedule/v/wip/talk/<slug>/', talk.WipTalkView.as_view(), name='versioned-wip-talk.detail'),
+    path('schedule/v/wip/speakers/', speaker.WipSpeakerList.as_view(), name='versioned-wip-speakers'),
+    path('schedule/v/wip/speakers/<code>/', speaker.WipSpeakerView.as_view(), name='versioned-wip-speaker'),
     path('featured/', featured.FeaturedView.as_view(), name='featured'),
     path('speakers/', speaker.SpeakerList.as_view(), name='speakers'),
     path(

--- a/app/eventyay/agenda/views/schedule.py
+++ b/app/eventyay/agenda/views/schedule.py
@@ -34,6 +34,7 @@ from eventyay.common.signals import register_my_data_exporters
 from eventyay.common.views.mixins import EventPermissionRequired, PermissionRequired
 from eventyay.schedule.ascii import draw_ascii_schedule
 from eventyay.schedule.exporters import ScheduleData
+from eventyay.talk_rules.agenda import require_wip_schedule_access
 from eventyay.talk_rules.submission import are_featured_submissions_visible
 
 
@@ -45,6 +46,21 @@ STARRED_ICS_TOKEN_MIN_VALIDITY = timedelta(seconds=10)
 
 
 class ScheduleMixin:
+    @staticmethod
+    def _version_from_kwargs(kwargs):
+        if version := kwargs.get('version'):
+            return unquote(version)
+        return None
+
+    def ensure_wip_schedule_access(self, kwargs=None, request=None):
+        """WIP preview is restricted to organisers and reviewers with schedule access."""
+        request = request or getattr(self, 'request', None)
+        if request is None:
+            return
+        if self._version_from_kwargs(kwargs or getattr(self, 'kwargs', {})) != 'wip':
+            return
+        require_wip_schedule_access(request)
+
     @cached_property
     def version(self):
         if version := self.kwargs.get('version'):
@@ -144,6 +160,10 @@ class ScheduleMixin:
 class ExporterView(EventPermissionRequired, ScheduleMixin, TemplateView):
     permission_required = 'base.list_schedule'
 
+    def dispatch(self, request, *args, **kwargs):
+        self.ensure_wip_schedule_access(kwargs, request)
+        return super().dispatch(request, *args, **kwargs)
+
     def get(self, request, *args, **kwargs):
         url = resolve(self.request.path_info)
         url_name = url.url_name or ''
@@ -200,7 +220,8 @@ class ScheduleView(PermissionRequired, ScheduleMixin, TemplateView):
         return HttpResponse(response_start + result, content_type='text/plain; charset=utf-8')
 
     def dispatch(self, request, **kwargs):
-        if self.version is None and is_public_schedule_empty(request):
+        self.ensure_wip_schedule_access(kwargs, request)
+        if self._version_from_kwargs(kwargs) is None and is_public_schedule_empty(request):
             if request.resolver_match and request.resolver_match.url_name == 'talks':
                 return redirect_to_presale_with_warning(request, _('No published sessions.'))
             return redirect_to_presale_with_warning(request, _('No published schedule.'))
@@ -309,7 +330,7 @@ class ScheduleView(PermissionRequired, ScheduleMixin, TemplateView):
     def get_context_data(self, **kwargs):
         ctx = super().get_context_data(**kwargs)
         schedule = ctx.get('schedule')
-        version = schedule.version if schedule else None
+        version = self.version or (schedule.version if schedule else None)
         released = list(
             self.request.event.schedules.filter(version__isnull=False)
             .order_by('-published')
@@ -329,6 +350,7 @@ class ScheduleView(PermissionRequired, ScheduleMixin, TemplateView):
             'exporters': build_public_schedule_exporters(self.request.event, version=version),
         }
         ctx['schedule_meta_json'] = escape_json_for_script(json.dumps(meta))
+        ctx['schedule_page_version'] = version or ''
         return ctx
 
 
@@ -354,6 +376,9 @@ def schedule_messages(request, **kwargs):
         'version_warning_editable': _(
             'You are currently viewing the editable schedule version. It may not match the released version.'
         ),
+        'version_warning_wip': _(
+            'You are currently viewing the unreleased schedule preview. It may change at any time and is not visible to the public.'
+        ),
         'version_warning_old': _('You are currently viewing an older schedule version.'),
         'join_room': _('Join room'),
         'view_video': _('View Video'),
@@ -361,6 +386,9 @@ def schedule_messages(request, **kwargs):
         'speaker_fallback': _('Speaker'),
         'speaker_name_not_provided': _('Speaker name not provided'),
         'add_to_calendar': _('Add to Calendar'),
+        'public_schedule_only': _(
+            'Only available on the public schedule once a schedule is released and public.'
+        ),
         'ical': _('iCal'),
         'json': _('JSON'),
         'xml': _('XML'),
@@ -442,6 +470,10 @@ class CalendarRedirectView(EventPermissionRequired, ScheduleMixin, TemplateView)
     """Handles redirects for both Google Calendar and other calendar applications."""
 
     permission_required = 'base.list_schedule'
+
+    def dispatch(self, request, *args, **kwargs):
+        self.ensure_wip_schedule_access(kwargs, request)
+        return super().dispatch(request, *args, **kwargs)
 
     def get(self, request, *args, **kwargs):
         url_name = request.resolver_match.url_name if request.resolver_match else ''

--- a/app/eventyay/agenda/views/speaker.py
+++ b/app/eventyay/agenda/views/speaker.py
@@ -16,7 +16,8 @@ from django.views.generic import DetailView, ListView, TemplateView, View
 from django_context_decorator import context
 from i18nfield.utils import I18nJSONEncoder
 
-from eventyay.agenda.views.utils import is_public_speakers_empty, redirect_to_presale_with_warning
+from eventyay.agenda.views.utils import WipAgendaPreviewPageMixin, is_public_speakers_empty, redirect_to_presale_with_warning
+from eventyay.talk_rules.agenda import agenda_speaker_talks
 from eventyay.base.models import SpeakerProfile, TalkQuestionTarget, User
 from eventyay.common.text.path import safe_filename
 from eventyay.common.urls import get_base_url
@@ -56,9 +57,10 @@ class SpeakerView(PermissionRequired, TemplateView):
     template_name = 'agenda/speaker.html'
     permission_required = 'base.view_speakerprofile'
     slug_field = 'code'
+    wip_preview = False
 
     def dispatch(self, request, *args, **kwargs):
-        if is_public_speakers_empty(request):
+        if not self.wip_preview and is_public_speakers_empty(request):
             return redirect_to_presale_with_warning(request, _('No published speakers.'))
         return super().dispatch(request, *args, **kwargs)
 
@@ -74,15 +76,20 @@ class SpeakerView(PermissionRequired, TemplateView):
     @context
     @cached_property
     def talks(self):
-        if not self.request.event.current_schedule:
-            return []
         return (
-            self.request.event.current_schedule.talks.filter(
-                submission__speakers__code=self.kwargs['code'], is_visible=True
+            agenda_speaker_talks(
+                self.request.event,
+                self.request.user,
+                speaker_code=self.kwargs['code'],
+                wip_preview=self.wip_preview,
             )
             .select_related('submission', 'room', 'submission__event', 'submission__event__organizer')
             .prefetch_related('submission__speakers')
         )
+
+    @context
+    def schedule_version(self):
+        return ''
 
     def get_permission_object(self):
         return self.profile
@@ -94,6 +101,14 @@ class SpeakerView(PermissionRequired, TemplateView):
             question__event=self.request.event,
             question__target=TalkQuestionTarget.SPEAKER,
         ).select_related('question')
+
+
+class WipSpeakerView(WipAgendaPreviewPageMixin, SpeakerView):
+    pass
+
+
+class WipSpeakerList(WipAgendaPreviewPageMixin, TemplateView):
+    template_name = 'agenda/speakers.html'
 
 
 class SpeakerRedirect(DetailView):
@@ -116,13 +131,16 @@ class SpeakerTalksIcalView(PermissionRequired, DetailView):
         return SpeakerProfile.objects.filter(event=self.request.event, user__code__iexact=self.kwargs['code']).first()
 
     def get(self, request, event, *args, **kwargs):
-        if not self.request.event.current_schedule:
+        speaker = self.get_object()
+        slots = agenda_speaker_talks(
+            request.event,
+            request.user,
+            speaker=speaker.user,
+            wip_preview=getattr(self, 'wip_preview', False),
+        ).select_related('room', 'submission')
+        if not slots.exists():
             raise Http404()
         netloc = urlparse(settings.SITE_URL).netloc
-        speaker = self.get_object()
-        slots = self.request.event.current_schedule.talks.filter(
-            submission__speakers=speaker.user, is_visible=True
-        ).select_related('room', 'submission')
 
         cal = vobject.iCalendar()
         cal.add('prodid').value = f'-//eventyay//{netloc}//{request.event.slug}//{speaker.code}'
@@ -156,14 +174,16 @@ class SpeakerTalksExportView(EventPermissionRequired, View):
         )
         if not speaker:
             raise Http404()
-        schedule = request.event.current_schedule
-        if not schedule:
+        slots = agenda_speaker_talks(
+            request.event,
+            request.user,
+            speaker=speaker.user,
+            wip_preview=getattr(self, 'wip_preview', False),
+        ).select_related(
+            'room', 'submission', 'submission__track', 'submission__submission_type'
+        ).prefetch_related('submission__speakers', 'submission__resources')
+        if not slots.exists():
             raise Http404()
-        slots = (
-            schedule.talks.filter(submission__speakers=speaker.user, is_visible=True)
-            .select_related('room', 'submission', 'submission__track', 'submission__submission_type')
-            .prefetch_related('submission__speakers', 'submission__resources')
-        )
         return speaker, slots
 
     def get(self, request, event, **kwargs):
@@ -272,12 +292,12 @@ class SpeakerTalksCalendarRedirectView(EventPermissionRequired, View):
         )
         if not speaker:
             raise Http404()
-        schedule = request.event.current_schedule
-        if not schedule:
-            raise Http404()
-        slots = schedule.talks.filter(submission__speakers=speaker.user, is_visible=True).select_related(
-            'room', 'submission'
-        )
+        slots = agenda_speaker_talks(
+            request.event,
+            request.user,
+            speaker=speaker.user,
+            wip_preview=getattr(self, 'wip_preview', False),
+        ).select_related('room', 'submission')
         if not slots.exists():
             raise Http404()
 

--- a/app/eventyay/agenda/views/talk.py
+++ b/app/eventyay/agenda/views/talk.py
@@ -22,7 +22,8 @@ from django_scopes import scope
 from i18nfield.utils import I18nJSONEncoder
 
 from eventyay.agenda.signals import register_recording_provider
-from eventyay.agenda.views.utils import build_enriched_schedule_json, encode_email, is_email_like
+from eventyay.agenda.views.utils import WipAgendaPreviewPageMixin, build_enriched_schedule_json, encode_email, is_email_like
+from eventyay.talk_rules.agenda import agenda_schedule_for_user, can_view_wip_schedule, filter_agenda_slots
 from eventyay.base.models import (
     Event,
     Order,
@@ -63,6 +64,7 @@ class VideoJoinError(StrEnum):
 
 class TalkMixin(PermissionRequired):
     permission_required = 'base.view_public_submission'
+    wip_preview = False
 
     def get_queryset(self):
         return self.request.event.submissions.prefetch_related(
@@ -84,6 +86,21 @@ class TalkMixin(PermissionRequired):
 
     def get_permission_object(self):
         return self.submission
+
+    def agenda_schedule(self):
+        return agenda_schedule_for_user(
+            self.request.event,
+            self.request.user,
+            wip_preview=self.wip_preview,
+        )
+
+    def filter_visible_slots(self, qs):
+        return filter_agenda_slots(
+            qs,
+            self.request.user,
+            self.request.event,
+            wip_preview=self.wip_preview,
+        )
 
 
 def talk_starrers(request, event, slug, **kwargs):
@@ -166,6 +183,10 @@ class TalkView(TalkMixin, TemplateView):
     def schedule_json(self):
         return build_enriched_schedule_json(self.request)
 
+    @context
+    def schedule_version(self):
+        return ''
+
     def get_contrast_color(self, bg_color):
         if not bg_color:
             return ''
@@ -207,7 +228,7 @@ class TalkView(TalkMixin, TemplateView):
         from django.db.models import Prefetch
 
         ctx = super().get_context_data(**kwargs)
-        schedule = self.request.event.current_schedule or self.request.event.wip_schedule
+        schedule = self.agenda_schedule()
         if not self.request.user.has_perm('base.view_schedule', schedule):
             return ctx
         qs = schedule.talks.filter(room__isnull=False).select_related('room') if schedule else TalkSlot.objects.none()
@@ -216,7 +237,9 @@ class TalkView(TalkMixin, TemplateView):
         for tag_item in ctx['submission_tags']:
             tag_item.contrast_color = self.get_contrast_color(tag_item.color)
         other_slots = (
-            schedule.talks.exclude(submission_id=self.submission.pk).filter(is_visible=True)
+            self.filter_visible_slots(
+                schedule.talks.exclude(submission_id=self.submission.pk)
+            )
             if schedule
             else TalkSlot.objects.none()
         )
@@ -255,6 +278,18 @@ class TalkView(TalkMixin, TemplateView):
     @cached_property
     def answers(self):
         return self.submission.public_answers
+
+
+class WipTalkView(WipAgendaPreviewPageMixin, TalkView):
+    def has_permission(self):
+        wip = self.request.event.wip_schedule
+        if not wip:
+            return False
+        return self.submission.slots.filter(schedule=wip).exists()
+
+    @context
+    def schedule_json(self):
+        return build_enriched_schedule_json(self.request, wip_preview=True)
 
 
 class TalkReviewView(TalkView):
@@ -312,9 +347,9 @@ class TalkReviewView(TalkView):
 class SingleICalView(EventPageMixin, TalkMixin, View):
     def get(self, request, event, **kwargs):
         code = self.submission.code
-        schedule = self.request.event.current_schedule or self.request.event.wip_schedule
+        schedule = self.agenda_schedule()
         talk_slots = (
-            self.submission.slots.filter(schedule=schedule, is_visible=True)
+            self.filter_visible_slots(self.submission.slots.filter(schedule=schedule))
             if schedule
             else self.submission.slots.none()
         )
@@ -338,11 +373,11 @@ class SingleExportView(EventPageMixin, TalkMixin, View):
 
     def get(self, request, event, slug, **kwargs):
         fmt = kwargs.get('format', '')
-        schedule = request.event.current_schedule or request.event.wip_schedule
+        schedule = self.agenda_schedule()
         if not schedule:
             raise Http404
         talk_slots = (
-            self.submission.slots.filter(schedule=schedule, is_visible=True)
+            self.filter_visible_slots(self.submission.slots.filter(schedule=schedule))
             .select_related('room', 'submission', 'submission__track', 'submission__submission_type')
             .prefetch_related('submission__speakers', 'submission__resources')
         )
@@ -460,10 +495,10 @@ class SingleCalendarRedirectView(EventPageMixin, TalkMixin, View):
 
     def get(self, request, event, slug, **kwargs):
         provider = kwargs.get('provider', '')
-        schedule = request.event.current_schedule or request.event.wip_schedule
+        schedule = self.agenda_schedule()
         if not schedule:
             raise Http404
-        talk_slots = self.submission.slots.filter(schedule=schedule, is_visible=True)
+        talk_slots = self.filter_visible_slots(self.submission.slots.filter(schedule=schedule))
         if not talk_slots.exists():
             raise Http404
 

--- a/app/eventyay/agenda/views/utils.py
+++ b/app/eventyay/agenda/views/utils.py
@@ -12,6 +12,7 @@ from django.urls import NoReverseMatch, reverse
 from django.utils import timezone
 from django.utils.encoding import force_str
 from django.utils.translation import activate
+from django_context_decorator import context
 from i18nfield.utils import I18nJSONEncoder
 
 from eventyay.base.models.submission import SubmissionFavourite
@@ -19,6 +20,7 @@ from eventyay.common.exporter import BaseExporter
 from eventyay.common.signals import register_data_exporters, register_my_data_exporters
 from eventyay.common.text.path import safe_filename
 from eventyay.schedule.exporters import FavedICalExporter
+from eventyay.talk_rules.agenda import require_wip_schedule_access
 from eventyay.talk_rules.submission import are_featured_submissions_visible
 
 
@@ -31,21 +33,28 @@ def escape_json_for_script(json_str: str) -> str:
     return json_str.translate(JSON_SCRIPT_ESCAPES)
 
 
-def build_enriched_schedule_json(request: HttpRequest) -> str:
-    """Serialize the current schedule for inline first-party agenda views.
+def build_enriched_schedule_json(request: HttpRequest, *, wip_preview: bool = False) -> str:
+    """Serialize schedule data for inline first-party agenda views.
 
-    Some public pages, such as featured talk pages, remain accessible even when the
-    standalone widget JSON endpoint is intentionally hidden. Those pages need a
-    self-contained payload instead of depending on ``widgets/schedule.json``.
+    Public talk/speaker pages embed the released schedule. WIP preview pages
+    (``schedule/v/wip/...``) embed the editable WIP schedule without public
+    visibility filters.
     """
 
-    schedule = request.event.current_schedule
+    event = request.event
+    if wip_preview:
+        require_wip_schedule_access(request)
+        schedule = event.wip_schedule
+    else:
+        schedule = event.current_schedule
     if not schedule:
         return '{}'
 
     data = schedule.build_data(
+        all_talks=wip_preview or not schedule.version,
         enrich=True,
-        include_featured_speaker_metadata=are_featured_submissions_visible(request.user, request.event),
+        include_featured_speaker_metadata=are_featured_submissions_visible(request.user, event),
+        respect_public_visibility=not wip_preview,
     )
     return escape_json_for_script(json.dumps(data, cls=I18nJSONEncoder))
 
@@ -292,3 +301,17 @@ def get_schedule_exporter_content(request, exporter_name, schedule, token=None):
     if exporter.cors:
         headers['Access-Control-Allow-Origin'] = exporter.cors
     return HttpResponse(data, content_type=file_type, headers=headers)
+
+
+class WipAgendaPreviewPageMixin:
+    """Shared setup for first-party HTML pages under ``schedule/v/wip/``."""
+
+    wip_preview = True
+
+    def dispatch(self, request, *args, **kwargs):
+        require_wip_schedule_access(request)
+        return super().dispatch(request, *args, **kwargs)
+
+    @context
+    def schedule_version(self):
+        return 'wip'

--- a/app/eventyay/agenda/views/widget.py
+++ b/app/eventyay/agenda/views/widget.py
@@ -14,7 +14,12 @@ from i18nfield.utils import I18nJSONEncoder
 from eventyay.base.models import SpeakerProfile, TalkSlot
 from eventyay.base.models.schedule import make_qr_svg
 from eventyay.common.views import conditional_cache_page
-from eventyay.talk_rules.agenda import is_widget_visible
+from eventyay.talk_rules.agenda import (
+    can_access_schedule_widget,
+    can_view_wip_schedule,
+    is_widget_visible,
+    wip_preview_build_data,
+)
 from eventyay.talk_rules.submission import (
     are_featured_submissions_visible,
     schedule_widget_featured_cache_key_part,
@@ -119,13 +124,13 @@ def widget_data(request, organizer=None, event=None, version=None, **kwargs):
         response['Access-Control-Allow-Headers'] = 'authorization,content-type'
         response['Access-Control-Allow-Methods'] = 'GET, OPTIONS'
         return response
-    if not request.user.has_perm('base.view_widget_schedule', event):
+    if not can_access_schedule_widget(request.user, event):
         raise Http404()
 
     version = version or unquote(request.GET.get('v') or '')
     schedule = None
     if version and version == 'wip':
-        if not request.user.has_perm('base.orga_view_schedule', event):
+        if not can_view_wip_schedule(request.user, event):
             raise Http404()
         schedule = request.event.wip_schedule
     elif version:
@@ -137,11 +142,13 @@ def widget_data(request, organizer=None, event=None, version=None, **kwargs):
 
     enrich = request.GET.get('enrich') in {'1', 'true', 'True'}
     include_qrcodes = request.GET.get('qrcodes') in {'1', 'true', 'True'}
+    preview = wip_preview_build_data(request.user, event, schedule)
     result = schedule.build_data(
         all_talks=not schedule.version,
         enrich=enrich,
         include_featured_speaker_metadata=are_featured_submissions_visible(AnonymousUser(), event),
         include_qrcodes=include_qrcodes,
+        respect_public_visibility=not preview,
     )
     response = JsonResponse(result, encoder=I18nJSONEncoder)
     response['Access-Control-Allow-Headers'] = 'authorization,content-type'
@@ -169,13 +176,13 @@ def widget_qrcodes(request, organizer=None, event=None, version=None, kind=None,
         response['Access-Control-Allow-Headers'] = 'authorization,content-type'
         response['Access-Control-Allow-Methods'] = 'GET, OPTIONS'
         return response
-    if not request.user.has_perm('base.view_widget_schedule', event):
+    if not can_access_schedule_widget(request.user, event):
         raise Http404()
 
     version = version or unquote(request.GET.get('v') or '')
     schedule = None
     if version and version == 'wip':
-        if not request.user.has_perm('base.orga_view_schedule', event):
+        if not can_view_wip_schedule(request.user, event):
             raise Http404()
         schedule = request.event.wip_schedule
     elif version:
@@ -187,12 +194,10 @@ def widget_qrcodes(request, organizer=None, event=None, version=None, kind=None,
     # Validate that the requested entity exists in this event/schedule to avoid
     # unbounded cache entries and unnecessary CPU work for random codes.
     if kind == 'talk':
-        exists = TalkSlot.objects.filter(
-            schedule=schedule,
-            is_visible=True,
-            submission__isnull=False,
-            submission__code__iexact=code,
-        ).exists()
+        talk_filter = {'schedule': schedule, 'submission__isnull': False, 'submission__code__iexact': code}
+        if not wip_preview_build_data(request.user, event, schedule):
+            talk_filter['is_visible'] = True
+        exists = TalkSlot.objects.filter(**talk_filter).exists()
         if not exists:
             raise Http404()
     elif kind == 'speaker':

--- a/app/eventyay/base/models/schedule.py
+++ b/app/eventyay/base/models/schedule.py
@@ -28,9 +28,12 @@ from eventyay.common.text.phrases import phrases
 from eventyay.common.urls import EventUrls
 from eventyay.schedule.notifications import render_notifications
 from eventyay.schedule.signals import schedule_release
-from eventyay.talk_rules.agenda import can_view_schedule, is_agenda_visible, is_widget_visible
-from eventyay.talk_rules.orga import can_view_speaker_names
-from eventyay.talk_rules.person import is_reviewer
+from eventyay.talk_rules.agenda import (
+    can_view_schedule,
+    can_view_wip_schedule,
+    is_agenda_visible,
+    is_widget_visible,
+)
 from eventyay.talk_rules.submission import is_wip, orga_can_change_submissions
 
 from .auth import (
@@ -97,12 +100,10 @@ class Schedule(PretalxModel):
         ordering = ('-published',)
         unique_together = (('event', 'version'),)
         rules_permissions = {
-            'list': can_view_schedule,
-            'view_widget': is_widget_visible | orga_can_change_submissions,
-            'view': (~is_wip & is_agenda_visible)
-            | orga_can_change_submissions
-            | (is_reviewer & can_view_speaker_names),
-            'orga_view': orga_can_change_submissions | (is_reviewer & can_view_speaker_names),
+            'list': (~is_wip & can_view_schedule) | can_view_wip_schedule,
+            'view_widget': is_widget_visible | can_view_wip_schedule,
+            'view': (~is_wip & is_agenda_visible) | can_view_wip_schedule,
+            'orga_view': can_view_wip_schedule,
             'release': orga_can_change_submissions,
         }
 

--- a/app/eventyay/base/models/slot.py
+++ b/app/eventyay/base/models/slot.py
@@ -17,7 +17,7 @@ from i18nfield.fields import I18nCharField
 from eventyay.base.models import PretalxModel
 from eventyay.common.text.serialize import serialize_duration
 from eventyay.common.urls import get_base_url
-from eventyay.talk_rules.agenda import is_agenda_submission_visible, is_agenda_visible
+from eventyay.talk_rules.agenda import can_view_wip_schedule, is_agenda_submission_visible, is_agenda_visible
 from eventyay.talk_rules.submission import is_break, is_wip, orga_can_change_submissions
 
 
@@ -78,7 +78,8 @@ class TalkSlot(PretalxModel):
                 # is down to the API/view
                 & ((is_break & is_agenda_visible) | is_agenda_submission_visible)
             )
-            | orga_can_change_submissions,
+            | orga_can_change_submissions
+            | (is_wip & can_view_wip_schedule),
             'update': is_wip & orga_can_change_submissions,
         }
 

--- a/app/eventyay/base/models/submission.py
+++ b/app/eventyay/base/models/submission.py
@@ -328,6 +328,7 @@ class Submission(GenerateCode, PretalxModel):
         confirm = '{user_base}confirm'
         public_base = '{self.event.urls.base}talk/{self.code}'
         public = '{public_base}/'
+        wip_public = '{self.event.urls.base}schedule/v/wip/talk/{self.code}/'
         feedback = '{public}feedback/'
         social_image = '{public}og-image'
         ical = '{public_base}.ics'

--- a/app/eventyay/common/templates/common/fragment_nav.html
+++ b/app/eventyay/common/templates/common/fragment_nav.html
@@ -27,19 +27,20 @@
     {% endif %}
     {% if show_talks_tab %}
         {% can_list_schedule current_event as show_schedule_tab %}
-        {% if show_schedule_tab and current_event.has_schedule_content %}
-            {% with schedule_url=current_event.talk_schedule_url|default:current_event.urls.schedule %}
-                <a href="{{ schedule_url }}" class="header-tab {% if '/schedule/' in path %}active{% endif %}">
+        {% is_wip_agenda_preview request as wip_preview %}
+        {% if show_schedule_tab %}
+        {% if current_event.has_schedule_content or wip_preview or schedule %}
+            {% agenda_schedule_nav_url request current_event as schedule_url %}
+                <a href="{{ schedule_url }}" class="header-tab {% if '/schedule/' in path and '/speakers/' not in path and '/talk/' not in path %}active{% endif %}">
                     <i class="fa fa-calendar"></i> {{ schedule_label }}
                 </a>
-            {% endwith %}
             {% if current_event.speakers.exists %}
-                {% with speakers_url=current_event.talk_speaker_url|default:current_event.urls.speakers %}
+                {% agenda_speakers_nav_url request current_event as speakers_url %}
                     <a href="{{ speakers_url }}" class="header-tab {% if '/speakers/' in path %}active{% endif %}">
                         <i class="fa fa-group"></i> {{ speakers_label }}
                     </a>
-                {% endwith %}
             {% endif %}
+        {% endif %}
         {% endif %}
     {% endif %}
 

--- a/app/eventyay/common/templatetags/nav_tags.py
+++ b/app/eventyay/common/templatetags/nav_tags.py
@@ -1,8 +1,11 @@
 from django import template
 from django.conf import settings
+from django.urls import reverse
 from django.utils import translation
 from django.utils.translation import gettext_lazy as _
 from i18nfield.strings import LazyI18nString
+
+from eventyay.talk_rules.agenda import is_wip_agenda_url
 
 register = template.Library()
 
@@ -72,3 +75,34 @@ def get_localized_menu_label(event, label_setting):
     if custom_label:
         return custom_label
     return MENU_LABEL_DEFAULTS.get(label_setting, '')
+
+
+@register.simple_tag
+def is_wip_agenda_preview(request):
+    return is_wip_agenda_url(getattr(request, 'path_info', ''))
+
+
+def _agenda_event_url_kwargs(event):
+    return {'organizer': event.organizer.slug, 'event': event.slug}
+
+
+@register.simple_tag
+def agenda_schedule_nav_url(request, event):
+    """Return the schedule tab URL, preserving WIP preview when applicable."""
+    if is_wip_agenda_url(getattr(request, 'path_info', '')):
+        return reverse(
+            'agenda:versioned-schedule',
+            kwargs={**_agenda_event_url_kwargs(event), 'version': 'wip'},
+        )
+    return event.talk_schedule_url
+
+
+@register.simple_tag
+def agenda_speakers_nav_url(request, event):
+    """Return the speakers tab URL, preserving WIP preview when applicable."""
+    if is_wip_agenda_url(getattr(request, 'path_info', '')):
+        return reverse(
+            'agenda:versioned-wip-speakers',
+            kwargs=_agenda_event_url_kwargs(event),
+        )
+    return event.talk_speaker_url

--- a/app/eventyay/static/agenda/css/_agenda.css
+++ b/app/eventyay/static/agenda/css/_agenda.css
@@ -511,3 +511,90 @@ article .pretalx-session .pretalx-session-info .abstract {
 .markdown-column .form-group {
   flex-direction: column;
 }
+
+dialog.agenda-wip-preview-leave-dialog {
+  border: none;
+  padding: 0;
+  border-radius: 8px;
+  box-shadow: 0 12px 40px rgba(0, 0, 0, 0.18);
+  max-width: min(460px, calc(100vw - 32px));
+  width: 100%;
+}
+
+dialog.agenda-wip-preview-leave-dialog[open] {
+  position: fixed;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  margin: 0;
+  animation: agenda-wip-preview-leave-dialog-in 0.2s ease-out;
+}
+
+dialog.agenda-wip-preview-leave-dialog::backdrop {
+  background-color: rgba(0, 0, 0, 0.35);
+  backdrop-filter: blur(2px);
+}
+
+@keyframes agenda-wip-preview-leave-dialog-in {
+  from {
+    opacity: 0;
+    transform: translate(-50%, calc(-50% + 8px));
+  }
+
+  to {
+    opacity: 1;
+    transform: translate(-50%, -50%);
+  }
+}
+
+.agenda-wip-preview-leave-dialog__card {
+  background: #fff;
+  border-radius: 8px;
+  padding: 32px 28px 24px;
+  text-align: center;
+}
+
+.agenda-wip-preview-leave-dialog__icon {
+  margin: 0 0 16px;
+}
+
+.agenda-wip-preview-leave-dialog__icon .fa {
+  font-size: 48px;
+  color: var(--color-primary, #2185d0);
+  line-height: 1;
+}
+
+.agenda-wip-preview-leave-dialog__card h3 {
+  margin: 0 0 12px;
+  font-size: 1.25rem;
+  font-weight: 600;
+  line-height: 1.3;
+}
+
+.agenda-wip-preview-leave-dialog__message {
+  margin: 0 0 24px;
+  line-height: 1.5;
+  color: #444;
+}
+
+.agenda-wip-preview-leave-dialog__actions {
+  display: flex;
+  justify-content: center;
+  flex-wrap: wrap;
+  gap: 10px;
+}
+
+.agenda-wip-preview-leave-dialog__actions .btn {
+  min-width: 132px;
+}
+
+@media (max-width: 480px) {
+  .agenda-wip-preview-leave-dialog__actions {
+    flex-direction: column-reverse;
+  }
+
+  .agenda-wip-preview-leave-dialog__actions .btn {
+    width: 100%;
+    min-width: 0;
+  }
+}

--- a/app/eventyay/static/agenda/js/wip-preview-guard.js
+++ b/app/eventyay/static/agenda/js/wip-preview-guard.js
@@ -1,0 +1,104 @@
+const WIP_PATH_MARKER = '/schedule/v/wip/' // keep in sync with talk_rules.agenda.WIP_AGENDA_URL_PATH
+const DIALOG_ID = 'agenda-wip-preview-leave-dialog'
+
+function isWipPreviewPath(pathname) {
+	return pathname.includes(WIP_PATH_MARKER)
+}
+
+function navigationStaysInWipPreview(href) {
+	const url = new URL(href, window.location.href)
+	if (url.origin !== window.location.origin) {
+		return true
+	}
+	return isWipPreviewPath(url.pathname)
+}
+
+function shouldInterceptLinkClick(event, link) {
+	if (!link || link.target === '_blank' || link.hasAttribute('download')) {
+		return false
+	}
+	if (event.defaultPrevented || event.button !== 0) {
+		return false
+	}
+	if (event.metaKey || event.ctrlKey || event.shiftKey || event.altKey) {
+		return false
+	}
+	const href = link.getAttribute('href')
+	if (!href || href.startsWith('#')) {
+		return false
+	}
+	return !navigationStaysInWipPreview(href)
+}
+
+function confirmLeavePreview() {
+	const dialog = document.getElementById(DIALOG_ID)
+	if (!dialog || typeof dialog.showModal !== 'function') {
+		return Promise.resolve(false)
+	}
+
+	return new Promise((resolve) => {
+		const stayButton = dialog.querySelector('[data-wip-preview-action="stay"]')
+		const leaveButton = dialog.querySelector('[data-wip-preview-action="leave"]')
+		if (!stayButton || !leaveButton) {
+			resolve(false)
+			return
+		}
+
+		const finish = (confirmed) => {
+			stayButton.removeEventListener('click', onStay)
+			leaveButton.removeEventListener('click', onLeave)
+			dialog.removeEventListener('cancel', onStay)
+			dialog.removeEventListener('click', onBackdropClick)
+			if (dialog.open) {
+				dialog.close()
+			}
+			resolve(confirmed)
+		}
+		const onStay = () => finish(false)
+		const onLeave = () => finish(true)
+		const onBackdropClick = (event) => {
+			if (event.target === dialog) {
+				finish(false)
+			}
+		}
+
+		stayButton.addEventListener('click', onStay)
+		leaveButton.addEventListener('click', onLeave)
+		dialog.addEventListener('cancel', onStay)
+		dialog.addEventListener('click', onBackdropClick)
+		dialog.showModal()
+		stayButton.focus()
+	})
+}
+
+function initWipPreviewGuard() {
+	if (!isWipPreviewPath(window.location.pathname)) {
+		return
+	}
+	if (!document.getElementById(DIALOG_ID)) {
+		return
+	}
+
+	document.addEventListener('click', (event) => {
+		const link = event.target.closest('a[href]')
+		if (!shouldInterceptLinkClick(event, link)) {
+			return
+		}
+
+		event.preventDefault()
+		event.stopImmediatePropagation()
+
+		const destination = link.href
+		confirmLeavePreview().then((confirmed) => {
+			if (confirmed) {
+				window.location.assign(destination)
+			}
+		})
+	}, true)
+}
+
+if (document.readyState === 'loading') {
+	document.addEventListener('DOMContentLoaded', initWipPreviewGuard)
+} else {
+	initWipPreviewGuard()
+}

--- a/app/eventyay/talk_rules/agenda.py
+++ b/app/eventyay/talk_rules/agenda.py
@@ -1,4 +1,5 @@
 import rules
+from django.http import Http404
 
 from .orga import can_view_speaker_names
 from .person import is_reviewer
@@ -22,6 +23,70 @@ def is_submission_visible_via_schedule(user, submission):
 
 
 @rules.predicate
+def can_view_wip_schedule(user, obj):
+    """Organisers and reviewers with schedule access; never anonymous public visitors."""
+    event = getattr(obj, 'event', None)
+    if event is None and hasattr(obj, 'schedule'):
+        event = obj.schedule.event
+    if event is None and hasattr(obj, 'submission'):
+        event = getattr(getattr(obj, 'submission', None), 'event', None)
+    if not event or not user or user.is_anonymous:
+        return False
+    if orga_can_change_submissions(user, event):
+        return True
+    return bool(is_reviewer(user, event) and can_view_speaker_names(user, event))
+
+
+WIP_AGENDA_URL_PATH = '/schedule/v/wip/'
+
+
+def is_wip_agenda_url(path):
+    return WIP_AGENDA_URL_PATH in (path or '')
+
+
+def require_wip_schedule_access(request):
+    if not can_view_wip_schedule(request.user, request.event):
+        raise Http404()
+
+
+def agenda_schedule_for_user(event, user, *, wip_preview=False):
+    """Return the schedule backing an agenda page."""
+    if wip_preview:
+        return event.wip_schedule
+    return event.current_schedule or event.wip_schedule
+
+
+def filter_agenda_slots(qs, user, event, *, wip_preview=False):
+    """Apply public ``is_visible`` filtering unless this is a WIP preview page."""
+    if wip_preview:
+        return qs
+    return qs.filter(is_visible=True)
+
+
+def wip_preview_build_data(user, event, schedule):
+    """Whether ``build_data`` should bypass release visibility for this schedule."""
+    return bool(schedule and not schedule.version and can_view_wip_schedule(user, event))
+
+
+def can_access_schedule_widget(user, event):
+    return user.has_perm('base.view_widget_schedule', event) or can_view_wip_schedule(user, event)
+
+
+def agenda_speaker_talks(event, user, *, speaker=None, speaker_code=None, wip_preview=False):
+    schedule = agenda_schedule_for_user(event, user, wip_preview=wip_preview)
+    if not schedule:
+        from eventyay.base.models import TalkSlot
+
+        return TalkSlot.objects.none()
+    qs = schedule.talks.all()
+    if speaker is not None:
+        qs = qs.filter(submission__speakers=speaker)
+    elif speaker_code is not None:
+        qs = qs.filter(submission__speakers__code=speaker_code)
+    return filter_agenda_slots(qs, user, event, wip_preview=wip_preview)
+
+
+@rules.predicate
 def is_agenda_visible(user, event):
     event = event.event
     return bool(event and event.talks_published and event.get_feature_flag('show_schedule') and event.current_schedule)
@@ -35,7 +100,10 @@ def is_agenda_submission_visible(user, submission):
     submission = getattr(submission, 'submission', submission)
     if not submission:
         return False
-    return is_submission_visible_via_schedule(user, submission) or is_submission_visible_via_featured(user, submission)
+    return (
+        is_submission_visible_via_schedule(user, submission)
+        or is_submission_visible_via_featured(user, submission)
+    )
 
 
 @rules.predicate

--- a/app/eventyay/talk_rules/submission.py
+++ b/app/eventyay/talk_rules/submission.py
@@ -283,6 +283,9 @@ def limit_for_reviewers(queryset, event, user, reviewer_tracks=None, add_assignm
 
 
 def submissions_for_user(event, user):
+    from eventyay.base.models import Submission
+    from eventyay.talk_rules.agenda import can_view_wip_schedule
+
     if not user.is_anonymous:
         if is_only_reviewer(user, event):
             return limit_for_reviewers(event.submissions.all(), event, user)
@@ -291,8 +294,16 @@ def submissions_for_user(event, user):
 
     # Fall through: both anon users and users without permissions
     # get here, e.g. speakers or attendees.
+    wip = event.wip_schedule
+    if not user.is_anonymous and wip and can_view_wip_schedule(user, event):
+        return Submission.objects.filter(
+            pk__in=wip.talks.filter(submission__isnull=False).values_list('submission_id', flat=True)
+        )
+
     if user.has_perm('base.list_schedule', event):
-        return event.current_schedule.slots
+        current = event.current_schedule
+        if current:
+            return current.slots
     return event.submissions.none()
 
 

--- a/app/eventyay/webapp/schedule/src/App.vue
+++ b/app/eventyay/webapp/schedule/src/App.vue
@@ -11,7 +11,7 @@
 		speaker-detail(v-else-if="view === 'speaker'", :speakerId="speakerCode", :onHomeServer="onHomeServer")
 	template(v-else-if="schedule && schedule.talks.length")
 		schedule-toolbar(v-if="(scheduleMeta || schedule) && !publicFavsUrl",
-			:version="scheduleMeta?.version || ''",
+			:version="version || scheduleMeta?.version || ''",
 			:isCurrent="scheduleMeta?.is_current !== false",
 			:changelogUrl="scheduleMeta?.changelog_url || ''",
 			:currentScheduleUrl="scheduleMeta?.current_schedule_url || ''",
@@ -219,6 +219,10 @@ export default {
 		}
 	},
 	provide () {
+		const wipLinkPrefix = () => {
+			const version = this.version || this.scheduleMeta?.version || ''
+			return version === 'wip' ? 'schedule/v/wip/' : ''
+		}
 		return {
 			eventUrl: this.eventUrl,
 			remoteApiUrl: computed(() => this.remoteApiUrl),
@@ -228,6 +232,10 @@ export default {
 				event.preventDefault()
 
 				this.showSessionDetails(session, event)
+			},
+			generateSessionLinkUrl: ({eventUrl, session}) => {
+				if (!this.onHomeServer) return `#session/${session.id}/`
+				return `${eventUrl}${wipLinkPrefix()}talk/${session.id}/`
 			},
 			scheduleFav: (id) => this.fav(id),
 			scheduleUnfav: (id) => this.unfav(id),
@@ -252,7 +260,7 @@ export default {
 				return roomId ? `${base}${roomId}/` : ''
 			},
 			generateSpeakerLinkUrl: ({speaker}) => {
-				if (this.onHomeServer) return `${this.eventUrl}speakers/${speaker.code}/`
+				if (this.onHomeServer) return `${this.eventUrl}${wipLinkPrefix()}speakers/${speaker.code}/`
 				return `#speakers/${speaker.code}`
 			},
 			onSpeakerLinkClick: (event, speaker) => {
@@ -262,7 +270,8 @@ export default {
 				}
 			},
 			loggedIn: computed(() => this.loggedIn),
-			translationMessages: computed(() => this.translationMessages)
+			translationMessages: computed(() => this.translationMessages),
+			isWipPreview: computed(() => (this.version || this.scheduleMeta?.version || '') === 'wip')
 		}
 	},
 	data () {

--- a/app/eventyay/webapp/schedule/src/components/ExportDropdown.vue
+++ b/app/eventyay/webapp/schedule/src/components/ExportDropdown.vue
@@ -1,6 +1,10 @@
 <template lang="pug">
 .c-export-dropdown(ref="dropdown")
-	button.export-toggle(@click="toggle")
+	button.export-toggle(
+		@click="toggle",
+		:class="{disabled}",
+		:aria-label="disabled ? resolvedDisabledHint : undefined"
+	)
 		svg.export-icon(viewBox="0 0 24 24", fill="none", stroke="currentColor", stroke-width="2")
 			path(d="M21 15v4a2 2 0 01-2 2H5a2 2 0 01-2-2v-4")
 			polyline(points="7 10 12 15 17 10")
@@ -43,6 +47,14 @@ export default {
 		qrcodesUrl: {
 			type: String,
 			default: ''
+		},
+		disabled: {
+			type: Boolean,
+			default: false
+		},
+		disabledHint: {
+			type: String,
+			default: ''
 		}
 	},
 	emits: ['export'],
@@ -70,7 +82,11 @@ export default {
 			const m = this.translationMessages || {}
 			return {
 				exports: m.exports || 'Exports',
+				public_schedule_only: m.public_schedule_only || 'Only available on the public schedule once a schedule is released and public.',
 			}
+		},
+		resolvedDisabledHint() {
+			return this.disabledHint || this.t.public_schedule_only
 		},
 		exportOptions() {
 			const q = this.qrcodes || {}
@@ -94,6 +110,7 @@ export default {
 			return FA_SVG_MAP[icon] || '<circle cx="12" cy="12" r="10"/>'
 		},
 		toggle() {
+			if (this.disabled) return
 			this.isOpen = !this.isOpen
 			if (this.isOpen) {
 				this.ensureQrcodesLoaded()
@@ -176,6 +193,35 @@ export default {
 		gap: 4px
 		&:hover
 			background-color: rgba(0, 0, 0, 0.05)
+		&.disabled
+			opacity: 0.5
+			cursor: not-allowed
+			&[aria-label]
+				position: relative
+				&::after
+					content: attr(aria-label)
+					position: absolute
+					top: calc(100% + 6px)
+					right: 0
+					transform: translateY(-2px)
+					opacity: 0
+					pointer-events: none
+					background-color: rgba(0, 0, 0, 0.87)
+					color: #fff
+					padding: 6px 8px
+					border-radius: 4px
+					font-size: 12px
+					line-height: 1.3
+					white-space: normal
+					width: max-content
+					max-width: 280px
+					z-index: 1000
+				&:hover::after, &:focus-visible::after
+					opacity: 1
+					transform: translateY(0)
+					transition: opacity 0.05s ease, transform 0.05s ease
+			&:hover
+				background-color: transparent
 	.export-icon
 		width: 16px
 		height: 16px

--- a/app/eventyay/webapp/schedule/src/components/ScheduleToolbar.vue
+++ b/app/eventyay/webapp/schedule/src/components/ScheduleToolbar.vue
@@ -1,8 +1,8 @@
 <template lang="pug">
 .c-schedule-toolbar(:class="{'mobile-filters-open': mobileFiltersOpen, 'mobile-more-open': mobileMoreOpen}")
-	.version-warning-banner(v-if="version && !isCurrent", ref="versionBanner")
+	.version-warning-banner(v-if="showVersionWarningBanner", ref="versionBanner")
 		span.version-warning-text {{ versionWarningText }}
-		a.current-version-link(v-if="currentScheduleUrl", :href="currentScheduleUrl")
+		a.current-version-link(v-if="currentScheduleUrl && !isWipPreview", :href="currentScheduleUrl")
 			|  {{ t.go_to_current_version }}
 	.toolbar-row
 		.toolbar-left
@@ -226,11 +226,12 @@
 								)
 									span {{ option.label }}
 				.timezone-label(v-else) {{ scheduleTimezone }}
-				.exporter-area(v-if="resolvedExporters.length")
+				.exporter-area(v-if="resolvedExporters.length || isWipPreview")
 					.exporter-dropdown(ref="exportDropdown")
-						button.toolbar-btn.icon-only(
-							@click="exportOpen = !exportOpen",
-							:aria-label="t.add_to_calendar",
+						button.toolbar-btn.icon-only.tooltip-align-right(
+							:class="{disabled: isWipPreview}",
+							@click="!isWipPreview && (exportOpen = !exportOpen)",
+							:aria-label="isWipPreview ? publicOnlyFeatureHint : t.add_to_calendar",
 							:aria-expanded="exportOpen ? 'true' : 'false'",
 							aria-haspopup="menu")
 							svg.tb-icon(viewBox="0 0 24 24", fill="none", stroke="currentColor", stroke-width="2", stroke-linecap="round", stroke-linejoin="round")
@@ -255,9 +256,13 @@
 								transition(name="fade")
 									.qr-hover(v-if="hoveredExporter === exp && exp.qrcode_svg", v-html="exp.qrcode_svg")
 			.toolbar-secondary(:class="{open: mobileMoreOpen}", ref="mobileMorePanel")
-				.version-area(v-if="versionOptions.length || changelogUrl")
+				.version-area(v-if="versionOptions.length || changelogUrl || isWipPreview")
 					.version-dropdown(ref="versionDropdown")
-						button.toolbar-btn.version-btn(@click="versionOpen = !versionOpen")
+						button.toolbar-btn.version-btn.tooltip-align-right(
+							:class="{disabled: isWipPreview}",
+							@click="!isWipPreview && (versionOpen = !versionOpen)",
+							:aria-label="isWipPreview ? publicOnlyFeatureHint : undefined"
+						)
 							svg.tb-icon(viewBox="0 0 24 24", fill="none", stroke="currentColor", stroke-width="2")
 								path(d="M12 8v4l3 3")
 								circle(cx="12", cy="12", r="10")
@@ -416,8 +421,10 @@ export default {
 				exit_fullscreen: m.exit_fullscreen || 'Exit Fullscreen',
 				latest: m.latest || 'Latest',
 				version_warning_editable: m.version_warning_editable || 'You are currently viewing the editable schedule version, which is unreleased and may change at any time.',
+				version_warning_wip: m.version_warning_wip || 'You are currently viewing the unreleased schedule preview. It may change at any time and is not visible to the public.',
 				version_warning_old: m.version_warning_old || 'You are currently viewing an older schedule version.',
 				add_to_calendar: m.add_to_calendar || 'Add to calendar',
+				public_schedule_only: m.public_schedule_only || 'Only available on the public schedule once a schedule is released and public.',
 				export: m.export || 'Export',
 				current: m.current || 'current',
 				list_view: m.list_view || 'List View',
@@ -491,6 +498,24 @@ export default {
 		resolvedExporters() {
 			return this.exporters || []
 		},
+		isWipPreview() {
+			if (this.version === 'wip') {
+				return true
+			}
+			if (typeof window !== 'undefined') {
+				return window.location.pathname.includes('/schedule/v/wip/')
+			}
+			return false
+		},
+		showVersionWarningBanner() {
+			if (this.isWipPreview) {
+				return true
+			}
+			return Boolean(this.version && !this.isCurrent)
+		},
+		publicOnlyFeatureHint() {
+			return this.t.public_schedule_only
+		},
 		languageGroup() {
 			return (this.filterGroups || []).find(g => g.refKey === 'language') || null
 		},
@@ -510,6 +535,9 @@ export default {
 			}))
 		},
 		versionWarningText() {
+			if (this.isWipPreview) {
+				return this.t.version_warning_wip
+			}
 			if (!this.version) {
 				return this.t.version_warning_editable
 			}
@@ -1468,6 +1496,33 @@ export default {
 				opacity: 1
 				transform: translateX(-50%) translateY(0)
 				transition: opacity 0.05s ease, transform 0.05s ease
+		&.disabled
+			opacity: 0.5
+			cursor: not-allowed
+			&[aria-label]
+				position: relative
+				&::after
+					content: attr(aria-label)
+					position: absolute
+					top: calc(100% + 6px)
+					right: 0
+					transform: translateY(-2px)
+					opacity: 0
+					pointer-events: none
+					background-color: rgba(0, 0, 0, 0.87)
+					color: #fff
+					padding: 6px 8px
+					border-radius: 4px
+					font-size: 12px
+					line-height: 1.3
+					white-space: normal
+					width: max-content
+					max-width: 280px
+					z-index: 1000
+				&:hover::after, &:focus-visible::after
+					opacity: 1
+					transform: translateY(0)
+					transition: opacity 0.05s ease, transform 0.05s ease
 		&.icon-only.tooltip-align-left[aria-label]
 			&::after
 				left: 0

--- a/app/eventyay/webapp/schedule/src/components/SpeakerDetail.vue
+++ b/app/eventyay/webapp/schedule/src/components/SpeakerDetail.vue
@@ -10,7 +10,7 @@
 			.speaker-content-area
 				.speaker-title
 					h2 {{ resolvedSpeaker.name || t.speaker_fallback }}
-				export-dropdown.speaker-export(v-if="speakerExportOptions.length", :options="speakerExportOptions", :qrcodesUrl="speakerQrcodesUrl")
+				export-dropdown.speaker-export(v-if="speakerExportOptions.length || isWipPreview", :options="speakerExportOptions", :qrcodesUrl="speakerQrcodesUrl", :disabled="isWipPreview")
 		markdown-content.biography(v-if="resolvedSpeaker.biography", :markdown="resolvedSpeaker.biography")
 		.speaker-sessions(v-if="resolvedSessions && resolvedSessions.length")
 			h3 {{ t.sessions }}
@@ -55,7 +55,8 @@ export default {
 				return () => {}
 			}
 		},
-		translationMessages: { default: () => ({}) }
+		translationMessages: { default: () => ({}) },
+		isWipPreview: { default: false }
 	},
 	props: {
 		speaker: Object,

--- a/app/eventyay/webapp/schedule/src/components/TalkDetail.vue
+++ b/app/eventyay/webapp/schedule/src/components/TalkDetail.vue
@@ -5,7 +5,7 @@
 			.talk-header(:class="{'has-actions': talkExportOptions.length || loggedIn}")
 				h1 {{ getLocalizedString(resolvedTalk.title) }}
 				.header-actions
-					export-dropdown.talk-export(v-if="talkExportOptions.length", :options="talkExportOptions", :qrcodesUrl="talkQrcodesUrl")
+					export-dropdown.talk-export(v-if="talkExportOptions.length || isWipPreview", :options="talkExportOptions", :qrcodesUrl="talkQrcodesUrl", :disabled="isWipPreview")
 					.button-container(v-if="loggedIn", :class="isFaved ? 'faved' : ''")
 						fav-button(@toggleFav="toggleFav")
 			.info
@@ -123,7 +123,8 @@ export default {
 		generateStarrerLinkUrl: { default: () => (user) => user.url || '' },
 		onStarrerLinkClick: { default: () => () => {} },
 		loggedIn: { default: false },
-		translationMessages: { default: () => ({}) }
+		translationMessages: { default: () => ({}) },
+		isWipPreview: { default: false }
 	},
 	props: {
 		talk: Object,

--- a/app/tests/talk/agenda/views/test_agenda_schedule.py
+++ b/app/tests/talk/agenda/views/test_agenda_schedule.py
@@ -296,3 +296,156 @@ def test_versioned_schedule_page(
     with django_assert_num_queries(queries_redirect):
         redirected_response = client.get(url, follow=True, HTTP_ACCEPT='text/html')
     assert redirected_response._request.path == response._request.path
+
+
+@pytest.mark.django_db
+@pytest.mark.usefixtures('other_slot')
+@pytest.mark.parametrize('version', ('js', 'nojs'))
+def test_anon_cannot_see_wip_schedule(client, event, slot, version):
+    with scope(event=event):
+        url = event.urls.schedule + 'v/wip/'
+        if version != 'js':
+            url += 'nojs'
+    response = client.get(url, follow=True, HTTP_ACCEPT='text/html')
+    assert response.status_code == 404
+
+
+@pytest.mark.django_db
+@pytest.mark.usefixtures('slot')
+def test_anon_cannot_export_wip_schedule(client, event):
+    with scope(event=event):
+        url = event.urls.schedule + 'v/wip.json'
+    response = client.get(url, follow=True)
+    assert response.status_code == 404
+
+
+@pytest.mark.django_db
+def test_anon_cannot_view_talk_scheduled_only_on_wip(client, unreleased_slot, event):
+    with scope(event=event):
+        event.feature_flags['show_schedule'] = False
+        event.save()
+        submission = unreleased_slot.submission
+        unreleased_slot.is_visible = False
+        unreleased_slot.save(update_fields=['is_visible'])
+        url = submission.urls.wip_public
+    response = client.get(url)
+    assert response.status_code == 404
+
+
+@pytest.mark.django_db
+def test_reviewer_cannot_view_wip_talk_via_public_url(review_client, unreleased_slot, event):
+    with scope(event=event):
+        event.feature_flags['show_schedule'] = False
+        event.save()
+        submission = unreleased_slot.submission
+        unreleased_slot.is_visible = False
+        unreleased_slot.save(update_fields=['is_visible'])
+        url = submission.urls.public
+    response = review_client.get(url)
+    assert response.status_code == 404
+
+
+@pytest.mark.django_db
+def test_orga_can_view_talk_scheduled_only_on_wip(orga_client, unreleased_slot, event):
+    with scope(event=event):
+        event.feature_flags['show_schedule'] = False
+        event.save()
+        submission = unreleased_slot.submission
+        unreleased_slot.is_visible = False
+        unreleased_slot.save(update_fields=['is_visible'])
+        url = submission.urls.wip_public
+    response = orga_client.get(url)
+    assert response.status_code == 200
+    assert 'pretalx-schedule-data' in response.text
+    assert submission.code in response.text
+
+
+@pytest.mark.django_db
+def test_reviewer_can_view_talk_scheduled_only_on_wip(review_client, unreleased_slot, event):
+    with scope(event=event):
+        event.feature_flags['show_schedule'] = False
+        event.save()
+        submission = unreleased_slot.submission
+        unreleased_slot.is_visible = False
+        unreleased_slot.save(update_fields=['is_visible'])
+        url = submission.urls.wip_public
+    response = review_client.get(url)
+    assert response.status_code == 200
+
+
+@pytest.mark.django_db
+def test_reviewer_can_retrieve_wip_submission_via_api(review_client, unreleased_slot, event):
+    with scope(event=event):
+        event.feature_flags['show_schedule'] = False
+        event.save()
+        submission = unreleased_slot.submission
+        unreleased_slot.is_visible = False
+        unreleased_slot.save(update_fields=['is_visible'])
+        url = event.api_urls.submissions + f'{submission.code}/'
+    response = review_client.get(url, follow=True)
+    assert response.status_code == 200
+    assert response.json()['code'] == submission.code
+
+
+@pytest.mark.django_db
+def test_orga_talk_page_includes_wip_only_session_in_schedule_json(orga_client, unreleased_slot, event):
+    with scope(event=event):
+        submission = unreleased_slot.submission
+        unreleased_slot.is_visible = False
+        unreleased_slot.save(update_fields=['is_visible'])
+        url = submission.urls.wip_public
+    response = orga_client.get(url)
+    assert response.status_code == 200
+    assert submission.code in response.text
+
+
+@pytest.mark.django_db
+def test_wip_pages_include_leave_preview_guard(orga_client, event):
+    with scope(event=event):
+        url = event.urls.schedule + 'v/wip/'
+    response = orga_client.get(url)
+    assert response.status_code == 200
+    assert 'agenda-wip-preview-leave-dialog' in response.text
+    assert 'wip-preview-guard.js' in response.text
+    assert 'Leave schedule preview?' in response.text
+
+
+@pytest.mark.django_db
+def test_orga_can_view_wip_speakers_list(orga_client, event):
+    with scope(event=event):
+        url = reverse(
+            'agenda:versioned-wip-speakers',
+            kwargs={'organizer': event.organizer.slug, 'event': event.slug},
+        )
+    response = orga_client.get(url)
+    assert response.status_code == 200
+    assert 'version="wip"' in response.text
+
+
+@pytest.mark.django_db
+def test_wip_nav_tabs_link_to_wip_schedule_and_speakers(orga_client, event, speaker):
+    with scope(event=event):
+        speaker_url = reverse(
+            'agenda:versioned-wip-speaker',
+            kwargs={
+                'organizer': event.organizer.slug,
+                'event': event.slug,
+                'code': speaker.code,
+            },
+        )
+        wip_schedule_url = reverse(
+            'agenda:versioned-schedule',
+            kwargs={
+                'organizer': event.organizer.slug,
+                'event': event.slug,
+                'version': 'wip',
+            },
+        )
+        wip_speakers_url = reverse(
+            'agenda:versioned-wip-speakers',
+            kwargs={'organizer': event.organizer.slug, 'event': event.slug},
+        )
+    response = orga_client.get(speaker_url)
+    assert response.status_code == 200
+    assert wip_schedule_url in response.text
+    assert wip_speakers_url in response.text


### PR DESCRIPTION
Summary
Adds a dedicated WIP schedule preview experience for organisers and reviewers with schedule access. Preview is URL-scoped (/schedule/v/wip/...), separate from the public agenda, so unreleased content is visible in preview without applying public visibility rules.

Introduce explicit WIP URLs for schedule, talks, and speakers; public URLs keep existing released-schedule behavior.
Centralize WIP access rules in talk_rules/agenda.py (can_view_wip_schedule, require_wip_schedule_access, is_wip_agenda_url).
Keep navigation inside WIP preview when switching between schedule and speakers tabs.
Disable export/changelog controls on WIP pages with hover explanations.
Show a styled confirmation dialog when leaving WIP preview for public pages.
What changed
Backend
WIP routes: /schedule/v/wip/, /schedule/v/wip/talk/{code}/, /schedule/v/wip/speakers/, /schedule/v/wip/speakers/{code}/
Access control: Shared helpers in talk_rules/agenda.py; WipAgendaPreviewPageMixin in agenda/views/utils.py for HTML WIP pages
Data loading: WIP pages embed/serve the editable WIP schedule without is_visible filtering; widget and enriched JSON respect the same rules
Nav URLs: agenda_schedule_nav_url / agenda_speakers_nav_url preserve WIP mode from header tabs
Header tab active state: Schedule tab no longer stays active on WIP speaker/talk pages
Frontend (schedule webapp)
WIP session/speaker links use schedule/v/wip/ prefix when version=wip
Schedule toolbar disables export and version/changelog on WIP with tooltips
Talk/speaker export dropdowns disabled on WIP pages
isWipPreview provided via inject for child components
UX
Leave-preview guard on WIP pages: native <dialog> with “Stay in preview” / “Go to public view” before navigating to public URLs (Info, Featured, logo, etc.)
Test plan

 As organiser/reviewer with schedule access, open /schedule/v/wip/ and confirm unreleased sessions are visible

 Open a WIP-only talk via /schedule/v/wip/talk/{code}/ and confirm full talk content loads

 Navigate WIP schedule → WIP speaker → WIP speakers list; header tabs stay in WIP and only the correct tab is active

 Confirm export/changelog buttons are disabled on WIP schedule with tooltip on hover

 Click Info or another public nav link from WIP preview; confirm dialog appears and “Stay in preview” cancels navigation

 Confirm anonymous users and reviewers without schedule access get 404 on WIP URLs

 Confirm public /talk/{code}/ and /schedule/ still follow normal visibility rules

 Run pytest tests/talk/agenda/views/test_agenda_schedule.py tests/talk/agenda/views/test_agenda_widget.py
Notes
Rebuild schedule assets after frontend changes: cd app && make staticfiles
WIP preview is intentionally URL-driven, not inferred from login state on public URLs