### PR TITLE
fix: event name and date should remain consistent across all navigation tabs

### DIFF
--- a/app/eventyay/common/templates/common/base_public.html
+++ b/app/eventyay/common/templates/common/base_public.html
@@ -150,7 +150,7 @@
                 {% endblock presale_back_navigation %}
                 <div class="event-hero">
                     <div class="event-hero-overlay">
-                        <div class="event-brand{% if current_event and current_event.visible_logo_url %} event-brand--has-logo{% elif request.organizer and organizer_logo %} event-brand--has-logo{% endif %}{% if request.organizer and organizer.settings.organizer_logo_image_large %} event-brand--logo-large{% endif %}">
+                        <div class="event-brand{% if current_event and current_event.visible_logo_url %} event-brand--has-logo{% elif request.organizer and organizer_logo %} event-brand--has-logo{% endif %}{% if current_event and current_event.settings.logo_image_large %} event-brand--logo-large{% elif not current_event and request.organizer and request.organizer.settings.organizer_logo_image_large %} event-brand--logo-large{% endif %}">
                             <div class="event-logo">
                                 <a href="{% block nav_link %}{% endblock nav_link %}">
                                     {% block event_logo %}


### PR DESCRIPTION
Fix: #4001

## Before :

https://github.com/user-attachments/assets/c756a638-25af-4d32-bae6-79d16903ee96

## After :

https://github.com/user-attachments/assets/f2512e43-f703-4823-a6d3-d24a0cf89475

