### PR TITLE
chore: bump eventyay-socialmedia plugin version

### DIFF
--- a/app/uv.lock
+++ b/app/uv.lock
@@ -1185,7 +1185,7 @@ source = { git = "https://github.com/fossasia/eventyay-paypal.git?rev=main#a6d9c
 [[package]]
 name = "eventyay-socialmedia"
 version = "1.0.0"
-source = { git = "https://github.com/fossasia/eventyay-socialmedia.git?rev=main#6a446eb56d4daecf58bc4cfc8d65f2877f049629" }
+source = { git = "https://github.com/fossasia/eventyay-socialmedia.git?rev=main#1d3912546df0d08cd73b4bf577a56a41972252f8" }
 
 [[package]]
 name = "eventyay-stripe"

--- a/app/uv.lock
+++ b/app/uv.lock
@@ -1185,7 +1185,7 @@ source = { git = "https://github.com/fossasia/eventyay-paypal.git?rev=main#a6d9c
 [[package]]
 name = "eventyay-socialmedia"
 version = "1.0.0"
-source = { git = "https://github.com/fossasia/eventyay-socialmedia.git?rev=main#19c9e3aae828973e247ff0200c2a2b119176c6ee" }
+source = { git = "https://github.com/fossasia/eventyay-socialmedia.git?rev=main#896c1d01cdb3899692459d6c3b99222187539fe1" }
 
 [[package]]
 name = "eventyay-stripe"

--- a/app/uv.lock
+++ b/app/uv.lock
@@ -1185,7 +1185,7 @@ source = { git = "https://github.com/fossasia/eventyay-paypal.git?rev=main#a6d9c
 [[package]]
 name = "eventyay-socialmedia"
 version = "1.0.0"
-source = { git = "https://github.com/fossasia/eventyay-socialmedia.git?rev=main#896c1d01cdb3899692459d6c3b99222187539fe1" }
+source = { git = "https://github.com/fossasia/eventyay-socialmedia.git?rev=main#6a446eb56d4daecf58bc4cfc8d65f2877f049629" }
 
 [[package]]
 name = "eventyay-stripe"


### PR DESCRIPTION
Updates the `eventyay-socialmedia` commit hash in `uv.lock` to `6a446eb56d4daecf58bc4cfc8d65f2877f049629`.

This imports the packaging fix for the plugin to resolve the `TemplateDoesNotExist` error on the social settings page.

## Summary by Sourcery

Build:
- Bump eventyay-socialmedia dependency commit in uv.lock to include the packaging fix resolving TemplateDoesNotExist on the social settings page.