### PR TITLE
fix: resolve API crash in exporters view for non-UserApiToken auth types

### DIFF
--- a/app/eventyay/api/views/exporters.py
+++ b/app/eventyay/api/views/exporters.py
@@ -57,7 +57,7 @@ class ExportersMixin:
         cf = get_object_or_404(CachedFile, id=kwargs['cfid'])
         if cf.file:
             resp = ChunkBasedFileResponse(cf.file.file, content_type=cf.type)
-            resp['Content-Disposition'] = 'attachment; filename="{}"'.format(cf.filename)
+            resp['Content-Disposition'] = f'attachment; filename="{cf.filename}"'
             return resp
         elif not settings.HAS_CELERY:
             return Response(
@@ -136,8 +136,11 @@ class OrganizerExportersViewSet(ExportersMixin, viewsets.ViewSet):
     @cached_property
     def exporters(self):
         exporters = []
+        perm_holder = (
+            self.request.auth if hasattr(self.request.auth, 'get_events_with_permission') else self.request.user
+        )
         events = (
-            (self.request.auth or self.request.user)
+            perm_holder
             .get_events_with_permission('can_view_orders', request=self.request)
             .filter(organizer=self.request.organizer)
         )
@@ -151,8 +154,11 @@ class OrganizerExportersViewSet(ExportersMixin, viewsets.ViewSet):
         return exporters
 
     def get_serializer_kwargs(self):
+        perm_holder = (
+            self.request.auth if hasattr(self.request.auth, 'get_events_with_permission') else self.request.user
+        )
         return {
-            'events': self.request.auth.get_events_with_permission('can_view_orders', request=self.request).filter(
+            'events': perm_holder.get_events_with_permission('can_view_orders', request=self.request).filter(
                 organizer=self.request.organizer
             )
         }

--- a/app/eventyay/api/views/exporters.py
+++ b/app/eventyay/api/views/exporters.py
@@ -145,15 +145,22 @@ class OrganizerExportersViewSet(ExportersMixin, viewsets.ViewSet):
             return perm_holder
         return self.request.user
 
+    def get_events_queryset(self):
+        """
+        Return the queryset of events the current permission holder is allowed to
+        view orders for, limited to the current request's organizer.
+        """
+        perm_holder = self.get_permission_holder()
+        return (
+            perm_holder
+            .get_events_with_permission("can_view_orders", request=self.request)
+            .filter(organizer=self.request.organizer)
+        )
+
     @cached_property
     def exporters(self):
         exporters = []
-        perm_holder = self.get_permission_holder()
-        events = (
-            perm_holder
-            .get_events_with_permission('can_view_orders', request=self.request)
-            .filter(organizer=self.request.organizer)
-        )
+        events = self.get_events_queryset()
         responses = register_multievent_data_exporters.send(self.request.organizer)
         for ex in sorted(
             [response(events) for r, response in responses if response],
@@ -164,11 +171,8 @@ class OrganizerExportersViewSet(ExportersMixin, viewsets.ViewSet):
         return exporters
 
     def get_serializer_kwargs(self):
-        perm_holder = self.get_permission_holder()
         return {
-            'events': perm_holder.get_events_with_permission('can_view_orders', request=self.request).filter(
-                organizer=self.request.organizer
-            )
+            'events': self.get_events_queryset()
         }
 
     def do_export(self, cf, instance, data):

--- a/app/eventyay/api/views/exporters.py
+++ b/app/eventyay/api/views/exporters.py
@@ -133,12 +133,22 @@ class EventExportersViewSet(ExportersMixin, viewsets.ViewSet):
 class OrganizerExportersViewSet(ExportersMixin, viewsets.ViewSet):
     permission = None
 
+    def get_permission_holder(self):
+        """
+        Return the object that should be used for permission-based event queries.
+
+        Prefer `request.auth` if it exposes `get_events_with_permission`, otherwise
+        fall back to `request.user`.
+        """
+        perm_holder = getattr(self.request, "auth", None)
+        if perm_holder is not None and hasattr(perm_holder, "get_events_with_permission"):
+            return perm_holder
+        return self.request.user
+
     @cached_property
     def exporters(self):
         exporters = []
-        perm_holder = (
-            self.request.auth if hasattr(self.request.auth, 'get_events_with_permission') else self.request.user
-        )
+        perm_holder = self.get_permission_holder()
         events = (
             perm_holder
             .get_events_with_permission('can_view_orders', request=self.request)
@@ -154,9 +164,7 @@ class OrganizerExportersViewSet(ExportersMixin, viewsets.ViewSet):
         return exporters
 
     def get_serializer_kwargs(self):
-        perm_holder = (
-            self.request.auth if hasattr(self.request.auth, 'get_events_with_permission') else self.request.user
-        )
+        perm_holder = self.get_permission_holder()
         return {
             'events': perm_holder.get_events_with_permission('can_view_orders', request=self.request).filter(
                 organizer=self.request.organizer


### PR DESCRIPTION
## Description
This pull request addresses a critical `AttributeError` (HTTP 500) crash in the `OrganizerExportersViewSet` that occurs when the endpoint is accessed using an `OAuthAccessToken` or Session Authentication where `request.auth` is `None`. 

Previously, the code directly invoked `.get_events_with_permission()` on `self.request.auth`, assuming it was always a `UserApiToken` object. 

### Changes Included
- Extracted the permission holder resolution into a central helper method: `get_permission_holder()`.
- Implemented a defensive duck-typing check (`hasattr`) to safely fall back to `request.user` if the authentication token does not implement the `get_events_with_permission` interface.
- Reduced code duplication by ensuring both `.exporters` and `.get_serializer_kwargs()` utilize the unified permission resolution logic.

### Related Issue
Closes  [#4014  ](https://github.com/fossasia/eventyay/issues/4014)

### Testing
- [x] Verified code syntax via local py_compile checks.
- [x] Addressed code quality improvements requested during early automated reviews (extracted duplicate logic into a central helper).

## Summary by Sourcery

Prevent organizer exporter crashes when authentication tokens lack event-permission methods and unify permission resolution.

Bug Fixes:
- Handle OAuth and session-authenticated requests where request.auth is None or lacks get_events_with_permission, avoiding AttributeError crashes.

Enhancements:
- Introduce a shared permission holder resolver used by exporters and serializer kwargs to reduce duplication and support both auth tokens and users.