### PR TITLE
feat(agenda): featured sessions page using schedule widget

### DIFF
--- a/app/eventyay/agenda/templates/agenda/featured.html
+++ b/app/eventyay/agenda/templates/agenda/featured.html
@@ -1,20 +1,27 @@
 {% extends "agenda/base.html" %}
 
-{% load compress %}
+{% load vite %}
+{% load html_signal %}
 {% load i18n %}
-{% load rich_text %}
-{% load static %}
-
-{% load presale_locale %}
 
 {% block title %}{% translate "Featured Sessions" %} ::{% endblock title %}
 {% block meta_title %}{% translate "Featured Sessions" %}{% endblock meta_title %}
 {% block social_title %}{% translate "Featured Sessions" %}{% endblock social_title %}
 
+{% block container_width %} main-schedule list-schedule{% endblock container_width %}
+
+{% block agenda_custom_header %}
+<script id="pretalx-messages" data-logged-in="{% if request.user.is_anonymous %}false{% else %}true{% endif %}" data-user-code="{% if request.user.is_authenticated %}{{ request.user.code }}{% endif %}" src="{{ request.event.urls.schedule }}widget/messages.js"></script>
+{% endblock agenda_custom_header %}
+
+{% block header_right %}
+{% include "common/fragment_header_user.html" with current_event=request.event nav_context="agenda" %}
+{% endblock header_right %}
+
 {% block agenda_content %}
 <div class="featured-page">
     <h3 class="talk-title featured-page-title">{% translate "Featured Sessions" %}</h3>
-    {% if talks %}
+    {% if has_featured_submissions %}
         <p>
             {% blocktranslate trimmed %}
                 We prepared a list of exciting sessions, so you can get a feel for our
@@ -22,29 +29,34 @@
                 We will follow up with the full schedule in time, stay tuned!
             {% endblocktranslate %}
         </p>
+        {% html_signal "eventyay.agenda.signals.html_above_schedule_pages" sender=request.event request=request %}
+        <div id="fahrplan" class="list">
+            <script id="pretalx-schedule-meta" type="application/json">{{ schedule_meta_json|safe }}</script>
+            {% if schedule_data_json %}<script id="pretalx-schedule-data" type="application/json">{{ schedule_data_json|safe }}</script>{% endif %}
+            {% vite_app_scripts 'schedule' 'src/main-wc.js' fallback='schedule/pretalx-schedule.js' %}
+
+            {% with event_tz=request.event.settings.timezone|default:request.event.timezone %}
+            <pretalx-schedule event-url="{{ request.event.urls.base }}" version="{{ schedule_page_version|default:'' }}" locale="{{ request.LANGUAGE_CODE }}" timezone="{{ event_tz }}" format="list" is-featured-page style="--pretalx-clr-primary: {{ request.event.visible_primary_color }}" disable-auto-scroll></pretalx-schedule>
+            {% endwith %}
+            <noscript class="d-block">
+                <div class="alert alert-info m-4">
+                    <div></div>
+                    <div>
+                        {% blocktranslate trimmed with href=request.event.urls.schedule_nojs %}
+                        To see our schedule, please either enable JavaScript or go <a href="{{ href }}">here</a> for our NoJS schedule.
+                        {% endblocktranslate %}
+                    </div>
+                </div>
+            </noscript>
+        </div>
+        {% html_signal "eventyay.agenda.signals.html_below_schedule_pages" sender=request.event request=request %}
     {% else %}
         <p>
             {% blocktranslate trimmed %}
-                In the near future you will see a curated list of sessions we’d like
-                to show off here. Right now we are busy reviewing proposals.<br>
-                Check back later!
+                No featured sessions have been selected yet. Once our organisers highlight sessions,
+                they will appear here. Please check back later!
             {% endblocktranslate %}
         </p>
     {% endif %}
-    <article id="featured-talks">
-        {% for talk in talks %}
-            <section>
-                <h5 class="talk-title">
-                    <div>{{ quotation_open }}{{ talk.title|event_localize }}{{ quotation_close }}</div>
-                    <small class="text-muted">
-                        {% if talk.display_speaker_names %}{{ talk.display_speaker_names }};{% endif %}
-                        <i>{{ talk.submission_type.name|event_localize }}</i>
-                    </small>
-                </h5>
-                <div class="featured-talk-abstract">{{ talk.abstract|default:talk.description|default:""|event_localize|rich_text }}</div>
-                {% if not forloop.last %}<hr>{% endif %}
-            </section>
-        {% endfor %}
-    </article>
 </div>
 {% endblock agenda_content %}

--- a/app/eventyay/agenda/views/featured.py
+++ b/app/eventyay/agenda/views/featured.py
@@ -4,16 +4,20 @@ from django.utils.functional import cached_property
 from django.views.generic import TemplateView
 from django_context_decorator import context
 
+from eventyay.agenda.views.schedule import ScheduleMixin
+from eventyay.agenda.views.utils import (
+    build_featured_schedule_json,
+    build_featured_schedule_meta_json,
+)
 from eventyay.common.views.mixins import EventPermissionRequired
-from eventyay.base.models.submission import SubmissionStates
-from eventyay.talk_rules.submission import are_featured_submissions_visible
+from eventyay.talk_rules.submission import are_featured_submissions_visible, event_has_featured_submissions
 
 
 def sneakpeek_redirect(request, *args, **kwargs):
     return HttpResponsePermanentRedirect(request.event.urls.featured)
 
 
-class FeaturedView(EventPermissionRequired, TemplateView):
+class FeaturedView(EventPermissionRequired, ScheduleMixin, TemplateView):
     template_name = 'agenda/featured.html'
     permission_required = 'base.list_featured_submission'
 
@@ -26,23 +30,22 @@ class FeaturedView(EventPermissionRequired, TemplateView):
         return are_featured_submissions_visible(user, request.event)
 
     @context
-    def talks(self):
-        return (
-            self.request.event.submissions.filter(is_featured=True)
-            .exclude(
-                state__in=[
-                    SubmissionStates.REJECTED,
-                    SubmissionStates.CANCELED,
-                    SubmissionStates.WITHDRAWN,
-                    SubmissionStates.DELETED,
-                ]
-            )
-            .select_related('event', 'event__organizer', 'submission_type')
-            .prefetch_related('speakers')
-            .order_by('title')
-        )
+    def schedule_data_json(self):
+        return build_featured_schedule_json(self.request)
+
+    @context
+    def has_featured_submissions(self):
+        return event_has_featured_submissions(self.request.event)
 
     @context
     @cached_property
     def hide_visibility_warning(self):
         return are_featured_submissions_visible(AnonymousUser(), self.request.event)
+
+    def get_context_data(self, **kwargs):
+        ctx = super().get_context_data(**kwargs)
+        schedule = ctx.get('schedule')
+        version = self.version or (schedule.version if schedule else None)
+        ctx['schedule_meta_json'] = build_featured_schedule_meta_json(self.request.event, schedule)
+        ctx['schedule_page_version'] = version or ''
+        return ctx

--- a/app/eventyay/agenda/views/schedule.py
+++ b/app/eventyay/agenda/views/schedule.py
@@ -39,7 +39,7 @@ from eventyay.common.views.mixins import EventPermissionRequired, PermissionRequ
 from eventyay.schedule.ascii import draw_ascii_schedule
 from eventyay.schedule.exporters import ScheduleData
 from eventyay.talk_rules.agenda import require_wip_schedule_access
-from eventyay.talk_rules.submission import are_featured_submissions_visible
+from eventyay.talk_rules.submission import are_featured_submissions_visible, can_use_featured_exports
 
 
 # Starred-ICS token timing: grace, fallback, refresh buffer.
@@ -163,6 +163,13 @@ class ScheduleMixin:
 
 class ExporterView(EventPermissionRequired, ScheduleMixin, TemplateView):
     permission_required = 'base.list_schedule'
