### PR TITLE
feat(agenda): featured speakers before schedule release and visibility controls

### DIFF
--- a/app/eventyay/agenda/templates/agenda/speakers.html
+++ b/app/eventyay/agenda/templates/agenda/speakers.html
@@ -14,6 +14,9 @@
 {% block agenda_content %}
 {% html_signal "eventyay.agenda.signals.html_above_speakers_list" sender=request.event request=request %}
 <div>
+    {% if schedule_json %}
+    <script id="pretalx-schedule-data" type="application/json">{{ schedule_json|safe }}</script>
+    {% endif %}
     {% vite_app_scripts 'schedule' 'src/main-wc.js' fallback='schedule/pretalx-schedule.js' %}
     {% with event_tz=request.event.settings.timezone|default:request.event.timezone %}
     <pretalx-schedule event-url="{{ request.event.urls.base }}" locale="{{ request.LANGUAGE_CODE }}" view="speakers" {% if schedule_version %}version="{{ schedule_version }}"{% endif %} style="--pretalx-clr-primary: {{ request.event.visible_primary_color }}"></pretalx-schedule>

--- a/app/eventyay/agenda/views/schedule.py
+++ b/app/eventyay/agenda/views/schedule.py
@@ -437,8 +437,7 @@ def schedule_messages(request, **kwargs):
         'view_profile': _('View speaker profile'),
         'no_starred_sessions': _('No starred sessions.'),
         'schedule_do_not_record': _('This session will not be recorded.'),
-        'back_to_schedule': _('Back to schedule'),
-        'back_to_speakers': _('Back to speakers'),
+        'back': _('Back'),
         'schedule_pending_secondary': _('Coming soon'),
     }
     strings = {key: str(value) for key, value in strings.items()}

--- a/app/eventyay/agenda/views/speaker.py
+++ b/app/eventyay/agenda/views/speaker.py
@@ -20,10 +20,17 @@ from eventyay.agenda.export_resources import public_resource_attachments, public
 from eventyay.agenda.views.utils import (
     WipAgendaPreviewPageMixin,
     build_speaker_schedule_json,
+    build_speakers_list_schedule_json,
     is_public_speakers_empty,
     redirect_to_presale_with_warning,
+    redirect_when_public_speakers_unavailable,
+    speaker_profile_display_order,
 )
-from eventyay.talk_rules.agenda import agenda_speaker_talks
+from eventyay.talk_rules.agenda import (
+    agenda_speaker_talks,
+    can_list_released_schedule_speakers,
+    should_hide_public_speaker_sessions,
+)
 from eventyay.base.models import SpeakerProfile, TalkQuestionTarget, User
 from eventyay.common.text.path import safe_filename
 from eventyay.common.urls import get_base_url
@@ -42,18 +49,25 @@ class SpeakerList(EventPermissionRequired, Filterable, ListView):
     permission_required = 'base.list_schedule'
     default_filters = ('user__fullname__icontains',)
 
+    def has_permission(self):
+        return can_list_released_schedule_speakers(self.request.user, self.request.event)
+
     def dispatch(self, request, *args, **kwargs):
         if is_public_speakers_empty(request):
             return redirect_to_presale_with_warning(request, _('No published speakers.'))
+        if not can_list_released_schedule_speakers(request.user, request.event):
+            return redirect_when_public_speakers_unavailable(request)
         return super().dispatch(request, *args, **kwargs)
 
     def get_queryset(self):
-        qs = (
-            SpeakerProfile.objects.filter(user__in=self.request.event.speakers, event=self.request.event)
-            .select_related('user', 'event', 'event__organizer')
-            .order_by('user__fullname')
-        )
+        event = self.request.event
+        qs = SpeakerProfile.objects.filter(user__in=event.speakers, event=event)
+        qs = qs.select_related('user', 'event', 'event__organizer').order_by(*speaker_profile_display_order())
         return self.filter_queryset(qs)
+
+    @context
+    def schedule_json(self):
+        return build_speakers_list_schedule_json(self.request)
 
     def get_context_data(self, **kwargs):
         return super().get_context_data(**kwargs)
@@ -86,6 +100,14 @@ class SpeakerView(PermissionRequired, TemplateView):
     @context
     @cached_property
     def talks(self):
