### PR TITLE
Fix voucher deletion for canceled orders

### DIFF
--- a/app/eventyay/api/views/voucher.py
+++ b/app/eventyay/api/views/voucher.py
@@ -16,7 +16,7 @@ from rest_framework.filters import OrderingFilter
 from rest_framework.response import Response
 
 from eventyay.api.serializers.voucher import VoucherSerializer
-from eventyay.base.models import Order, OrderPosition, Voucher
+from eventyay.base.models import CartPosition, Voucher
 
 with scopes_disabled():
 
@@ -130,7 +130,7 @@ class VoucherViewSet(viewsets.ModelViewSet):
             auth=self.request.auth,
         )
         with transaction.atomic():
-            instance.cartposition_set.filter(addon_to__isnull=False).delete()
+            CartPosition.objects.filter(addon_to__voucher=instance).delete()
             instance.cartposition_set.all().delete()
             instance._clear_canceled_order_positions()
             super().perform_destroy(instance)

--- a/app/eventyay/api/views/voucher.py
+++ b/app/eventyay/api/views/voucher.py
@@ -16,7 +16,7 @@ from rest_framework.filters import OrderingFilter
 from rest_framework.response import Response
 
 from eventyay.api.serializers.voucher import VoucherSerializer
-from eventyay.base.models import Voucher
+from eventyay.base.models import Order, OrderPosition, Voucher
 
 with scopes_disabled():
 
@@ -132,6 +132,7 @@ class VoucherViewSet(viewsets.ModelViewSet):
         with transaction.atomic():
             instance.cartposition_set.filter(addon_to__isnull=False).delete()
             instance.cartposition_set.all().delete()
+            instance._clear_canceled_order_positions()
             super().perform_destroy(instance)
 
     @action(detail=False, methods=['POST'])

--- a/app/eventyay/base/models/vouchers.py
+++ b/app/eventyay/base/models/vouchers.py
@@ -232,6 +232,15 @@ class Voucher(LoggedModel):
             order__status=Order.STATUS_CANCELED
         ).exists()
 
+    def _clear_canceled_order_positions(self):
+        """Null out the voucher FK on positions that belong to canceled orders
+        or are individually canceled, so the voucher row can be deleted
+        without hitting the PROTECT constraint."""
+        OrderPosition.all.filter(
+            Q(order__status=Order.STATUS_CANCELED) | Q(canceled=True),
+            voucher=self,
+        ).update(voucher=None)
+
     def clean(self):
         Voucher.clean_product_properties(
             {

--- a/app/eventyay/base/models/vouchers.py
+++ b/app/eventyay/base/models/vouchers.py
@@ -226,7 +226,11 @@ class Voucher(LoggedModel):
         return self.code
 
     def allow_delete(self):
-        return self.redeemed == 0 and not self.orderposition_set.exists()
+        return not OrderPosition.objects.filter(
+            voucher=self,
+        ).exclude(
+            order__status=Order.STATUS_CANCELED
+        ).exists()
 
     def clean(self):
         Voucher.clean_product_properties(

--- a/app/eventyay/control/views/vouchers.py
+++ b/app/eventyay/control/views/vouchers.py
@@ -524,7 +524,7 @@ class VoucherBulkAction(EventPermissionRequiredMixin, View):
             for obj in self.objects:
                 if obj.allow_delete():
                     obj.log_action('eventyay.voucher.deleted', user=self.request.user)
-                    OrderPosition.objects.filter(addon_to__voucher=obj).delete()
+                    CartPosition.objects.filter(addon_to__voucher=obj).delete()
                     obj.cartposition_set.all().delete()
                     obj._clear_canceled_order_positions()
                     obj.delete()

--- a/app/eventyay/control/views/vouchers.py
+++ b/app/eventyay/control/views/vouchers.py
@@ -5,7 +5,7 @@ from django.conf import settings
 from django.contrib import messages
 from django.core.exceptions import ValidationError
 from django.db import connection, transaction
-from django.db.models import Sum
+from django.db.models import Exists, OuterRef, Sum
 from django.http import (
     Http404,
     HttpResponse,
@@ -28,7 +28,7 @@ from django.views.generic import (
     View,
 )
 
-from eventyay.base.models import CartPosition, LogEntry, OrderPosition, Voucher
+from eventyay.base.models import CartPosition, LogEntry, Order, OrderPosition, Voucher
 from eventyay.base.models.vouchers import _generate_random_code
 from eventyay.base.services.locking import NoLockManager
 from eventyay.base.services.vouchers import vouchers_send
@@ -506,12 +506,17 @@ class VoucherBulkAction(EventPermissionRequiredMixin, View):
     @transaction.atomic
     def post(self, request, *args, **kwargs):
         if request.POST.get('action') == 'delete':
+            active_op_qs = OrderPosition.objects.filter(
+                voucher=OuterRef('pk'),
+            ).exclude(order__status=Order.STATUS_CANCELED)
+            deletable = self.objects.filter(~Exists(active_op_qs))
+            forbidden = self.objects.filter(Exists(active_op_qs))
             return render(
                 request,
                 'pretixcontrol/vouchers/delete_bulk.html',
                 {
-                    'allowed': self.objects.filter(redeemed=0),
-                    'forbidden': self.objects.exclude(redeemed=0),
+                    'allowed': deletable,
+                    'forbidden': forbidden,
                 },
             )
         elif request.POST.get('action') == 'delete_confirm':

--- a/app/eventyay/control/views/vouchers.py
+++ b/app/eventyay/control/views/vouchers.py
@@ -195,6 +195,7 @@ class VoucherDelete(EventPermissionRequiredMixin, DeleteView):
             self.object.log_action('eventyay.voucher.deleted', user=self.request.user)
             CartPosition.objects.filter(addon_to__voucher=self.object).delete()
             self.object.cartposition_set.all().delete()
+            self.object._clear_canceled_order_positions()
             self.object.delete()
             messages.success(self.request, _('The selected voucher has been deleted.'))
         return HttpResponseRedirect(success_url)
@@ -525,6 +526,7 @@ class VoucherBulkAction(EventPermissionRequiredMixin, View):
                     obj.log_action('eventyay.voucher.deleted', user=self.request.user)
                     OrderPosition.objects.filter(addon_to__voucher=obj).delete()
                     obj.cartposition_set.all().delete()
+                    obj._clear_canceled_order_positions()
                     obj.delete()
                 else:
                     obj.log_action(


### PR DESCRIPTION

https://github.com/user-attachments/assets/88bbd328-0eac-4a47-b0d0-9ba38db1af0c

Vouchers referenced exclusively by canceled orders were incorrectly
blocked from deletion. The old check (redeemed == 0 and no order
positions) did not account for the fact that order cancellation
decrements the redeemed counter but leaves OrderPosition rows in place.

New logic: a voucher is deletable unless at least one non-canceled
OrderPosition (active/pending/paid) references it. 

