### PR TITLE
Added Social-Media Plugin latest commit head to uv.lock

### DIFF
--- a/app/uv.lock
+++ b/app/uv.lock
@@ -1185,7 +1185,7 @@ source = { git = "https://github.com/fossasia/eventyay-paypal.git?rev=main#a6d9c
 [[package]]
 name = "eventyay-socialmedia"
 version = "1.0.0"
-source = { git = "https://github.com/fossasia/eventyay-socialmedia.git?rev=main#19c9e3aae828973e247ff0200c2a2b119176c6ee" }
+source = { git = "https://github.com/fossasia/eventyay-socialmedia.git?rev=main#896c1d01cdb3899692459d6c3b99222187539fe1" }
 
 [[package]]
 name = "eventyay-stripe"


### PR DESCRIPTION
This pr adds Social-Media Plugin latest commit head to uv.lock.

## Summary by Sourcery

Update dependency lockfile to reference the latest Social-Media plugin commit head.

Build:
- Refresh uv.lock to capture the latest Social-Media plugin commit.

Chores:
- Regenerate uv.lock to align with current dependency state.