### PR TITLE
Fix review helper text showing raw JSON instead of readable content

### DIFF
--- a/app/eventyay/base/settings.py
+++ b/app/eventyay/base/settings.py
@@ -40,6 +40,7 @@ for k, v in DEFAULTS.items():
 # Eventyay Video (integrated)
 settings_hierarkey.add_default('venueless_start', None, RelativeDateWrapper)
 settings_hierarkey.add_default('venueless_text', None, LazyI18nString)
+settings_hierarkey.add_default('review_help_text', None, LazyI18nString)
 settings_hierarkey.add_default('venueless_allow_pending', 'False', bool)
 settings_hierarkey.add_default('venueless_all_products', 'True', bool)
 settings_hierarkey.add_default('venueless_products', '[]', list)

--- a/app/eventyay/common/utils/language.py
+++ b/app/eventyay/common/utils/language.py
@@ -1,3 +1,4 @@
+import json
 from contextlib import suppress
 from contextvars import ContextVar
 
@@ -75,6 +76,13 @@ def get_current_event_language() -> str | None:
 def localize_event_text(value):
     if value is None:
         return value
+    if isinstance(value, dict):
+        value = LazyI18nString(value)
+    elif isinstance(value, str):
+        with suppress(ValueError, TypeError):
+            parsed = json.loads(value)
+            if isinstance(parsed, dict):
+                value = LazyI18nString(parsed)
     event_lang = get_current_event_language()
     ui_lang = translation.get_language() or settings.LANGUAGE_CODE
     default_lang = settings.LANGUAGE_CODE

--- a/app/eventyay/orga/templates/orga/submission/review.html
+++ b/app/eventyay/orga/templates/orga/submission/review.html
@@ -3,6 +3,7 @@
 {% load compress %}
 {% load staff_session %}
 {% load i18n %}
+{% load presale_locale %}
 {% load rich_text %}
 {% load rules %}
 {% load static %}
@@ -34,7 +35,7 @@
             {% if request.event.settings.review_help_text %}
                 <div class="alert alert-info">
                     <div>
-                        <p>{{ request.event.settings.review_help_text|rich_text }}</p>
+                        <p>{{ request.event.settings.review_help_text|event_localize|rich_text }}</p>
                     </div>
                 </div>
             {% elif not form.instance.pk and not can_view_other_reviews and request.event.active_review_phase and request.event.active_review_phase.can_see_other_reviews == "after_review" %}


### PR DESCRIPTION
## Summary
- Fixes #4070: review helper text on the submission Reviews tab was rendered as a raw JSON object instead of localized, readable markdown.
- Registers `review_help_text` as `LazyI18nString` on event `settings_hierarkey` so stored values deserialize correctly.
- Hardens `localize_event_text` to handle dict/JSON string values as a fallback.
- Applies `event_localize` before `rich_text` in the review submission template.

## Before

<img width="1920" height="1080" alt="Before" src="https://github.com/user-attachments/assets/33e84178-bfb9-4538-8fa6-65500ece7a8e" />

## After

https://github.com/user-attachments/assets/068a6154-3138-4d82-bcc9-d98fee35c5ca

## Test plan
- [ ] As organizer/reviewer, go to **Settings → Review → General** and set **Help text for reviewers** (optionally in multiple languages).
- [ ] Open any submission → **Reviews** tab.
- [ ] Confirm the blue info box shows readable helper text in the active language, not raw JSON like `{"en":"...", "de":"..."}`.
- [ ] Switch UI/event language and confirm the correct translation is shown when available.