+
+    def has_permission(self):
+        if super().has_permission():
+            return True
+        if self.request.GET.get('featured') == 'true':
+            return can_use_featured_exports(self.request.user, self.request.event)
+        return False
 
     def dispatch(self, request, *args, **kwargs):
         self.ensure_wip_schedule_access(kwargs, request)
@@ -432,6 +439,7 @@ def schedule_messages(request, **kwargs):
         'schedule_do_not_record': _('This session will not be recorded.'),
         'back_to_schedule': _('Back to schedule'),
         'back_to_speakers': _('Back to speakers'),
+        'schedule_pending_secondary': _('Coming soon'),
     }
     strings = {key: str(value) for key, value in strings.items()}
     return HttpResponse(
@@ -546,6 +554,9 @@ class CalendarRedirectView(EventPermissionRequired, ScheduleMixin, TemplateView)
                     },
                 ),
             )
+
+        if request.GET.get('featured') == 'true':
+            ics_url = f'{ics_url}?featured=true'
 
         if is_google:
             google_url = f'https://calendar.google.com/calendar/r?{urlencode({"cid": ics_url.replace("https://", "http://")})}'

--- a/app/eventyay/agenda/views/utils.py
+++ b/app/eventyay/agenda/views/utils.py
@@ -17,14 +17,19 @@ from django.utils.translation import activate, get_language
 from django_context_decorator import context
 from i18nfield.utils import I18nJSONEncoder
 
-from eventyay.base.models import SpeakerProfile, User
+from eventyay.base.models import SpeakerProfile, TalkSlot, User
 from eventyay.base.models.submission import SubmissionFavourite
 from eventyay.common.exporter import BaseExporter
 from eventyay.common.signals import register_data_exporters, register_my_data_exporters
 from eventyay.common.text.path import safe_filename
-from eventyay.schedule.exporters import FavedICalExporter
+from eventyay.schedule.exporters import FavedICalExporter, filter_featured_public_talk_slots
 from eventyay.talk_rules.agenda import require_wip_schedule_access
-from eventyay.talk_rules.submission import are_featured_submissions_visible
+from eventyay.talk_rules.submission import (
+    are_featured_exports_available,
+    are_featured_submissions_visible,
+    can_use_featured_exports,
+    featured_submissions_for_event,
+)
 
 
 # Same escaping Django applies inside json_script to prevent XSS in <script> tags.
@@ -54,6 +59,20 @@ def _serialize_schedule_build_data(schedule, **build_kwargs) -> str:
     return escape_json_for_script(json.dumps(data, cls=I18nJSONEncoder))
 
 
+def featured_schedule_talk_slots(schedule):
+    """Featured talk slots that match public schedule visibility rules."""
+    if not schedule:
+        return TalkSlot.objects.none()
+    return filter_featured_public_talk_slots(schedule.talks.filter(is_visible=True))
+
+
+def event_has_public_featured_schedule_talks(event):
+    """Whether the event has featured sessions displayable on the public schedule."""
+    if not event.current_schedule:
+        return False
+    return featured_schedule_talk_slots(event.current_schedule).exists()
+
+
 def build_schedule_meta_json(event, schedule) -> str:
     """Build escaped JSON for the pretalx-schedule-meta inline script tag."""
     version = schedule.version if schedule else None
@@ -74,6 +93,30 @@ def build_schedule_meta_json(event, schedule) -> str:
         'current_schedule_url': base_schedule_url if event.current_schedule else '',
         'versions': versions,
         'exporters': build_public_schedule_exporters(event, version=version),
+    }
+    return escape_json_for_script(json.dumps(meta))
+
+
+def _featured_exporter_url(url: str) -> str:
+    separator = '&' if '?' in url else '?'
+    return f'{url}{separator}featured=true'
+
+
+def build_featured_schedule_meta_json(event, schedule) -> str:
+    version = schedule.version if schedule else None
+    featured_exporters = []
+    if are_featured_exports_available(event):
+        featured_exporters = [
+            {**exporter, 'export_url': _featured_exporter_url(exporter['export_url'])}
+            for exporter in build_public_schedule_exporters(event, version=version)
+        ]
+    meta = {
+        'version': version or '',
+        'is_current': schedule == event.current_schedule if schedule else False,
+        'changelog_url': '',
+        'current_schedule_url': '',
+        'versions': [],
+        'exporters': featured_exporters,
     }
     return escape_json_for_script(json.dumps(meta))
 
@@ -146,6 +189,147 @@ def build_schedule_json(request: HttpRequest, schedule=None) -> str:
     if schedule.version:
         cache.set(cache_key, result, CACHE_TTL)
     return result
+
+
+def build_featured_schedule_json(request: HttpRequest) -> str:
+    """Build schedule JSON for the featured page, including unscheduled featured sessions."""
+    event = request.event
+    featured_qs = featured_submissions_for_event(event)
+    if not featured_qs.exists():
+        return '{}'
+
+    featured = are_featured_submissions_visible(request.user, event)
+    featured_by_code = {sub.code: sub for sub in featured_qs}
+    published = event.current_schedule
+
+    if published:
+        scheduled_codes = set(
+            featured_schedule_talk_slots(published).values_list('submission__code', flat=True)
+        )
+        if scheduled_codes:
+            data = published.build_data(
+                all_talks=False,
+                enrich=False,
+                submission_codes=scheduled_codes,
+                include_featured_speaker_metadata=featured,
+            )
+        else:
+            data = _empty_featured_schedule_data(event)
+    else:
+        wip = event.wip_schedule
+        if wip and featured_by_code:
+            data = wip.build_data(
+                all_talks=True,
+                enrich=False,
+                submission_codes=set(featured_by_code.keys()),
+                include_featured_speaker_metadata=featured,
+                respect_public_visibility=False,
+            )
+            for talk in data['talks']:
+                _mark_talk_schedule_pending(talk)
+        else:
+            data = _empty_featured_schedule_data(event)
+
+    _append_missing_featured_submissions(data, featured_by_code, event)
+    _ensure_schedule_speakers(data, event, featured)
+    return escape_json_for_script(json.dumps(data, cls=I18nJSONEncoder))
+
+
+def _append_missing_featured_submissions(data, featured_by_code, event):
+    present_codes = {talk.get('code') for talk in data.get('talks', [])}
+    for code, submission in sorted(featured_by_code.items(), key=lambda item: str(item[1].title)):
+        if code not in present_codes:
+            data['talks'].append(_pending_featured_talk_data(submission, event))
+
+
+def _empty_featured_schedule_data(event):
+    schedule = event.wip_schedule
+    data = schedule.build_data(
+        all_talks=True,
+        enrich=False,
+        submission_codes=set(),
+        include_featured_speaker_metadata=True,
+        respect_public_visibility=False,
+    )
+    data['talks'] = []
+    return data
+
+
+def _pending_featured_talk_data(submission, event):
+    cfp = event.cfp
+    show_abstract = cfp.public_abstract
+    show_do_not_record = cfp.request_do_not_record
+    show_content_locale = cfp.public_content_locale
+    talk_speakers = list(submission.speakers.all())
+    return {
+        'code': submission.code,
+        'id': submission.code,
+        'title': submission.title,
+        'abstract': submission.abstract if show_abstract else '',
+        'description': '',
+        'speakers': [speaker.code for speaker in talk_speakers],
+        'track': submission.track_id,
+        'start': None,
+        'end': None,
+        'room': None,
+        'duration': submission.get_duration(),
+        'updated': submission.updated.isoformat() if submission.updated else None,
+        'state': None,
+        'fav_count': 0,
+        'do_not_record': submission.do_not_record if show_do_not_record else None,
+        'tags': submission.get_tag(),
+        'session_type': submission.submission_type.name,
+        'content_locale': submission.content_locale if show_content_locale else '',
+        'schedule_pending': True,
+    }
+
+
+def _mark_talk_schedule_pending(talk_data):
+    talk_data['start'] = None
+    talk_data['end'] = None
+    talk_data['room'] = None
+    talk_data['schedule_pending'] = True
+    return talk_data
+
+
+def _ensure_schedule_speakers(data, event, include_featured_speaker_metadata):
+    existing = {speaker['code'] for speaker in data.get('speakers', [])}
+    needed_codes = {
+        code
+        for talk in data.get('talks', [])
+        for code in talk.get('speakers') or []
+        if code not in existing
+    }
+    if not needed_codes:
+        return
+
+    users = User.objects.filter(code__in=needed_codes)
+    profiles = {
+        profile.user_id: profile
+        for profile in SpeakerProfile.objects.filter(event=event, user__in=users).select_related('user')
+    }
+    include_avatar, include_biography = speaker_public_field_flags(event)
+
+    for user in users:
+        profile = profiles.get(user.pk)
+        speaker_data = {
+            'code': user.code,
+            'name': user.fullname or None,
+            'biography': getattr(profile, 'biography', '') if include_biography else '',
+            'avatar': user.get_avatar_url(event=event) if include_avatar else None,
+            'avatar_thumbnail_default': (
+                user.get_avatar_url(event=event, thumbnail='default') if include_avatar else None
+            ),
+            'avatar_thumbnail_tiny': (
+                user.get_avatar_url(event=event, thumbnail='tiny') if include_avatar else None
+            ),
+            'is_featured': bool(getattr(profile, 'is_featured', False)),
+            'featured_position': getattr(profile, 'position', None),
+        }
+        if not include_featured_speaker_metadata:
+            speaker_data['is_featured'] = False
+            speaker_data['featured_position'] = None
+        data.setdefault('speakers', []).append(speaker_data)
 
 
 def build_talk_schedule_json(request: HttpRequest, submission_code: str) -> str:
