### PR TITLE
fix: render password reset help text as safe HTML

### DIFF
--- a/app/eventyay/jinja-templates/account/password_reset_from_key.jinja
+++ b/app/eventyay/jinja-templates/account/password_reset_from_key.jinja
@@ -57,7 +57,7 @@
             </div>
           {% endif %}
           {% if form.password1.help_text %}
-            <div class='field-help'>{{ form.password1.help_text }}</div>
+            <div class='field-help'>{{ form.password1.help_text | safe }}</div>
           {% endif %}
         </div>
 
@@ -75,7 +75,7 @@
             </div>
           {% endif %}
           {% if form.password2.help_text %}
-            <div class='field-help'>{{ form.password2.help_text }}</div>
+            <div class='field-help'>{{ form.password2.help_text | safe }}</div>
           {% endif %}
         </div>
 


### PR DESCRIPTION
**Closes:** #3990

**What was changed:**
Added the `| safe` filter to the `help_text` rendering of the password fields in the `django-allauth` password reset template (`app/eventyay/jinja-templates/account/password_reset_from_key.jinja`).

**Why:**
The password validation rules (e.g., minimum length, similarity, common password checks) return their help text formatted with HTML tags (`<ul><li>...</li></ul>`). Because Jinja automatically escapes variables by default, these HTML tags were being rendered literally on the page as raw text instead of actual bullet points. Adding the `| safe` filter tells Jinja that the string contains safe HTML to be rendered by the browser, fixing the display issue.

## Before 

<img width="1920" height="1080" alt="Before" src="https://github.com/user-attachments/assets/a0ef6ddb-f262-4ad3-955c-9341ea80599d" />


## After

<img width="1920" height="1080" alt="After" src="https://github.com/user-attachments/assets/7e2217bc-6dcd-4412-9bf0-5910c7af2b93" />

## Summary by Sourcery

Bug Fixes:
- Fix HTML-formatted password validation help text being displayed as escaped raw text on the password reset form.