### PR TITLE
chore: update uv lock to latest exhibitor pointer

### DIFF
--- a/app/uv.lock
+++ b/app/uv.lock
@@ -1683,7 +1683,7 @@ wheels = [
 [[package]]
 name = "exhibition"
 version = "1.0.0"
-source = { git = "https://github.com/fossasia/eventyay-exhibition.git?rev=main#4f0b349ced130c4f9585f71e12f08b5257a7837d" }
+source = { git = "https://github.com/fossasia/eventyay-exhibition.git?rev=main#480e68cf7bf9dc15019b9615739d1ea806b01ce3" }
 dependencies = [
     { name = "flake8" },
 ]


### PR DESCRIPTION
## Summary by Sourcery

Chores:
- Regenerate the uv.lock file to track the latest Exhibitor pointer.