@@ -374,11 +558,32 @@ def is_visible(exporter: BaseExporter, request: HttpRequest, public: bool = Fals
         return request.user.is_authenticated
 
     if not request.user.has_perm('base.list_schedule', request.event):
-        return False
+        if request.GET.get('featured') != 'true':
+            return False
+        return can_use_featured_exports(request.user, request.event)
 
     if isinstance(exporter, FavedICalExporter):
         return exporter.is_public(request=request)
     return bool(exporter.public)
+
+
+def clear_schedule_caches(event, submission=None, speaker=None):
+    """Clear all eagenda schedule caches for the event's schedules."""
+    schedules = event.schedules.all()
+    keys = []
+    for schedule in schedules:
+        for featured in (0, 1):
+            keys.append(f'eagenda:schedule:{schedule.pk}:{featured}')
+            keys.append(f'eagenda:enriched:{schedule.pk}:{featured}')
+            if submission:
+                keys.append(f'eagenda:talk:{schedule.pk}:{submission.code}:{featured}')
+            if speaker:
+                keys.append(f'eagenda:speaker:{schedule.pk}:{speaker.code}:{featured}')
+            elif submission:
+                for sp in submission.speakers.all():
+                    keys.append(f'eagenda:speaker:{schedule.pk}:{sp.code}:{featured}')
+
+    cache.delete_many(keys)
 
 
 def get_schedule_exporters(request, public=False):
@@ -491,6 +696,7 @@ def get_schedule_exporter_content(request, exporter_name, schedule, token=None):
         return
     exporter.schedule = schedule
     exporter.is_orga = is_organizer
+    exporter.featured_only = request.GET.get('featured') == 'true'
     lang_code = request.GET.get('lang')
     if lang_code and lang_code in request.event.locales:
         activate(lang_code)

--- a/app/eventyay/common/middleware/event.py
+++ b/app/eventyay/common/middleware/event.py
@@ -31,15 +31,31 @@ logger = logging.getLogger(__name__)
 
 
 def _agenda_featured_allowed_without_talks_published(url, request, event):
-    """Let /featured/ load when org settings allow it, even if talks are not published yet."""
-    if 'agenda' not in url.namespaces or url.url_name != 'featured':
+    """Let /featured/ (and featured exports after schedule release) load when org settings allow,
+    even if talks are not published yet.
+    """
+    if 'agenda' not in url.namespaces:
         return False
-    from eventyay.talk_rules.submission import are_featured_submissions_visible
+
+    from eventyay.talk_rules.submission import are_featured_submissions_visible, can_use_featured_exports
 
     user = getattr(request, 'user', None)
     if user is None:
         return False
-    return are_featured_submissions_visible(user, event)
+
+    is_featured_page = url.url_name == 'featured'
+    is_featured_export = (
+        (url.url_name in ('export', 'export-tokenized') or url.url_name.startswith('export.'))
+        and request.GET.get('featured') == 'true'
+    )
+
+    if is_featured_export:
+        return can_use_featured_exports(user, event)
+
+    if is_featured_page:
+        return are_featured_submissions_visible(user, event)
+
+    return False
 
 
 def get_login_redirect(request):

--- a/app/eventyay/common/templatetags/event_tags.py
+++ b/app/eventyay/common/templatetags/event_tags.py
@@ -12,7 +12,12 @@ from django_scopes import scopes_disabled
 from eventyay.base.models import Order, OrderPosition
 from eventyay.common.urls import is_http_url
 from eventyay.common.permissions import is_admin_mode_active, user_has_cfp_submissions
-from eventyay.talk_rules.submission import are_featured_submissions_visible
+from eventyay.talk_rules.submission import (
+    are_featured_submissions_visible,
+    event_has_featured_submissions,
+    show_featured_always,
+)
+from eventyay.agenda.views.utils import event_has_public_featured_schedule_talks
 
 register = template.Library()
 logger = logging.getLogger(__name__)
@@ -216,10 +221,21 @@ def can_view_featured_sessions_public(context, event=None):
     event = event or getattr(request, 'event', None)
     if not request or not event:
         return False
+
     user = getattr(request, 'user', None)
     if user is None:
         return False
-    return are_featured_submissions_visible(user, event)
+    if not are_featured_submissions_visible(user, event):
+        return False
+    if show_featured_always(event):
+        return True
+
+    if event.current_schedule:
+        has_featured = event_has_public_featured_schedule_talks(event)
+    else:
+        has_featured = event_has_featured_submissions(event)
+
+    return has_featured
 
 
 @register.simple_tag(takes_context=True)

--- a/app/eventyay/orga/views/submission.py
+++ b/app/eventyay/orga/views/submission.py
@@ -506,6 +506,9 @@ class SubmissionContent(ActionFromUrl, ReviewerSubmissionFilter, SubmissionViewM
             action = 'eventyay.submission.' + ('create' if created else 'update')
             form.instance.log_action(action, person=self.request.user, orga=True)
             self.request.event.cache.set('rebuild_schedule_export', True, None)
+            if 'is_featured' in form.changed_data:
+                from eventyay.agenda.views.utils import clear_schedule_caches
+                clear_schedule_caches(self.request.event, submission=form.instance)
         return redirect(self.get_success_url())
 
     def get_form_kwargs(self):
@@ -636,6 +639,8 @@ class ToggleFeatured(SubmissionViewMixin, View):
     def post(self, *args, **kwargs):
         self.object.is_featured = not self.object.is_featured
         self.object.save(update_fields=['is_featured'])
+        from eventyay.agenda.views.utils import clear_schedule_caches
+        clear_schedule_caches(self.request.event, submission=self.object)
         return HttpResponse()
 
 

--- a/app/eventyay/schedule/exporters.py
+++ b/app/eventyay/schedule/exporters.py
@@ -29,6 +29,14 @@ if TYPE_CHECKING:
     from eventyay.base.models.slot import TalkSlot
 
 
+def filter_featured_public_talk_slots(queryset):
+    """Limit talk slots to featured sessions with a visible, non-deleted room."""
+    return queryset.filter(
+        submission__is_featured=True,
+        room__isnull=False,
+    ).exclude(room__deleted=True)
+
+
 class RoomData(TypedDict):
     id: int
     guid: str
@@ -73,6 +81,8 @@ class ScheduleData(BaseExporter):
         schedule = self.schedule
 
         base_qs = schedule.talks.all() if self.with_accepted else schedule.talks.filter(is_visible=True)
+        if getattr(self, 'featured_only', False):
+            base_qs = filter_featured_public_talk_slots(base_qs)
         talks = (
             base_qs.select_related(
                 'submission',
@@ -417,6 +427,8 @@ class ICalExporter(BaseExporter):
             .select_related('submission', 'room', 'submission__event')
             .order_by('start')
         )
+        if getattr(self, 'featured_only', False):
+            talks = filter_featured_public_talk_slots(talks)
         for talk in talks:
             if self.favs_retrieve and talk.submission and talk.submission.code not in self.talk_ids:
                 continue
@@ -456,6 +468,8 @@ class FavedICalExporter(BaseExporter):
         if not schedule:
             return None
         slots = schedule.scheduled_talks.filter(submission__favourites__user__in=[request.user])
+        if getattr(self, 'featured_only', False):
+            slots = slots.filter(submission__is_featured=True)
 
         cal = vobject.iCalendar()
         cal.add('prodid').value = f'-//pretalx//{netloc}//{request.event.slug}//faved'

--- a/app/eventyay/static/agenda/css/_agenda.css
+++ b/app/eventyay/static/agenda/css/_agenda.css
@@ -4,11 +4,26 @@ body.page-agenda #main-container > header {
   margin-top: 24px;
 }
 
+body.page-agenda {
+  --page-inset-block-start: 0.75rem;
+  --page-inset-inline: 1rem;
+  --page-inset-block-end: 1rem;
+}
+
+@media (max-width: 768px) {
+  body.page-agenda {
+    --page-inset-block-start: 0.5rem;
+    --page-inset-inline: 0.75rem;
+    --page-inset-block-end: 0.875rem;
+  }
+}
+
 /* Featured page typography */
 body.page-agenda .featured-page {
   --featured-intro-size: 0.9375rem;
   --featured-body-size: 0.9375rem;
   --featured-meta-size: 0.875rem;
+  padding: var(--page-inset-block-start) var(--page-inset-inline) var(--page-inset-block-end);
 }
 
 body.page-agenda .featured-page > .talk-title.featured-page-title {
@@ -175,12 +190,18 @@ body.page-agenda .featured-page #featured-talks .talk-title small {
   #main-card {
     margin: 0 auto;
     main {
-      padding: 5px;
       width: 100%;
+    }
+    main:not(:has(.featured-page)) {
+      padding: calc(var(--page-inset-block-start) / 2) calc(var(--page-inset-inline) / 2)
+        calc(var(--page-inset-block-end) / 2);
+    }
+    main:has(.featured-page) {
+      padding: 0;
     }
   }
 
-  /* The container main now provides the 5px padding. We can set it to 0 or leave as minimal here. */
+  /* The container main now provides the inset. Keep the widget flush inside #fahrplan. */
   pretalx-schedule[view="schedule"],
   #fahrplan {
     padding: 0 !important;
@@ -192,7 +213,11 @@ body.page-agenda .featured-page #featured-talks .talk-title small {
     padding-left: 0;
     padding-right: 0;
     padding-bottom: 0;
-    #main-card main {
+    #main-card main:not(:has(.featured-page)) {
+      padding: calc(var(--page-inset-block-start) / 2) calc(var(--page-inset-inline) / 2)
+        calc(var(--page-inset-block-end) / 2);
+    }
+    #main-card main:has(.featured-page) {
       padding: 0;
     }
   }

