### PR TITLE
style: improve beta badge visual presentation

### DIFF
--- a/app/eventyay/eventyay_common/templates/eventyay_common/component/_beta_badge.html
+++ b/app/eventyay/eventyay_common/templates/eventyay_common/component/_beta_badge.html
@@ -1,1 +1,1 @@
-{% load i18n %}<span class="label label-success">{% trans "Beta" %}</span>
+{% load i18n %}<span class="badge-beta" title="{% trans 'This feature is currently in beta.' %}"><i class="fa fa-flask" aria-hidden="true"></i>{% trans "Beta" %}</span>

--- a/app/eventyay/eventyay_common/templates/eventyay_common/component/_beta_badge.html
+++ b/app/eventyay/eventyay_common/templates/eventyay_common/component/_beta_badge.html
@@ -1,1 +1,1 @@
-{% load i18n %}<span class="badge-beta" title="{% trans 'This feature is currently in beta.' %}"><i class="fa fa-flask" aria-hidden="true"></i>{% trans "Beta" %}</span>
+{% load i18n %}<span class="badge-beta" title="{% trans 'This feature is currently in beta.' %}" aria-label="{% trans 'This feature is currently in beta.' %}"><i class="fa fa-flask" aria-hidden="true"></i><span aria-hidden="true">{% trans "Beta" %}</span></span>

--- a/app/eventyay/static/eventyay-common/css/settings.css
+++ b/app/eventyay/static/eventyay-common/css/settings.css
@@ -65,15 +65,15 @@
     display: inline-block;
     padding: 2px 6px;
     margin-left: 6px;
-    font-size: 9px;
+    font-size: 11px;
     font-weight: 600;
     line-height: 1.2;
     color: #fff;
-    background-color: #f0ad4e; /* Orange for beta/warning */
+    background-color: #c05600; /* Darker orange for WCAG contrast */
     border-radius: 3px;
     vertical-align: middle;
     position: relative;
-    top: -2px;
+    top: -1px;
     letter-spacing: 0.05em;
     white-space: nowrap;
     text-transform: uppercase;
@@ -81,5 +81,5 @@
 
 .badge-beta .fa {
     margin-right: 3px;
-    font-size: 9px;
+    font-size: 10px;
 }

--- a/app/eventyay/static/eventyay-common/css/settings.css
+++ b/app/eventyay/static/eventyay-common/css/settings.css
@@ -59,3 +59,27 @@
 .form-narrow {
     max-width: 600px;
 }
+
+/* Reusable beta badge */
+.badge-beta {
+    display: inline-block;
+    padding: 2px 6px;
+    margin-left: 6px;
+    font-size: 9px;
+    font-weight: 600;
+    line-height: 1.2;
+    color: #fff;
+    background-color: #f0ad4e; /* Orange for beta/warning */
+    border-radius: 3px;
+    vertical-align: middle;
+    position: relative;
+    top: -2px;
+    letter-spacing: 0.05em;
+    white-space: nowrap;
+    text-transform: uppercase;
+}
+
+.badge-beta .fa {
+    margin-right: 3px;
+    font-size: 9px;
+}


### PR DESCRIPTION
## What changed
- Switched beta badge from Bootstrap success label to a custom styled orange badge (`badge-beta`) for better visibility against active plugin rows.
- Added a `fa-flask` icon to the badge for a more experimental look.
- Adjusted `vertical-align` and `font-size` so the badge perfectly aligns with the plugin name text.

## Why
- The previous green badge blended in with enabled plugin rows.
- The custom styling provides a cleaner layout and clearer 'beta' semantics (orange + flask icon) without requiring SCSS recompilation.


<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/61e9c2a3-52da-49a2-b750-2bbbaf964a26" />


## Summary by Sourcery

Introduce a custom-styled beta badge component for clearer visual distinction of beta features.

New Features:
- Add a reusable `.badge-beta` CSS class for orange beta badges with icon support.

Enhancements:
- Replace the Bootstrap success label-based beta badge with the new beta badge component including a flask icon and tooltip text.