### PR TITLE
Fix ticket code button to show PDF-matching QR code

### DIFF
--- a/app/eventyay/base/models/orders.py
+++ b/app/eventyay/base/models/orders.py
@@ -2223,6 +2223,15 @@ class OrderPosition(AbstractPosition):
             self.event.settings.ticket_download_nonadm or self.product.admission
         )
 
+    @property
+    def ticket_qrcode_content(self):
+        """Return the JSON-encoded QR code content matching the ticket PDF barcode."""
+        return json.dumps({
+            'event': str(self.order.event),
+            'ticket': self.secret,
+            'lead': self.pseudonymization_id,
+        })
+
     @classmethod
     def transform_cart_positions(cls, cp: List, order) -> list:
         from . import Voucher

--- a/app/eventyay/control/templates/pretixcontrol/order/index.html
+++ b/app/eventyay/control/templates/pretixcontrol/order/index.html
@@ -367,7 +367,7 @@
                                                 </form>
                                             {% endfor %}
                                         {% endif %}
-                                        <button type="submit" data-toggle="qrcode" data-qrcode="{{ line.secret }}"
+                                        <button type="submit" data-toggle="qrcode" data-qrcode="{{ line.ticket_qrcode_content }}"
                                                 class="btn btn-xs btn-default">
                                             <span class="fa fa-qrcode"></span> {% trans "Ticket code" %}
                                         </button>


### PR DESCRIPTION
The Ticket code button was showing a QR code of just the raw position secret, while the actual ticket PDF QR code encodes a JSON object {event, ticket, lead}. Add a ticket_qrcode_content property to OrderPosition and use it in the order detail template.

<img width="5088" height="3352" alt="image" src="https://github.com/user-attachments/assets/954c306f-687f-4167-8f1a-56e6b19daec7" />

## Summary by Sourcery

Align ticket QR code content in the order detail view with the JSON payload used in generated ticket PDFs.

New Features:
- Expose a ticket_qrcode_content property on order positions providing the JSON-encoded data for ticket QR codes.

Bug Fixes:
- Update the order detail 'Ticket code' button to use the same JSON-based QR code content as the ticket PDF instead of the raw position secret.