--- a/app/eventyay/talk_rules/submission.py
+++ b/app/eventyay/talk_rules/submission.py
@@ -69,9 +69,41 @@ def _show_featured_setting(event):
     return defaults.get('show_featured', 'never')
 
 
+def show_featured_always(event):
+    """Whether org setting shows the featured page even before a schedule exists."""
+    return _show_featured_setting(event) == 'always'
+
+
+def featured_submissions_for_event(event):
+    """Public featured submissions that may appear before a schedule is released."""
+    from eventyay.base.models import SubmissionStates
+
+    return (
+        event.submissions.filter(is_featured=True)
+        .exclude(
+            state__in=(
+                SubmissionStates.REJECTED,
+                SubmissionStates.CANCELED,
+                SubmissionStates.WITHDRAWN,
+                SubmissionStates.DELETED,
+            )
+        )
+        .select_related('event', 'event__organizer', 'submission_type')
+        .prefetch_related('speakers')
+        .order_by('title')
+    )
+
+
+def event_has_featured_submissions(event):
+    return featured_submissions_for_event(event).exists()
+
+
 def _event_has_published_schedule(event):
     """True once at least one schedule version has been published (``published`` is set)."""
     return event.current_schedule is not None
+
+
+are_featured_exports_available = _event_has_published_schedule
 
 
 def schedule_widget_featured_cache_key_part(event):
@@ -87,9 +119,9 @@ def are_featured_submissions_visible(user, event):
     ``orga_can_change_submissions``) for API/orga rules. Public pages and nav must use this
     predicate so "Never" is respected for organizers viewing the public site.
 