+        if should_hide_public_speaker_sessions(
+            self.request.user,
+            self.request.event,
+            wip_preview=self.wip_preview,
+        ):
+            from eventyay.base.models import TalkSlot
+
+            return TalkSlot.objects.none()
         return (
             agenda_speaker_talks(
                 self.request.event,

--- a/app/eventyay/agenda/views/utils.py
+++ b/app/eventyay/agenda/views/utils.py
@@ -13,7 +13,7 @@ from django.http import HttpRequest, HttpResponse, HttpResponseNotModified, Http
 from django.urls import NoReverseMatch, reverse
 from django.utils import timezone
 from django.utils.encoding import force_str
-from django.utils.translation import activate, get_language
+from django.utils.translation import activate, get_language, gettext_lazy as _
 from django_context_decorator import context
 from i18nfield.utils import I18nJSONEncoder
 
@@ -23,12 +23,24 @@ from eventyay.common.exporter import BaseExporter
 from eventyay.common.signals import register_data_exporters, register_my_data_exporters
 from eventyay.common.text.path import safe_filename
 from eventyay.schedule.exporters import FavedICalExporter, filter_featured_public_talk_slots
-from eventyay.talk_rules.agenda import require_wip_schedule_access
+from eventyay.talk_rules.agenda import (
+    can_list_released_schedule_speakers,
+    can_view_public_schedule_sessions,
+    has_public_featured_speakers,
+    is_submission_visible_via_featured,
+    pending_public_submission_codes_for_speaker,
+    public_speakers_list_available,
+    require_wip_schedule_access,
+    speaker_may_show_pending_sessions,
+)
 from eventyay.talk_rules.submission import (
     are_featured_exports_available,
+    are_featured_speakers_visible,
     are_featured_submissions_visible,
     can_use_featured_exports,
     featured_submissions_for_event,
+    include_public_featured_speaker_metadata,
+    schedule_widget_featured_cache_key_part,
 )
 
 
@@ -54,8 +66,132 @@ def speaker_public_field_flags(event):
     return include_avatar, include_biography
 
 
-def _serialize_schedule_build_data(schedule, **build_kwargs) -> str:
-    data = schedule.build_data(**build_kwargs)
+# --- Featured speaker widget payloads (pre-agenda public access) ---
+
+
+def speaker_profile_display_order():
+    """Order speaker profiles by orga position, then named speakers before unnamed."""
+    from django.db.models import Case, F, IntegerField, OrderBy, Value, When
+
+    return (
+        OrderBy(F('position'), nulls_last=True),
+        Case(
+            When(user__fullname='', then=Value(1)),
+            When(user__fullname__isnull=True, then=Value(1)),
+            default=Value(0),
+            output_field=IntegerField(),
+        ),
+        'user__fullname',
+        'pk',
+    )
+
+
+def get_public_featured_speaker_profiles(event):
+    """Return featured speaker profiles in public display order."""
+    return list(
+        SpeakerProfile.objects.filter(event=event, is_featured=True)
+        .select_related('user')
+        .order_by(*speaker_profile_display_order())
+    )
+
+
+def get_featured_speaker_profile_by_code(event, speaker_code):
+    return (
+        SpeakerProfile.objects.filter(
+            event=event,
+            user__code__iexact=speaker_code,
+            is_featured=True,
+        )
+        .select_related('user')
+        .first()
+    )
+
+
+def get_speaker_profile_by_code(event, speaker_code):
+    return (
+        SpeakerProfile.objects.filter(event=event, user__code__iexact=speaker_code)
+        .select_related('user', 'event', 'event__organizer')
+        .first()
+    )
+
+
+def load_public_featured_speaker_profiles(user, event):
+    if not are_featured_speakers_visible(user, event):
+        return []
+    from django_scopes import scope
+
+    with scope(event=event):
+        return get_public_featured_speaker_profiles(event)
+
+
+def public_featured_speaker_profiles_queryset(event):
+    return SpeakerProfile.objects.filter(event=event, is_featured=True).select_related(
+        'user',
+        'event',
+        'event__organizer',
+    )
+
+
+def speaker_dict_from_profile(
+    event,
+    profile,
+    *,
+    include_avatar=None,
+    include_biography=None,
+    include_featured_metadata=True,
+):
+    """Serialize a speaker profile for schedule-shaped widget payloads."""
+    if not profile or not profile.user_id:
+        return None
+    if include_avatar is None or include_biography is None:
+        avatar_flag, biography_flag = speaker_public_field_flags(event)
+        if include_avatar is None:
+            include_avatar = avatar_flag
+        if include_biography is None:
+            include_biography = biography_flag
+    user = profile.user
+    is_featured = bool(profile.is_featured) if include_featured_metadata else False
+    return {
+        'code': user.code,
+        'name': user.fullname or None,
+        'biography': (profile.biography or '') if include_biography else '',
+        'avatar': user.get_avatar_url(event=event) if include_avatar else None,
+        'avatar_thumbnail_default': (
+            user.get_avatar_url(event=event, thumbnail='default') if include_avatar else None
+        ),
+        'avatar_thumbnail_tiny': (
+            user.get_avatar_url(event=event, thumbnail='tiny') if include_avatar else None
+        ),
+        'is_featured': is_featured,
+        'featured_position': profile.position if is_featured else None,
+    }
+
+
+def _empty_widget_schedule_meta(event, *, speakers_list_public=False):
+    return {
+        'tracks': [],
+        'rooms': [],
+        'version': '',
+        'timezone': event.timezone,
+        'event_start': event.date_from.isoformat(),
+        'event_end': event.date_to.isoformat(),
+        'content_locales': event.content_locales,
+        'speakers_list_public': speakers_list_public,
+        'feature_flags': event.schedule_client_feature_flags(),
+    }
+
+
+def serialize_widget_schedule_data(data, *, event=None, user=None):
+    if event is not None and isinstance(data, dict):
+        from django.contrib.auth.models import AnonymousUser
+
+        data = dict(data)
+        data['exports_disabled'] = (
+            not are_featured_exports_available(event)
+            or bool(data.get('exports_disabled'))
+        )
+        if 'speakers_list_public' not in data:
+            data['speakers_list_public'] = can_list_released_schedule_speakers(AnonymousUser(), event)
     return escape_json_for_script(json.dumps(data, cls=I18nJSONEncoder))
 
 
@@ -71,6 +207,187 @@ def event_has_public_featured_schedule_talks(event):
     if not event.current_schedule:
         return False
     return featured_schedule_talk_slots(event.current_schedule).exists()
+
+
+def build_featured_only_schedule_data_from_profiles(event, profiles, *, speakers_list_public=False):
+    speakers = []
+    for profile in profiles:
+        speaker_data = speaker_dict_from_profile(event, profile)
+        if speaker_data:
+            speakers.append(speaker_data)
+    if not speakers:
+        return None
+    return {
+        'talks': [],
+        'speakers': speakers,
+        **_empty_widget_schedule_meta(event, speakers_list_public=speakers_list_public),
+    }
+
+
+def build_featured_only_schedule_data(event, *, extra_speakers=None):
+    """Build schedule-shaped data containing featured speakers and no talk slots."""
+    data = build_featured_only_schedule_data_from_profiles(
+        event,
+        get_public_featured_speaker_profiles(event),
+    )
+    if not data:
+        speakers = [speaker for speaker in (extra_speakers or []) if isinstance(speaker, dict)]
+        if not speakers:
+            return None
+        return {'talks': [], 'speakers': speakers, **_empty_widget_schedule_meta(event, speakers_list_public=False)}
+    if extra_speakers:
+        seen_codes = {speaker.get('code') for speaker in data['speakers'] if speaker.get('code')}
+        for speaker in extra_speakers:
+            if isinstance(speaker, dict) and speaker.get('code') not in seen_codes:
+                data['speakers'].append(speaker)
+                seen_codes.add(speaker['code'])
+    return data
+
+
+def merge_featured_speakers_into_schedule_data(event, schedule_data, featured_profiles):
+    schedule_speakers = list(schedule_data.get('speakers', []) or [])
+    speakers_by_code = {
+        speaker.get('code'): speaker
+        for speaker in schedule_speakers
+        if isinstance(speaker, dict) and speaker.get('code')
+    }
+    for profile in featured_profiles:
+        if not profile.user_id:
+            continue
+        speaker_data = speaker_dict_from_profile(event, profile)
+        if not speaker_data:
+            continue
+        code = profile.user.code
+        existing = speakers_by_code.get(code)
+        if existing:
+            existing['is_featured'] = True
+            existing['featured_position'] = profile.position
+            if speaker_data.get('biography') and not existing.get('biography'):
+                existing['biography'] = speaker_data['biography']
+            for field in ('avatar', 'avatar_thumbnail_default', 'avatar_thumbnail_tiny'):
+                if speaker_data.get(field) and not existing.get(field):
+                    existing[field] = speaker_data[field]
+            continue
+        schedule_speakers.append(speaker_data)
+        speakers_by_code[code] = speaker_data
+    schedule_data['speakers'] = schedule_speakers
+    return schedule_data
+
+
+def filter_schedule_data_to_featured_speakers(schedule_data, featured_speaker_user_codes):
+    featured_codes = {(code or '').lower() for code in featured_speaker_user_codes if code}
+    filtered_talks = [
+        talk
+        for talk in schedule_data.get('talks', []) or []
+        if featured_codes.intersection({(code or '').lower() for code in talk.get('speakers') or []})
+    ]
+    schedule_data['talks'] = filtered_talks
+    track_ids = {talk.get('track') for talk in filtered_talks if talk.get('track') is not None}
+    room_ids = {talk.get('room') for talk in filtered_talks if talk.get('room') is not None}
+    schedule_data['tracks'] = [
+        track for track in schedule_data.get('tracks', []) if track.get('id') in track_ids
+    ]
+    schedule_data['rooms'] = [
+        room for room in schedule_data.get('rooms', []) if room.get('id') in room_ids
+    ]
+    schedule_data['speakers'] = [
+        speaker
+        for speaker in schedule_data.get('speakers', []) or []
+        if isinstance(speaker, dict) and (speaker.get('code') or '').lower() in featured_codes
+    ]
+    return schedule_data
+
+
+def _ordered_featured_speakers_from_profiles(event, featured_profiles, schedule_speakers_by_code=None):
+    schedule_speakers_by_code = schedule_speakers_by_code or {}
+    ordered_speakers = []
+    for profile in featured_profiles:
+        speaker_data = speaker_dict_from_profile(event, profile)
+        if not speaker_data:
+            continue
+        schedule_speaker = schedule_speakers_by_code.get(speaker_data['code'])
+        if schedule_speaker:
+            speaker_data = {
+                **schedule_speaker,
+                **speaker_data,
+                'is_featured': True,
+                'featured_position': profile.position,
+            }
+        ordered_speakers.append(speaker_data)
+    return ordered_speakers
+
+
+def build_landing_featured_speakers_widget_schedule(event, user, featured_profiles):
+    """Build widget schedule payload for the event landing page featured speakers block."""
+    from django_scopes import scope
+
+    featured_speaker_user_codes = {profile.user.code for profile in featured_profiles if profile.user_id}
+    speakers_list_public = public_speakers_list_available(user, event)
+    base_data = build_featured_only_schedule_data_from_profiles(
+        event,
+        featured_profiles,
+        speakers_list_public=speakers_list_public,
+    )
+    if not base_data:
+        return None
+
+    schedule = event.current_schedule or getattr(event, 'wip_schedule', None)
+    show_public_times = can_view_public_schedule_sessions(user, event, schedule)
+    featured = include_public_featured_speaker_metadata(user, event)
+
+    if show_public_times and schedule:
+        with scope(event=event):
+            schedule_data = schedule.build_data(
+                all_talks=not schedule.version,
+                include_featured_speaker_metadata=featured,
+                respect_public_visibility=True,
+            )
+        schedule_data = merge_featured_speakers_into_schedule_data(event, schedule_data, featured_profiles)
+        filtered = filter_schedule_data_to_featured_speakers(schedule_data, featured_speaker_user_codes)
+        base_data['talks'] = filtered.get('talks', [])
+        base_data['tracks'] = filtered.get('tracks', [])
+        base_data['rooms'] = filtered.get('rooms', [])
+    else:
+        filtered = _apply_pending_speaker_talks(
+            base_data,
+            event,
+            user,
+            schedule,
+            featured_speaker_user_codes,
+            featured=featured,
+        )
+
+    schedule_speakers_by_code = {
+        speaker['code']: speaker
+        for speaker in filtered.get('speakers', [])
+        if isinstance(speaker, dict) and speaker.get('code')
+    }
+    base_data['speakers'] = _ordered_featured_speakers_from_profiles(
+        event,
+        featured_profiles,
+        schedule_speakers_by_code,
+    )
+    base_data['speakers_list_public'] = speakers_list_public
+    return base_data
+
+
+def build_pending_speaker_schedule_json(event, user, speaker_code, featured):
+    """Build speaker-scoped schedule JSON with coming-soon sessions before public release."""
+    profile = get_speaker_profile_by_code(event, speaker_code)
+    if not profile:
+        return '{}'
+    data = build_featured_only_schedule_data_from_profiles(event, [profile])
+    if not data:
+        return '{}'
+
+    schedule = event.current_schedule or getattr(event, 'wip_schedule', None)
+    _apply_pending_speaker_talks(data, event, user, schedule, {speaker_code}, featured=featured)
+    data['exports_disabled'] = True
+    return serialize_widget_schedule_data(data, event=event)
+
+
+def _serialize_schedule_build_data(schedule, **build_kwargs) -> str:
+    return serialize_widget_schedule_data(schedule.build_data(**build_kwargs), event=schedule.event)
 
 
 def build_schedule_meta_json(event, schedule) -> str:
@@ -140,7 +457,7 @@ def build_enriched_schedule_json(request: HttpRequest, *, wip_preview: bool = Fa
     if not schedule:
         return '{}'
 
-    featured = are_featured_submissions_visible(request.user, event)
+    featured = include_public_featured_speaker_metadata(request.user, event)
     if schedule.version:
         cache_key = f'eagenda:enriched:{schedule.pk}:{int(featured)}'
         cached = cache.get(cache_key)
@@ -172,9 +489,10 @@ def build_schedule_json(request: HttpRequest, schedule=None) -> str:
     if not schedule:
         return '{}'
 
-    featured = are_featured_submissions_visible(request.user, request.event)
+    featured = include_public_featured_speaker_metadata(request.user, request.event)
+    settings_part = schedule_widget_featured_cache_key_part(request.event)
     if schedule.version:
-        cache_key = f'eagenda:schedule:{schedule.pk}:{int(featured)}'
+        cache_key = f'eagenda:schedule:{schedule.pk}:{int(featured)}:{settings_part}'
         cached = cache.get(cache_key)
         if cached is not None:
             return cached
@@ -232,7 +550,64 @@ def build_featured_schedule_json(request: HttpRequest) -> str:
 
     _append_missing_featured_submissions(data, featured_by_code, event)
     _ensure_schedule_speakers(data, event, featured)
+    data['exports_disabled'] = not are_featured_exports_available(event)
     return escape_json_for_script(json.dumps(data, cls=I18nJSONEncoder))
+
+
+def _pending_submission_codes_for_speakers(event, user, speaker_user_codes):
+    pending_codes = set()
+    for speaker_code in speaker_user_codes:
+        pending_codes.update(pending_public_submission_codes_for_speaker(event, user, speaker_code))
+    return pending_codes
+
+
+def _load_pending_speaker_talks(event, user, schedule, speaker_user_codes, *, featured):
+    from django_scopes import scope
+
+    pending_codes = _pending_submission_codes_for_speakers(event, user, speaker_user_codes)
+    if not schedule or not pending_codes:
+        return {'talks': [], 'tracks': [], 'rooms': [], 'speakers': []}
+    with scope(event=event):
+        schedule_data = schedule.build_data(
+            all_talks=False,
+            submission_codes=pending_codes,
+            include_featured_speaker_metadata=featured,
+            respect_public_visibility=False,
+        )
+    filtered = filter_schedule_data_to_featured_speakers(schedule_data, speaker_user_codes)
+    for talk in filtered.get('talks', []):
+        _mark_talk_schedule_pending(talk)
+    return filtered
+
+
+def _append_missing_pending_submissions(data, event, user, speaker_user_codes):
+    """Add coming-soon talk entries for pending sessions missing from schedule data."""
+    if not speaker_user_codes:
+        return
+    present_codes = {talk.get('code') for talk in data.get('talks', []) if talk.get('code')}
+    missing_codes = _pending_submission_codes_for_speakers(event, user, speaker_user_codes) - present_codes
+    if not missing_codes:
+        return
+    from django_scopes import scope
+
+    with scope(event=event):
+        submissions = (
+            event.submissions.filter(code__in=missing_codes)
+            .select_related('submission_type', 'event', 'event__organizer')
+            .prefetch_related('speakers')
+            .order_by('title')
+        )
+    for submission in submissions:
+        data['talks'].append(_pending_featured_talk_data(submission, event))
+
+
+def _apply_pending_speaker_talks(data, event, user, schedule, speaker_user_codes, *, featured):
+    filtered = _load_pending_speaker_talks(event, user, schedule, speaker_user_codes, featured=featured)
+    data['talks'] = filtered.get('talks', [])
+    data['tracks'] = filtered.get('tracks', [])
+    data['rooms'] = filtered.get('rooms', [])
+    _append_missing_pending_submissions(data, event, user, speaker_user_codes)
+    return filtered
 
 
 def _append_missing_featured_submissions(data, featured_by_code, event):
@@ -332,6 +707,40 @@ def _ensure_schedule_speakers(data, event, include_featured_speaker_metadata):
         data.setdefault('speakers', []).append(speaker_data)
 
 
+def _schedule_json_includes_talk(schedule_json: str, submission_code: str) -> bool:
+    try:
+        data = json.loads(schedule_json)
+    except json.JSONDecodeError:
+        return False
+    code = (submission_code or '').lower()
+    if not code:
+        return False
+    for talk in data.get('talks', []) or []:
+        if isinstance(talk, dict) and (talk.get('code') or '').lower() == code:
+            return True
+    return False
+
+
+def build_pre_agenda_featured_talk_schedule_json(event, user, submission_code):
+    """Build talk detail JSON for featured sessions before a schedule is released."""
+    from eventyay.talk_rules.agenda import is_submission_visible_via_featured
+
+    submission = (
+        event.submissions.filter(code__iexact=submission_code)
+        .select_related('submission_type')
+        .prefetch_related('speakers')
+        .first()
+    )
+    if not submission or not is_submission_visible_via_featured(user, submission):
+        return '{}'
+
+    featured = include_public_featured_speaker_metadata(user, event)
+    data = _empty_featured_schedule_data(event)
+    data['talks'] = [_pending_featured_talk_data(submission, event)]
+    _ensure_schedule_speakers(data, event, featured)
+    return serialize_widget_schedule_data(data, event=event)
+
+
 def build_talk_schedule_json(request: HttpRequest, submission_code: str) -> str:
     """Build a minimal non-enriched schedule JSON scoped to a single talk.
 
@@ -339,15 +748,18 @@ def build_talk_schedule_json(request: HttpRequest, submission_code: str) -> str:
     are intentionally omitted here; the Vue ``TalkDetail`` component fetches them
     from the submissions API endpoint so the inlined HTML payload stays tiny.
     """
-    schedule = request.event.current_schedule
-    if not schedule:
-        return '{}'
+    event = request.event
+    user = request.user
+    schedule = event.current_schedule
+    featured = include_public_featured_speaker_metadata(user, event)
 
-    featured = are_featured_submissions_visible(request.user, request.event)
+    if not schedule:
+        return build_pre_agenda_featured_talk_schedule_json(event, user, submission_code)
+
     if schedule.version:
         cache_key = f'eagenda:talk:{schedule.pk}:{submission_code}:{int(featured)}'
         cached = cache.get(cache_key)
-        if cached is not None:
+        if cached is not None and _schedule_json_includes_talk(cached, submission_code):
             return cached
 
     result = _serialize_schedule_build_data(
@@ -357,7 +769,12 @@ def build_talk_schedule_json(request: HttpRequest, submission_code: str) -> str:
         include_featured_speaker_metadata=featured,
     )
 
-    if schedule.version:
+    if not _schedule_json_includes_talk(result, submission_code):
+        featured_result = build_pre_agenda_featured_talk_schedule_json(event, user, submission_code)
+        if featured_result != '{}':
+            result = featured_result
+
+    if schedule.version and _schedule_json_includes_talk(result, submission_code):
         cache.set(cache_key, result, CACHE_TTL)
     return result
 
@@ -378,28 +795,20 @@ def build_speaker_schedule_json_for_schedule(event, schedule, speaker_code, feat
     )
 
     if not any(s['code'].lower() == speaker_code.lower() for s in data.get('speakers', [])):
-        user = User.objects.filter(code__iexact=speaker_code).first()
-        if user:
-            profile = SpeakerProfile.objects.filter(
-                event=event, user=user
-            ).select_related('user').first()
-            include_avatar, include_biography = speaker_public_field_flags(event)
-            data.setdefault('speakers', []).append({
-                'code': user.code,
-                'name': user.fullname or None,
-                'biography': getattr(profile, 'biography', '') if include_biography else '',
-                'avatar': user.get_avatar_url(event=event) if include_avatar else None,
-                'avatar_thumbnail_default': (
-                    user.get_avatar_url(event=event, thumbnail='default') if include_avatar else None
-                ),
-                'avatar_thumbnail_tiny': (
-                    user.get_avatar_url(event=event, thumbnail='tiny') if include_avatar else None
-                ),
-                'is_featured': bool(getattr(profile, 'is_featured', False)) if featured else False,
-                'featured_position': getattr(profile, 'position', None) if featured else None,
-            })
+        profile = get_speaker_profile_by_code(event, speaker_code)
+        if profile:
+            speaker_data = speaker_dict_from_profile(
+                event,
+                profile,
+                include_featured_metadata=featured,
+            )
+            if speaker_data:
+                data.setdefault('speakers', []).append(speaker_data)
 
-    return escape_json_for_script(json.dumps(data, cls=I18nJSONEncoder))
+    if not talk_codes:
+        data['exports_disabled'] = True
+
+    return serialize_widget_schedule_data(data, event=event)
 
 
 def build_speaker_schedule_json(request: HttpRequest, speaker_code: str) -> str:
@@ -411,22 +820,45 @@ def build_speaker_schedule_json(request: HttpRequest, speaker_code: str) -> str:
     Speaker calendar export URLs are computed client-side by ``speakerExportOptions``
     in ``SessionModal.vue``, so ``enrich=False`` is safe here.
     """
-    schedule = request.event.current_schedule
-    if not schedule:
+    event = request.event
+    featured = include_public_featured_speaker_metadata(request.user, event)
+    schedule = event.current_schedule
+    if schedule and can_view_public_schedule_sessions(request.user, event, schedule):
+        if schedule.version:
+            cache_key = f'eagenda:speaker:{schedule.pk}:{speaker_code}:{int(featured)}'
+            cached = cache.get(cache_key)
+            if cached is not None:
+                return cached
+
+        result = build_speaker_schedule_json_for_schedule(event, schedule, speaker_code, featured)
+
+        if schedule.version:
+            cache.set(cache_key, result, CACHE_TTL)
+        return result
+
+    if not speaker_may_show_pending_sessions(request.user, event, speaker_code):
         return '{}'
+    return build_pending_speaker_schedule_json(event, request.user, speaker_code, featured)
 
-    featured = are_featured_submissions_visible(request.user, request.event)
-    if schedule.version:
-        cache_key = f'eagenda:speaker:{schedule.pk}:{speaker_code}:{int(featured)}'
-        cached = cache.get(cache_key)
-        if cached is not None:
-            return cached
 
-    result = build_speaker_schedule_json_for_schedule(request.event, schedule, speaker_code, featured)
+def build_speakers_list_schedule_json(request: HttpRequest) -> str:
+    """Build inline schedule JSON for the public speakers overview."""
+    from django_scopes import scope
 
-    if schedule.version:
-        cache.set(cache_key, result, CACHE_TTL)
-    return result
+    event = request.event
+    user = request.user
+    if not can_list_released_schedule_speakers(user, event):
+        return ''
+    schedule = event.current_schedule
+    featured = include_public_featured_speaker_metadata(user, event)
+    with scope(event=event):
+        data = schedule.build_data(
+            all_talks=not schedule.version,
+            include_featured_speaker_metadata=featured,
+        )
+    if not data:
+        return ''
+    return serialize_widget_schedule_data(data, event=event)
 
 
 def warm_scoped_schedule_caches(schedule, *, featured):
@@ -533,6 +965,11 @@ def redirect_to_presale_with_warning(request, message):
     return HttpResponseRedirect(request.event.urls.base)
 
 
+def redirect_when_public_speakers_unavailable(request):
+    """Send visitors back to the info page with the same messaging as the schedule page."""
+    return redirect_to_presale_with_warning(request, _('No published schedule.'))
+
+
 def is_public_schedule_empty(request):
     """True if a schedule is public but contains no published sessions."""
     return bool(
@@ -545,6 +982,10 @@ def is_public_schedule_empty(request):
 
 def is_public_speakers_empty(request):
     """True if speakers are public but there are no published speakers."""
+    if has_public_featured_speakers(request.user, request.event):
+        return False
+    if can_list_released_schedule_speakers(request.user, request.event):
+        return False
     return bool(
         request.event.is_public
         and request.event.get_feature_flag('show_schedule')

--- a/app/eventyay/agenda/views/widget.py
+++ b/app/eventyay/agenda/views/widget.py
@@ -21,7 +21,7 @@ from eventyay.talk_rules.agenda import (
     wip_preview_build_data,
 )
 from eventyay.talk_rules.submission import (
-    are_featured_submissions_visible,
+    are_featured_speakers_visible,
     schedule_widget_featured_cache_key_part,
 )
 
@@ -146,7 +146,7 @@ def widget_data(request, organizer=None, event=None, version=None, **kwargs):
     result = schedule.build_data(
         all_talks=not schedule.version,
         enrich=enrich,
-        include_featured_speaker_metadata=are_featured_submissions_visible(AnonymousUser(), event),
+        include_featured_speaker_metadata=are_featured_speakers_visible(AnonymousUser(), event),
         include_qrcodes=include_qrcodes,
         respect_public_visibility=not preview,
     )

--- a/app/eventyay/base/models/event.py
+++ b/app/eventyay/base/models/event.py
@@ -194,10 +194,10 @@ def default_feature_flags():
     return {
         'show_schedule': True,
         'show_featured': 'never',
+        'show_featured_speakers': 'never',
         'show_widget_if_not_public': False,
         'session_popularity_enabled': False,
-        'session_popularity_show_on_calendar': True,
-        'session_popularity_show_on_list': True,
+        'session_popularity_show_on_schedule': True,
         'export_html_on_release': False,
         'use_tracks': True,
         'use_feedback': True,
@@ -2604,6 +2604,26 @@ class Event(
         if feature in self.feature_flags:
             return self.feature_flags[feature]
         return default_feature_flags().get(feature, False)
+
+    def session_popularity_show_on_schedule(self):
+        flags = self.feature_flags or {}
+        if 'session_popularity_show_on_schedule' in flags:
+            return bool(flags['session_popularity_show_on_schedule'])
+        return bool(
+            flags.get('session_popularity_show_on_calendar', True)
+            or flags.get('session_popularity_show_on_list', True)
+        )
+
+    def schedule_client_feature_flags(self):
+        """Feature flags exposed to schedule webapp clients via inline JSON."""
+        from eventyay.talk_rules.submission import are_featured_speakers_visible
+
+        popularity_enabled = bool(self.feature_flags.get('session_popularity_enabled', False))
+        return {
+            'session_popularity_enabled': popularity_enabled,
+            'session_popularity_show_on_schedule': self.session_popularity_show_on_schedule(),
+            'featured_speakers_enabled': are_featured_speakers_visible(None, self),
+        }
 
     @cached_property
     def duration(self):

--- a/app/eventyay/base/models/schedule.py
+++ b/app/eventyay/base/models/schedule.py
@@ -826,8 +826,6 @@ class Schedule(PretalxModel):
         talks = talks.order_by('start')
 
         popularity_enabled = bool(self.event.feature_flags.get('session_popularity_enabled', False))
-        show_popularity_calendar = bool(self.event.feature_flags.get('session_popularity_show_on_calendar', True))
-        show_popularity_list = bool(self.event.feature_flags.get('session_popularity_show_on_list', True))
         show_content_locale = not respect_public_visibility or self.event.cfp.public_content_locale
 
         talk_list = list(talks)
@@ -885,11 +883,7 @@ class Schedule(PretalxModel):
             'event_start': self.event.date_from.isoformat(),
             'event_end': self.event.date_to.isoformat(),
             'content_locales': self.event.content_locales if show_content_locale else [],
-            'feature_flags': {
-                'session_popularity_enabled': popularity_enabled,
-                'session_popularity_show_on_calendar': show_popularity_calendar,
-                'session_popularity_show_on_list': show_popularity_list,
-            },
+            'feature_flags': self.event.schedule_client_feature_flags(),
         }
         show_do_not_record = self.event.cfp.request_do_not_record
         show_abstract = self.event.cfp.public_abstract

--- a/app/eventyay/common/middleware/event.py
+++ b/app/eventyay/common/middleware/event.py
@@ -25,37 +25,31 @@ from eventyay.common.utils.language import (
     strict_match_language,
     validate_language,
 )
+from eventyay.talk_rules.agenda import agenda_page_allowed_without_talks_published
 
 
 logger = logging.getLogger(__name__)
 
 
 def _agenda_featured_allowed_without_talks_published(url, request, event):
-    """Let /featured/ (and featured exports after schedule release) load when org settings allow,
-    even if talks are not published yet.
-    """
+    """Let featured/speaker pages load when org settings allow it, even if talks are not published yet."""
     if 'agenda' not in url.namespaces:
         return False
-
-    from eventyay.talk_rules.submission import are_featured_submissions_visible, can_use_featured_exports
 
     user = getattr(request, 'user', None)
     if user is None:
         return False
 
-    is_featured_page = url.url_name == 'featured'
     is_featured_export = (
         (url.url_name in ('export', 'export-tokenized') or url.url_name.startswith('export.'))
         and request.GET.get('featured') == 'true'
     )
-
     if is_featured_export:
+        from eventyay.talk_rules.submission import can_use_featured_exports
+
         return can_use_featured_exports(user, event)
 
-    if is_featured_page:
-        return are_featured_submissions_visible(user, event)
-
-    return False
+    return agenda_page_allowed_without_talks_published(url.url_name, user, event, url_kwargs=url.kwargs)
 
 
 def get_login_redirect(request):
@@ -155,8 +149,9 @@ class EventPermissionMiddleware:
         if event and not event.user_can_view_talks(request.user, request=request):
             if 'agenda' in url.namespaces or 'cfp' in url.namespaces:
                 if url.url_name != 'event.css':
-                    if not _agenda_featured_allowed_without_talks_published(url, request, event):
-                        raise Http404()
+                    with scope(event=event):
+                        if not _agenda_featured_allowed_without_talks_published(url, request, event):
+                            raise Http404()
         if event:
             with scope(event=event):
                 response = self.get_response(request)

--- a/app/eventyay/common/templates/common/fragment_nav.html
+++ b/app/eventyay/common/templates/common/fragment_nav.html
@@ -26,22 +26,20 @@
         </a>
     {% endif %}
     {% if show_talks_tab %}
-        {% can_list_schedule current_event as show_schedule_tab %}
-        {% is_wip_agenda_preview request as wip_preview %}
-        {% if show_schedule_tab %}
-        {% if current_event.has_schedule_content or wip_preview or schedule %}
+        {% show_schedule_nav_tab current_event as show_schedule_nav %}
+            {% if show_schedule_nav %}
             {% agenda_schedule_nav_url request current_event as schedule_url %}
                 <a href="{{ schedule_url }}" class="header-tab {% if '/schedule/' in path and '/speakers/' not in path and '/talk/' not in path %}active{% endif %}">
                     <i class="fa fa-calendar"></i> {{ schedule_label }}
                 </a>
-            {% if current_event.speakers.exists %}
+            {% endif %}
+            {% show_public_speakers_list current_event as show_speakers_list %}
+            {% if show_speakers_list %}
                 {% agenda_speakers_nav_url request current_event as speakers_url %}
                     <a href="{{ speakers_url }}" class="header-tab {% if '/speakers/' in path %}active{% endif %}">
                         <i class="fa fa-group"></i> {{ speakers_label }}
                     </a>
             {% endif %}
-        {% endif %}
-        {% endif %}
     {% endif %}
 
     {% eventsignal current_event "eventyay.presale.signals.header_nav_tabs" request=request %}

--- a/app/eventyay/common/templatetags/event_tags.py
+++ b/app/eventyay/common/templatetags/event_tags.py
@@ -12,6 +12,11 @@ from django_scopes import scopes_disabled
 from eventyay.base.models import Order, OrderPosition
 from eventyay.common.urls import is_http_url
 from eventyay.common.permissions import is_admin_mode_active, user_has_cfp_submissions
+from eventyay.talk_rules.agenda import (
+    can_list_released_schedule_speakers,
+    is_agenda_visible,
+    is_wip_agenda_url,
+)
 from eventyay.talk_rules.submission import (
     are_featured_submissions_visible,
     event_has_featured_submissions,
@@ -198,6 +203,40 @@ def can_list_schedule(context, event=None):
         and event.get_feature_flag('show_schedule')
         and event.current_schedule
     )
+
+
+@register.simple_tag(takes_context=True)
+def show_public_speakers_list(context, event=None):
+    """Whether the public speakers overview page and nav link may be shown."""
+    request = context.get('request')
+    event = event or getattr(request, 'event', None)
+    if not request or not event:
+        return False
+    return can_list_released_schedule_speakers(AnonymousUser(), event)
+
+
+@register.simple_tag(takes_context=True)
+def show_schedule_nav_tab(context, event=None):
+    """Whether the schedule header tab should link to the public schedule."""
+    request = context.get('request')
+    event = event or getattr(request, 'event', None)
+    if not request or not event:
+        return False
+    if not can_list_schedule(context, event):
+        return False
+
+    path = getattr(request, 'path_info', '') or ''
+    user = getattr(request, 'user', None) or AnonymousUser()
+
+    if is_wip_agenda_url(path):
+        return True
+    if is_agenda_visible(user, event) and event.has_schedule_content:
+        return True
+    if '/featured/' in path:
+        return False
+    if '/schedule/' in path and '/speakers/' not in path and '/talk/' not in path:
+        return True
+    return False
 
 
 @register.simple_tag(takes_context=True)

--- a/app/eventyay/orga/forms/event.py
+++ b/app/eventyay/orga/forms/event.py
@@ -38,6 +38,21 @@ SCHEDULE_DISPLAY_CHOICES = (
     ('list', _('List')),
 )
 
+SHOW_FEATURED_VISIBILITY_CHOICES = (
+    ('never', _('Never')),
+    ('after_schedule', _('Once the first schedule version is published')),
+    ('always', _('Always')),
+)
+
+SHOW_FEATURED_SESSIONS_HELP = _(
+    'Controls when the featured sessions page and nav tab are shown. '
+    'Mark sessions as featured for content — Always alone does not populate the page.'
+)
+SHOW_FEATURED_SPEAKERS_HELP = _(
+    'Controls the featured speakers block on the event info page. '
+    'Mark speakers as featured for content — Always alone does not populate the page.'
+)
+
 
 class EventForm(ReadOnlyFlag, I18nHelpText, JsonSubfieldMixin, I18nModelForm):
     custom_css_text = forms.CharField(
@@ -53,29 +68,16 @@ class EventForm(ReadOnlyFlag, I18nHelpText, JsonSubfieldMixin, I18nModelForm):
         ),
         required=False,
     )
-    show_schedule = forms.BooleanField(
-        label=_('Show schedule publicly'),
-        help_text=_('Unset to hide your schedule, e.g. if you want to use the HTML export exclusively.'),
-        required=False,
-    )
-    schedule = forms.ChoiceField(
-        label=phrases.orga.event_schedule_format_label,
-        choices=SCHEDULE_DISPLAY_CHOICES,
-        required=True,
-    )
     show_featured = forms.ChoiceField(
         label=_('Show featured sessions'),
-        choices=(
-            ('never', _('Never')),
-            ('after_schedule', _('Once the first schedule version is published'),),
-            ('always', _('Always')),
-        ),
-        help_text=_(
-            'Never: the featured page and nav entry are always hidden. '
-            '"Once the first schedule version is published": featured sessions are hidden until you '
-            'release a schedule version; after the first release the featured page and tab appear. '
-            'Always: the featured page and tab are always visible (even before a schedule is released).'
-        ),
+        choices=SHOW_FEATURED_VISIBILITY_CHOICES,
+        help_text=SHOW_FEATURED_SESSIONS_HELP,
+        required=True,
+    )
+    show_featured_speakers = forms.ChoiceField(
+        label=_('Show featured speakers'),
+        choices=SHOW_FEATURED_VISIBILITY_CHOICES,
+        help_text=SHOW_FEATURED_SPEAKERS_HELP,
         required=True,
     )
     use_feedback = forms.BooleanField(
@@ -88,14 +90,9 @@ class EventForm(ReadOnlyFlag, I18nHelpText, JsonSubfieldMixin, I18nModelForm):
         help_text=_('Enables session popularity (favourites) counts and sorting options in the schedule webapp.'),
         required=False,
     )
-    session_popularity_show_on_calendar = forms.BooleanField(
-        label=_('Show popularity on calendar view'),
-        help_text=_('Shows favourite counts on session cards in the calendar/grid view. Only used if popularity is enabled.'),
-        required=False,
-    )
-    session_popularity_show_on_list = forms.BooleanField(
-        label=_('Show popularity on list view'),
-        help_text=_('Shows favourite counts on session cards in the list view. Only used if popularity is enabled.'),
+    session_popularity_show_on_schedule = forms.BooleanField(
+        label=_('Show popularity on schedule'),
+        help_text=_('Shows favourite counts on session cards in the schedule.'),
         required=False,
     )
     export_html_on_release = forms.BooleanField(
@@ -123,17 +120,37 @@ class EventForm(ReadOnlyFlag, I18nHelpText, JsonSubfieldMixin, I18nModelForm):
         self.is_administrator = kwargs.pop('is_administrator', False)
         super().__init__(*args, **kwargs)
         self.initial['custom_css_text'] = self.instance.custom_css.read().decode() if self.instance.custom_css else ''
-        self.fields['show_featured'].help_text = (
-            str(self.fields['show_featured'].help_text)
-            + ' '
-            + str(_('You can find the page <a {href}>here</a>.')).format(href=f'href="{self.instance.urls.featured}"')
-        )
+        flags = self.instance.feature_flags or {}
+        if 'show_featured_speakers' not in flags and 'show_featured' in flags:
+            self.fields['show_featured_speakers'].initial = flags['show_featured']
+        self._configure_session_popularity_fields(flags)
 
-    def clean_show_featured(self):
-        value = self.cleaned_data.get('show_featured', '')
+    def _configure_session_popularity_fields(self, flags):
+        if 'session_popularity_show_on_schedule' not in flags:
+            self.fields['session_popularity_show_on_schedule'].initial = bool(
+                flags.get('session_popularity_show_on_calendar', True)
+                or flags.get('session_popularity_show_on_list', True)
+            )
+        if not self._is_session_popularity_enabled():
+            self.fields['session_popularity_show_on_schedule'].disabled = True
+
+    def _is_session_popularity_enabled(self):
+        if self.is_bound:
+            return self.data.get('session_popularity_enabled') in ('on', 'true', 'True', '1')
+        flags = self.instance.feature_flags or {}
+        return bool(flags.get('session_popularity_enabled', False))
+
+    @staticmethod
+    def _normalize_featured_visibility(value):
         if value == 'pre_schedule':
             return 'after_schedule'
         return value
+
+    def clean_show_featured(self):
+        return self._normalize_featured_visibility(self.cleaned_data.get('show_featured', ''))
+
+    def clean_show_featured_speakers(self):
+        return self._normalize_featured_visibility(self.cleaned_data.get('show_featured_speakers', ''))
 
     def clean_custom_css(self):
         if self.cleaned_data.get('custom_css') or self.files.get('custom_css'):
@@ -160,12 +177,17 @@ class EventForm(ReadOnlyFlag, I18nHelpText, JsonSubfieldMixin, I18nModelForm):
 
     def clean(self):
         data = super().clean()
+        enabled = bool(data.get('session_popularity_enabled'))
+        if enabled:
+            data['session_popularity_show_on_schedule'] = bool(
+                data.get('session_popularity_show_on_schedule', True)
+            )
+        else:
+            data['session_popularity_show_on_schedule'] = False
         return data
 
     def save(self, *args, **kwargs):
         result = super().save(*args, **kwargs)
-        if 'show_schedule' in self.cleaned_data:
-            self.instance.settings.talk_schedule_public = bool(self.cleaned_data['show_schedule'])
         css_text = self.cleaned_data.get('custom_css_text', '')
         if css_text and 'custom_css_text' in self.changed_data:
             self.instance.custom_css.save(self.instance.slug + '.css', ContentFile(css_text))
@@ -180,13 +202,11 @@ class EventForm(ReadOnlyFlag, I18nHelpText, JsonSubfieldMixin, I18nModelForm):
         ]
         json_fields = {
             'imprint_url': 'display_settings',
-            'show_schedule': 'feature_flags',
-            'schedule': 'display_settings',
             'show_featured': 'feature_flags',
+            'show_featured_speakers': 'feature_flags',
             'use_feedback': 'feature_flags',
             'session_popularity_enabled': 'feature_flags',
-            'session_popularity_show_on_calendar': 'feature_flags',
-            'session_popularity_show_on_list': 'feature_flags',
+            'session_popularity_show_on_schedule': 'feature_flags',
             'export_html_on_release': 'feature_flags',
             'html_export_url': 'display_settings',
             'header_pattern': 'display_settings',
@@ -387,28 +407,9 @@ class WidgetSettingsForm(JsonSubfieldMixin, forms.Form):
         required=False,
     )
 
-    session_popularity_enabled = forms.BooleanField(
-        label=_('Activate most popular session feature'),
-        help_text=_('Enables session popularity (favourites) counts and sorting options in the schedule webapp.'),
-        required=False,
-    )
-    session_popularity_show_on_calendar = forms.BooleanField(
-        label=_('Show popularity on calendar view'),
-        help_text=_('Shows favourite counts on session cards in the calendar/grid view. Only used if popularity is enabled.'),
-        required=False,
-    )
-    session_popularity_show_on_list = forms.BooleanField(
-        label=_('Show popularity on list view'),
-        help_text=_('Shows favourite counts on session cards in the list view. Only used if popularity is enabled.'),
-        required=False,
-    )
-
     class Meta:
         json_fields = {
             'show_widget_if_not_public': 'feature_flags',
-            'session_popularity_enabled': 'feature_flags',
-            'session_popularity_show_on_calendar': 'feature_flags',
-            'session_popularity_show_on_list': 'feature_flags',
         }
 
 

--- a/app/eventyay/orga/templates/orga/settings/form.html
+++ b/app/eventyay/orga/templates/orga/settings/form.html
@@ -55,12 +55,12 @@
             </fieldset>
             <fieldset>
                 <legend id="schedule">{% translate "Schedule" %}</legend>
-                {{ form.show_schedule.as_field_group }}
-                {{ form.schedule.as_field_group }}
                 {{ form.show_featured.as_field_group }}
+                {{ form.show_featured_speakers.as_field_group }}
                 {{ form.session_popularity_enabled.as_field_group }}
-                {{ form.session_popularity_show_on_calendar.as_field_group }}
-                {{ form.session_popularity_show_on_list.as_field_group }}
+                <div class="form-subfield-group{% if form.fields.session_popularity_show_on_schedule.disabled %} subfield-disabled{% endif %}" id="session-popularity-subfields">
+                    {{ form.session_popularity_show_on_schedule.as_field_group }}
+                </div>
                 {{ form.use_feedback.as_field_group }}
                 {{ form.export_html_on_release.as_field_group }}
                 {{ form.html_export_url.as_field_group }}

--- a/app/eventyay/orga/views/speaker.py
+++ b/app/eventyay/orga/views/speaker.py
@@ -52,7 +52,7 @@ class SpeakerList(EventPermissionRequired, Sortable, Filterable, PaginationMixin
     context_object_name = 'speakers'
     default_filters = ('user__email__icontains', 'user__fullname__icontains')
     sortable_fields = ('position', 'user__email', 'user__fullname')
-    default_sort_field = None
+    default_sort_field = 'position'
     secondary_sort = {'position': ('user__fullname',)}
     permission_required = 'base.orga_list_speakerprofile'
 

--- a/app/eventyay/presale/templates/pretixpresale/event/fragment_nav.html
+++ b/app/eventyay/presale/templates/pretixpresale/event/fragment_nav.html
@@ -34,12 +34,12 @@
                 <a href="{{ request.event.talk_session_url }}" class="header-tab {% if '/sessions/' in request.path_info %}active{% endif %}">
                     <i class="fa fa-comments-o"></i> {% translate "Sessions" %}
                 </a>
-
-                {% if request.event.speakers.exists %}
+            {% endif %}
+            {% show_public_speakers_list request.event as show_speakers_list %}
+            {% if show_speakers_list %}
                     <a href="{{ request.event.talk_speaker_url }}" class="header-tab {% if '/speakers/' in request.path_info %}active{% endif %}">
                         <i class="fa fa-group"></i> {% translate "Speakers" %}
                     </a>
-                {% endif %}
             {% endif %}
         {% endif %}
 

--- a/app/eventyay/presale/templates/pretixpresale/event/index.html
+++ b/app/eventyay/presale/templates/pretixpresale/event/index.html
@@ -383,9 +383,10 @@
     {% if subevent or not event.has_subevents %}
         {% if featured_speakers %}
             <section class="front-page" id="featured-speakers" aria-label="{% trans 'Featured Speakers' %}">
+                <script id="pretalx-messages" data-logged-in="{% if request.user.is_anonymous %}false{% else %}true{% endif %}"></script>
                 <script id="pretalx-schedule-data" type="application/json">{{ featured_speakers_widget_schedule_json|safe }}</script>
                 {% vite_app_scripts 'schedule' 'src/main-wc.js' fallback='schedule/pretalx-schedule.js' %}
-                <pretalx-schedule event-url="{{ request.event.urls.base }}" locale="{{ request.LANGUAGE_CODE }}" view="featured-speakers" style="--pretalx-clr-primary: {{ request.event.visible_primary_color }}"></pretalx-schedule>
+                <pretalx-schedule event-url="{{ request.event.urls.base }}" locale="{{ request.LANGUAGE_CODE }}" view="featured-speakers" speakers-list-public="{% if featured_speakers_list_public %}true{% else %}false{% endif %}" style="--pretalx-clr-primary: {{ request.event.visible_primary_color }}"></pretalx-schedule>
             </section>
         {% endif %}
     {% endif %}

--- a/app/eventyay/presale/views/event.py
+++ b/app/eventyay/presale/views/event.py
@@ -15,6 +15,7 @@ import jwt
 import pytz
 from django.conf import settings
 from django.contrib import messages
+from django.contrib.auth.models import AnonymousUser
 from django.core.exceptions import PermissionDenied
 from django.db.models import (
     Count,
@@ -39,10 +40,14 @@ from django.views import View
 from django.views.decorators.csrf import csrf_exempt
 from django.views.generic import TemplateView
 from django_scopes import scope
-from i18nfield.utils import I18nJSONEncoder
 
-from eventyay.agenda.views.utils import escape_json_for_script
-from eventyay.talk_rules.submission import are_featured_submissions_visible
+from eventyay.agenda.views.utils import (
+    build_landing_featured_speakers_widget_schedule,
+    build_featured_only_schedule_data_from_profiles,
+    load_public_featured_speaker_profiles,
+    serialize_widget_schedule_data,
+)
+from eventyay.talk_rules.agenda import public_speakers_list_available
 
 from eventyay.base.channels import get_all_sales_channels
 from eventyay.base.models import (
@@ -50,7 +55,6 @@ from eventyay.base.models import (
     ProductVariation,
     Quota,
     SeatCategoryMapping,
-    SpeakerProfile,
     Voucher,
 )
 from eventyay.base.models.event import SubEvent
@@ -620,124 +624,30 @@ class EventIndex(EventViewMixin, EventListMixin, CartMixin, TemplateView):
         context['featured_speakers'] = []
         context['featured_speakers_widget_schedule'] = None
         context['featured_speakers_widget_schedule_json'] = ''
+        context['featured_speakers_list_public'] = False
 
         event = self.request.event
-        featured_sessions_visible = are_featured_submissions_visible(self.request.user, event)
-        featured_speaker_profiles = []
-        if featured_sessions_visible:
-            with scope(event=event):
-                featured_speaker_profiles = list(
-                    SpeakerProfile.objects.filter(
-                        event=event,
-                        is_featured=True,
-                    )
-                    .select_related('user')
-                    .order_by(OrderBy(F('position'), nulls_last=True), 'user__fullname', 'pk')
-                )
+        featured_speaker_profiles = load_public_featured_speaker_profiles(self.request.user, event)
 
         if featured_speaker_profiles:
             context['featured_speakers'] = featured_speaker_profiles
-
-            featured_speaker_user_codes = {
-                profile.user.code for profile in featured_speaker_profiles if profile.user_id
-            }
-
-            schedule = event.current_schedule or getattr(event, 'wip_schedule', None)
-            can_view_schedule = (
-                bool(schedule)
-                and (
-                    self.request.user.has_perm('base.view_widget_schedule', event)
-                    or event.talks_published
-                )
+            schedule_data = build_landing_featured_speakers_widget_schedule(
+                event,
+                self.request.user,
+                featured_speaker_profiles,
             )
-
-            if schedule and can_view_schedule:
-                with scope(event=event):
-                    schedule_data = schedule.build_data(all_talks=not schedule.version)
-
-                schedule_speakers = list(schedule_data.get('speakers', []) or [])
-                schedule_speaker_codes = {s.get('code') for s in schedule_speakers if isinstance(s, dict)}
-                include_avatar = event.cfp.request_avatar
-                for speaker_profile in featured_speaker_profiles:
-                    if not speaker_profile.user_id:
-                        continue
-                    user = speaker_profile.user
-                    if user.code in schedule_speaker_codes:
-                        continue
-                    schedule_speakers.append(
-                        {
-                            'code': user.code,
-                            'name': user.fullname or None,
-                            'biography': speaker_profile.biography or '',
-                            'avatar': (user.get_avatar_url(event=event) if include_avatar else None),
-                            'avatar_thumbnail_default': (
-                                user.get_avatar_url(event=event, thumbnail='default') if include_avatar else None
-                            ),
-                            'avatar_thumbnail_tiny': (
-                                user.get_avatar_url(event=event, thumbnail='tiny') if include_avatar else None
-                            ),
-                            'is_featured': True,
-                            'featured_position': speaker_profile.position,
-                        }
-                    )
-                schedule_data['speakers'] = schedule_speakers
-
-                all_talks_list = list(schedule_data.get('talks', []) or [])
-                filtered_talks = [
-                    t
-                    for t in all_talks_list
-                    if featured_speaker_user_codes.intersection(set(t.get('speakers') or []))
-                ]
-                schedule_data['talks'] = filtered_talks
-
-                track_ids = {t.get('track') for t in schedule_data['talks'] if t.get('track') is not None}
-                room_ids = {t.get('room') for t in schedule_data['talks'] if t.get('room') is not None}
-                schedule_data['tracks'] = [
-                    tr for tr in schedule_data.get('tracks', []) if tr.get('id') in track_ids
-                ]
-                schedule_data['rooms'] = [
-                    rm for rm in schedule_data.get('rooms', []) if rm.get('id') in room_ids
-                ]
-                context['featured_speakers_widget_schedule'] = schedule_data
-                context['featured_speakers_widget_schedule_json'] = escape_json_for_script(
-                    json.dumps(schedule_data, cls=I18nJSONEncoder)
+            if not schedule_data:
+                schedule_data = build_featured_only_schedule_data_from_profiles(
+                    event,
+                    featured_speaker_profiles,
+                    speakers_list_public=public_speakers_list_available(AnonymousUser(), event),
                 )
-            else:
-                include_avatar = event.cfp.request_avatar
-                widget_speakers = []
-                for speaker_profile in featured_speaker_profiles:
-                    if not speaker_profile.user_id:
-                        continue
-                    user = speaker_profile.user
-                    widget_speakers.append(
-                        {
-                            'code': user.code,
-                            'name': user.fullname or None,
-                            'biography': speaker_profile.biography or '',
-                            'avatar': (user.get_avatar_url(event=event) if include_avatar else None),
-                            'avatar_thumbnail_default': (
-                                user.get_avatar_url(event=event, thumbnail='default') if include_avatar else None
-                            ),
-                            'avatar_thumbnail_tiny': (
-                                user.get_avatar_url(event=event, thumbnail='tiny') if include_avatar else None
-                            ),
-                            'is_featured': True,
-                            'featured_position': speaker_profile.position,
-                        }
-                    )
-                context['featured_speakers_widget_schedule'] = {
-                    'talks': [],
-                    'speakers': widget_speakers,
-                    'tracks': [],
-                    'rooms': [],
-                    'version': '',
-                    'timezone': event.timezone,
-                    'event_start': event.date_from.isoformat(),
-                    'event_end': event.date_to.isoformat(),
-                    'content_locales': event.content_locales,
-                }
-                context['featured_speakers_widget_schedule_json'] = escape_json_for_script(
-                    json.dumps(context['featured_speakers_widget_schedule'], cls=I18nJSONEncoder)
+            if schedule_data:
+                context['featured_speakers_widget_schedule'] = schedule_data
+                context['featured_speakers_list_public'] = schedule_data.get('speakers_list_public', False)
+                context['featured_speakers_widget_schedule_json'] = serialize_widget_schedule_data(
+                    schedule_data,
+                    event=event,
                 )
 
         return context

--- a/app/eventyay/static/orga/css/_layout.css
+++ b/app/eventyay/static/orga/css/_layout.css
@@ -1810,3 +1810,21 @@ h2 .user-name-display img {
   pointer-events: auto;
   transition: max-height 0.3s ease-in-out, opacity 0.3s ease, margin-bottom 0.3s ease, visibility 0s linear 0s;
 }
+
+.form-subfield-group {
+  padding-left: 2rem;
+}
+
+.form-subfield-group.subfield-disabled {
+  opacity: 0.55;
+  pointer-events: none;
+}
+
+.form-subfield-group.subfield-disabled .col-form-label,
+.form-subfield-group.subfield-disabled label {
+  color: var(--color-text-muted, #6c757d);
+}
+
+.form-subfield-group.subfield-disabled input[type="checkbox"] {
+  cursor: not-allowed;
+}

--- a/app/eventyay/static/orga/js/eventSettings.js
+++ b/app/eventyay/static/orga/js/eventSettings.js
@@ -4,8 +4,31 @@ const showDateHelpText = () => {
     dateHelpText.classList.remove("d-none")
 }
 
+function updateSessionPopularitySubfields({ defaultChildOnEnable = false } = {}) {
+    const parent = document.getElementById("id_session_popularity_enabled")
+    const child = document.getElementById("id_session_popularity_show_on_schedule")
+    const wrapper = document.getElementById("session-popularity-subfields")
+    if (!parent || !child || !wrapper) return
+
+    const enabled = parent.checked
+    child.disabled = !enabled
+    wrapper.classList.toggle("subfield-disabled", !enabled)
+    if (!enabled) {
+        child.checked = false
+    } else if (defaultChildOnEnable) {
+        child.checked = true
+    }
+}
+
 onReady(() => {
-    dateHelpText.classList.add("d-none")
-    document.getElementById("id_date_to").addEventListener("change", showDateHelpText)
-    document.getElementById("id_date_from").addEventListener("change", showDateHelpText)
+    if (dateHelpText) {
+        dateHelpText.classList.add("d-none")
+        document.getElementById("id_date_to")?.addEventListener("change", showDateHelpText)
+        document.getElementById("id_date_from")?.addEventListener("change", showDateHelpText)
+    }
+
+    updateSessionPopularitySubfields()
+    document.getElementById("id_session_popularity_enabled")?.addEventListener("change", () => {
+        updateSessionPopularitySubfields({ defaultChildOnEnable: true })
+    })
 })

--- a/app/eventyay/talk_rules/agenda.py
+++ b/app/eventyay/talk_rules/agenda.py
@@ -4,6 +4,7 @@ from django.http import Http404
 from .orga import can_view_speaker_names
 from .person import is_reviewer
 from .submission import (
+    are_featured_speakers_visible,
     are_featured_submissions_visible,
     is_speaker,
     orga_can_change_submissions,
@@ -89,7 +90,13 @@ def agenda_speaker_talks(event, user, *, speaker=None, speaker_code=None, wip_pr
 @rules.predicate
 def is_agenda_visible(user, event):
     event = event.event
-    return bool(event and event.talks_published and event.get_feature_flag('show_schedule') and event.current_schedule)
+    return bool(
+        event
+        and event.talks_published
+        and event.get_feature_flag('show_schedule')
+        and event.current_schedule
+        and not event.private_testmode_talks_enabled
+    )
 
 
 can_view_schedule = is_agenda_visible | orga_can_change_submissions | (is_reviewer & can_view_speaker_names)
@@ -111,7 +118,207 @@ def is_viewable_profile(user, profile):
     return is_speaker(profile.user, profile.event)
 
 
-is_speaker_viewable = is_viewable_profile & can_view_schedule
+@rules.predicate
+def is_pre_agenda_featured_public(user, event):
+    """Featured speaker content is public before the full agenda is released."""
+    event_obj = getattr(event, 'event', event)
+    return bool(
+        event_obj
+        and are_featured_speakers_visible(user, event_obj)
+        and not is_agenda_visible(user, event_obj)
+    )
+
+
+def speaker_has_released_schedule_slots(event, user):
+    """True if the user has any talk slot on the published schedule."""
+    schedule = getattr(event, 'current_schedule', None)
+    if not schedule or not user:
+        return False
+    from django_scopes import scope
+
+    from eventyay.base.models import TalkSlot
+
+    with scope(event=event):
+        return TalkSlot.objects.filter(
+            schedule=schedule,
+            submission__isnull=False,
+            submission__speakers=user,
+        ).exists()
+
+
+@rules.predicate
+def is_featured_speaker_profile(user, profile):
+    if not profile or not profile.is_featured:
+        return False
+    event_obj = profile.event
+    if not are_featured_speakers_visible(user, event_obj):
+        return False
+    # Speakers on the released schedule follow normal schedule visibility instead.
+    if is_agenda_visible(user, event_obj) and speaker_has_released_schedule_slots(event_obj, profile.user):
+        return False
+    return True
+
+
+@rules.predicate
+def speaker_has_public_featured_submissions(user, profile):
+    """Speaker profiles stay public before schedule release when they have featured talks."""
+    if not profile or not profile.user_id:
+        return False
+    return bool(pending_public_submission_codes_for_speaker(profile.event, user, profile.user.code))
+
+
+is_speaker_viewable = (
+    (is_viewable_profile & can_view_schedule)
+    | is_featured_speaker_profile
+    | speaker_has_public_featured_submissions
+)
+
+
+@rules.predicate
+def has_public_featured_speakers(user, event):
+    event = getattr(event, 'event', event)
+    if not event or not are_featured_speakers_visible(user, event):
+        return False
+    from eventyay.base.models import SpeakerProfile
+
+    return SpeakerProfile.objects.filter(event=event, is_featured=True).exists()
+
+
+def can_view_public_schedule_sessions(user, event, schedule=None):
+    """Whether real schedule times may be shown on public featured/speaker pages."""
+    event_obj = getattr(event, 'event', event)
+    if schedule is None:
+        schedule = getattr(event_obj, 'current_schedule', None) or getattr(event_obj, 'wip_schedule', None)
+    if not schedule:
+        return False
+    return can_list_released_schedule_speakers(user, event_obj)
+
+
+def can_list_released_schedule_speakers(user, event):
+    """Whether the public speakers overview is available.
+
+    Same gate for every visitor (including organisers): the schedule must be
+    publicly released (``talks_published``, ``show_schedule``, a released version)
+    and talk pages must not be limited to private test mode.
+    """
+    event_obj = getattr(event, 'event', event)
+    if not event_obj or not event_obj.current_schedule:
+        return False
+    if not event_obj.get_feature_flag('show_schedule'):
+        return False
+    return is_agenda_visible(user, event_obj)
+
+
+def _speaker_profile_by_code(event, speaker_code, *, select_related=()):
+    from eventyay.base.models import SpeakerProfile
+
+    queryset = SpeakerProfile.objects.filter(event=event, user__code__iexact=speaker_code)
+    if select_related:
+        queryset = queryset.select_related(*select_related)
+    return queryset.first()
+
+
+def public_speakers_list_available(user, event):
+    """Whether the public speakers overview page and its nav links may be shown."""
+    return can_list_released_schedule_speakers(user, getattr(event, 'event', event))
+
+
+def agenda_speakers_page_reachable(user, event):
+    """Whether the speakers list view may run and show schedule-style redirects."""
+    event_obj = getattr(event, 'event', event)
+    if not event_obj or not event_obj.get_feature_flag('show_schedule'):
+        return False
+    if can_list_released_schedule_speakers(user, event):
+        return True
+    if has_public_featured_speakers(user, event):
+        return True
+    if event_obj.current_schedule and event_obj.speakers.exists():
+        return True
+    return False
+
+
+def should_hide_public_speaker_sessions(user, event, *, wip_preview=False):
+    if wip_preview:
+        return False
+    return not is_agenda_visible(user, event)
+
+
+def pending_public_submission_codes_for_speaker(event, user, speaker_code):
+    """Submission codes that may appear as coming-soon for this speaker on public pages."""
+    from django_scopes import scope
+
+    from eventyay.base.models import SubmissionStates
+
+    profile = _speaker_profile_by_code(event, speaker_code, select_related=('user', 'event'))
+    if not profile:
+        return set()
+
+    featured_speaker = profile.is_featured and are_featured_speakers_visible(user, event)
+    codes = set()
+    with scope(event=event):
+        submissions = (
+            event.submissions.filter(speakers__code__iexact=speaker_code)
+            .exclude(
+                state__in=(
+                    SubmissionStates.REJECTED,
+                    SubmissionStates.CANCELED,
+                    SubmissionStates.WITHDRAWN,
+                    SubmissionStates.DELETED,
+                )
+            )
+            .select_related('event')
+        )
+        for submission in submissions:
+            if featured_speaker or is_submission_visible_via_featured(user, submission):
+                codes.add(submission.code)
+    return codes
+
+
+def speaker_may_show_pending_sessions(user, event, speaker_code):
+    profile = _speaker_profile_by_code(event, speaker_code)
+    if not profile:
+        return False
+    if profile.is_featured and are_featured_speakers_visible(user, event):
+        return True
+    return bool(pending_public_submission_codes_for_speaker(event, user, speaker_code))
+
+
+AGENDA_PAGES_WITHOUT_TALKS_PUBLISHED = frozenset(
+    {
+        'featured',
+        'speakers',
+        'speaker',
+        'talk.detail',
+        'widget.messages',
+    }
+)
+
+
+def agenda_page_allowed_without_talks_published(url_name, user, event, *, url_kwargs=None):
+    if url_name not in AGENDA_PAGES_WITHOUT_TALKS_PUBLISHED:
+        return False
+    if user is None:
+        return False
+    if url_name == 'speakers':
+        return agenda_speakers_page_reachable(user, event)
+    if url_name == 'talk.detail':
+        slug = (url_kwargs or {}).get('slug')
+        if not slug:
+            return False
+        submission = event.submissions.filter(code__iexact=slug).first()
+        return is_submission_visible_via_featured(user, submission)
+    if url_name in ('speaker', 'widget.messages'):
+        if url_name == 'speaker':
+            code = (url_kwargs or {}).get('code')
+            if not code:
+                return False
+            profile = _speaker_profile_by_code(event, code)
+            return bool(profile and is_speaker_viewable(user, profile))
+        return (
+            has_public_featured_speakers(user, event)
+            or can_list_released_schedule_speakers(user, event)
+        )
+    return are_featured_submissions_visible(user, event)
 
 
 @rules.predicate

--- a/app/eventyay/talk_rules/submission.py
+++ b/app/eventyay/talk_rules/submission.py
@@ -41,22 +41,7 @@ def is_cfp_open(user, obj):
     return event and event.talks_published and event.cfp.is_open
 
 
-def _show_featured_setting(event):
-    """Normalized value for org setting ``show_featured`` (stored: never / after_schedule / always).
-
-    ``after_schedule`` means: featured is shown only *after* the first **published** schedule
-    version exists (``Schedule.published`` set on a versioned release).
-    """
-    from eventyay.base.models.event import default_feature_flags
-
-    defaults = default_feature_flags()
-    flags = event.feature_flags
-    if not isinstance(flags, dict):
-        flags = {}
-    if 'show_featured' in flags and flags['show_featured'] is not None:
-        raw = flags['show_featured']
-    else:
-        raw = defaults.get('show_featured', 'never')
+def _normalize_featured_visibility(raw, default='never'):
     if isinstance(raw, bool):
         return 'always' if raw else 'never'
     if isinstance(raw, str):
@@ -66,7 +51,34 @@ def _show_featured_setting(event):
         # Migrate legacy value saved before rename.
         if normalized == 'pre_schedule':
             return 'after_schedule'
-    return defaults.get('show_featured', 'never')
+    return default
+
+
+def _show_featured_visibility_setting(event, flag_key, fallback_key=None):
+    """Normalized value for org featured visibility (never / after_schedule / always)."""
+    from eventyay.base.models.event import default_feature_flags
+
+    defaults = default_feature_flags()
+    flags = event.feature_flags
+    if not isinstance(flags, dict):
+        flags = {}
+    if flag_key in flags and flags[flag_key] is not None:
+        raw = flags[flag_key]
+    elif fallback_key and fallback_key in flags and flags[fallback_key] is not None:
+        raw = flags[fallback_key]
+    else:
+        raw = defaults.get(flag_key, 'never')
+    return _normalize_featured_visibility(raw, defaults.get(flag_key, 'never'))
+
+
+def _show_featured_setting(event):
+    """Normalized value for org setting ``show_featured`` (featured sessions)."""
+    return _show_featured_visibility_setting(event, 'show_featured')
+
+
+def _show_featured_speakers_setting(event):
+    """Normalized value for org setting ``show_featured_speakers`` (featured speakers)."""
+    return _show_featured_visibility_setting(event, 'show_featured_speakers', fallback_key='show_featured')
 
 
 def show_featured_always(event):
@@ -103,12 +115,48 @@ def _event_has_published_schedule(event):
     return event.current_schedule is not None
 
 
-are_featured_exports_available = _event_has_published_schedule
+def are_featured_exports_available(event):
+    """Public calendar/file exports require the same release as the main agenda."""
+    return bool(
+        event
+        and event.talks_published
+        and event.get_feature_flag('show_schedule')
+        and event.current_schedule
+    )
+
+
+def event_has_featured_speakers(event):
+    from eventyay.base.models import SpeakerProfile
+
+    return SpeakerProfile.objects.filter(event=event, is_featured=True).exists()
 
 
 def schedule_widget_featured_cache_key_part(event):
-    """Vary schedule widget JSON cache when featured rules or release state change."""
-    return f'{_show_featured_setting(event)}|rel={int(_event_has_published_schedule(event))}'
+    """Vary schedule JSON cache when featured rules, popularity, or release state change."""
+    flags = event.feature_flags or {}
+    popularity_enabled = bool(flags.get('session_popularity_enabled', False))
+    return (
+        f'sess={_show_featured_setting(event)}|'
+        f'spk={_show_featured_speakers_setting(event)}|'
+        f'rel={int(_event_has_published_schedule(event))}|'
+        f'pop={int(popularity_enabled)}|'
+        f'popshow={int(event.session_popularity_show_on_schedule())}'
+    )
+
+
+def _after_schedule_featured_sessions_visible(event):
+    if _event_has_published_schedule(event):
+        return event.talks_published
+    return event_has_featured_submissions(event)
+
+
+def _featured_public_visible(event, setting_fn, after_schedule_fn):
+    show = setting_fn(event)
+    if show == 'never':
+        return False
+    if show == 'always':
+        return True
+    return after_schedule_fn(event)
 
 
 @rules.predicate
@@ -123,20 +171,31 @@ def are_featured_submissions_visible(user, event):
     published (and talks are published), or earlier when featured submissions exist as a
     preview before the schedule is released.
     """
-    show_featured = _show_featured_setting(event)
-    if show_featured == 'never':
-        return False
-    # "Always" shows regardless of schedule state or talks_published.
-    if show_featured == 'always':
-        return True
-    if _event_has_published_schedule(event):
-        return event.talks_published
-    return event_has_featured_submissions(event)
+    return _featured_public_visible(event, _show_featured_setting, _after_schedule_featured_sessions_visible)
 
 
 def can_use_featured_exports(user, event):
     """Whether public featured export URLs are allowed for this user and event."""
     return are_featured_submissions_visible(user, event) and are_featured_exports_available(event)
+
+
+@rules.predicate
+def are_featured_speakers_visible(user, event):
+    """Whether public pages may show speakers marked as featured.
+
+    Unlike :func:`are_featured_submissions_visible`, this does not require ``talks_published``
+    or a published schedule. For ``after_schedule``, featured speakers appear once organisers
+    mark at least one speaker as featured.
+    """
+    event_obj = getattr(event, 'event', event)
+    if not event_obj:
+        return False
+    return _featured_public_visible(event_obj, _show_featured_speakers_setting, event_has_featured_speakers)
+
+
+def include_public_featured_speaker_metadata(user, event):
+    """Whether schedule JSON should expose ``is_featured`` / ``featured_position``."""
+    return are_featured_speakers_visible(user, event)
 
 
 @rules.predicate

--- a/app/eventyay/webapp/schedule/src/App.vue
+++ b/app/eventyay/webapp/schedule/src/App.vue
@@ -41,7 +41,9 @@
 			v-model:includeDateSortKey="sortIncludeDate",
 			v-model:includePopularitySortKey="sortIncludePopularity",
 			:popularityFeatureEnabled="popularityFeatureEnabled",
+			:popularitySortAvailable="popularitySortAvailable",
 			:loggedIn="loggedIn",
+			:exportsDisabled="exportsDisabled",
 			@selectDay="selectDay($event)",
 			@filterToggle="onlyFavs = false",
 			@toggleFavs="onlyFavs = !onlyFavs; if (onlyFavs) resetAllFilters()",
@@ -60,7 +62,7 @@
 			:locale="locale",
 			:scrollParent="scrollParent",
 			:favs="favs",
-			:showFavCount="showPopularityOnCalendar",
+			:showFavCount="showPopularityOnSchedule",
 			:onHomeServer="onHomeServer",
 			:disableAutoScroll="disableAutoScroll",
 			:forceScrollDay="forceScrollDay",
@@ -79,7 +81,7 @@
 			:locale="locale",
 			:scrollParent="scrollParent",
 			:favs="favs",
-			:showFavCount="showPopularityOnList",
+			:showFavCount="showPopularityOnSchedule",
 			:sortBy="effectiveSortBy",
 			:includeRoomSortKey="sortIncludeRoom",
 			:includeDateSortKey="sortIncludeDate",
@@ -129,7 +131,7 @@ const SpeakersList = defineAsyncComponent(() => import('~/components/SpeakersLis
 const FeaturedSpeakers = defineAsyncComponent(() => import('~/components/FeaturedSpeakers'))
 const SpeakerDetail = defineAsyncComponent(() => import('~/components/SpeakerDetail'))
 const TalkDetail = defineAsyncComponent(() => import('~/components/TalkDetail'))
-import { findScrollParent, getLocalizedString, getSessionTime, getSessionTypeLabel, isProperSession, normalizePopularityCount, computeTalkExporters, areScheduleExportsDisabled } from '~/utils'
+import { findScrollParent, getLocalizedString, getSessionTime, getSessionTypeLabel, isProperSession, isPopularityFeatureEnabled, isPopularitySortAvailable, isPopularityVisibleOnSchedule, normalizePopularityCount, computeTalkExporters, areScheduleExportsDisabled, talksToScheduleSessions, buildSessionsBySpeaker, talkToSession, sortSessionsByStart, isTalkSchedulePending } from '~/utils'
 
 function getCsrfToken () {
 	const match = document.cookie.match(/eventyay_csrftoken=([^;]+)/)
@@ -222,6 +224,10 @@ export default {
 		enrichData: {
 			type: Boolean,
 			default: false
+		},
+		speakersListPublic: {
+			type: [Boolean, String],
+			default: null
 		}
 	},
 	provide () {
@@ -247,7 +253,7 @@ export default {
 			scheduleUnfav: (id) => this.unfav(id),
 			scheduleData: computed(() => ({
 				schedule: this.schedule,
-				sessions: this.sessions || [],
+				sessions: this.sessions || this.inlineScheduleSessions || [],
 				sessionsBySpeaker: this.sessionsBySpeaker,
 				sessionsLookup: this.sessionsLookup,
 				speakersLookup: this.speakersLookup,
@@ -279,6 +285,7 @@ export default {
 			translationMessages: computed(() => this.translationMessages),
 			isWipPreview: computed(() => (this.version || this.scheduleMeta?.version || '') === 'wip'),
 			exportsDisabled: computed(() => this.exportsDisabled),
+			speakersListPublic: computed(() => this.resolvedSpeakersListPublic),
 		}
 	},
 	data () {
@@ -346,7 +353,15 @@ export default {
 				scheduleMetaVersion: this.scheduleMeta?.version,
 				isFeaturedPage: this.isFeaturedPage,
 				exportersCount: this.scheduleMeta?.exporters?.length || 0,
-			})
+				isWipPreview: this.isWipPreview,
+				scheduleExportsDisabled: Boolean(this.schedule?.exports_disabled),
+			}) || (this.isTalkView && Boolean(this.resolvedTalk?.schedule_pending))
+		},
+		resolvedSpeakersListPublic () {
+			const prop = this.speakersListPublic
+			if (prop === false || prop === 'false') return false
+			if (prop === true || prop === 'true') return true
+			return Boolean(this.schedule?.speakers_list_public) && !this.schedule?.exports_disabled
 		},
 		roomsLookup () {
 			if (!this.schedule) return {}
@@ -402,16 +417,8 @@ export default {
 			return (this.schedule.talks || []).reduce((acc, t) => { acc[t.code] = t; return acc }, {})
 		},
 		sessionsBySpeaker () {
-			if (!this.sessions) return {}
-			return this.sessions.reduce((acc, session) => {
-				(session.speakers || []).forEach((speaker) => {
-					const code = typeof speaker === 'string' ? speaker : speaker?.code
-					if (!code) return
-					if (!acc[code]) acc[code] = []
-					acc[code].push(session)
-				})
-				return acc
-			}, {})
+			const sessions = this.sessions || this.inlineScheduleSessions
+			return buildSessionsBySpeaker(sessions)
 		},
 		favSet () {
 			return new Set(this.favs || [])
@@ -436,92 +443,47 @@ export default {
 						.filter(Boolean)
 				)
 			}
+			const sessionContext = {
+				timezone: this.currentTimezone,
+				speakersLookup: this.speakersLookup,
+				tracksLookup: this.tracksLookup,
+				roomsLookup: this.roomsLookup,
+				includePopularity: true,
+			}
 			const sessions = []
-			for (const session of this.schedule.talks) {
-				const isPending = Boolean(session.schedule_pending || !session.start)
-				if (favSet && !favSet.has(session.code)) continue
+			for (const talk of this.schedule.talks) {
+				if (favSet && !favSet.has(talk.code)) continue
 				if (this.showRecordingFilter) {
-					if (this.recordingFilter === 'yes' && session.do_not_record !== false) continue
-					if (this.recordingFilter === 'no' && session.do_not_record !== true) continue
+					if (this.recordingFilter === 'yes' && talk.do_not_record !== false) continue
+					if (this.recordingFilter === 'no' && talk.do_not_record !== true) continue
 				}
-				if (filteredTrackIds && !filteredTrackIds.has(session.track)) continue
-				if (filteredRoomIds && !filteredRoomIds.has(session.room)) continue
-				if (filteredTypeValues && !filteredTypeValues.has(getSessionTypeLabel(session.session_type))) continue
+				if (filteredTrackIds && !filteredTrackIds.has(talk.track)) continue
+				if (filteredRoomIds && !filteredRoomIds.has(talk.room)) continue
+				if (filteredTypeValues && !filteredTypeValues.has(getSessionTypeLabel(talk.session_type))) continue
 				if (langExact) {
 					const fallbackLocale = this.schedule?.content_locales?.[0] || null
-					const sessionLocale = session.content_locale || fallbackLocale
+					const sessionLocale = talk.content_locale || fallbackLocale
 					const normalized = normalizeLocaleCode(sessionLocale)
 					if (!normalized) continue
 					const primary = localePrimary(normalized)
 					if (!langExact.has(normalized) && !(primary && langPrimary.has(primary))) continue
 				}
-				if (isPending) {
-					sessions.push({
-						id: session.code,
-						title: session.title,
-						abstract: session.abstract,
-						description: session.description,
-						do_not_record: session.do_not_record,
-						duration: session.duration,
-						start: null,
-						end: null,
-						schedule_pending: true,
-						speakers: (session.speakers || [])
-							.map(code => this.speakersLookup[code] || { code })
-							.filter(Boolean),
-						track: this.tracksLookup[session.track],
-						room: null,
-						fav_count: normalizePopularityCount(session),
-						tags: session.tags,
-						session_type: session.session_type,
-						content_locale: session.content_locale,
-						resources: session.resources,
-						answers: session.answers,
-						exporters: session.exporters,
-						recording_iframe: session.recording_iframe,
-						stream_url: session.stream_url || null,
-						stream_type: session.stream_type || null,
-					})
-					continue
+				if (!isTalkSchedulePending(talk)) {
+					const start = moment.tz(talk.start, this.currentTimezone)
+					if (displayDateSet && !displayDateSet.has(start.clone().tz(this.schedule.timezone).format('YYYY-MM-DD'))) continue
 				}
-				const start = moment.tz(session.start, this.currentTimezone)
-				if (displayDateSet && !displayDateSet.has(start.clone().tz(this.schedule.timezone).format('YYYY-MM-DD'))) continue
-				sessions.push({
-					id: session.code,
-					code: session.code,
-					title: session.title,
-					abstract: session.abstract,
-					description: session.description,
-					do_not_record: session.do_not_record,
-					duration: session.duration,
-					start: start,
-					end: moment.tz(session.end, this.currentTimezone),
-					speakers: (session.speakers || [])
-						.map(code => this.speakersLookup[code] || { code })
-						.filter(Boolean),
-					track: this.tracksLookup[session.track],
-					room: this.roomsLookup[session.room],
-					fav_count: normalizePopularityCount(session),
-					tags: session.tags,
-					session_type: session.session_type,
-					content_locale: session.content_locale,
-					resources: session.resources,
-					answers: session.answers,
-					exporters: session.exporters,
-					recording_iframe: session.recording_iframe,
-					stream_url: session.stream_url || null,
-					stream_type: session.stream_type || null,
-				})
+				sessions.push(talkToSession(talk, sessionContext))
 			}
-			sessions.sort((a, b) => {
-				if (a.schedule_pending && !b.schedule_pending) return 1
-				if (!a.schedule_pending && b.schedule_pending) return -1
-				if (a.schedule_pending && b.schedule_pending) {
-					return getLocalizedString(a.title).localeCompare(getLocalizedString(b.title))
-				}
-				return a.start.diff(b.start)
+			return sortSessionsByStart(sessions)
+		},
+		inlineScheduleSessions () {
+			return talksToScheduleSessions(this.schedule?.talks, {
+				timezone: this.currentTimezone,
+				speakersLookup: this.speakersLookup,
+				tracksLookup: this.tracksLookup,
+				roomsLookup: this.roomsLookup,
+				includePopularity: true,
 			})
-			return sessions
 		},
 		// sessions: baseSessions + search filter. Used for display.
 		sessions () {
@@ -630,17 +592,23 @@ export default {
 			return `${eventUrlObj.protocol}//${eventUrlObj.host}/api/v1/events/${this.eventSlug}/`
 		},
 		popularityFeatureEnabled () {
-			return !!this.schedule?.feature_flags?.session_popularity_enabled
+			return isPopularityFeatureEnabled(this.schedule?.feature_flags || {})
 		},
-		showPopularityOnCalendar () {
-			return this.loggedIn && this.popularityFeatureEnabled && !!this.schedule?.feature_flags?.session_popularity_show_on_calendar
+		showPopularityOnSchedule () {
+			return isPopularityVisibleOnSchedule({
+				flags: this.schedule?.feature_flags || {},
+				loggedIn: this.loggedIn,
+			})
 		},
-		showPopularityOnList () {
-			return this.loggedIn && this.popularityFeatureEnabled && !!this.schedule?.feature_flags?.session_popularity_show_on_list
+		popularitySortAvailable () {
+			return isPopularitySortAvailable({
+				flags: this.schedule?.feature_flags || {},
+				loggedIn: this.loggedIn,
+			})
 		},
 		sortOptions () {
 			const options = ['title', 'title_desc']
-			if (this.showPopularityOnList) options.push('popularity')
+			if (this.popularitySortAvailable) options.push('popularity')
 			return options
 		},
 		effectiveSortBy () {
@@ -649,8 +617,16 @@ export default {
 	},
 	watch: {
 		popularityFeatureEnabled (enabled) {
-			// When the popularity feature is disabled, also disable the popularity sort toggle
-			if (!enabled) this.sortIncludePopularity = false
+			if (!enabled) {
+				this.sortIncludePopularity = false
+				if (this.sortBy === 'popularity') this.sortBy = 'title'
+			}
+		},
+		popularitySortAvailable (enabled) {
+			if (!enabled) {
+				this.sortIncludePopularity = false
+				if (this.sortBy === 'popularity') this.sortBy = 'title'
+			}
 		},
 		loggedIn (isLoggedIn) {
 			if (!isLoggedIn) {
@@ -705,7 +681,7 @@ export default {
 
 		// Use inline data if available, otherwise fetch the schedule JSON.
 		const dataEl = document.getElementById('pretalx-schedule-data')
-		if (dataEl) {
+		if (dataEl && dataEl.textContent.trim()) {
 			try { this.schedule = JSON.parse(dataEl.textContent) } catch (e) { /* ignore parse error, fall through to fetch */ }
 		}
 		if (this.schedule) {
@@ -1077,7 +1053,11 @@ export default {
 				return;
 			}
 
-			const speakerSessions = (this.sessionsBySpeaker[speaker.code] || [])
+			const speakerSessions = (
+				this.sessionsBySpeaker[speaker.code?.toLowerCase()]
+				|| this.sessionsBySpeaker[speaker.code]
+				|| []
+			)
 
 			// Show speaker immediately with loading state
 			this.modalContent = {

--- a/app/eventyay/webapp/schedule/src/components/DetailBackNav.vue
+++ b/app/eventyay/webapp/schedule/src/components/DetailBackNav.vue
@@ -1,48 +1,50 @@
 <template lang="pug">
-.c-detail-top-bar(v-if="backLink || $slots.default")
-	nav.back-nav(v-if="backLink", :aria-label="backLink.label")
-		a.back-link(:href="backLink.href")
+.c-detail-top-bar(v-if="showBack || $slots.default")
+	nav.back-nav(v-if="showBack", :aria-label="backLabel")
+		button.back-link(type="button", @click="goBack")
 			svg.back-icon(viewBox="0 0 24 24", aria-hidden="true")
 				path(fill="currentColor", d="M20,11V13H8L13.5,18.5L12.08,19.92L4.16,12L12.08,4.08L13.5,5.5L8,11H20Z")
-			span.back-label {{ backLink.label }}
+			span.back-label {{ backLabel }}
 	.detail-top-actions(v-if="$slots.default")
 		slot
 </template>
 
 <script>
-import { getDetailBackLink } from '../utils'
-
 export default {
 	name: 'DetailBackNav',
 	inject: {
 		parentEventUrl: { from: 'eventUrl', default: '' },
 		translationMessages: { default: () => ({}) },
-		isWipPreview: { default: false },
 	},
 	props: {
 		eventUrl: {
 			type: String,
 			default: ''
 		},
-		destination: {
-			type: String,
-			required: true,
-			validator: (value) => ['schedule', 'speakers'].includes(value)
-		}
 	},
 	computed: {
 		resolvedEventUrl () {
 			return this.eventUrl || this.parentEventUrl || ''
 		},
-		backLink () {
-			return getDetailBackLink({
-				eventUrl: this.resolvedEventUrl,
-				destination: this.destination,
-				isWipPreview: this.isWipPreview,
-				messages: this.translationMessages || {},
-			})
-		}
-	}
+		backLabel () {
+			const messages = this.translationMessages || {}
+			return messages.back || 'Back'
+		},
+		showBack () {
+			return Boolean(this.resolvedEventUrl || (typeof window !== 'undefined' && window.history.length > 1))
+		},
+	},
+	methods: {
+		goBack () {
+			if (typeof window !== 'undefined' && window.history.length > 1) {
+				window.history.back()
+				return
+			}
+			if (this.resolvedEventUrl) {
+				window.location.href = this.resolvedEventUrl
+			}
+		},
+	},
 }
 </script>
 
@@ -72,6 +74,7 @@ export default {
 		line-height: 1.2
 		box-shadow: 0 1px 2px rgba(0, 0, 0, 0.04)
 		transition: background-color 0.2s ease, border-color 0.2s ease, color 0.2s ease, box-shadow 0.2s ease, transform 0.15s ease
+		cursor: pointer
 		max-width: 100%
 		.back-icon
 			width: 18px

--- a/app/eventyay/webapp/schedule/src/components/DetailTopActions.vue
+++ b/app/eventyay/webapp/schedule/src/components/DetailTopActions.vue
@@ -1,5 +1,5 @@
 <template lang="pug">
-export-dropdown(v-if="showExport", :options="exportOptions", :qrcodesUrl="qrcodesUrl", :disabled="isWipPreview")
+export-dropdown(v-if="showExport", :options="exportOptions", :qrcodesUrl="qrcodesUrl", :disabled="exportControlDisabled")
 .button-container(v-if="showFav", :class="{ faved }")
 	fav-button(@toggleFav="$emit('toggleFav')")
 </template>
@@ -14,6 +14,7 @@ export default {
 	emits: ['toggleFav'],
 	inject: {
 		isWipPreview: { default: false },
+		exportsDisabled: { default: false },
 	},
 	props: {
 		exportOptions: {
@@ -34,8 +35,11 @@ export default {
 		},
 	},
 	computed: {
+		exportControlDisabled () {
+			return this.isWipPreview || this.exportsDisabled
+		},
 		showExport () {
-			return this.exportOptions.length > 0 || this.isWipPreview
+			return this.exportOptions.length > 0 || this.exportControlDisabled
 		},
 	},
 }

--- a/app/eventyay/webapp/schedule/src/components/FeaturedSpeakers.vue
+++ b/app/eventyay/webapp/schedule/src/components/FeaturedSpeakers.vue
@@ -23,24 +23,28 @@
 						hr.featured-speaker-divider
 						.featured-speaker-sessions
 							h4 {{ t.sessions }}
-							.featured-speaker-session(v-for="session in speaker.sessions", :key="session.id")
-								small.featured-speaker-session-time {{ formatSessionDateTime(session) }}
+							.featured-speaker-session(
+								v-for="session in speaker.sessions",
+								:key="session.id",
+								:class="{'featured-speaker-session-pending': isTalkSchedulePending(session)}"
+							)
+								small.featured-speaker-session-time {{ isTalkSchedulePending(session) ? t.schedule_pending : formatSessionDateTime(session) }}
 								a.featured-speaker-session-link(
 									:href="getSessionLink(session)",
 									:style="getSessionStyle(session)",
 									@click="onSessionClick($event, session)"
 								)
-									span.featured-speaker-session-slot {{ formatSessionSlot(session) }}
+									span.featured-speaker-session-slot(v-if="!isTalkSchedulePending(session)") {{ formatSessionSlot(session) }}
 									span.featured-speaker-session-title {{ getLocalizedString(session.title) }}
 					.featured-speaker-profile-link
 						a(:href="getSpeakerLink(speaker)", @click="onSpeakerClick($event, speaker)") {{ t.view_profile }}
-	p.featured-speakers-more
+	p.featured-speakers-more(v-if="showMoreSpeakersLink")
 		a.more-link(:href="moreSpeakersUrl") {{ t.more_speakers }}
 </template>
 
 <script>
+import { getLocalizedString, compareFeaturedSpeakers, talksToScheduleSessions, buildSessionsBySpeaker, sessionsForSpeaker, sortSessionsByStart, isTalkSchedulePending } from '../utils'
 import moment from 'moment-timezone'
-import { getLocalizedString } from '../utils'
 import MarkdownContent from './MarkdownContent'
 
 export default {
@@ -64,7 +68,8 @@ export default {
 				return () => {}
 			}
 		},
-		translationMessages: { default: () => ({}) }
+		translationMessages: { default: () => ({}) },
+		speakersListPublic: { default: null },
 	},
 	props: {
 		showAll: {
@@ -75,6 +80,7 @@ export default {
 	data() {
 		return {
 			getLocalizedString,
+			isTalkSchedulePending,
 		}
 	},
 	computed: {
@@ -86,11 +92,19 @@ export default {
 				sessions: m.sessions || 'Sessions',
 				view_profile: m.view_profile || 'View speaker profile',
 				more_speakers: m.more_speakers || 'More speakers',
+				schedule_pending: m.schedule_pending_secondary || 'Coming soon',
 			}
 		},
 		moreSpeakersUrl() {
 			const base = (this.eventUrl || '').replace(/\/?$/, '/')
 			return `${base}speakers/`
+		},
+		showMoreSpeakersLink() {
+			if (this.speakersListPublic === false) return false
+			const schedule = this.scheduleData?.schedule
+			if (!schedule?.speakers_list_public) return false
+			if (schedule.exports_disabled) return false
+			return true
 		},
 		trackById() {
 			const schedule = this.scheduleData?.schedule
@@ -105,73 +119,34 @@ export default {
 			const rawTalks = schedule?.talks || []
 			const timezone = this.scheduleData?.timezone || schedule?.timezone
 			if (!schedule?.speakers?.length) return []
-			const speakerCodeFromAny = (sp) => {
-				if (!sp) return null
-				if (typeof sp === 'string') return sp
-				return sp.code || null
-			}
 			const featured = schedule.speakers
 				.filter(s => this.showAll || s?.is_featured)
 				.slice()
-				.sort((a, b) => {
-					// If showing all, strictly put featured first
-					if (this.showAll) {
-						if (a.is_featured && !b.is_featured) return -1
-						if (!a.is_featured && b.is_featured) return 1
-					}
-					const ap = Number.isFinite(a.featured_position) ? a.featured_position : 1e9
-					const bp = Number.isFinite(b.featured_position) ? b.featured_position : 1e9
-					if (ap !== bp) return ap - bp
-					return (a.name || '').localeCompare(b.name || '')
-				})
+				.sort((a, b) => compareFeaturedSpeakers(a, b, { featuredFirst: this.showAll }))
 
 			const speakerByCode = (schedule.speakers || []).reduce((acc, s) => {
 				if (s?.code) acc[s.code] = s
 				return acc
 			}, {})
-			const trackById = this.trackById
-			const roomById = (schedule.rooms || []).reduce((acc, r) => {
+			const tracksLookup = this.trackById
+			const roomsLookup = (schedule.rooms || []).reduce((acc, r) => {
 				if (r?.id != null) acc[r.id] = r
 				return acc
 			}, {})
 
-			const normalizeRawTalk = (talk) => {
-				const start = talk?.start && timezone ? moment.tz(talk.start, timezone) : null
-				const end = talk?.end && timezone ? moment.tz(talk.end, timezone) : null
-				const speakerCodes = (talk?.speakers || []).map(speakerCodeFromAny).filter(Boolean)
-				return {
-					id: talk?.code,
-					title: talk?.title,
-					start,
-					end,
-					speakers: speakerCodes
-						.map(code => speakerByCode[code] || { code })
-						.filter(Boolean),
-					track: trackById[talk?.track],
-					room: roomById[talk?.room],
-					content_locale: talk?.content_locale,
-				}
-			}
-
-			const normalizedRawSessions = rawTalks
-				.map(normalizeRawTalk)
-				.filter(session => session?.start && session?.end)
+			const normalizedRawSessions = talksToScheduleSessions(rawTalks, {
+				timezone,
+				speakersLookup: speakerByCode,
+				tracksLookup,
+				roomsLookup,
+			}).filter(session => session.schedule_pending || (session.start && session.end))
 			const sessionsPool = resolvedSessions.length ? resolvedSessions : normalizedRawSessions
 			const sessionsBySpeaker = resolvedSessions.length && this.scheduleData?.sessionsBySpeaker
 				? this.scheduleData.sessionsBySpeaker
-				: sessionsPool
-					.flatMap((session) => (session.speakers || []).map((sp) => [speakerCodeFromAny(sp), session]))
-					.reduce((acc, [code, session]) => {
-						if (!code) return acc
-						if (!acc[code]) acc[code] = []
-						acc[code].push(session)
-						return acc
-					}, {})
+				: buildSessionsBySpeaker(sessionsPool, { lowercaseKeys: false })
 
 			return featured.map(speaker => {
-				const speakerSessions = (sessionsBySpeaker[speaker.code] || [])
-					.slice()
-					.sort((a, b) => (a.start && b.start ? a.start.diff(b.start) : 0))
+				const speakerSessions = sortSessionsByStart(sessionsForSpeaker(sessionsBySpeaker, speaker.code))
 				return {
 					...speaker,
 					sessions: speakerSessions,
@@ -355,6 +330,10 @@ export default {
 		margin-bottom: 12px
 		&:last-child
 			margin-bottom: 0
+
+	.featured-speaker-session-pending
+		.featured-speaker-session-time
+			color: var(--pretalx-clr-primary, var(--clr-primary))
 
 	.featured-speaker-session-time
 		display: block

--- a/app/eventyay/webapp/schedule/src/components/ScheduleToolbar.vue
+++ b/app/eventyay/webapp/schedule/src/components/ScheduleToolbar.vue
@@ -81,7 +81,7 @@
 							span.filter-dropdown-label {{ item.label }}
 					.filter-dropdown-empty(v-else) No {{ languageGroup.title.toLowerCase() }} available
 			button.toolbar-btn.icon-only.fav-toggle(
-				v-if="loggedIn && favsCount",
+				v-if="loggedIn && popularityFeatureEnabled && favsCount",
 				:disabled="!favsCount",
 				:aria-label="t.starred",
 				:aria-pressed="onlyFavs ? 'true' : 'false'",
@@ -128,7 +128,7 @@
 							span.sort-inclusion-label {{ t.sort_include_datetime }}
 							button.sort-toggle-slider(type="button", :class="{on: includeDateSortKeyModel}", role="menuitemcheckbox", :aria-label="t.sort_include_datetime", :aria-checked="includeDateSortKeyModel ? 'true' : 'false'", @click.prevent.stop="toggleDatetimeSort")
 								span.toggle-slider(aria-hidden="true")
-						.sort-inclusion-row
+						.sort-inclusion-row(v-if="popularitySortAvailable")
 							span.sort-inclusion-label {{ t.sort_include_popularity }}
 							button.sort-toggle-slider(type="button", :class="{on: includePopularitySortKeyModel}", role="menuitemcheckbox", :aria-label="t.sort_include_popularity", :aria-checked="includePopularitySortKeyModel ? 'true' : 'false'", @click.prevent.stop="togglePopularitySort")
 								span.toggle-slider(aria-hidden="true")
@@ -324,8 +324,6 @@
 </template>
 
 <script>
-import { areScheduleExportsDisabled } from '../utils'
-
 // FA icon name → inline SVG path mapping (shadow DOM blocks external CSS)
 const FA_SVG_MAP = {
 	'fa-calendar': '<rect x="3" y="4" width="18" height="18" rx="2" ry="2"/><line x1="16" y1="2" x2="16" y2="6"/><line x1="8" y1="2" x2="8" y2="6"/><line x1="3" y1="10" x2="21" y2="10"/>',
@@ -372,7 +370,9 @@ export default {
 		includeDateSortKey: { type: Boolean, default: false },
 		includePopularitySortKey: { type: Boolean, default: false },
 		popularityFeatureEnabled: { type: Boolean, default: false },
+		popularitySortAvailable: { type: Boolean, default: false },
 		loggedIn: { type: Boolean, default: false },
+		exportsDisabled: { type: Boolean, default: false },
 		sortOptions: { type: Array, default: () => ['title', 'title_desc'] },
 		timeDensityMinutes: { type: Number, default: 30 },
 		isFeaturedPage: { type: Boolean, default: false },
@@ -492,6 +492,7 @@ export default {
 			}
 			return allowed
 				.filter(v => ['title', 'title_desc', 'popularity'].includes(v))
+				.filter(v => v !== 'popularity' || this.popularitySortAvailable)
 				.map(v => ({ value: v, label: labelMap[v] || v }))
 		},
 		currentSortLabel() {
@@ -504,14 +505,6 @@ export default {
 				list = list.filter(exp => !exp.identifier.includes('-my') && !exp.identifier.includes('my-') && exp.identifier !== 'faved.ics')
 			}
 			return list
-		},
-		exportsDisabled() {
-			return areScheduleExportsDisabled({
-				version: this.version,
-				isFeaturedPage: this.isFeaturedPage,
-				exportersCount: this.resolvedExporters.length,
-				isWipPreview: this.isWipPreview,
-			})
 		},
 		isWipPreview() {
 			if (this.version === 'wip') {

--- a/app/eventyay/webapp/schedule/src/components/ScheduleView.vue
+++ b/app/eventyay/webapp/schedule/src/components/ScheduleView.vue
@@ -29,6 +29,9 @@
 			v-model:includeRoomSortKey="sortIncludeRoom",
 			v-model:includeDateSortKey="sortIncludeDate",
 			v-model:includePopularitySortKey="sortIncludePopularity",
+			:loggedIn="loggedIn",
+			:popularityFeatureEnabled="popularityFeatureEnabled",
+			:popularitySortAvailable="popularitySortAvailable",
 			@selectDay="changeDay($event)",
 			@filterToggle="onFilterChange",
 			@toggleFavs="toggleFavs",
@@ -48,7 +51,7 @@
 				:locale="locale",
 				:scrollParent="$refs.scrollParent",
 				:favs="resolvedFavs",
-				:showFavCount="showFavCountOnCalendar",
+				:showFavCount="showFavCountOnSchedule",
 				:density="'default'",
 				:timeDensityMinutes="timeDensityMinutes",
 				@changeDay="setCurrentDay",
@@ -64,7 +67,7 @@
 				:locale="locale",
 				:scrollParent="$refs.scrollParent",
 				:favs="resolvedFavs",
-				:showFavCount="showFavCountOnList",
+				:showFavCount="showFavCountOnSchedule",
 				:sortBy="effectiveSortBy",
 				:includeRoomSortKey="sortIncludeRoom",
 				:includeDateSortKey="sortIncludeDate",
@@ -85,7 +88,7 @@ import moment from 'moment-timezone'
 import LinearSchedule from './LinearSchedule'
 import GridScheduleWrapper from './GridScheduleWrapper'
 import ScheduleToolbar from './ScheduleToolbar'
-import { getLocalizedString, getSessionTypeLabel, isProperSession, normalizePopularityCount } from '../utils'
+import { getLocalizedString, getSessionTypeLabel, isProperSession, isPopularityFeatureEnabled, isPopularitySortAvailable, isPopularityVisibleOnSchedule, normalizePopularityCount } from '../utils'
 
 function normalizeLocaleCode (code) {
 	if (!code) return ''
@@ -205,13 +208,9 @@ export default {
 		scheduleReady() {
 			return !!(this.resolvedSchedule && this.enrichedSessions.length)
 		},
-		showFavCountOnCalendar() {
-			const flags = this.scheduleData?.schedule?.feature_flags || {}
-			return !!(this.loggedIn && flags.session_popularity_enabled && flags.session_popularity_show_on_calendar)
-		},
-		showFavCountOnList() {
-			const flags = this.scheduleData?.schedule?.feature_flags || {}
-			return !!(this.loggedIn && flags.session_popularity_enabled && flags.session_popularity_show_on_list)
+		showFavCountOnSchedule() {
+			const flags = this.scheduleData?.schedule?.feature_flags || this.resolvedSchedule?.feature_flags || {}
+			return isPopularityVisibleOnSchedule({ flags, loggedIn: this.loggedIn })
 		},
 		hasError() {
 			return !!(this.errorLoading || this.scheduleData?.errorLoading)
@@ -386,11 +385,16 @@ export default {
 			return !this.linearOnly && this.scrollParentWidth > 710
 		},
 		popularityFeatureEnabled() {
-			return !!this.resolvedSchedule?.feature_flags?.session_popularity_enabled
+			const flags = this.resolvedSchedule?.feature_flags || {}
+			return isPopularityFeatureEnabled(flags)
+		},
+		popularitySortAvailable() {
+			const flags = this.resolvedSchedule?.feature_flags || {}
+			return isPopularitySortAvailable({ flags, loggedIn: this.loggedIn })
 		},
 		sortOptions() {
 			const options = ['title', 'title_desc']
-			if (this.loggedIn && this.popularityFeatureEnabled) options.push('popularity')
+			if (this.popularitySortAvailable) options.push('popularity')
 			return options
 		},
 		effectiveSortBy() {
@@ -413,6 +417,18 @@ export default {
 				if (val && val !== this.internalSortBy) this.internalSortBy = val
 			},
 			immediate: true
+		},
+		popularitySortAvailable(enabled) {
+			if (!enabled) {
+				this.sortIncludePopularity = false
+				if (this.internalSortBy === 'popularity') this.internalSortBy = 'title'
+			}
+		},
+		popularityFeatureEnabled(enabled) {
+			if (!enabled) {
+				this.sortIncludePopularity = false
+				if (this.internalSortBy === 'popularity') this.internalSortBy = 'title'
+			}
 		},
 		resolvedSchedule: {
 			handler(val) {

--- a/app/eventyay/webapp/schedule/src/components/Session.vue
+++ b/app/eventyay/webapp/schedule/src/components/Session.vue
@@ -1,5 +1,5 @@
 <template lang="pug">
-a.c-linear-schedule-session(:class="{faved, 'has-date': showDate, 'short-session': isShortSession, 'schedule-pending-session': isSchedulePending}", :style="style", :href="link", @click="onSessionLinkClick($event, session)", :target="linkTarget")
+a.c-linear-schedule-session(:class="{faved, 'has-date': showDate, 'short-session': isShortSession, 'schedule-pending-session': isSchedulePending, 'has-fav-count': hasFavCount}", :style="style", :href="link", @click="onSessionLinkClick($event, session)", :target="linkTarget")
 	.time-box
 		.start.schedule-pending(v-if="isSchedulePending")
 			svg.schedule-pending-icon(viewBox="0 0 24 24", fill="none", stroke="currentColor", stroke-width="2", stroke-linecap="round", stroke-linejoin="round", aria-hidden="true")
@@ -19,7 +19,7 @@ a.c-linear-schedule-session(:class="{faved, 'has-date': showDate, 'short-session
 				.duration {{ getPrettyDuration(session.start, session.end) }}
 		.buffer(v-if="!isSchedulePending")
 		.is-live(v-if="showLiveBadge && isLive") live
-	.info(:class="{'has-fav-count': hasFavCount, 'has-icons': hasAnyRightIcons}")
+	.info(:class="{'has-icons': hasAnyRightIcons}")
 		.title(:class="{'title-clamped': isShortSession}") {{ getLocalizedString(session.title) }}
 		.speakers(v-if="namedSpeakers.length", :class="{'names-clamped': isShortSession}")
 			template(v-for="(speaker, i) of namedSpeakers", :key="speaker.code || i")
@@ -40,7 +40,7 @@ a.c-linear-schedule-session(:class="{faved, 'has-date': showDate, 'short-session
 					rect(style="fill:#000000;fill-opacity;stroke:none;stroke-width:11.2589;stroke-linecap:round;stroke-dasharray:none;stroke-opacity:1;paint-order:markers stroke fill", width="52.753284", height="39.619537", x="35.496307", y="43.927021", rx="5.5179553", ry="7.573648")
 					path(style="fill:#000000;fill-opacity:1;stroke:none;stroke-width:18.7997;stroke-linecap:round;stroke-dasharray:none;stroke-opacity:1;paint-order:markers stroke fill", d="M 99.787546,47.04792 V 80.425654 L 77.727407,63.736793 Z")
 					path(style="fill:none;stroke:#b23e65;stroke-width:12;stroke-linecap:round;stroke-dasharray:none;stroke-opacity:1;paint-order:markers stroke fill", d="m 35.553146,95.825578 64.177559,-64.17757 m 16.294055,32.08879 A 48.382828,48.382828 0 0 1 67.641925,112.11961 48.382828,48.382828 0 0 1 19.259099,63.736798 48.382828,48.382828 0 0 1 67.641925,15.353968 48.382828,48.382828 0 0 1 116.02476,63.736798 Z")
-		.fav-count(v-if="loggedIn && showFavCount && session.fav_count > 0") {{ session.fav_count > 99 ? "99+" : session.fav_count }}
+	span.fav-count(v-if="hasFavCount", :aria-label="favCountLabel") {{ favCountLabel }}
 	.stream-indicator(v-if="canOpenStream", :class="{live: isLive}", :title="streamTooltip", @click.prevent.stop="openStream")
 		svg(viewBox="0 0 24 24", width="20", height="20", fill="currentColor", xmlns="http://www.w3.org/2000/svg")
 			path(d="M17 10.5V7c0-.55-.45-1-1-1H4c-.55 0-1 .45-1 1v10c0 .55.45 1 1 1h12c.55 0 1-.45 1-1v-3.5l4 4v-11l-4 4z")
@@ -50,7 +50,7 @@ a.c-linear-schedule-session(:class="{faved, 'has-date': showDate, 'short-session
 </template>
 <script>
 import MarkdownIt from 'markdown-it'
-import { getLocalizedString, getPrettyDuration, getSessionTime, getContrastColor } from '../utils'
+import { getLocalizedString, getPrettyDuration, getSessionTime, getContrastColor, normalizePopularityCount } from '../utils'
 import FavButton from './FavButton.vue'
 
 const markdownIt = MarkdownIt({
@@ -195,7 +195,11 @@ export default {
 			}
 		},
 		hasFavCount () {
-			return this.loggedIn && this.showFavCount && this.session.fav_count > 0
+			return this.loggedIn && this.showFavCount && normalizePopularityCount(this.session) > 0
+		},
+		favCountLabel () {
+			const count = normalizePopularityCount(this.session)
+			return count > 99 ? '99+' : String(count)
 		},
 		doNotRecordTooltip () {
 			const m = this.translationMessages || {}
@@ -389,8 +393,6 @@ sessionTextExpand()
 		padding-right: 8px
 		&.has-icons
 			padding-right: 44px
-		&.has-fav-count
-			padding-right: 72px
 		border: border-separator()
 		border-left: none
 		border-radius: 0 6px 6px 0
@@ -456,20 +458,6 @@ sessionTextExpand()
 			align-items: center
 			line-height: 0
 			z-index: 5
-		.fav-count
-			border: 1px solid
-			border-radius: 50%
-			position: absolute
-			top: 5px
-			right: 40px
-			width: 25px
-			height: 25px
-			display: flex
-			justify-content: center
-			align-items: center
-			text-align: center
-			background-color: var(--track-color)
-			color: $clr-primary-text-dark
 	.tags-box
 		display: flex
 		flex-wrap: wrap
@@ -503,6 +491,28 @@ sessionTextExpand()
 			transform: translateY(-50%) scale(1.15)
 	svg
 			pointer-events: none
+	.fav-count
+		position: absolute
+		top: 10px
+		right: 38px
+		z-index: 12
+		display: inline-flex
+		align-items: center
+		justify-content: center
+		min-width: 20px
+		height: 18px
+		padding: 0 6px
+		border-radius: 999px
+		font-size: 10px
+		font-weight: 700
+		line-height: 1
+		letter-spacing: 0.02em
+		white-space: nowrap
+		color: var(--track-color)
+		background-color: unquote('color-mix(in srgb, var(--track-color) 16%, transparent)')
+		border: 1px solid unquote('color-mix(in srgb, var(--track-color) 32%, transparent)')
+		box-shadow: 0 1px 2px rgba(0, 0, 0, 0.08)
+		pointer-events: none
 	.session-icons
 		position: absolute
 		top: 2px
@@ -515,6 +525,9 @@ sessionTextExpand()
 			padding: 2px
 			width: 32px
 			height: 32px
+	&.has-fav-count
+		.info.has-icons
+			padding-right: 68px
 	&:hover
 		.info
 			border: 1px solid var(--track-color)
@@ -558,14 +571,21 @@ sessionTextExpand()
 			padding-right: 6px
 			&.has-icons
 				padding-right: 40px
-			&.has-fav-count
-				padding-right: 64px
 			.title
 				font-size: 14px
 			.abstract
 				sessionTextClamp(2)
 			.bottom-info
 				font-size: 12px
+		&.has-fav-count .info.has-icons
+			padding-right: 62px
+		.fav-count
+			top: 8px
+			right: 34px
+			height: 16px
+			min-width: 18px
+			padding: 0 5px
+			font-size: 9px
 
 .density-compact .c-linear-schedule-session,
 .density-compact .break
@@ -595,14 +615,14 @@ sessionTextExpand()
 		padding-right: 4px
 		&.has-icons
 			padding-right: 36px
-		&.has-fav-count
-			padding-right: 56px
 		.title
 			font-size: 13px
 		.speakers
 			font-size: 12px
 		.bottom-info
 			font-size: 11px
+	&.has-fav-count .info.has-icons
+		padding-right: 60px
 
 .density-comfortable .c-linear-schedule-session,
 .density-comfortable .break
@@ -634,12 +654,12 @@ sessionTextExpand()
 		padding-right: 12px
 		&.has-icons
 			padding-right: 52px
-		&.has-fav-count
-			padding-right: 80px
 		.title
 			font-size: 18px
 		.speakers
 			font-size: 15px
 		.bottom-info
 			font-size: 14px
+	&.has-fav-count .info.has-icons
+		padding-right: 76px
 </style>

--- a/app/eventyay/webapp/schedule/src/components/SpeakerDetail.vue
+++ b/app/eventyay/webapp/schedule/src/components/SpeakerDetail.vue
@@ -1,6 +1,6 @@
 <template lang="pug">
 .c-speaker-detail
-	detail-back-nav(destination="speakers")
+	detail-back-nav(:event-url="eventUrl")
 		detail-top-actions(
 			:export-options="speakerExportOptions",
 			:qrcodes-url="speakerQrcodesUrl")
@@ -50,7 +50,7 @@
 
 <script>
 import moment from 'moment-timezone'
-import { getLocalizedString, buildExportMenuItems, computeSpeakerExporters, parseBooleanAnswer, buildQrcodesUrl } from '../utils'
+import { getLocalizedString, buildExportMenuItems, computeSpeakerExporters, parseBooleanAnswer, buildQrcodesUrl, sessionsForSpeaker } from '../utils'
 import MarkdownContent from './MarkdownContent.vue'
 import Session from './Session.vue'
 import DetailBackNav from './DetailBackNav.vue'
@@ -76,7 +76,8 @@ export default {
 			}
 		},
 		translationMessages: { default: () => ({}) },
-		isWipPreview: { default: false }
+		isWipPreview: { default: false },
+		exportsDisabled: { default: false },
 	},
 	props: {
 		speaker: Object,
@@ -149,26 +150,15 @@ export default {
 		resolvedSessions() {
 			if (this.sessions?.length) return this.sessions
 			const id = this.speakerId || this.speaker?.code
-			if (id && this.scheduleData?.sessionsBySpeaker?.[id]) {
-				return this.scheduleData.sessionsBySpeaker[id]
-			}
-			if (id && this.scheduleData) {
-				const list = this.scheduleData.sessions || []
-				const out = []
-				for (let i = 0; i < list.length; i++) {
-					const s = list[i]
-					const spk = s.speakers
-					if (!spk) continue
-					for (let j = 0; j < spk.length; j++) {
-						if (spk[j] && spk[j].code === id) {
-							out.push(s)
-							break
-						}
-					}
-				}
-				return out
-			}
-			return []
+			if (!id) return []
+			const fromBySpeaker = sessionsForSpeaker(this.scheduleData?.sessionsBySpeaker, id)
+			if (fromBySpeaker.length) return fromBySpeaker
+			const list = this.scheduleData?.sessions || []
+			const normalizedId = id.toLowerCase()
+			return list.filter((session) => (session.speakers || []).some((sp) => {
+				const code = typeof sp === 'string' ? sp : sp?.code
+				return code && code.toLowerCase() === normalizedId
+			}))
 		},
 		resolvedFavs() {
 			if (this.favs?.length) return this.favs
@@ -226,6 +216,7 @@ export default {
 			return `${this.eventUrl}speakers/${code}`
 		},
 		speakerExportOptions() {
+			if (this.exportsDisabled || !this.resolvedSessions?.length) return []
 			const exporters = this.resolvedSpeaker?.exporters
 			const base = this.speakerBaseUrl
 			if (!exporters && !base) return []

--- a/app/eventyay/webapp/schedule/src/components/SpeakersList.vue
+++ b/app/eventyay/webapp/schedule/src/components/SpeakersList.vue
@@ -154,7 +154,7 @@
 
 <script>
 import moment from 'moment-timezone'
-import { getLocalizedString } from '../utils'
+import { getLocalizedString, compareFeaturedSpeakers, isFeaturedSpeakersSortAvailable } from '../utils'
 import MarkdownContent from './MarkdownContent'
 
 function normalizeLocaleCode (code) {
@@ -224,6 +224,16 @@ export default {
 	},
 	mounted() {
 		document.addEventListener('click', this.onOutsideClick, true)
+		if (!this.featuredSortAvailable && this.sortBy === 'featured') {
+			this.sortBy = 'a-z'
+		}
+	},
+	watch: {
+		featuredSortAvailable(available) {
+			if (!available && this.sortBy === 'featured') {
+				this.sortBy = 'a-z'
+			}
+		},
 	},
 	beforeUnmount() {
 		document.removeEventListener('click', this.onOutsideClick, true)
@@ -262,11 +272,20 @@ export default {
 			return Boolean(this.searchQuery) || this.selectedLanguages.length > 0 || this.selectedTracks.length > 0
 		},
 		sortOptions() {
-			return [
-				{ value: 'featured', label: this.t.featured },
+			const options = [
 				{ value: 'a-z', label: this.t.a_to_z },
 				{ value: 'z-a', label: this.t.z_to_a },
 			]
+			if (this.featuredSortAvailable) {
+				options.unshift({ value: 'featured', label: this.t.featured })
+			}
+			return options
+		},
+		featuredSortAvailable() {
+			return isFeaturedSpeakersSortAvailable({
+				flags: this.scheduleData?.schedule?.feature_flags || {},
+				speakers: this.scheduleData?.schedule?.speakers || [],
+			})
 		},
 		currentSortLabel() {
 			const opt = this.sortOptions.find(o => o.value === this.sortBy)
@@ -358,15 +377,7 @@ export default {
 				return dir * an.localeCompare(bn)
 			}
 			if (this.sortBy === 'featured') {
-				return speakers.sort((a, b) => {
-					const af = a.is_featured ? 1 : 0
-					const bf = b.is_featured ? 1 : 0
-					if (af !== bf) return bf - af
-					const ap = Number.isFinite(a.featured_position) ? a.featured_position : 1e9
-					const bp = Number.isFinite(b.featured_position) ? b.featured_position : 1e9
-					if (ap !== bp) return ap - bp
-					return byName(a, b)
-				})
+				return speakers.sort((a, b) => compareFeaturedSpeakers(a, b, { featuredFirst: true }))
 			}
 			if (this.sortBy === 'a-z') {
 				return speakers.sort((a, b) => byName(a, b))

--- a/app/eventyay/webapp/schedule/src/components/TalkDetail.vue
+++ b/app/eventyay/webapp/schedule/src/components/TalkDetail.vue
@@ -1,6 +1,6 @@
 <template lang="pug">
 .c-talk-detail
-	detail-back-nav(:event-url="baseUrl", destination="schedule")
+	detail-back-nav
 		detail-top-actions(
 			:export-options="talkExportOptions",
 			:qrcodes-url="talkQrcodesUrl",
@@ -12,8 +12,8 @@
 			.talk-header
 				h1 {{ getLocalizedString(resolvedTalk.title) }}
 			.info
-				span.info-main {{ datetime }} {{ roomName }}
-				span.session-language(v-if="sessionLanguageLabel")  · {{ t.session_language }}: {{ sessionLanguageLabel }}
+				span.info-main {{ sessionTimeLabel }}
+				span.session-language(v-if="!isSchedulePending && sessionLanguageLabel")  · {{ t.session_language }}: {{ sessionLanguageLabel }}
 			.field-section.abstract-section(v-if="resolvedTalk.abstract")
 				h2.field-heading Abstract
 				.field-content
@@ -147,6 +147,7 @@ export default {
 		loggedIn: { default: false },
 		translationMessages: { default: () => ({}) },
 		isWipPreview: { default: false },
+		exportsDisabled: { default: false },
 		remoteApiUrl: { default: null },
 	},
 	props: {
@@ -258,8 +259,20 @@ export default {
 			return favs.includes(favId)
 		},
 		datetime() {
-			if (!this.resolvedTalk) return ''
+			if (!this.resolvedTalk || this.isSchedulePending) return ''
 			return moment(this.resolvedTalk.start).format('L LT') + ' - ' + moment(this.resolvedTalk.end).format('LT')
+		},
+		isSchedulePending () {
+			return Boolean(this.resolvedTalk?.schedule_pending || !this.resolvedTalk?.start)
+		},
+		schedulePendingText () {
+			const m = this.translationMessages || {}
+			return m.schedule_pending_secondary || 'Coming soon'
+		},
+		sessionTimeLabel () {
+			if (this.isSchedulePending) return this.schedulePendingText
+			const parts = [this.datetime, this.roomName].filter(Boolean)
+			return parts.join(' ')
 		},
 		roomName() {
 			if (!this.resolvedTalk) return ''
@@ -329,6 +342,7 @@ export default {
 			})
 		},
 		talkExportOptions() {
+			if (this.exportsDisabled || this.isSchedulePending) return []
 			const code = this.resolvedTalk?.code || this.resolvedTalk?.id || this.talkId
 			const exporters = this.resolvedTalk?.exporters ||
 				(this.baseUrl && code ? computeTalkExporters(this.baseUrl, code) : null)

--- a/app/eventyay/webapp/schedule/src/utils.js
+++ b/app/eventyay/webapp/schedule/src/utils.js
@@ -1,3 +1,5 @@
+import moment from 'moment-timezone'
+
 export function getLocalizedString (string) {
 	if (!string) return ''
 	if (typeof string === 'string') return string
@@ -115,7 +117,8 @@ export function buildExportMenuItems(exporters) {
 	].filter(o => o.url)
 }
 
-export function areScheduleExportsDisabled ({ version = '', scheduleMetaVersion = '', isFeaturedPage = false, exportersCount = 0, isWipPreview = false } = {}) {
+export function areScheduleExportsDisabled ({ version = '', scheduleMetaVersion = '', isFeaturedPage = false, exportersCount = 0, isWipPreview = false, scheduleExportsDisabled = false } = {}) {
+	if (scheduleExportsDisabled) return true
 	if (isWipPreview || (version || scheduleMetaVersion) === 'wip') return true
 	if (isFeaturedPage && !exportersCount) return true
 	return false
@@ -154,6 +157,49 @@ export function normalizePopularityCount (session) {
 	return Number.isFinite(value) ? value : 0
 }
 
+export function isPopularityFeatureEnabled (flags = {}) {
+	return !!flags.session_popularity_enabled
+}
+
+export function isPopularityVisibleOnSchedule ({ flags = {}, loggedIn = false } = {}) {
+	if (!loggedIn || !isPopularityFeatureEnabled(flags)) return false
+	if ('session_popularity_show_on_schedule' in flags) {
+		return !!flags.session_popularity_show_on_schedule
+	}
+	return !!(flags.session_popularity_show_on_calendar || flags.session_popularity_show_on_list)
+}
+
+export function isPopularitySortAvailable ({ flags = {}, loggedIn = false } = {}) {
+	return loggedIn && isPopularityFeatureEnabled(flags)
+}
+
+export function isFeaturedSpeakersSortAvailable ({ flags = {}, speakers = [] } = {}) {
+	if (!flags.featured_speakers_enabled) return false
+	return speakers.some(speaker => speaker?.is_featured)
+}
+
+export function featuredPosition (speaker) {
+	const position = speaker?.featured_position
+	if (position === null || position === undefined || position === '') {
+		return Number.MAX_SAFE_INTEGER
+	}
+	const numeric = Number(position)
+	return Number.isFinite(numeric) ? numeric : Number.MAX_SAFE_INTEGER
+}
+
+export function compareFeaturedSpeakers (a, b, { featuredFirst = false } = {}) {
+	if (featuredFirst) {
+		if (a?.is_featured && !b?.is_featured) return -1
+		if (!a?.is_featured && b?.is_featured) return 1
+	}
+	const positionDelta = featuredPosition(a) - featuredPosition(b)
+	if (positionDelta !== 0) return positionDelta
+	const nameA = (a?.name || '').trim()
+	const nameB = (b?.name || '').trim()
+	if (!!nameA !== !!nameB) return nameA ? -1 : 1
+	return nameA.localeCompare(nameB)
+}
+
 export function buildEventPageUrl (eventUrl, pagePath = '', isWipPreview = false) {
 	if (!eventUrl) return ''
 	const base = eventUrl.replace(/\/?$/, '/')
@@ -162,28 +208,96 @@ export function buildEventPageUrl (eventUrl, pagePath = '', isWipPreview = false
 	return `${base}${wipPrefix}${normalizedPath}`
 }
 
-const DETAIL_BACK_DESTINATIONS = {
-	schedule: {
-		messageKey: 'back_to_schedule',
-		defaultLabel: 'Back to schedule',
-		pagePath (isWipPreview) {
-			return isWipPreview ? '' : 'schedule/'
-		},
-	},
-	speakers: {
-		messageKey: 'back_to_speakers',
-		defaultLabel: 'Back to speakers',
-		pagePath () {
-			return 'speakers/'
-		},
-	},
+export function speakerCodeFromReference (sp) {
+	if (!sp) return null
+	if (typeof sp === 'string') return sp
+	return sp.code || null
 }
 
-export function getDetailBackLink ({ eventUrl, destination, isWipPreview = false, messages = {} }) {
-	const config = DETAIL_BACK_DESTINATIONS[destination]
-	if (!config || !eventUrl) return null
-	return {
-		href: buildEventPageUrl(eventUrl, config.pagePath(isWipPreview), isWipPreview),
-		label: messages[config.messageKey] || config.defaultLabel,
+export function isTalkSchedulePending (talk) {
+	return Boolean(talk?.schedule_pending || !talk?.start)
+}
+
+export function talkToSession (talk, {
+	timezone,
+	speakersLookup = {},
+	tracksLookup = {},
+	roomsLookup = {},
+	includePopularity = false,
+} = {}) {
+	const isPending = isTalkSchedulePending(talk)
+	const speakers = (talk.speakers || []).map((sp) => {
+		if (typeof sp === 'object' && sp?.code) return sp
+		const code = speakerCodeFromReference(sp)
+		return speakersLookup[code] || { code }
+	}).filter(Boolean)
+	const track = typeof talk.track === 'object' ? talk.track : tracksLookup[talk.track]
+	const base = {
+		id: talk.code,
+		code: talk.code,
+		title: talk.title,
+		abstract: talk.abstract,
+		description: talk.description,
+		do_not_record: talk.do_not_record,
+		duration: talk.duration,
+		speakers,
+		track,
+		tags: talk.tags,
+		session_type: talk.session_type,
+		content_locale: talk.content_locale,
+		resources: talk.resources,
+		answers: talk.answers,
+		exporters: talk.exporters,
+		recording_iframe: talk.recording_iframe,
+		stream_url: talk.stream_url || null,
+		stream_type: talk.stream_type || null,
 	}
+	if (includePopularity) {
+		base.fav_count = normalizePopularityCount(talk)
+	}
+	if (isPending) {
+		return { ...base, start: null, end: null, schedule_pending: true, room: null }
+	}
+	return {
+		...base,
+		start: moment.tz(talk.start, timezone),
+		end: moment.tz(talk.end, timezone),
+		room: typeof talk.room === 'object' ? talk.room : roomsLookup[talk.room],
+	}
+}
+
+export function sortSessionsByStart (sessions) {
+	return sessions.slice().sort((a, b) => {
+		if (a.schedule_pending && !b.schedule_pending) return 1
+		if (!a.schedule_pending && b.schedule_pending) return -1
+		if (a.schedule_pending && b.schedule_pending) {
+			return getLocalizedString(a.title).localeCompare(getLocalizedString(b.title))
+		}
+		return a.start.diff(b.start)
+	})
+}
+
+export function talksToScheduleSessions (talks, context) {
+	if (!talks?.length || !context?.timezone) return []
+	return sortSessionsByStart(talks.map(talk => talkToSession(talk, context)))
+}
+
+export function sessionsForSpeaker (sessionsBySpeaker, speakerId) {
+	if (!speakerId || !sessionsBySpeaker) return []
+	const key = speakerId.toLowerCase()
+	return sessionsBySpeaker[key] || sessionsBySpeaker[speakerId] || []
+}
+
+export function buildSessionsBySpeaker (sessions, { lowercaseKeys = true } = {}) {
+	if (!sessions?.length) return {}
+	return sessions.reduce((acc, session) => {
+		(session.speakers || []).forEach((speaker) => {
+			const code = speakerCodeFromReference(speaker)
+			if (!code) return
+			const key = lowercaseKeys ? code.toLowerCase() : code
+			if (!acc[key]) acc[key] = []
+			acc[key].push(session)
+		})
+		return acc
+	}, {})
 }

--- a/app/tests/stable/test_featured.py
+++ b/app/tests/stable/test_featured.py
@@ -1,8 +1,12 @@
 import json
+import re
+
 import pytest
 import datetime as dt
+from django.contrib.auth.models import AnonymousUser
 from django_scopes import scope
 from eventyay.base.models import Submission, Room, TalkSlot, SubmissionType
+from eventyay.common.templatetags.event_tags import show_schedule_nav_tab
 
 @pytest.mark.django_db
 class TestFeaturedSessions:
@@ -105,9 +109,18 @@ class TestFeaturedSessions:
         schedule_data = context['schedule_data_json']
         assert "Featured Session Title" in schedule_data
         assert "Regular Session Title" not in schedule_data
+        assert '"exports_disabled": true' in schedule_data
 
-        # 5. Request exporters with featured=true
+        # 5. Featured exports stay blocked until the schedule is publicly released
         export_json_url = f'{schedule_export_base}.json?featured=true'
+        response = client.get(export_json_url)
+        assert response.status_code == 404
+
+        with scope(event=event):
+            event.settings.show_schedule = True
+            event.talks_published = True
+            event.save()
+
         response = client.get(export_json_url)
         assert response.status_code == 200
         export_content = response.content.decode('utf-8')
@@ -115,11 +128,6 @@ class TestFeaturedSessions:
         assert "Regular Session Title" not in export_content
 
         # Request exporters without featured=true (should contain both)
-        with scope(event=event):
-            event.settings.show_schedule = True
-            event.talks_published = True
-            event.save()
-
         export_json_url_all = f'{schedule_export_base}.json'
         response = client.get(export_json_url_all)
         assert response.status_code == 200
@@ -163,8 +171,8 @@ class TestFeaturedSessions:
         assert "Featured Session Title" in content
         assert 'schedule_pending' in content or 'Coming soon' in content
         assert '<article id="featured-talks">' not in content
-        meta_json = response.context['schedule_meta_json']
-        assert json.loads(meta_json)['exporters'] == []
+        meta = json.loads(response.context['schedule_meta_json'])
+        assert meta['exporters'] == []
 
         export_json_url = f'{schedule_export_base}.json?featured=true'
         response = client.get(export_json_url)
@@ -191,4 +199,110 @@ class TestFeaturedSessions:
 
         assert can_view_featured_sessions_public(ctx, event) is True
 
+
+@pytest.mark.django_db
+def test_featured_page_hides_schedule_nav_before_public_release(
+    client, organizer_client, event, user, rf
+):
+    with scope(event=event):
+        sub_type = SubmissionType.objects.create(event=event, name='Talk')
+        sub_featured = Submission.objects.create(
+            title='Featured Session Title',
+            event=event,
+            submission_type=sub_type,
+            abstract='An abstract for a featured session',
+            content_locale='en',
+            is_featured=True,
+        )
+        sub_featured.speakers.add(user)
+        sub_featured.accept()
+        sub_featured.confirm()
+        room = Room.objects.create(event=event, name='Room A')
+        TalkSlot.objects.update_or_create(
+            submission=sub_featured,
+            schedule=event.wip_schedule,
+            defaults={
+                'is_visible': True,
+                'start': event.date_from + dt.timedelta(hours=10),
+                'end': event.date_from + dt.timedelta(hours=11),
+                'room': room,
+            },
+        )
+        event.release_schedule('v1')
+        event.feature_flags['show_featured'] = 'always'
+        event.feature_flags['show_schedule'] = True
+        event.talks_published = False
+        event.save(update_fields=['feature_flags', 'talks_published'])
+        featured_url = str(event.urls.featured)
+        schedule_url = str(event.urls.schedule)
+
+    request = rf.get(featured_url)
+    request.event = event
+    request.user = AnonymousUser()
+    assert show_schedule_nav_tab({'request': request}, event=event) is False
+
+    schedule_nav_pattern = re.compile(
+        rf'<a href="{re.escape(schedule_url)}" class="header-tab[^"]*"'
+    )
+    for test_client in (client, organizer_client):
+        response = test_client.get(featured_url)
+        assert response.status_code == 200
+        assert schedule_nav_pattern.search(response.content.decode()) is None
+
+
+@pytest.mark.django_db
+def test_featured_talk_detail_shows_pending_data_when_slot_not_public(client, event, user):
+    """Featured talk pages must render when the session is not on the public schedule yet."""
+    from django.urls import reverse
+
+    with scope(event=event):
+        sub_type = SubmissionType.objects.create(event=event, name='Talk')
+        sub_featured = Submission.objects.create(
+            title='Hidden Featured Session',
+            event=event,
+            submission_type=sub_type,
+            abstract='Featured abstract',
+            content_locale='en',
+            is_featured=True,
+        )
+        sub_featured.speakers.add(user)
+        sub_featured.accept()
+        sub_featured.confirm()
+        room = Room.objects.create(event=event, name='Room A')
+        TalkSlot.objects.update_or_create(
+            submission=sub_featured,
+            schedule=event.wip_schedule,
+            defaults={
+                'is_visible': False,
+                'start': None,
+                'end': None,
+                'room': room,
+            },
+        )
+        event.release_schedule('v1')
+        schedule = event.current_schedule
+        TalkSlot.objects.update_or_create(
+            submission=sub_featured,
+            schedule=schedule,
+            defaults={
+                'is_visible': False,
+                'start': None,
+                'end': None,
+                'room': room,
+            },
+        )
+        event.feature_flags['show_featured'] = 'always'
+        event.feature_flags['show_schedule'] = True
+        event.talks_published = True
+        event.save(update_fields=['feature_flags', 'talks_published'])
+        talk_url = reverse(
+            'agenda:talk.detail',
+            kwargs={'slug': sub_featured.code, 'event': event.slug, 'organizer': event.organizer.slug},
+        )
+
+    response = client.get(talk_url, follow=True)
+    assert response.status_code == 200
+    schedule_data = json.loads(response.context['schedule_json'])
+    assert schedule_data['talks'][0]['code'] == sub_featured.code
+    assert schedule_data['talks'][0]['schedule_pending'] is True
 

--- a/app/tests/stable/test_featured_speakers.py
+++ b/app/tests/stable/test_featured_speakers.py
@@ -1,3 +1,5 @@
+from urllib.parse import urlparse
+
 import pytest
 from django.contrib.auth import get_user_model
 from django.contrib.messages import get_messages
@@ -10,6 +12,10 @@ from eventyay.talk_rules.agenda import is_pre_agenda_featured_public, is_speaker
 User = get_user_model()
 
 
+def _event_base_path(event):
+    return urlparse(str(event.urls.base)).path.rstrip('/')
+
+
 def _assert_speakers_list_redirects(client, event, *, expected_message):
     speakers_list_url = reverse(
         'agenda:speakers',
@@ -20,7 +26,7 @@ def _assert_speakers_list_redirects(client, event, *, expected_message):
     )
     response = client.get(speakers_list_url, follow=True)
     assert response.status_code == 200
-    assert response.request['PATH_INFO'].rstrip('/') == event.urls.base.path.rstrip('/')
+    assert response.request['PATH_INFO'].rstrip('/') == _event_base_path(event)
     messages = [str(message) for message in get_messages(response.wsgi_request)]
     assert expected_message in messages
 
@@ -111,26 +117,19 @@ def test_featured_speakers_list_blocked_before_public_schedule_release(client, e
 
 @pytest.mark.django_db
 def test_speakers_list_blocked_when_no_schedule_released(client, event):
-    """Speakers page stays hidden when no schedule version has been released."""
+    """Speakers list redirects to the info page when no schedule version has been released."""
     with scope(event=event):
         event.talks_published = True
         event.feature_flags['show_schedule'] = True
         event.save(update_fields=['talks_published', 'feature_flags'])
         assert event.current_schedule is None
 
-    speakers_list_url = reverse(
-        'agenda:speakers',
-        kwargs={
-            'event': event.slug,
-            'organizer': event.organizer.slug,
-        },
-    )
-    assert client.get(speakers_list_url, follow=True).status_code == 404
+    _assert_speakers_list_redirects(client, event, expected_message='No published schedule.')
 
 
 @pytest.mark.django_db
 def test_speakers_list_blocked_when_featured_visible_without_schedule(client, event):
-    """Speakers page stays hidden when only featured content is public."""
+    """Speakers list redirects when only featured sessions are public without a released schedule."""
     with scope(event=event):
         event.talks_published = True
         event.feature_flags['show_schedule'] = True
@@ -138,23 +137,28 @@ def test_speakers_list_blocked_when_featured_visible_without_schedule(client, ev
         event.save(update_fields=['talks_published', 'feature_flags'])
         assert event.current_schedule is None
 
-    speakers_list_url = reverse(
-        'agenda:speakers',
-        kwargs={
-            'event': event.slug,
-            'organizer': event.organizer.slug,
-        },
-    )
-    assert client.get(speakers_list_url, follow=True).status_code == 404
+    _assert_speakers_list_redirects(client, event, expected_message='No published schedule.')
 
 
 @pytest.mark.django_db
 def test_speakers_list_blocked_for_organiser_until_public_release(organizer_client, event):
     """Organisers use orga/WIP preview; the public speakers page redirects until release."""
     with scope(event=event):
+        user = User.objects.create_user(
+            email='featured-orga-pre-release@example.com',
+            password='testpass123',
+            fullname='Organiser Pre Release Speaker',
+        )
+        SpeakerProfile.objects.create(
+            event=event,
+            user=user,
+            biography='Featured biography.',
+            is_featured=True,
+        )
         event.talks_published = True
         event.private_testmode = True
         event.settings.private_testmode_talks = True
+        event.feature_flags['show_featured_speakers'] = 'always'
         event.feature_flags['show_schedule'] = True
         event.save(update_fields=['talks_published', 'private_testmode', 'feature_flags'])
         event.release_schedule('v1')

--- a/app/tests/stable/test_featured_speakers.py
+++ b/app/tests/stable/test_featured_speakers.py
@@ -1,0 +1,196 @@
+import pytest
+from django.contrib.auth import get_user_model
+from django.contrib.messages import get_messages
+from django.urls import reverse
+from django_scopes import scope
+
+from eventyay.base.models import SpeakerProfile
+from eventyay.talk_rules.agenda import is_pre_agenda_featured_public, is_speaker_viewable
+
+User = get_user_model()
+
+
+def _assert_speakers_list_redirects(client, event, *, expected_message):
+    speakers_list_url = reverse(
+        'agenda:speakers',
+        kwargs={
+            'event': event.slug,
+            'organizer': event.organizer.slug,
+        },
+    )
+    response = client.get(speakers_list_url, follow=True)
+    assert response.status_code == 200
+    assert response.request['PATH_INFO'].rstrip('/') == event.urls.base.path.rstrip('/')
+    messages = [str(message) for message in get_messages(response.wsgi_request)]
+    assert expected_message in messages
+
+
+@pytest.mark.django_db
+def test_featured_speaker_without_talks_still_viewable_after_schedule_release(client, event):
+    """Featured speakers with no sessions stay public after the schedule is released."""
+    with scope(event=event):
+        user = User.objects.create_user(
+            email='featured-only@example.com',
+            password='testpass123',
+            fullname='Featured Only Speaker',
+        )
+        profile = SpeakerProfile.objects.create(
+            event=event,
+            user=user,
+            biography='Featured biography.',
+            is_featured=True,
+        )
+        event.feature_flags['show_featured_speakers'] = 'always'
+        event.feature_flags['show_schedule'] = True
+        event.talks_published = False
+        event.save(update_fields=['feature_flags', 'talks_published'])
+        event.release_schedule('v1')
+        event.talks_published = True
+        event.save(update_fields=['talks_published'])
+
+    with scope(event=event):
+        assert is_pre_agenda_featured_public(None, event) is False
+        assert is_speaker_viewable(None, profile) is True
+
+    speaker_url = reverse(
+        'agenda:speaker',
+        kwargs={
+            'code': user.code,
+            'event': event.slug,
+            'organizer': event.organizer.slug,
+        },
+    )
+    response = client.get(speaker_url, follow=True)
+    assert response.status_code == 200
+    assert user.fullname in response.content.decode()
+    assert '"exports_disabled": true' in response.context['schedule_json']
+
+
+@pytest.mark.django_db
+def test_featured_speakers_list_blocked_before_public_schedule_release(client, event):
+    """Featured speakers stay on the info page, but the full list stays hidden until release."""
+    with scope(event=event):
+        user = User.objects.create_user(
+            email='featured-pre-release@example.com',
+            password='testpass123',
+            fullname='Pre Release Featured Speaker',
+        )
+        SpeakerProfile.objects.create(
+            event=event,
+            user=user,
+            biography='Featured biography.',
+            is_featured=True,
+        )
+        event.feature_flags['show_featured_speakers'] = 'always'
+        event.feature_flags['show_schedule'] = True
+        event.talks_published = False
+        event.save(update_fields=['feature_flags', 'talks_published'])
+        event.release_schedule('v1')
+
+    landing = client.get(event.urls.base)
+    assert landing.status_code == 200
+    widget_schedule = landing.context['featured_speakers_widget_schedule']
+    assert widget_schedule is not None
+    assert widget_schedule['speakers_list_public'] is False
+    assert '"speakers_list_public": false' in landing.context['featured_speakers_widget_schedule_json']
+    assert 'speakers-list-public="false"' in landing.text
+    assert landing.context['featured_speakers_list_public'] is False
+
+    speaker_url = reverse(
+        'agenda:speaker',
+        kwargs={
+            'code': user.code,
+            'event': event.slug,
+            'organizer': event.organizer.slug,
+        },
+    )
+    assert client.get(speaker_url, follow=True).status_code == 200
+
+    _assert_speakers_list_redirects(client, event, expected_message='No published schedule.')
+
+
+@pytest.mark.django_db
+def test_speakers_list_blocked_when_no_schedule_released(client, event):
+    """Speakers page stays hidden when no schedule version has been released."""
+    with scope(event=event):
+        event.talks_published = True
+        event.feature_flags['show_schedule'] = True
+        event.save(update_fields=['talks_published', 'feature_flags'])
+        assert event.current_schedule is None
+
+    speakers_list_url = reverse(
+        'agenda:speakers',
+        kwargs={
+            'event': event.slug,
+            'organizer': event.organizer.slug,
+        },
+    )
+    assert client.get(speakers_list_url, follow=True).status_code == 404
+
+
+@pytest.mark.django_db
+def test_speakers_list_blocked_when_featured_visible_without_schedule(client, event):
+    """Speakers page stays hidden when only featured content is public."""
+    with scope(event=event):
+        event.talks_published = True
+        event.feature_flags['show_schedule'] = True
+        event.feature_flags['show_featured'] = 'always'
+        event.save(update_fields=['talks_published', 'feature_flags'])
+        assert event.current_schedule is None
+
+    speakers_list_url = reverse(
+        'agenda:speakers',
+        kwargs={
+            'event': event.slug,
+            'organizer': event.organizer.slug,
+        },
+    )
+    assert client.get(speakers_list_url, follow=True).status_code == 404
+
+
+@pytest.mark.django_db
+def test_speakers_list_blocked_for_organiser_until_public_release(organizer_client, event):
+    """Organisers use orga/WIP preview; the public speakers page redirects until release."""
+    with scope(event=event):
+        event.talks_published = True
+        event.private_testmode = True
+        event.settings.private_testmode_talks = True
+        event.feature_flags['show_schedule'] = True
+        event.save(update_fields=['talks_published', 'private_testmode', 'feature_flags'])
+        event.release_schedule('v1')
+
+    _assert_speakers_list_redirects(
+        organizer_client,
+        event,
+        expected_message='No published schedule.',
+    )
+
+
+@pytest.mark.django_db
+def test_speakers_list_blocked_in_private_talk_testmode(client, event):
+    """Speakers list stays private while talk pages are in private test mode."""
+    with scope(event=event):
+        user = User.objects.create_user(
+            email='featured-private@example.com',
+            password='testpass123',
+            fullname='Featured Private Speaker',
+        )
+        SpeakerProfile.objects.create(
+            event=event,
+            user=user,
+            biography='Featured biography.',
+            is_featured=True,
+        )
+        event.talks_published = True
+        event.private_testmode = True
+        event.settings.private_testmode_talks = True
+        event.feature_flags['show_featured_speakers'] = 'always'
+        event.feature_flags['show_schedule'] = True
+        event.save(update_fields=['talks_published', 'private_testmode', 'feature_flags'])
+        event.release_schedule('v1')
+
+    landing = client.get(event.urls.base)
+    assert landing.status_code == 200
+    assert landing.context['featured_speakers_list_public'] is False
+
+    _assert_speakers_list_redirects(client, event, expected_message='No published schedule.')

--- a/app/tests/talk/agenda/views/test_agenda_landing_speakers.py
+++ b/app/tests/talk/agenda/views/test_agenda_landing_speakers.py
@@ -1,5 +1,18 @@
+import json
+
 import pytest
+from django.urls import reverse
 from django_scopes import scope
+
+from eventyay.talk_rules.agenda import is_pre_agenda_featured_public, is_speaker_viewable
+
+
+def _enable_public_featured_speakers(event):
+    with scope(event=event):
+        event.talks_published = False
+        event.feature_flags['show_featured_speakers'] = 'always'
+        event.feature_flags['show_schedule'] = True
+        event.save(update_fields=['talks_published', 'feature_flags'])
 
 
 @pytest.mark.django_db
@@ -38,8 +51,97 @@ def test_landing_page_shows_featured_speakers_in_custom_order(
         other_slot.submission.code,
         slot.submission.code,
     }.issubset(talk_codes)
+    speaker_codes = [s['code'] for s in widget_schedule['speakers']]
+    assert speaker_codes.index(other_speaker.code) < speaker_codes.index(speaker.code)
     assert 'pretalx-schedule-data' in response.text
     assert 'view="featured-speakers"' in response.text
+    assert response.context['featured_speakers_widget_schedule']['speakers_list_public'] is True
+
+
+@pytest.mark.django_db
+def test_landing_page_featured_speakers_use_profile_order_without_agenda(
+    client, event, speaker, other_speaker
+):
+    _enable_public_featured_speakers(event)
+    with scope(event=event):
+        first_profile = speaker.event_profile(event)
+        second_profile = other_speaker.event_profile(event)
+        first_profile.is_featured = True
+        first_profile.position = 2
+        first_profile.save(update_fields=['is_featured', 'position'])
+        second_profile.is_featured = True
+        second_profile.position = 0
+        second_profile.save(update_fields=['is_featured', 'position'])
+
+    response = client.get(event.urls.base)
+
+    assert response.status_code == 200
+    widget_schedule = response.context['featured_speakers_widget_schedule']
+    speaker_codes = [s['code'] for s in widget_schedule['speakers']]
+    assert speaker_codes == [other_speaker.code, speaker.code]
+    assert widget_schedule['speakers_list_public'] is False
+
+
+@pytest.mark.django_db
+def test_landing_page_shows_more_speakers_link_when_agenda_is_public(
+    client, event, slot, speaker
+):
+    with scope(event=event):
+        event.talks_published = True
+        event.feature_flags['show_featured_speakers'] = 'always'
+        event.feature_flags['show_schedule'] = True
+        event.save(update_fields=['talks_published', 'feature_flags'])
+        profile = speaker.event_profile(event)
+        profile.is_featured = True
+        profile.save(update_fields=['is_featured'])
+
+    response = client.get(event.urls.base)
+
+    assert response.status_code == 200
+    assert response.context['featured_speakers_widget_schedule']['speakers_list_public'] is True
+
+
+@pytest.mark.django_db
+def test_landing_page_shows_featured_speakers_with_after_schedule_before_release(
+    client, event, speaker
+):
+    with scope(event=event):
+        event.talks_published = False
+        event.feature_flags['show_featured_speakers'] = 'after_schedule'
+        event.feature_flags['show_schedule'] = True
+        event.save(update_fields=['talks_published', 'feature_flags'])
+        profile = speaker.event_profile(event)
+        profile.is_featured = True
+        profile.position = 0
+        profile.save(update_fields=['is_featured', 'position'])
+        assert event.current_schedule is None
+
+    response = client.get(event.urls.base)
+
+    assert response.status_code == 200
+    assert 'view="featured-speakers"' in response.text
+    widget_schedule = response.context['featured_speakers_widget_schedule']
+    assert {s['code'] for s in widget_schedule['speakers']} == {speaker.code}
+    assert widget_schedule['speakers_list_public'] is False
+
+
+@pytest.mark.django_db
+def test_speakers_page_lists_all_speakers_after_schedule_release(
+    client, event, slot, other_slot, speaker, other_speaker
+):
+    with scope(event=event):
+        event.talks_published = True
+        event.feature_flags['show_featured_speakers'] = 'always'
+        event.feature_flags['show_schedule'] = True
+        event.save(update_fields=['talks_published', 'feature_flags'])
+        speaker.event_profile(event)
+        other_speaker.event_profile(event)
+
+    response = client.get(event.urls.speakers, follow=True)
+
+    assert response.status_code == 200
+    schedule_data = json.loads(response.context['schedule_json'])
+    assert {s['code'] for s in schedule_data['speakers']} >= {speaker.code, other_speaker.code}
 
 
 @pytest.mark.django_db
@@ -57,3 +159,241 @@ def test_landing_page_hides_featured_speakers_when_none_are_marked(
     assert 'Featured Speakers' not in response.text
     assert 'pretalx-schedule-data' not in response.text
     assert 'view="featured-speakers"' not in response.text
+
+
+@pytest.mark.django_db
+def test_featured_speaker_links_work_without_published_schedule(client, event, speaker):
+    _enable_public_featured_speakers(event)
+    with scope(event=event):
+        profile = speaker.event_profile(event)
+        profile.is_featured = True
+        profile.save(update_fields=['is_featured'])
+        assert event.current_schedule is None
+
+    landing = client.get(event.urls.base)
+    assert landing.status_code == 200
+    assert 'view="featured-speakers"' in landing.text
+    widget_schedule = landing.context['featured_speakers_widget_schedule']
+    assert widget_schedule['talks'] == []
+
+    speaker_url = reverse('agenda:speaker', kwargs={'code': speaker.code, 'event': event.slug})
+    speaker_response = client.get(speaker_url, follow=True)
+    assert speaker_response.status_code == 200
+    assert speaker.fullname in speaker_response.text
+    assert 'pretalx-schedule-data' in speaker_response.text
+    schedule_data = json.loads(speaker_response.context['schedule_json'])
+    assert schedule_data['talks'] == []
+    assert {s['code'] for s in schedule_data['speakers']} == {speaker.code}
+    assert list(speaker_response.context['talks']) == []
+
+    speakers_list_response = client.get(event.urls.speakers, follow=True)
+    assert speakers_list_response.status_code == 404
+
+    talk_url = reverse(
+        'agenda:talk.detail',
+        kwargs={'slug': 'nonexistent', 'event': event.slug},
+    )
+    assert client.get(talk_url).status_code == 404
+
+
+@pytest.mark.django_db
+def test_featured_speakers_show_pending_sessions_before_agenda_is_public(
+    client, event, slot, speaker
+):
+    _enable_public_featured_speakers(event)
+    with scope(event=event):
+        profile = speaker.event_profile(event)
+        profile.is_featured = True
+        profile.save(update_fields=['is_featured'])
+
+    landing = client.get(event.urls.base)
+    assert landing.status_code == 200
+    widget_schedule = landing.context['featured_speakers_widget_schedule']
+    assert len(widget_schedule['talks']) == 1
+    assert widget_schedule['talks'][0]['code'] == slot.submission.code
+    assert widget_schedule['talks'][0]['schedule_pending'] is True
+    assert widget_schedule['talks'][0]['start'] is None
+
+
+@pytest.mark.django_db
+def test_featured_speakers_show_pending_sessions_in_private_talk_testmode(
+    client, event, slot, speaker
+):
+    with scope(event=event):
+        event.talks_published = True
+        event.private_testmode = True
+        event.settings.private_testmode_talks = True
+        event.feature_flags['show_featured_speakers'] = 'always'
+        event.feature_flags['show_schedule'] = True
+        event.save(update_fields=['talks_published', 'private_testmode', 'feature_flags'])
+        profile = speaker.event_profile(event)
+        profile.is_featured = True
+        profile.save(update_fields=['is_featured'])
+
+    landing = client.get(event.urls.base)
+    assert landing.status_code == 200
+    widget_schedule = landing.context['featured_speakers_widget_schedule']
+    assert len(widget_schedule['talks']) == 1
+    assert widget_schedule['talks'][0]['code'] == slot.submission.code
+    assert widget_schedule['talks'][0]['schedule_pending'] is True
+    assert widget_schedule['talks'][0]['start'] is None
+
+    speaker_response = client.get(
+        reverse('agenda:speaker', kwargs={'code': speaker.code, 'event': event.slug}),
+        follow=True,
+    )
+    assert speaker_response.status_code == 200
+    speaker_schedule = json.loads(speaker_response.context['schedule_json'])
+    assert len(speaker_schedule['talks']) == 1
+    assert speaker_schedule['talks'][0]['schedule_pending'] is True
+    assert speaker_schedule['talks'][0]['start'] is None
+
+
+@pytest.mark.django_db
+def test_featured_submission_visible_on_speaker_profile_before_public_release(
+    client, event, slot, speaker
+):
+    """Featured sessions show as coming soon on the speaker profile before public release."""
+    with scope(event=event):
+        event.talks_published = False
+        event.feature_flags['show_featured'] = 'always'
+        event.feature_flags['show_featured_speakers'] = 'never'
+        event.feature_flags['show_schedule'] = True
+        event.save(update_fields=['talks_published', 'feature_flags'])
+        slot.submission.is_featured = True
+        slot.submission.save(update_fields=['is_featured'])
+        assert speaker.event_profile(event).is_featured is False
+
+    speaker_response = client.get(
+        reverse('agenda:speaker', kwargs={'code': speaker.code, 'event': event.slug}),
+        follow=True,
+    )
+    assert speaker_response.status_code == 200
+    speaker_schedule = json.loads(speaker_response.context['schedule_json'])
+    assert len(speaker_schedule['talks']) == 1
+    assert speaker_schedule['talks'][0]['code'] == slot.submission.code
+    assert speaker_schedule['talks'][0]['schedule_pending'] is True
+
+
+@pytest.mark.django_db
+def test_featured_talk_detail_available_without_published_schedule(client, event, confirmed_submission):
+    with scope(event=event):
+        event.talks_published = False
+        event.feature_flags['show_featured'] = 'always'
+        event.save(update_fields=['talks_published', 'feature_flags'])
+        confirmed_submission.is_featured = True
+        confirmed_submission.save(update_fields=['is_featured'])
+        assert event.current_schedule is None
+
+    talk_url = reverse(
+        'agenda:talk.detail',
+        kwargs={'slug': confirmed_submission.code, 'event': event.slug},
+    )
+    response = client.get(talk_url, follow=True)
+    assert response.status_code == 200
+    schedule_data = json.loads(response.context['schedule_json'])
+    assert schedule_data['talks'][0]['code'] == confirmed_submission.code
+    assert schedule_data['talks'][0]['schedule_pending'] is True
+
+
+@pytest.mark.django_db
+def test_non_featured_speaker_profile_not_public_without_schedule(client, event, speaker):
+    _enable_public_featured_speakers(event)
+    with scope(event=event):
+        assert event.current_schedule is None
+
+    speaker_url = reverse('agenda:speaker', kwargs={'code': speaker.code, 'event': event.slug})
+    response = client.get(speaker_url, follow=True)
+    assert response.status_code == 403
+
+
+@pytest.mark.django_db
+def test_featured_speaker_not_duplicated_after_schedule_release(
+    client, event, speaker, slot, other_speaker
+):
+    _enable_public_featured_speakers(event)
+    with scope(event=event):
+        profile = speaker.event_profile(event)
+        profile.is_featured = True
+        profile.save(update_fields=['is_featured'])
+        other_profile = other_speaker.event_profile(event)
+        other_profile.is_featured = True
+        other_profile.save(update_fields=['is_featured'])
+
+    landing_before = client.get(event.urls.base)
+    speakers_before = landing_before.context['featured_speakers_widget_schedule']['speakers']
+    assert len([s for s in speakers_before if s['code'] == speaker.code]) == 1
+
+    with scope(event=event):
+        event.talks_published = True
+        event.release_schedule('v1')
+
+    landing_after = client.get(event.urls.base)
+    speakers_after = landing_after.context['featured_speakers_widget_schedule']['speakers']
+    assert len([s for s in speakers_after if s['code'] == speaker.code]) == 1
+
+
+@pytest.mark.django_db
+def test_featured_speaker_without_talks_still_viewable_after_schedule_release(
+    client, event, speaker
+):
+    _enable_public_featured_speakers(event)
+    with scope(event=event):
+        profile = speaker.event_profile(event)
+        profile.is_featured = True
+        profile.save(update_fields=['is_featured'])
+        event.release_schedule('v1')
+        event.talks_published = True
+        event.save(update_fields=['talks_published'])
+
+    with scope(event=event):
+        assert is_pre_agenda_featured_public(None, event) is False
+        assert is_speaker_viewable(None, profile) is True
+
+    speaker_url = reverse(
+        'agenda:speaker',
+        kwargs={
+            'code': speaker.code,
+            'event': event.slug,
+            'organizer': event.organizer.slug,
+        },
+    )
+    response = client.get(speaker_url, follow=True)
+    assert response.status_code == 200
+    assert speaker.fullname in response.text
+
+
+@pytest.mark.django_db
+def test_featured_speaker_profile_is_viewable_without_published_schedule(event, speaker):
+    _enable_public_featured_speakers(event)
+    with scope(event=event):
+        profile = speaker.event_profile(event)
+        profile.is_featured = True
+        profile.save(update_fields=['is_featured'])
+        assert is_pre_agenda_featured_public(None, event) is True
+        assert is_speaker_viewable(None, profile) is True
+
+
+@pytest.mark.django_db
+def test_featured_speaker_profile_uses_schedule_rules_once_agenda_is_public(
+    event, speaker, slot
+):
+    with scope(event=event):
+        event.talks_published = True
+        event.feature_flags['show_featured_speakers'] = 'always'
+        event.feature_flags['show_schedule'] = True
+        event.save(update_fields=['talks_published', 'feature_flags'])
+        profile = speaker.event_profile(event)
+        profile.is_featured = True
+        profile.save(update_fields=['is_featured'])
+
+    with scope(event=event):
+        assert is_speaker_viewable(None, profile) is True
+
+    with scope(event=event):
+        slot.is_visible = False
+        slot.save()
+
+    with scope(event=event):
+        assert is_pre_agenda_featured_public(None, event) is False
+        assert is_speaker_viewable(None, profile) is False


### PR DESCRIPTION
Fixes #4009

Builds on the featured sessions page (#4045).

## Summary

This PR fixes public featured-speaker behavior when the schedule is **not yet fully released**, while also landing the org/UI work for splitting featured speakers from featured sessions and simplifying session popularity settings.

**Before full public schedule release** (`talks_published`, `show_schedule`, a released schedule version, and not in private talk test mode), visitors can still:

- See the **featured speakers widget** on the event info page (when org settings allow)
- Open **individual featured speaker profiles**
- Open **speaker profiles for anyone listed on a featured submission** (even if that speaker is not marked featured)
- Open **featured talk detail pages**
- See **coming soon** sessions on the widget and speaker profiles (no times/rooms/exports)

Visitors **cannot** (until the same gate as the public schedule):

- Browse the full **`/speakers/`** list (redirects to the info page with **“No published schedule.”**)
- Use **“More speakers”** on the widget
- See real schedule times or use schedule/speaker exports on pre-release pages

Visibility rules, middleware bypasses, nav tags, and schedule JSON builders share the same gates in `talk_rules/agenda.py`, `talk_rules/submission.py`, and `agenda/views/utils.py`.

## Org settings & UI (included in this branch)

- **`show_featured_speakers`** — independent from **`show_featured`** (Never / After first schedule version / Always); legacy events inherit `show_featured` when unset
- **Session popularity** — single **Show popularity on schedule** sub-field under **Enable session popularity**; legacy calendar/list flags migrated on read
- **Talk settings cleanup** — `show_schedule` and schedule format removed from Talk settings (still on Schedule page)
- **Schedule webapp** — shared helpers in `utils.js` (`talkToSession`, pending session handling, popularity gating); featured speaker card uses compact coming-soon layout

## Automated tests

```bash
cd app
pytest tests/stable/test_featured.py
pytest tests/stable/test_featured_speakers.py
pytest tests/talk/agenda/views/test_agenda_landing_speakers.py
```

After frontend changes, rebuild assets if not using Vite dev mode:

```bash
cd app && npm run build:wc --prefix=eventyay/webapp/schedule && make staticfiles
```

---

## Manual testing guide

Use an **incognito / logged-out window** (or a non-org test account) for public behavior. Organisers bypass some gates in orga/WIP views but **not** on the public site.

### A. Prepare a test event

1. Create or pick an event with at least:
   - One **featured speaker** (orga → Speakers → mark **Featured**, set **Position** if testing order)
   - One **non-featured speaker** with an accepted submission
   - One submission marked **Featured** whose speaker is **not** featured (co-speaker/multi-speaker optional)
   - A **schedule version** built in orga (WIP schedule with slots is enough before release)
2. Note the event slug and ensure **Show schedule** is enabled on the Schedule page.
3. For pre-release scenarios, keep **`talks_published` off** until section C/D explicitly turns it on.

### B. Org settings matrix (Talk → Settings)

| Setting | Values to try | What to verify |
|--------|----------------|----------------|
| **Show featured speakers** | Never / After schedule / Always | Widget + featured speaker profiles follow speakers setting |
| **Show featured sessions** | Never / After schedule / Always | Featured page + featured talks follow sessions setting (independent) |
| **Enable session popularity** | on/off | Sub-field enable/disable in form (`eventSettings.js`) |
| **Show popularity on schedule** | on/off (when popularity enabled) | Fav-count pills + popularity sort on schedule (logged-in attendee) |

**Backward compatibility:** open an event that never had `show_featured_speakers` saved — confirm it loads the same value as **Show featured sessions** on first open.

**Help text:** **Always** alone does not show content until speakers/sessions are actually marked featured in orga.

### C. Pre-release public behavior (`talks_published = false`, schedule version exists)

Recommended flags: **Show featured speakers = Always**, **Show featured sessions = Always**, **Show schedule = on**.

| # | Action | Expected result |
|---|--------|-----------------|
| 1 | Open **event info page** | Featured speakers widget visible; speakers ordered by featured position |
| 2 | Expand a featured speaker card → **Sessions** | Sessions show **Coming soon** label + title (compact card, not broken layout); no times/rooms |
| 3 | Click **View speaker profile** on a featured speaker | Profile loads; sessions listed as coming soon |
| 4 | Open **featured talk** URL directly (`/talk/<code>/`) | Talk detail loads; schedule pending / no export menu for full schedule |
| 5 | From featured talk, click a **co-speaker** who is **not** marked featured | That speaker’s profile opens (featured submission path) |
| 6 | Open **non-featured speaker** profile (no featured submissions) | Blocked (403/404) or redirect — not publicly viewable |
| 7 | Open **`/speakers/`** | Redirect to info page with warning **“No published schedule.”** (same messaging as schedule) |
| 8 | On widget, check **“More speakers”** | Link **hidden** (`speakers-list-public="false"` in page source) |
| 9 | Header nav | **Speakers** tab hidden or non-public; **Featured** tab visible if sessions setting allows |
| 10 | Try schedule/speaker **export URLs** on pre-release pages | Exports disabled / not offered |

### D. Private talk test mode

With **`private_testmode_talks`** enabled, schedule version published, and **`talks_published = true`**:

| # | Action | Expected result |
|---|--------|-----------------|
| 1 | Info page widget | Featured speakers still visible; **More speakers** still hidden |
| 2 | **`/speakers/`** (anonymous) | Redirect with **“No published schedule.”** |
| 3 | Featured speaker profile | Loads; sessions still **coming soon** (no public times) |
| 4 | Repeat as **organiser** on public URLs | Same public gates — no full speakers list until test mode is off |

### E. Full public release

Set **`talks_published = true`**, release schedule, ensure **not** in private talk test mode.

| # | Action | Expected result |
|---|--------|-----------------|
| 1 | **`/speakers/`** | Public speakers list loads |
| 2 | Info widget **“More speakers”** | Link visible and works |
| 3 | Featured speaker sessions | Real dates/times/rooms where scheduled |
| 4 | Featured speaker **with no talks** | Profile still public; exports may be disabled when empty |
| 5 | Featured speaker **not duplicated** on info widget after release | One card per featured speaker |

### F. Session popularity (logged-in attendee)

1. Enable **Enable session popularity** → confirm **Show popularity on schedule** enables and defaults **on**.
2. Disable parent → sub-field disables and clears.
3. On schedule (after public release): fav-count pills and popularity sort appear only when both flags allow.
4. Toggle popularity settings in orga → reload schedule; counts/sort update (cache key includes popularity flags).

### G. Regression checks

- **Featured sessions page** (`/featured/`) still driven by **`show_featured`**, not speakers setting
- **Speakers page Featured sort** only when speakers setting allows and featured speakers exist
- **WIP schedule preview** (`/schedule/v/wip/`) unchanged for org/reviewers
- No inline CSS hacks on info page for hiding “More speakers” — Vue + `speakers_list_public` attribute

---

## Reviewer notes

- Public release gate is centralized in `can_list_released_schedule_speakers()` / `is_agenda_visible()` (includes private talk test mode).
- Pre-release session data uses shared pending JSON builders in `agenda/views/utils.py`.
- Frontend session normalization lives in `webapp/schedule/src/utils.js` to avoid duplicating talk→session mapping across `App.vue`, `SpeakerDetail.vue`, and `FeaturedSpeakers.vue`.