### PR TITLE
feat(agenda): enable anonymous session starring via localStorage

### DIFF
--- a/app/eventyay/agenda/views/schedule.py
+++ b/app/eventyay/agenda/views/schedule.py
@@ -373,14 +373,17 @@ class ScheduleView(PermissionRequired, ScheduleMixin, TemplateView):
         return ctx
 
 
-@cache_page(60 * 60 * 24)
+@cache_page(60 * 60 * 24, key_prefix='schedule-messages-v3')
 def schedule_messages(request, **kwargs):
-    """This view is cached for a day, as it is small and non-critical, but loaded synchronously."""
+    """Cached for static exports; bump key_prefix when message keys or copy change."""
     strings = {
-        'favs_not_logged_in': _(
-            "You're currently not logged in, so your favourited talks will only be stored locally in your browser."
+        'favs_anonymous_notice': _(
+            'Your favourites can only be saved locally in this browser. '
+            'Please sign in or register to sync starred sessions and use more features. '
+            'Locally saved stars may be lost if you clear your browser data; '
+            'we are not responsible for data loss in this case.'
         ),
-        'favs_not_saved': _('Your favourites could only be saved locally in your browser.'),
+        'favs_not_saved': _('Your favourites could not be saved. Please try again.'),
         'no_matching_options': _('Sorry, no matching options.'),
         'view_changelog': _('View Changelog'),
         'go_to_current_version': _('Go to current version'),
@@ -396,7 +399,8 @@ def schedule_messages(request, **kwargs):
             'You are currently viewing the editable schedule version. It may not match the released version.'
         ),
         'version_warning_wip': _(
-            'You are currently viewing the unreleased schedule preview. It may change at any time and is not visible to the public.'
+            'You are currently viewing the unreleased schedule preview. '
+            'It may change at any time and is not visible to the public.'
         ),
         'version_warning_old': _('You are currently viewing an older schedule version.'),
         'join_room': _('Join room'),

--- a/app/eventyay/agenda/views/schedule.py
+++ b/app/eventyay/agenda/views/schedule.py
@@ -373,7 +373,7 @@ class ScheduleView(PermissionRequired, ScheduleMixin, TemplateView):
         return ctx
 
 
-@cache_page(60 * 60 * 24, key_prefix='schedule-messages-v3')
+@cache_page(60 * 60 * 24, key_prefix='schedule-messages-v4')
 def schedule_messages(request, **kwargs):
     """Cached for static exports; bump key_prefix when message keys or copy change."""
     strings = {
@@ -383,7 +383,9 @@ def schedule_messages(request, **kwargs):
             'Locally saved stars may be lost if you clear your browser data; '
             'we are not responsible for data loss in this case.'
         ),
-        'favs_not_saved': _('Your favourites could not be saved. Please try again.'),
+        'favs_not_saved': _(
+            'Could not sync favourites to your account. They remain stored locally in this browser.'
+        ),
         'no_matching_options': _('Sorry, no matching options.'),
         'view_changelog': _('View Changelog'),
         'go_to_current_version': _('Go to current version'),

--- a/app/eventyay/multidomain/views.py
+++ b/app/eventyay/multidomain/views.py
@@ -150,10 +150,13 @@ class VideoSPAView(View):
                 'locales': ['en', 'de', 'pt_BR', 'ar', 'fr', 'es', 'uk', 'ru'],
                 'noThemeEndpoint': True,  # Prevent frontend from requesting missing /theme endpoint
                 'translationMessages': {
-                    'favs_not_logged_in': str(_(
-                        "You're currently not logged in, so your favourited talks will only be stored locally in your browser."
+                    'favs_anonymous_notice': str(_(
+                        'Your favourites can only be saved locally in this browser. '
+                        'Please sign in or register to sync starred sessions and use more features. '
+                        'Locally saved stars may be lost if you clear your browser data; '
+                        'we are not responsible for data loss in this case.'
                     )),
-                    'favs_not_saved': str(_('Your favourites could only be saved locally in your browser.')),
+                    'favs_not_saved': str(_('Your favourites could not be saved. Please try again.')),
                     'no_matching_options': str(_('Sorry, no matching options.')),
                     'view_changelog': str(_('View Changelog')),
                     'go_to_current_version': str(_('Go to current version')),

--- a/app/eventyay/multidomain/views.py
+++ b/app/eventyay/multidomain/views.py
@@ -156,7 +156,9 @@ class VideoSPAView(View):
                         'Locally saved stars may be lost if you clear your browser data; '
                         'we are not responsible for data loss in this case.'
                     )),
-                    'favs_not_saved': str(_('Your favourites could not be saved. Please try again.')),
+                    'favs_not_saved': str(_(
+                        'Could not sync favourites to your account. They remain stored locally in this browser.'
+                    )),
                     'no_matching_options': str(_('Sorry, no matching options.')),
                     'view_changelog': str(_('View Changelog')),
                     'go_to_current_version': str(_('Go to current version')),

--- a/app/eventyay/presale/templates/pretixpresale/event/index.html
+++ b/app/eventyay/presale/templates/pretixpresale/event/index.html
@@ -383,7 +383,6 @@
     {% if subevent or not event.has_subevents %}
         {% if featured_speakers %}
             <section class="front-page" id="featured-speakers" aria-label="{% trans 'Featured Speakers' %}">
-                <script id="pretalx-messages" data-logged-in="{% if request.user.is_anonymous %}false{% else %}true{% endif %}"></script>
                 <script id="pretalx-schedule-data" type="application/json">{{ featured_speakers_widget_schedule_json|safe }}</script>
                 {% vite_app_scripts 'schedule' 'src/main-wc.js' fallback='schedule/pretalx-schedule.js' %}
                 <pretalx-schedule event-url="{{ request.event.urls.base }}" locale="{{ request.LANGUAGE_CODE }}" view="featured-speakers" speakers-list-public="{% if featured_speakers_list_public %}true{% else %}false{% endif %}" style="--pretalx-clr-primary: {{ request.event.visible_primary_color }}"></pretalx-schedule>

--- a/app/eventyay/webapp/schedule/src/App.vue
+++ b/app/eventyay/webapp/schedule/src/App.vue
@@ -42,7 +42,6 @@
 			v-model:includePopularitySortKey="sortIncludePopularity",
 			:popularityFeatureEnabled="popularityFeatureEnabled",
 			:popularitySortAvailable="popularitySortAvailable",
-			:loggedIn="loggedIn",
 			:exportsDisabled="exportsDisabled",
 			@selectDay="selectDay($event)",
 			@filterToggle="onlyFavs = false",
@@ -281,7 +280,7 @@ export default {
 					this.showSpeakerDetails(speaker, event)
 				}
 			},
-			loggedIn: computed(() => this.loggedIn),
+			favsReadOnly: computed(() => this.favsReadOnly),
 			translationMessages: computed(() => this.translationMessages),
 			isWipPreview: computed(() => (this.version || this.scheduleMeta?.version || '') === 'wip'),
 			exportsDisabled: computed(() => this.exportsDisabled),
@@ -597,13 +596,11 @@ export default {
 		showPopularityOnSchedule () {
 			return isPopularityVisibleOnSchedule({
 				flags: this.schedule?.feature_flags || {},
-				loggedIn: this.loggedIn,
 			})
 		},
 		popularitySortAvailable () {
 			return isPopularitySortAvailable({
 				flags: this.schedule?.feature_flags || {},
-				loggedIn: this.loggedIn,
 			})
 		},
 		sortOptions () {
@@ -628,14 +625,11 @@ export default {
 				if (this.sortBy === 'popularity') this.sortBy = 'title'
 			}
 		},
-		loggedIn (isLoggedIn) {
-			if (!isLoggedIn) {
-				this.sortIncludePopularity = false
-			}
-			if (!isLoggedIn) {
-				this.onlyFavs = false
-				this.favs = []
-			}
+		loggedIn () {
+			if (!this.schedule) return
+			this.loadFavs().then((favs) => {
+				this.favs = this.pruneFavs(favs, this.schedule)
+			})
 		},
 		recordingFilter () {
 			this.writeRecordingQueryParam()
@@ -662,8 +656,6 @@ export default {
 			this.sessionsMode = true
 		}
 
-		// Detect login state from the DOM element (always rendered by Django),
-		// independent of whether the PRETALX_MESSAGES JS global loaded
 		const messagesEl = document.querySelector('#pretalx-messages')
 		if (messagesEl) {
 			this.onHomeServer = true
@@ -673,7 +665,6 @@ export default {
 			}
 		}
 
-		// Load translation messages if available
 		/* global PRETALX_MESSAGES */
 		if (typeof PRETALX_MESSAGES !== 'undefined') {
 			this.translationMessages = PRETALX_MESSAGES
@@ -731,6 +722,7 @@ export default {
 				this.favs = this.pruneFavs(await this.loadPublicFavs(), this.schedule)
 			} else {
 				this.favs = this.pruneFavs(await this.loadFavs(), this.schedule)
+				if (!this.loggedIn && this.favs.length) this.showAnonymousFavsInfo()
 			}
 			if (this.view === 'speaker' && this.speakerCode) {
 				this.fetchSpeakerApiContentIfNeeded(this.speakerCode)
@@ -796,6 +788,7 @@ export default {
 			this.favs = this.pruneFavs(await this.loadPublicFavs(), this.schedule)
 		} else {
 			this.favs = this.pruneFavs(await this.loadFavs(), this.schedule)
+			if (!this.loggedIn && this.favs.length) this.showAnonymousFavsInfo()
 		}
 
 		if (fragment && fragment.length === 10) {
@@ -929,30 +922,31 @@ export default {
 			return response.json()
 		},
 		async loadFavs () {
-			if (!this.loggedIn) return []
-			const userStorageKey = this.getFavStorageKey(this.userCode)
 			const anonymousStorageKey = this.getFavStorageKey(null)
-			const localFavs = [...new Set([
-				...this.readLocalFavs(userStorageKey),
-				...this.readLocalFavs(anonymousStorageKey),
-			])]
-			if (this.loggedIn) {
-				try {
-					const merged = await this.apiRequest(
-						'submissions/favourites/merge/',
-						'POST',
-						localFavs
-					)
-					if (Array.isArray(merged)) {
-						localStorage.setItem(userStorageKey, JSON.stringify(merged))
-						localStorage.removeItem(anonymousStorageKey)
-						return merged
-					}
-				} catch {
-					this.pushErrorMessage(this.translationMessages.favs_not_saved)
-				}
+			const localFavs = this.readLocalFavs(anonymousStorageKey)
+			if (!this.loggedIn) {
+				return localFavs
 			}
-			return localFavs
+			const userStorageKey = this.getFavStorageKey(this.userCode)
+			const mergedLocal = [...new Set([
+				...this.readLocalFavs(userStorageKey),
+				...localFavs,
+			])]
+			try {
+				const merged = await this.apiRequest(
+					'submissions/favourites/merge/',
+					'POST',
+					mergedLocal
+				)
+				if (Array.isArray(merged)) {
+					localStorage.setItem(userStorageKey, JSON.stringify(merged))
+					localStorage.removeItem(anonymousStorageKey)
+					return merged
+				}
+			} catch {
+				this.pushErrorMessage(this.translationMessages.favs_not_saved)
+			}
+			return mergedLocal
 		},
 		async loadPublicFavs () {
 			if (!this.publicFavsUrl) return []
@@ -972,17 +966,25 @@ export default {
 			if (this.errorMessages.includes(message)) return
 			this.errorMessages.push(message)
 		},
+		showAnonymousFavsInfo () {
+			if (this.loggedIn || this.favsReadOnly) return
+			const message = this.translationMessages.favs_anonymous_notice
+			if (message) this.pushErrorMessage(message)
+		},
 		pruneFavs (favs, schedule) {
-			// we're not pushing the changed list to the server, as if a talk vanished but will appear again,
-			// we want it to still be faved
-			const talkSet = new Set((schedule.talks || []).map(e => e.code))
-			return favs.filter(e => talkSet.has(e))
+			const talkSet = new Set((schedule.talks || []).map(talk => talk.code))
+			return favs.filter(code => talkSet.has(code))
 		},
 		saveFavs () {
-			if (!this.loggedIn) return
+			const storageKey = this.getFavStorageKey(this.loggedIn ? this.userCode : null)
+			try {
+				localStorage.setItem(storageKey, JSON.stringify(this.favs))
+			} catch {
+				this.pushErrorMessage(this.translationMessages.favs_not_saved)
+			}
 		},
 		toggleSessionModalFav (id) {
-			if (!this.loggedIn) return
+			if (this.favsReadOnly) return
 			if (this.favSet.has(id)) {
 				this.unfav(id)
 			} else {
@@ -990,7 +992,6 @@ export default {
 			}
 		},
 		async fav (id) {
-			if (!this.loggedIn) return
 			if (this.favsReadOnly) return
 			if (this.favSet.has(id)) return
 			this.favs.push(id)
@@ -999,6 +1000,10 @@ export default {
 				talk.fav_count = Math.max(0, Number(talk.fav_count || 0) + 1)
 			}
 			this.saveFavs()
+			if (!this.loggedIn) {
+				this.showAnonymousFavsInfo()
+				return
+			}
 			try {
 				await this.apiRequest(`submissions/${id}/favourite/`, 'POST')
 			} catch (error) {
@@ -1007,7 +1012,6 @@ export default {
 			}
 		},
 		async unfav (id) {
-			if (!this.loggedIn) return
 			if (this.favsReadOnly) return
 			this.favs = this.favs.filter(elem => elem !== id)
 			const talk = this.schedule?.talks?.find(t => t.code === id)
@@ -1015,6 +1019,7 @@ export default {
 				talk.fav_count = Math.max(0, Number(talk.fav_count || 0) - 1)
 			}
 			this.saveFavs()
+			if (!this.loggedIn) return
 			try {
 				await this.apiRequest(`submissions/${id}/favourite/`, 'DELETE')
 			} catch (error) {

--- a/app/eventyay/webapp/schedule/src/components/ScheduleToolbar.vue
+++ b/app/eventyay/webapp/schedule/src/components/ScheduleToolbar.vue
@@ -81,7 +81,7 @@
 							span.filter-dropdown-label {{ item.label }}
 					.filter-dropdown-empty(v-else) No {{ languageGroup.title.toLowerCase() }} available
 			button.toolbar-btn.icon-only.fav-toggle(
-				v-if="loggedIn && popularityFeatureEnabled && favsCount",
+				v-if="favsCount",
 				:disabled="!favsCount",
 				:aria-label="t.starred",
 				:aria-pressed="onlyFavs ? 'true' : 'false'",
@@ -338,7 +338,6 @@ export default {
 	name: 'ScheduleToolbar',
 	inject: {
 		translationMessages: { default: () => ({}) },
-		loggedIn: { default: false }
 	},
 	props: {
 		version: { type: String, default: '' },
@@ -371,7 +370,6 @@ export default {
 		includePopularitySortKey: { type: Boolean, default: false },
 		popularityFeatureEnabled: { type: Boolean, default: false },
 		popularitySortAvailable: { type: Boolean, default: false },
-		loggedIn: { type: Boolean, default: false },
 		exportsDisabled: { type: Boolean, default: false },
 		sortOptions: { type: Array, default: () => ['title', 'title_desc'] },
 		timeDensityMinutes: { type: Number, default: 30 },

--- a/app/eventyay/webapp/schedule/src/components/ScheduleView.vue
+++ b/app/eventyay/webapp/schedule/src/components/ScheduleView.vue
@@ -29,7 +29,6 @@
 			v-model:includeRoomSortKey="sortIncludeRoom",
 			v-model:includeDateSortKey="sortIncludeDate",
 			v-model:includePopularitySortKey="sortIncludePopularity",
-			:loggedIn="loggedIn",
 			:popularityFeatureEnabled="popularityFeatureEnabled",
 			:popularitySortAvailable="popularitySortAvailable",
 			@selectDay="changeDay($event)",
@@ -116,7 +115,6 @@ export default {
 		scheduleData: { default: null },
 		scheduleFav: { default: null },
 		scheduleUnfav: { default: null },
-		loggedIn: { default: false },
 		scheduleExporters: { default: () => [] },
 		scheduleMetaData: { default: () => ({}) }
 	},
@@ -210,7 +208,7 @@ export default {
 		},
 		showFavCountOnSchedule() {
 			const flags = this.scheduleData?.schedule?.feature_flags || this.resolvedSchedule?.feature_flags || {}
-			return isPopularityVisibleOnSchedule({ flags, loggedIn: this.loggedIn })
+			return isPopularityVisibleOnSchedule({ flags })
 		},
 		hasError() {
 			return !!(this.errorLoading || this.scheduleData?.errorLoading)
@@ -390,7 +388,7 @@ export default {
 		},
 		popularitySortAvailable() {
 			const flags = this.resolvedSchedule?.feature_flags || {}
-			return isPopularitySortAvailable({ flags, loggedIn: this.loggedIn })
+			return isPopularitySortAvailable({ flags })
 		},
 		sortOptions() {
 			const options = ['title', 'title_desc']
@@ -556,7 +554,6 @@ export default {
 			this.currentDay = dayStr
 		},
 		toggleFavs() {
-			if (!this.loggedIn) return
 			this.onlyFavs = !this.onlyFavs
 			if (this.onlyFavs) this.resetFilters()
 		},
@@ -577,12 +574,10 @@ export default {
 			localStorage.setItem('userTimezone', this.currentTimezone)
 		},
 		onFav(id) {
-			if (!this.loggedIn) return
 			if (this.scheduleFav) this.scheduleFav(id)
 			this.$emit('fav', id)
 		},
 		onUnfav(id) {
-			if (!this.loggedIn) return
 			if (this.scheduleUnfav) this.scheduleUnfav(id)
 			this.$emit('unfav', id)
 		},

--- a/app/eventyay/webapp/schedule/src/components/Session.vue
+++ b/app/eventyay/webapp/schedule/src/components/Session.vue
@@ -44,7 +44,7 @@ a.c-linear-schedule-session(:class="{faved, 'has-date': showDate, 'short-session
 	.stream-indicator(v-if="canOpenStream", :class="{live: isLive}", :title="streamTooltip", @click.prevent.stop="openStream")
 		svg(viewBox="0 0 24 24", width="20", height="20", fill="currentColor", xmlns="http://www.w3.org/2000/svg")
 			path(d="M17 10.5V7c0-.55-.45-1-1-1H4c-.55 0-1 .45-1 1v10c0 .55.45 1 1 1h12c.55 0 1-.45 1-1v-3.5l4 4v-11l-4 4z")
-	.session-icons(v-if="loggedIn")
+	.session-icons(v-if="!favsReadOnly")
 		fav-button(@toggleFav="toggleFav")
 
 </template>
@@ -116,7 +116,7 @@ export default {
 			}
 		},
 		getJoinRoomLink: { default: () => () => '' },
-		loggedIn: { default: false },
+		favsReadOnly: { default: false },
 		translationMessages: { default: () => ({}) }
 	},
 	components: {
@@ -195,7 +195,7 @@ export default {
 			}
 		},
 		hasFavCount () {
-			return this.loggedIn && this.showFavCount && normalizePopularityCount(this.session) > 0
+			return this.showFavCount && normalizePopularityCount(this.session) > 0
 		},
 		favCountLabel () {
 			const count = normalizePopularityCount(this.session)
@@ -206,7 +206,7 @@ export default {
 			return m.schedule_do_not_record || 'This session will not be recorded.'
 		},
 		hasAnyRightIcons () {
-			return this.loggedIn || this.canOpenStream || this.session.do_not_record
+			return !this.favsReadOnly || this.canOpenStream || this.session.do_not_record
 		},
 		isShortSession () {
 			let minutes = 0
@@ -223,7 +223,7 @@ export default {
 	},
 	methods: {
 		toggleFav () {
-			if (!this.loggedIn) return
+			if (this.favsReadOnly) return
 			if (this.faved) {
 				this.$emit('unfav', this.session.id)
 			} else {

--- a/app/eventyay/webapp/schedule/src/components/SessionModal.vue
+++ b/app/eventyay/webapp/schedule/src/components/SessionModal.vue
@@ -4,7 +4,7 @@ dialog.pretalx-modal#session-modal(ref="modal", @click.stop="close()")
 		button.close-button(@click="close()") ✕
 		template(v-if="modalContent && modalContent.contentType === 'session'")
 			h3 {{ modalContent.contentObject.title }}
-				.button-container(v-if="loggedIn", :class="isFaved ? 'faved' : ''")
+				.button-container(v-if="!favsReadOnly", :class="isFaved ? 'faved' : ''")
 					fav-button(@toggleFav="$emit('toggleFav', modalContent.contentObject.id)")
 
 			.card-content
@@ -141,7 +141,7 @@ export default {
 	inject: {
 		remoteApiUrl: { default: '' },
 		eventUrl: { default: '' },
-		loggedIn: { default: false },
+		favsReadOnly: { default: false },
 		showJoinRoom: { default: false },
 		getJoinRoomLink: { default: () => () => '' },
 		translationMessages: { default: () => ({}) },

--- a/app/eventyay/webapp/schedule/src/components/TalkDetail.vue
+++ b/app/eventyay/webapp/schedule/src/components/TalkDetail.vue
@@ -4,7 +4,7 @@
 		detail-top-actions(
 			:export-options="talkExportOptions",
 			:qrcodes-url="talkQrcodesUrl",
-			:show-fav="loggedIn",
+			:show-fav="!favsReadOnly",
 			:faved="isFaved",
 			@toggleFav="toggleFav")
 	.talk-wrapper(v-if="talkDetailReady")
@@ -75,7 +75,7 @@
 								path(fill="currentColor", d="M12,1A5.8,5.8 0 0,1 17.8,6.8A5.8,5.8 0 0,1 12,12.6A5.8,5.8 0 0,1 6.2,6.8A5.8,5.8 0 0,1 12,1M12,15C18.63,15 24,17.67 24,21V23H0V21C0,17.67 5.37,15 12,15Z")
 						.name(:class="{'no-name': !speaker.name}") {{ speaker.name || t.speaker_name_not_provided }}
 					markdown-content.biography(v-if="speaker.biography", :markdown="speaker.biography")
-		.starrers(v-if="popularityFeatureEnabled && loggedIn && starrers && starrers.total > 0")
+		.starrers(v-if="popularityFeatureEnabled && starrers && starrers.total > 0")
 			.header
 				span {{ t.starred_by }} ({{ starrers.total }})
 				button.expand-toggle(type="button", @click="toggleStarrersExpanded") {{ starrersExpanded ? t.hide_list : t.view_all }}
@@ -144,7 +144,7 @@ export default {
 		getJoinRoomLink: { default: () => () => '' },
 		generateStarrerLinkUrl: { default: () => (user) => user.url || '' },
 		onStarrerLinkClick: { default: () => () => {} },
-		loggedIn: { default: false },
+		favsReadOnly: { default: false },
 		translationMessages: { default: () => ({}) },
 		isWipPreview: { default: false },
 		exportsDisabled: { default: false },
@@ -443,7 +443,7 @@ export default {
 			this.$emit('joinRoom', event)
 		},
 		async toggleFav() {
-			if (!this.loggedIn) return
+			if (this.favsReadOnly) return
 			if (!this.resolvedTalk) return
 			const favId = this.resolvedTalk.code || this.resolvedTalk.id || this.talkId
 			if (this.isFaved) {

--- a/app/eventyay/webapp/schedule/src/utils.js
+++ b/app/eventyay/webapp/schedule/src/utils.js
@@ -161,16 +161,16 @@ export function isPopularityFeatureEnabled (flags = {}) {
 	return !!flags.session_popularity_enabled
 }
 
-export function isPopularityVisibleOnSchedule ({ flags = {}, loggedIn = false } = {}) {
-	if (!loggedIn || !isPopularityFeatureEnabled(flags)) return false
+export function isPopularityVisibleOnSchedule ({ flags = {} } = {}) {
+	if (!isPopularityFeatureEnabled(flags)) return false
 	if ('session_popularity_show_on_schedule' in flags) {
 		return !!flags.session_popularity_show_on_schedule
 	}
 	return !!(flags.session_popularity_show_on_calendar || flags.session_popularity_show_on_list)
 }
 
-export function isPopularitySortAvailable ({ flags = {}, loggedIn = false } = {}) {
-	return loggedIn && isPopularityFeatureEnabled(flags)
+export function isPopularitySortAvailable ({ flags = {} } = {}) {
+	return isPopularityFeatureEnabled(flags)
 }
 
 export function isFeaturedSpeakersSortAvailable ({ flags = {}, speakers = [] } = {}) {


### PR DESCRIPTION
## Summary
- Allow visitors to star/unstar sessions without signing in; favourites persist in `localStorage` per event and merge into the account on sign-in via the existing favourites merge API.
- Show session popularity (counts, sort, starrers list) to all users when `session_popularity_enabled` is on, not only signed-in users.
- Display a single bottom-right notice explaining that stars are browser-only until sign-in and may be lost if browser data is cleared.

## Test plan
- [ ] With session popularity enabled, open the public schedule while logged out and confirm star buttons, popularity counts, and popularity sort are visible.
- [ ] Star a session while logged out; refresh the page and confirm the star persists.
- [ ] Confirm the anonymous notice appears after starring (and on reload when stored favourites exist).
- [ ] Sign in and confirm local stars merge to the account and sync to the server.
- [ ] Confirm starring still works for signed-in users and API failures show an error notice.
- [ ] On a public stars page (`people/.../stars`), confirm stars are read-only (no starring UI).
- [ ] Run `make staticfiles` from `app/` before deploying so built schedule assets are updated.