### PR TITLE
fix: prevent page scroll by disabling autofocus on Toast UI Editor

### DIFF
--- a/app/eventyay/static/common/js/formTools.js
+++ b/app/eventyay/static/common/js/formTools.js
@@ -216,6 +216,7 @@ const initToastUiMarkdownTextarea = (textarea) => {
         previewStyle: 'tab',
         usageStatistics: false,
         hideModeSwitch: true,
+        autofocus: false,
         initialValue: String(textarea.value || ''),
         plugins: [underlinePlugin],
         toolbarItems: [


### PR DESCRIPTION
Closes: #3989


https://github.com/user-attachments/assets/8f94212c-5d22-4ee3-9ac5-31c21c6a90f7