-    For ``after_schedule`` ("once the first schedule version is published"), featured is shown
-    only **after** at least one published ``Schedule`` version exists. Before the first release,
-    featured is hidden. Uses a scoped DB check; does not depend on "show schedule publicly".
+    For ``after_schedule``, the featured page is available once a schedule version is
+    published (and talks are published), or earlier when featured submissions exist as a
+    preview before the schedule is released.
     """
     show_featured = _show_featured_setting(event)
     if show_featured == 'never':
@@ -97,10 +129,14 @@ def are_featured_submissions_visible(user, event):
     # "Always" shows regardless of schedule state or talks_published.
     if show_featured == 'always':
         return True
-    if not event.talks_published:
-        return False
-    # after_schedule: visible only once the first published schedule version exists
-    return _event_has_published_schedule(event)
+    if _event_has_published_schedule(event):
+        return event.talks_published
+    return event_has_featured_submissions(event)
+
+
+def can_use_featured_exports(user, event):
+    """Whether public featured export URLs are allowed for this user and event."""
+    return are_featured_submissions_visible(user, event) and are_featured_exports_available(event)
 
 
 @rules.predicate

--- a/app/eventyay/webapp/schedule/src/App.vue
+++ b/app/eventyay/webapp/schedule/src/App.vue
@@ -13,6 +13,8 @@
 		schedule-toolbar(v-if="(scheduleMeta || schedule) && !publicFavsUrl",
 			:version="version || scheduleMeta?.version || ''",
 			:isCurrent="scheduleMeta?.is_current !== false",
+			:isFeaturedPage="isFeaturedPage",
+			:isListView="!showGrid || sessionsMode",
 			:changelogUrl="scheduleMeta?.changelog_url || ''",
 			:currentScheduleUrl="scheduleMeta?.current_schedule_url || ''",
 			:exporters="scheduleMeta?.exporters || []",
@@ -127,7 +129,7 @@ const SpeakersList = defineAsyncComponent(() => import('~/components/SpeakersLis
 const FeaturedSpeakers = defineAsyncComponent(() => import('~/components/FeaturedSpeakers'))
 const SpeakerDetail = defineAsyncComponent(() => import('~/components/SpeakerDetail'))
 const TalkDetail = defineAsyncComponent(() => import('~/components/TalkDetail'))
-import { findScrollParent, getLocalizedString, getSessionTime, getSessionTypeLabel, isProperSession, normalizePopularityCount, computeTalkExporters } from '~/utils'
+import { findScrollParent, getLocalizedString, getSessionTime, getSessionTypeLabel, isProperSession, normalizePopularityCount, computeTalkExporters, areScheduleExportsDisabled } from '~/utils'
 
 function getCsrfToken () {
 	const match = document.cookie.match(/eventyay_csrftoken=([^;]+)/)
@@ -171,6 +173,10 @@ export default {
 		version: {
 			type: String,
 			default: ''
+		},
+		isFeaturedPage: {
+			type: Boolean,
+			default: false
 		},
 		// View mode: 'schedule' (default), 'speakers' (list), 'speaker' (detail), 'talk' (single talk), 'sessions' (sessions only, no breaks)
 		view: {
@@ -271,7 +277,8 @@ export default {
 			},
 			loggedIn: computed(() => this.loggedIn),
 			translationMessages: computed(() => this.translationMessages),
-			isWipPreview: computed(() => (this.version || this.scheduleMeta?.version || '') === 'wip')
+			isWipPreview: computed(() => (this.version || this.scheduleMeta?.version || '') === 'wip'),
+			exportsDisabled: computed(() => this.exportsDisabled),
 		}
 	},
 	data () {
@@ -332,6 +339,14 @@ export default {
 		showGrid () {
 			// Always allow a distinct calendar grid view when not explicitly in list format
 			return this.format !== 'list'
+		},
+		exportsDisabled () {
+			return areScheduleExportsDisabled({
+				version: this.version,
+				scheduleMetaVersion: this.scheduleMeta?.version,
+				isFeaturedPage: this.isFeaturedPage,
+				exportersCount: this.scheduleMeta?.exporters?.length || 0,
+			})
 		},
 		roomsLookup () {
 			if (!this.schedule) return {}
@@ -423,7 +438,7 @@ export default {
 			}
 			const sessions = []
 			for (const session of this.schedule.talks) {
-				if (!session.start) continue
+				const isPending = Boolean(session.schedule_pending || !session.start)
 				if (favSet && !favSet.has(session.code)) continue
 				if (this.showRecordingFilter) {
 					if (this.recordingFilter === 'yes' && session.do_not_record !== false) continue
@@ -439,6 +454,35 @@ export default {
 					if (!normalized) continue
 					const primary = localePrimary(normalized)
 					if (!langExact.has(normalized) && !(primary && langPrimary.has(primary))) continue
+				}
+				if (isPending) {
+					sessions.push({
+						id: session.code,
+						title: session.title,
+						abstract: session.abstract,
+						description: session.description,
+						do_not_record: session.do_not_record,
+						duration: session.duration,
+						start: null,
+						end: null,
+						schedule_pending: true,
+						speakers: (session.speakers || [])
+							.map(code => this.speakersLookup[code] || { code })
+							.filter(Boolean),
+						track: this.tracksLookup[session.track],
+						room: null,
+						fav_count: normalizePopularityCount(session),
+						tags: session.tags,
+						session_type: session.session_type,
+						content_locale: session.content_locale,
+						resources: session.resources,
+						answers: session.answers,
+						exporters: session.exporters,
+						recording_iframe: session.recording_iframe,
+						stream_url: session.stream_url || null,
+						stream_type: session.stream_type || null,
+					})
+					continue
 				}
 				const start = moment.tz(session.start, this.currentTimezone)
 				if (displayDateSet && !displayDateSet.has(start.clone().tz(this.schedule.timezone).format('YYYY-MM-DD'))) continue
@@ -469,7 +513,14 @@ export default {
 					stream_type: session.stream_type || null,
 				})
 			}
-			sessions.sort((a, b) => a.start.diff(b.start))
+			sessions.sort((a, b) => {
+				if (a.schedule_pending && !b.schedule_pending) return 1
+				if (!a.schedule_pending && b.schedule_pending) return -1
+				if (a.schedule_pending && b.schedule_pending) {
+					return getLocalizedString(a.title).localeCompare(getLocalizedString(b.title))
+				}
+				return a.start.diff(b.start)
+			})
 			return sessions
 		},
 		// sessions: baseSessions + search filter. Used for display.
@@ -507,6 +558,7 @@ export default {
 			const seen = new Set()
 			const days = []
 			for (const session of this.baseSessions) {
+				if (!session.start) continue
 				const day = session.start.clone().tz(this.currentTimezone).startOf('day')
 				const key = day.valueOf()
 				if (!seen.has(key)) {
@@ -523,6 +575,7 @@ export default {
 			if (!this.baseSessions) return
 			const days = []
 			for (const session of this.baseSessions) {
+				if (!session.start) continue
 				const day = session.start.clone().tz(this.currentTimezone).startOf('day')
 				if (!days.find(d => d.valueOf() === day.valueOf())) days.push(day)
 			}
@@ -629,6 +682,9 @@ export default {
 		if (this.view === 'sessions') {
 			this.sessionsMode = true
 		}
+		if (this.isFeaturedPage) {
+			this.sessionsMode = true
+		}
 
 		// Detect login state from the DOM element (always rendered by Django),
 		// independent of whether the PRETALX_MESSAGES JS global loaded
@@ -712,7 +768,9 @@ export default {
 		}
 		this.currentTimezone = localStorage.getItem(`${this.eventSlug}_timezone`)
 		this.currentTimezone = [this.schedule.timezone, this.userTimezone].includes(this.currentTimezone) ? this.currentTimezone : this.schedule.timezone
-		this.currentDay = this.days[0].format('YYYY-MM-DD')
+		if (this.days?.length) {
+			this.currentDay = this.days[0].format('YYYY-MM-DD')
+		}
 		this.now = moment.tz(this.currentTimezone)
 		setInterval(() => this.now = moment.tz(this.currentTimezone), 30000)
 		if (!this.scrollParentResizeObserver) {
@@ -1057,7 +1115,7 @@ export default {
 			ev.preventDefault()
 
 			const talk = this.talksLookup[session.id]
-			const exporters = session.exporters || (this.onHomeServer ? this.computedExporters(session.id) : null)
+			const exporters = session.exporters || (this.onHomeServer && !this.exportsDisabled ? this.computedExporters(session.id) : null)
 
 			// Show session immediately with loading state
 			this.modalContent = {

--- a/app/eventyay/webapp/schedule/src/components/LinearSchedule.vue
+++ b/app/eventyay/webapp/schedule/src/components/LinearSchedule.vue
@@ -106,7 +106,8 @@ export default {
 		sessionBuckets () {
 			if (!this.includeDateSortKey) {
 				const sortedFlat = this.sortBucketSessions(this.sessions)
-				const fallbackDate = sortedFlat.length ? sortedFlat[0].start.clone().startOf('day') : moment()
+				const firstStart = sortedFlat.find(session => session.start)?.start
+				const fallbackDate = firstStart ? firstStart.clone().startOf('day') : moment()
 				return [{
 					date: fallbackDate,
 					sessions: sortedFlat
@@ -115,7 +116,12 @@ export default {
 
 			const buckets = {}
 			const seenBreakIds = {}
+			const pendingSessions = []
 			for (const session of this.sessions) {
+				if (!session.start) {
+					if (session.id) pendingSessions.push(session)
+					continue
+				}
 				const key = this.getBucketName(session.start)
 				if (!buckets[key]) {
 					buckets[key] = []
@@ -155,6 +161,13 @@ export default {
 					const bySort = this.sessionComparator(a._sortKey, b._sortKey)
 					if (bySort !== 0) return bySort
 					return a.date.diff(b.date)
+				})
+			}
+			if (pendingSessions.length) {
+				const sortedPending = this.sortBucketSessions(pendingSessions)
+				groupedBuckets.push({
+					date: moment(),
+					sessions: sortedPending,
 				})
 			}
 			return groupedBuckets
@@ -253,6 +266,12 @@ export default {
 			}
 
 			if (this.includeDateSortKey) {
+				if (a.schedule_pending && !b.schedule_pending) return 1
+				if (!a.schedule_pending && b.schedule_pending) return -1
+				if (a.schedule_pending || b.schedule_pending || !a.start || !b.start) {
+					const direction = this.sortBy === 'title_desc' ? -1 : 1
+					return this.titleSortKey(a).localeCompare(this.titleSortKey(b)) * direction
+				}
 				const dateCmp = a.start.diff(b.start)
 				if (dateCmp !== 0) return dateCmp
 			}

--- a/app/eventyay/webapp/schedule/src/components/ScheduleToolbar.vue
+++ b/app/eventyay/webapp/schedule/src/components/ScheduleToolbar.vue
@@ -1,6 +1,6 @@
 <template lang="pug">
 .c-schedule-toolbar(:class="{'mobile-filters-open': mobileFiltersOpen, 'mobile-more-open': mobileMoreOpen}")
-	.version-warning-banner(v-if="showVersionWarningBanner", ref="versionBanner")
+	.version-warning-banner(v-if="!isFeaturedPage && showVersionWarningBanner", ref="versionBanner")
 		span.version-warning-text {{ versionWarningText }}
 		a.current-version-link(v-if="currentScheduleUrl && !isWipPreview", :href="currentScheduleUrl")
 			|  {{ t.go_to_current_version }}
@@ -132,7 +132,7 @@
 							span.sort-inclusion-label {{ t.sort_include_popularity }}
 							button.sort-toggle-slider(type="button", :class="{on: includePopularitySortKeyModel}", role="menuitemcheckbox", :aria-label="t.sort_include_popularity", :aria-checked="includePopularitySortKeyModel ? 'true' : 'false'", @click.prevent.stop="togglePopularitySort")
 								span.toggle-slider(aria-hidden="true")
-			button.toolbar-btn.sessions-toggle(:class="{active: sessionsMode}", @click="$emit('toggleSessionsMode')", :title="sessionsMode ? t.cal : t.list", :aria-label="sessionsMode ? t.cal : t.list")
+			button.toolbar-btn.sessions-toggle(v-if="!isFeaturedPage", :class="{active: sessionsMode}", @click="$emit('toggleSessionsMode')", :title="sessionsMode ? t.cal : t.list", :aria-label="sessionsMode ? t.cal : t.list")
 				template(v-if="sessionsMode")
 					svg.tb-icon(viewBox="0 0 24 24", fill="none", stroke="currentColor", stroke-width="2")
 						rect(x="3", y="4", width="18", height="18", rx="2", ry="2")
@@ -148,7 +148,7 @@
 						line(x1="3", y1="12", x2="3.01", y2="12")
 						line(x1="3", y1="18", x2="3.01", y2="18")
 				span.sessions-toggle-label {{ sessionsMode ? t.cal : t.list }}
-		.toolbar-center(v-if="days && days.length > 1")
+		.toolbar-center(v-if="!isListView && days && days.length > 1")
 			button.day-arrow(:disabled="dayWindowStart <= 0", @click="shiftDays(-2)", :title="t.previous_days", :aria-label="t.previous_days")
 				svg(viewBox="0 0 24 24", fill="none", stroke="currentColor", stroke-width="2")
 					path(d="M15 18l-6-6 6-6")
@@ -225,12 +225,12 @@
 								)
 									span {{ option.label }}
 				.timezone-label(v-else) {{ scheduleTimezone }}
-				.exporter-area(v-if="resolvedExporters.length || isWipPreview")
+				.exporter-area(v-if="resolvedExporters.length || exportsDisabled")
 					.exporter-dropdown(ref="exportDropdown")
 						button.toolbar-btn.icon-only.tooltip-align-right(
-							:class="{disabled: isWipPreview}",
-							@click="!isWipPreview && (exportOpen = !exportOpen)",
-							:aria-label="isWipPreview ? publicOnlyFeatureHint : t.add_to_calendar",
+							:class="{disabled: exportsDisabled}",
+							@click="!exportsDisabled && (exportOpen = !exportOpen)",
+							:aria-label="exportsDisabled ? publicOnlyFeatureHint : t.add_to_calendar",
 							:aria-expanded="exportOpen ? 'true' : 'false'",
 							aria-haspopup="menu")
 							svg.tb-icon(viewBox="0 0 24 24", fill="none", stroke="currentColor", stroke-width="2", stroke-linecap="round", stroke-linejoin="round")
@@ -255,7 +255,7 @@
 								transition(name="fade")
 									.qr-hover(v-if="hoveredExporter === exp && exp.qrcode_svg", v-html="exp.qrcode_svg")
 			.toolbar-secondary(:class="{open: mobileMoreOpen}", ref="mobileMorePanel")
-				.version-area(v-if="versionOptions.length || changelogUrl || isWipPreview")
+				.version-area(v-if="!isFeaturedPage && (versionOptions.length || changelogUrl || isWipPreview)")
 					.version-dropdown(ref="versionDropdown")
 						button.toolbar-btn.version-btn.tooltip-align-right(
 							:class="{disabled: isWipPreview}",
@@ -324,6 +324,8 @@
 </template>
 
 <script>
+import { areScheduleExportsDisabled } from '../utils'
+
 // FA icon name → inline SVG path mapping (shadow DOM blocks external CSS)
 const FA_SVG_MAP = {
 	'fa-calendar': '<rect x="3" y="4" width="18" height="18" rx="2" ry="2"/><line x1="16" y1="2" x2="16" y2="6"/><line x1="8" y1="2" x2="8" y2="6"/><line x1="3" y1="10" x2="21" y2="10"/>',
@@ -372,7 +374,9 @@ export default {
 		popularityFeatureEnabled: { type: Boolean, default: false },
 		loggedIn: { type: Boolean, default: false },
 		sortOptions: { type: Array, default: () => ['title', 'title_desc'] },
-		timeDensityMinutes: { type: Number, default: 30 }
+		timeDensityMinutes: { type: Number, default: 30 },
+		isFeaturedPage: { type: Boolean, default: false },
+		isListView: { type: Boolean, default: false }
 	},
 	emits: ['fullscreen-change', 'toggleFavs', 'resetFilters', 'saveTimezone', 'update:currentTimezone', 'update:searchQuery', 'update:recordingFilter', 'update:sortBy', 'update:includeRoomSortKey', 'update:includeDateSortKey', 'update:includePopularitySortKey', 'filterToggle', 'selectDay', 'toggleSessionsMode', 'setTimeDensityMinutes'],
 	data() {
@@ -495,7 +499,19 @@ export default {
 			return current ? current.label : this.t.sort_by_title
 		},
 		resolvedExporters() {
-			return this.exporters || []
+			let list = this.exporters || []
+			if (this.isFeaturedPage) {
+				list = list.filter(exp => !exp.identifier.includes('-my') && !exp.identifier.includes('my-') && exp.identifier !== 'faved.ics')
+			}
+			return list
+		},
+		exportsDisabled() {
+			return areScheduleExportsDisabled({
+				version: this.version,
+				isFeaturedPage: this.isFeaturedPage,
+				exportersCount: this.resolvedExporters.length,
+				isWipPreview: this.isWipPreview,
+			})
 		},
 		isWipPreview() {
 			if (this.version === 'wip') {

--- a/app/eventyay/webapp/schedule/src/components/Session.vue
+++ b/app/eventyay/webapp/schedule/src/components/Session.vue
@@ -1,14 +1,23 @@
 <template lang="pug">
-a.c-linear-schedule-session(:class="{faved, 'has-date': showDate, 'short-session': isShortSession}", :style="style", :href="link", @click="onSessionLinkClick($event, session)", :target="linkTarget")
+a.c-linear-schedule-session(:class="{faved, 'has-date': showDate, 'short-session': isShortSession, 'schedule-pending-session': isSchedulePending}", :style="style", :href="link", @click="onSessionLinkClick($event, session)", :target="linkTarget")
 	.time-box
-		.start(:class="{'has-ampm': hasAmPm}")
-			.date(v-if="showDate")
-				.weekday {{ weekdayLabel }}
-				.day-month {{ dayMonthLabel }}
-			.time {{ startTime.time }}
-			.ampm(v-if="startTime.ampm") {{ startTime.ampm }}
-			.duration {{ getPrettyDuration(session.start, session.end) }}
-		.buffer
+		.start.schedule-pending(v-if="isSchedulePending")
+			svg.schedule-pending-icon(viewBox="0 0 24 24", fill="none", stroke="currentColor", stroke-width="2", stroke-linecap="round", stroke-linejoin="round", aria-hidden="true")
+				rect(x="3", y="4", width="18", height="18", rx="2", ry="2")
+				line(x1="16", y1="2", x2="16", y2="6")
+				line(x1="8", y1="2", x2="8", y2="6")
+				line(x1="3", y1="10", x2="21", y2="10")
+			.schedule-pending-label
+				span.schedule-pending-text {{ schedulePendingText }}
+		template(v-else)
+			.start(:class="{'has-ampm': hasAmPm}")
+				.date(v-if="showDate")
+					.weekday {{ weekdayLabel }}
+					.day-month {{ dayMonthLabel }}
+				.time {{ startTime.time }}
+				.ampm(v-if="startTime.ampm") {{ startTime.ampm }}
+				.duration {{ getPrettyDuration(session.start, session.end) }}
+		.buffer(v-if="!isSchedulePending")
 		.is-live(v-if="showLiveBadge && isLive") live
 	.info(:class="{'has-fav-count': hasFavCount, 'has-icons': hasAnyRightIcons}")
 		.title(:class="{'title-clamped': isShortSession}") {{ getLocalizedString(session.title) }}
@@ -142,10 +151,17 @@ export default {
 			}
 		},
 		startTime () {
+			if (this.isSchedulePending) {
+				return { time: this.schedulePendingText }
+			}
 			return getSessionTime(this.session, this.effectiveTimezone, this.locale, this.effectiveHasAmPm)
 		},
-		shortDate () {
-			return this.session.start.clone().tz(this.effectiveTimezone).format('MMM D')
+		isSchedulePending () {
+			return Boolean(this.session.schedule_pending || !this.session.start)
+		},
+		schedulePendingText () {
+			const m = this.translationMessages || {}
+			return m.schedule_pending_secondary || 'Coming soon'
 		},
 		weekdayLabel () {
 			return this.session.start.clone().tz(this.effectiveTimezone).locale(this.locale || 'en').format('ddd')
@@ -266,6 +282,35 @@ sessionTextExpand()
 		display: flex
 		flex-direction: column
 		align-items: center
+		.start.schedule-pending
+			display: flex
+			flex-direction: column
+			align-items: center
+			justify-content: center
+			gap: 4px
+			width: 100%
+			margin-bottom: 0
+			flex: 1
+			color: $clr-primary-text-dark
+			.schedule-pending-icon
+				width: 16px
+				height: 16px
+				opacity: 0.9
+				flex-shrink: 0
+			.schedule-pending-label
+				display: flex
+				flex-direction: column
+				align-items: center
+				width: 100%
+			.schedule-pending-text
+				font-size: 11px
+				font-weight: 600
+				line-height: 1.25
+				text-align: center
+				letter-spacing: 0.02em
+				color: $clr-primary-text-dark
+				max-width: 100%
+				word-break: break-word
 		.start
 			color: $clr-primary-text-dark
 			display: flex
@@ -329,6 +374,12 @@ sessionTextExpand()
 			color: $clr-primary-text-dark
 			letter-spacing: 0.5px
 			text-transform: uppercase
+	&.schedule-pending-session
+		.time-box
+			justify-content: center
+	&.has-date
+		.time-box
+			width: 88px
 	.info
 		position: relative
 		flex: auto

--- a/app/eventyay/webapp/schedule/src/components/SessionModal.vue
+++ b/app/eventyay/webapp/schedule/src/components/SessionModal.vue
@@ -14,7 +14,7 @@ dialog.pretalx-modal#session-modal(ref="modal", @click.stop="close()")
 						span.ampm(v-if="getSessionTime(modalContent.contentObject, currentTimezone, locale, hasAmPm).ampm") {{ getSessionTime(modalContent.contentObject, currentTimezone, locale, hasAmPm).ampm }}
 					.room(v-if="modalContent.contentObject.room") {{ getLocalizedString(modalContent.contentObject.room.name) }}
 					.track(v-if="modalContent.contentObject.track", :style="{ color: modalContent.contentObject.track.color }") {{ getLocalizedString(modalContent.contentObject.track.name) }}
-					export-dropdown.session-export-area(v-if="talkExportOptions.length", :options="talkExportOptions", :qrcodesUrl="talkQrcodesUrl")
+					export-dropdown.session-export-area(v-if="talkExportOptions.length || exportsDisabled", :options="talkExportOptions", :qrcodesUrl="talkQrcodesUrl", :disabled="exportsDisabled")
 				.text-content
 					.recording-embed(v-if="modalContent.contentObject.recording_iframe", v-html="modalContent.contentObject.recording_iframe")
 					.field-section(v-if="modalContent.contentObject.abstract")
@@ -85,7 +85,7 @@ dialog.pretalx-modal#session-modal(ref="modal", @click.stop="close()")
 								path(fill="currentColor", d="M12,1A5.8,5.8 0 0,1 17.8,6.8A5.8,5.8 0 0,1 12,12.6A5.8,5.8 0 0,1 6.2,6.8A5.8,5.8 0 0,1 12,1M12,15C18.63,15 24,17.67 24,21V23H0V21C0,17.67 5.37,15 12,15Z")
 					.speaker-title
 						h3 {{ modalContent.contentObject.name }}
-						export-dropdown.speaker-export(v-if="speakerExportOptions.length", :options="speakerExportOptions", :qrcodesUrl="speakerQrcodesUrl")
+						export-dropdown.speaker-export(v-if="speakerExportOptions.length || exportsDisabled", :options="speakerExportOptions", :qrcodesUrl="speakerQrcodesUrl", :disabled="exportsDisabled")
 				.speaker-content.card-content
 					.biography(v-if="(modalContent.contentObject.apiContent?.biography || modalContent.contentObject.biography)?.length > 0", v-html="renderRichText(modalContent.contentObject.apiContent?.biography || modalContent.contentObject.biography)")
 					template(v-if="modalContent.contentObject.isLoading")
@@ -144,7 +144,8 @@ export default {
 		loggedIn: { default: false },
 		showJoinRoom: { default: false },
 		getJoinRoomLink: { default: () => () => '' },
-		translationMessages: { default: () => ({}) }
+		translationMessages: { default: () => ({}) },
+		exportsDisabled: { default: false },
 	},
 	props: {
 		modalContent: Object,

--- a/app/eventyay/webapp/schedule/src/utils.js
+++ b/app/eventyay/webapp/schedule/src/utils.js
@@ -115,6 +115,12 @@ export function buildExportMenuItems(exporters) {
 	].filter(o => o.url)
 }
 
+export function areScheduleExportsDisabled ({ version = '', scheduleMetaVersion = '', isFeaturedPage = false, exportersCount = 0, isWipPreview = false } = {}) {
+	if (isWipPreview || (version || scheduleMetaVersion) === 'wip') return true
+	if (isFeaturedPage && !exportersCount) return true
+	return false
+}
+
 export function parseBooleanAnswer (value) {
 	if (typeof value === 'boolean') return value
 	return ['true', '1', 'yes'].includes(String(value).toLowerCase())

--- a/app/tests/stable/test_featured.py
+++ b/app/tests/stable/test_featured.py
@@ -1,0 +1,194 @@
+import json
+import pytest
+import datetime as dt
+from django_scopes import scope
+from eventyay.base.models import Submission, Room, TalkSlot, SubmissionType
+
+@pytest.mark.django_db
+class TestFeaturedSessions:
+    def test_featured_sessions_and_exporters(self, client, organizer, event, user):
+        with scope(event=event):
+            # 1. Create a submission type
+            sub_type = SubmissionType.objects.create(event=event, name="Talk")
+            
+            # 2. Create featured and non-featured submissions
+            sub_featured = Submission.objects.create(
+                title="Featured Session Title",
+                event=event,
+                submission_type=sub_type,
+                abstract="An abstract for a featured session",
+                content_locale="en",
+                is_featured=True,
+            )
+            sub_featured.speakers.add(user)
+            sub_featured.accept()
+            sub_featured.confirm()
+
+            sub_regular = Submission.objects.create(
+                title="Regular Session Title",
+                event=event,
+                submission_type=sub_type,
+                abstract="An abstract for a regular session",
+                content_locale="en",
+                is_featured=False,
+            )
+            sub_regular.speakers.add(user)
+            sub_regular.accept()
+            sub_regular.confirm()
+
+            # 3. Create room and release schedule
+            room = Room.objects.create(event=event, name="Room A")
+            
+            # WIP slot for featured
+            TalkSlot.objects.update_or_create(
+                submission=sub_featured,
+                schedule=event.wip_schedule,
+                defaults={
+                    "is_visible": True,
+                    "start": event.date_from + dt.timedelta(hours=10),
+                    "end": event.date_from + dt.timedelta(hours=11),
+                    "room": room,
+                },
+            )
+            # WIP slot for regular
+            TalkSlot.objects.update_or_create(
+                submission=sub_regular,
+                schedule=event.wip_schedule,
+                defaults={
+                    "is_visible": True,
+                    "start": event.date_from + dt.timedelta(hours=11),
+                    "end": event.date_from + dt.timedelta(hours=12),
+                    "room": room,
+                },
+            )
+            
+            # Release schedule
+            event.release_schedule("v1")
+            schedule = event.current_schedule
+            
+            # Put slots in current schedule
+            TalkSlot.objects.update_or_create(
+                submission=sub_featured,
+                schedule=schedule,
+                defaults={
+                    "is_visible": True,
+                    "start": event.date_from + dt.timedelta(hours=10),
+                    "end": event.date_from + dt.timedelta(hours=11),
+                    "room": room,
+                },
+            )
+            TalkSlot.objects.update_or_create(
+                submission=sub_regular,
+                schedule=schedule,
+                defaults={
+                    "is_visible": True,
+                    "start": event.date_from + dt.timedelta(hours=11),
+                    "end": event.date_from + dt.timedelta(hours=12),
+                    "room": room,
+                },
+            )
+            
+            # Set show_featured flag
+            event.feature_flags["show_featured"] = "always"
+            event.save()
+
+            featured_url = str(event.urls.featured)
+            schedule_export_base = str(event.urls.schedule).rstrip('/')
+
+        # 4. Request the featured page
+        response = client.get(featured_url)
+        assert response.status_code == 200
+        
+        # Verify schedule JSON only contains the featured talk
+        context = response.context
+        assert 'schedule_data_json' in context
+        schedule_data = context['schedule_data_json']
+        assert "Featured Session Title" in schedule_data
+        assert "Regular Session Title" not in schedule_data
+
+        # 5. Request exporters with featured=true
+        export_json_url = f'{schedule_export_base}.json?featured=true'
+        response = client.get(export_json_url)
+        assert response.status_code == 200
+        export_content = response.content.decode('utf-8')
+        assert "Featured Session Title" in export_content
+        assert "Regular Session Title" not in export_content
+
+        # Request exporters without featured=true (should contain both)
+        with scope(event=event):
+            event.settings.show_schedule = True
+            event.talks_published = True
+            event.save()
+
+        export_json_url_all = f'{schedule_export_base}.json'
+        response = client.get(export_json_url_all)
+        assert response.status_code == 200
+        export_content_all = response.content.decode('utf-8')
+        assert "Featured Session Title" in export_content_all
+        assert "Regular Session Title" in export_content_all
+
+        # 6. Test navigation tab visibility
+        from django.test import RequestFactory
+        from eventyay.common.templatetags.event_tags import can_view_featured_sessions_public
+
+        rf = RequestFactory()
+        req = rf.get('/')
+        req.event = event
+        req.user = user
+
+        # 6.1. No featured sessions anywhere (always mode still shows the nav tab)
+        with scope(event=event):
+            sub_featured.is_featured = False
+            sub_featured.save()
+            TalkSlot.objects.filter(schedule=schedule, submission=sub_featured).delete()
+
+        ctx = {'request': req}
+        assert can_view_featured_sessions_public(ctx, event) is True
+
+        response = client.get(featured_url)
+        assert response.status_code == 200
+        assert 'No featured sessions have been selected yet' in response.content.decode()
+
+        # 6.2. Featured submission present, but no schedule released — schedule list with pending pill
+        with scope(event=event):
+            sub_featured.is_featured = True
+            sub_featured.save()
+            event.schedules.filter(version__isnull=False).update(published=None)
+            event.__dict__.pop('current_schedule', None)
+
+        assert can_view_featured_sessions_public(ctx, event) is True
+        response = client.get(featured_url)
+        assert response.status_code == 200
+        content = response.content.decode()
+        assert "Featured Session Title" in content
+        assert 'schedule_pending' in content or 'Coming soon' in content
+        assert '<article id="featured-talks">' not in content
+        meta_json = response.context['schedule_meta_json']
+        assert json.loads(meta_json)['exporters'] == []
+
+        export_json_url = f'{schedule_export_base}.json?featured=true'
+        response = client.get(export_json_url)
+        assert response.status_code == 404
+
+        # 6.3. Schedule released, has featured talks
+        with scope(event=event):
+            event.release_schedule("v2")
+            new_schedule = event.current_schedule
+            TalkSlot.objects.create(
+                submission=sub_featured,
+                schedule=new_schedule,
+                is_visible=True,
+                start=event.date_from + dt.timedelta(hours=10),
+                end=event.date_from + dt.timedelta(hours=11),
+                room=room,
+            )
+
+        assert can_view_featured_sessions_public(ctx, event) is True
+
+        # 6.4. Schedule released, but has NO featured talks (even if confirmed submission exists)
+        with scope(event=event):
+            TalkSlot.objects.filter(schedule=new_schedule, submission=sub_featured).delete()
+
+        assert can_view_featured_sessions_public(ctx, event) is True
+
+


### PR DESCRIPTION
## Summary

Replaces the featured sessions page with the public schedule widget in list-only mode, so featured content uses the same session UI as the main schedule while respecting org visibility rules.

- **Featured page** embeds `<pretalx-schedule>` (list view) instead of a static HTML submission list; shows an empty state when no featured sessions exist.
- **Pre-release preview**: when org setting is **Always** or **After schedule**, featured submissions appear before a schedule version is published, shown as pending sessions with a “Coming soon” time pill (no room/time).
- **Exports**: featured-only exports use `?featured=true`; backend and UI are gated until a schedule version is published (same disabled-export pattern as WIP preview).
- **Visibility**: nav and page access follow `show_featured` (`never` / `after_schedule` / `always`); featured page and exports can load before `talks_published` when rules allow.
- **Layout**: shared page inset variables for featured and schedule padding.

## Changes

### Backend
- `FeaturedView` builds featured schedule JSON/meta via `build_featured_schedule_json()` / `build_featured_schedule_meta_json()`.
- Centralized featured helpers in `talk_rules/submission.py` (`featured_submissions_for_event`, `can_use_featured_exports`, etc.).
- Exporters filter to featured public talk slots; cache cleared when `is_featured` changes.
- Middleware allows `/featured/` and featured exports without full talks publication when appropriate.

### Frontend
- `is-featured-page` mode: hides date bar, calendar toggle, and version picker; forces sessions list view.
- Pending sessions supported in list/linear schedule and session time pill.
- Export controls disabled when no published schedule (reuses WIP `exportsDisabled` / `public_schedule_only` pattern).

### Tests
- `app/tests/stable/test_featured.py` — page content, featured exporters, nav visibility, pre-release pending state.

## Test plan

- [ ] Set org **Show featured sessions** to **Always**; mark a confirmed submission as featured → `/featured/` shows in nav and lists the session with “Coming soon” before schedule release.
- [ ] Before schedule release: export button is disabled; direct `?featured=true` export URLs return 404.
- [ ] Release schedule with featured slot → session shows real time/room; exports appear and only include featured sessions.
- [ ] Set **Show featured sessions** to **Never** → featured nav and page hidden for public users (including organizers on public site).
- [ ] Set **After schedule** → preview before release when featured submissions exist; full behavior after release + `talks_published`.
- [ ] Toggle featured flag in orga → page updates without stale cache.
- [ ] Run `pytest tests/stable/test_featured.py` (requires PostgreSQL).

## Notes

- Default org setting for featured is **`never`** — organizers must enable **Always** or **After schedule** for the page to appear.
- Rebuild schedule assets after frontend changes: `npm run build:wc --prefix=eventyay/webapp/schedule` (or `make staticfiles` from `app/`).