### PR TITLE
feat: Add reusable beta badge for plugins

### DIFF
--- a/app/eventyay/base/plugins.py
+++ b/app/eventyay/base/plugins.py
@@ -28,6 +28,17 @@ class PluginType(Enum):
     EXPORT = 4
 
 
+# Module names of plugins that are currently in beta.
+# For plugins whose source cannot be edited (e.g. external git packages), add
+# their Python module name here to have the beta badge shown automatically.
+BETA_PLUGINS: frozenset[str] = frozenset(
+    [
+        'socialmedia',
+        'teamshifts',
+    ]
+)
+
+
 def get_all_plugins(event=None) -> List[type]:
     """
     Returns the EventyayPluginMeta classes of all plugins found in the installed Django apps.
@@ -45,6 +56,11 @@ def get_all_plugins(event=None) -> List[type]:
             if hasattr(app, 'is_available') and event:
                 if not app.is_available(event):
                     continue
+
+            # Annotate beta flag: the plugin's own meta may set beta=True,
+            # or it may be listed in BETA_PLUGINS for external packages.
+            if not getattr(meta, 'beta', False):
+                meta.beta = app.name in BETA_PLUGINS
 
             plugins.append(meta)
     return sorted(

--- a/app/eventyay/eventyay_common/templates/eventyay_common/component/_beta_badge.html
+++ b/app/eventyay/eventyay_common/templates/eventyay_common/component/_beta_badge.html
@@ -1,0 +1,1 @@
+{% load i18n %}<span class="label label-success">{% trans "Beta" %}</span>

--- a/app/eventyay/eventyay_common/templates/eventyay_common/event/plugins.html
+++ b/app/eventyay/eventyay_common/templates/eventyay_common/event/plugins.html
@@ -27,7 +27,7 @@
                             {% for plugin in plist %}
                                 <tr class="{% if plugin.app.compatibility_errors %}warning{% elif plugin.module in plugins_active %}success{% else %}default{% endif %}">
                                     <td>
-                                        <strong>{{ plugin.name }}</strong>
+                                        <strong>{{ plugin.name }}{% if plugin.beta %} {% include "eventyay_common/component/_beta_badge.html" %}{% endif %}</strong>
                                         {% if plugin.author %}
                                             <p class="meta text-muted">
                                                 {% blocktrans trimmed with v=plugin.version a=plugin.author %}

--- a/app/eventyay/plugins/webcheckin/apps.py
+++ b/app/eventyay/plugins/webcheckin/apps.py
@@ -13,6 +13,7 @@ class WebCheckinApp(AppConfig):
         version = version
         category = 'FEATURE'
         featured = True
+        beta = True
         description = _('This plugin allows you to perform check-in actions in your browser.')
 
     def ready(self):


### PR DESCRIPTION
## What Changed

*   Created a reusable `_beta_badge.html` partial template.
*   Utilized the built-in Bootstrap 3 `label label-success` classes for a standard, clean green pill UI without any custom CSS or inline styles.
*   Added a `BETA_PLUGINS` frozenset in `eventyay/base/plugins.py` to seamlessly add the beta flag to external plugins (e.g., `socialmedia`, `teamshifts`) that cannot be modified directly.
*   Added `beta = True` to the `webcheckin` plugin's metadata.
*   Added spacing between the plugin name and the badge in the plugin list template.

## Why

*   Allows users to easily identify which plugins are currently in beta testing.
*   Relying on existing Bootstrap classes keeps the codebase clean, avoids adding unnecessary or conflicting CSS, and ensures visual consistency with the rest of the application.


<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/85f63eb7-22b4-4f79-a21b-be765173206d" />
