### PR TITLE
fix(cropper): align aspect ratios with usage matrix and handle cancellation

### DIFF
--- a/app/eventyay/static/eventyay-common/image_cropper.js
+++ b/app/eventyay/static/eventyay-common/image_cropper.js
@@ -6,9 +6,11 @@ $(function() {
     var image = document.getElementById('cropperImage');
     var $saveBtn = $('#cropperSaveBtn');
 
+    var cropApplied = false;
+
     var config = {
-        'id_settings-event_logo_image': { ratio: 1 },
-        'id_settings-logo_image': { ratio: 6 / 1 }
+        'id_settings-event_logo_image': { ratio: NaN }, // Free form aspect ratio for Logo
+        'id_settings-logo_image': { ratio: 1920 / 640 } // 3:1 aspect ratio for Header Image (recommended 1920x640)
     };
 
     function initCropperForInput(inputId) {
@@ -37,6 +39,7 @@ $(function() {
                     return;
                 }
                 
+                cropApplied = false;
                 currentInput = inputId;
                 var reader = new FileReader();
                 reader.onload = function(evt) {
@@ -67,10 +70,16 @@ $(function() {
             cropper.destroy();
             cropper = null;
         }
+        if (!cropApplied && currentInput) {
+            // If the user cancelled, clear the file input so the uncropped image isn't saved.
+            $('#' + currentInput).val('');
+        }
+        currentInput = null;
     });
 
     $saveBtn.on('click', function() {
         if (cropper && currentInput) {
+            cropApplied = true;
             var cropData = cropper.getData(true);
             var $input = $('#' + currentInput);
             var fieldName = $input.attr('name');


### PR DESCRIPTION
Follow-up to #4056. 
- Allows free-form cropping for logos to support non-square brand marks.
- Locks header cropping to the recommended 3:1 (1920x640) ratio.
- Ensures the file input is cleared if the user cancels the crop dialog to prevent accidental uncropped uploads.

## Summary by Sourcery

Align image cropping behavior with recommended aspect ratios and ensure cancelled crops do not result in unintended uploads.

New Features:
- Support free-form aspect ratio cropping for event logo images.

Bug Fixes:
- Clear the selected file input when the crop dialog is cancelled so uncropped images are not uploaded unintentionally.

Enhancements:
- Update header image cropping to use a 3:1 aspect ratio consistent with the recommended 1920x640 size.