### PR TITLE
fix(checkin): avoid crash on variation ticket require_attention

### DIFF
--- a/app/eventyay/api/serializers/order.py
+++ b/app/eventyay/api/serializers/order.py
@@ -537,11 +537,6 @@ class OrderPositionSerializer(I18nAwareModelSerializer):
         return instance
 
 
-class RequireAttentionField(serializers.Field):
-    def to_representation(self, instance: OrderPosition):
-        return instance.require_checkin_attention
-
-
 class AttendeeNameField(serializers.Field):
     def to_representation(self, instance: OrderPosition):
         an = instance.attendee_name
@@ -573,7 +568,7 @@ class AttendeeNamePartsField(serializers.Field):
 
 
 class CheckinListOrderPositionSerializer(OrderPositionSerializer):
-    require_attention = RequireAttentionField(source='*')
+    require_attention = serializers.BooleanField(source='require_checkin_attention', read_only=True)
     attendee_name = AttendeeNameField(source='*')
     attendee_name_parts = AttendeeNamePartsField(source='*')
     order__status = serializers.SlugRelatedField(read_only=True, slug_field='status', source='order')

--- a/app/eventyay/api/serializers/order.py
+++ b/app/eventyay/api/serializers/order.py
@@ -539,7 +539,7 @@ class OrderPositionSerializer(I18nAwareModelSerializer):
 
 class RequireAttentionField(serializers.Field):
     def to_representation(self, instance: OrderPosition):
-        return instance.order.checkin_attention or instance.product.checkin_attention
+        return instance.require_checkin_attention
 
 
 class AttendeeNameField(serializers.Field):

--- a/app/eventyay/api/views/checkin.py
+++ b/app/eventyay/api/views/checkin.py
@@ -979,7 +979,7 @@ class CheckinListPositionViewSet(viewsets.ReadOnlyModelViewSet):
             return Response(
                 {
                     'status': 'incomplete',
-                    'require_attention': op.product.checkin_attention or op.order.checkin_attention,
+                    'require_attention': op.require_checkin_attention,
                     'position': CheckinListOrderPositionSerializer(op, context=self.get_serializer_context()).data,
                     'questions': [QuestionSerializer(q).data for q in e.questions],
                 },
@@ -1004,7 +1004,7 @@ class CheckinListPositionViewSet(viewsets.ReadOnlyModelViewSet):
                 {
                     'status': 'error',
                     'reason': e.code,
-                    'require_attention': op.product.checkin_attention or op.order.checkin_attention,
+                    'require_attention': op.require_checkin_attention,
                     'position': CheckinListOrderPositionSerializer(op, context=self.get_serializer_context()).data,
                 },
                 status=400,
@@ -1013,7 +1013,7 @@ class CheckinListPositionViewSet(viewsets.ReadOnlyModelViewSet):
             return Response(
                 {
                     'status': 'ok',
-                    'require_attention': op.product.checkin_attention or op.order.checkin_attention,
+                    'require_attention': op.require_checkin_attention,
                     'position': CheckinListOrderPositionSerializer(op, context=self.get_serializer_context()).data,
                 },
                 status=201,

--- a/app/eventyay/base/models/orders.py
+++ b/app/eventyay/base/models/orders.py
@@ -2206,10 +2206,13 @@ class OrderPosition(AbstractPosition):
 
     @cached_property
     def require_checkin_attention(self):
+        variation_attention = (
+            getattr(self.variation, 'checkin_attention', False) if self.variation_id else False
+        )
         return (
             self.order.checkin_attention
             or self.product.checkin_attention
-            or (self.variation_id and self.variation.checkin_attention)
+            or variation_attention
         )
 
     @property


### PR DESCRIPTION
## Summary

- Fix `OrderPosition.require_checkin_attention` crashing on variation tickets because `ProductVariation` has no `checkin_attention` field.
- Use safe `getattr` for variation attention and return explicit `False` when there is no variation (fixes plain tickets returning `None` from the old `(variation_id and ...)` term).
- Align check-in list redeem responses and device sync serializer with the centralized property so `require_attention` is consistent everywhere.

## Summary by Sourcery

Ensure check-in attention flags are computed centrally on order positions and used consistently across check-in APIs and serializers to prevent crashes on variation tickets.

Bug Fixes:
- Prevent AttributeError crashes when computing require_checkin_attention for positions with product variations.
- Ensure plain tickets return a boolean require_attention flag instead of None when no attention is required.

Enhancements:
- Route all check-in attention checks through the OrderPosition.require_checkin_attention property for consistent behavior across redeem responses and device sync serializers.