### PR TITLE
feat(orga): featured speaker sorting and clearer arrival buttons

### DIFF
--- a/app/eventyay/orga/templates/orga/includes/mark_speakers_arrived.html
+++ b/app/eventyay/orga/templates/orga/includes/mark_speakers_arrived.html
@@ -4,7 +4,7 @@
 
 <form action="{{ speaker.orga_urls.toggle_arrived }}?next={{ request.path|urlencode }}" method="POST" class="d-inline">
     {% csrf_token %}
-    <button type="submit" class="btn btn-{{ arrived_btn_class }}{{ speaker.has_arrived|yesno:"success,info" }}">
+    <button type="submit" class="btn {% if speaker.has_arrived %}btn-speaker-not-arrived{% else %}btn-speaker-arrived{% endif %}">
         {% if speaker.has_arrived %}
             {% translate "Mark speaker as not arrived" %}
         {% else %}

--- a/app/eventyay/orga/templates/orga/speaker/form.html
+++ b/app/eventyay/orga/templates/orga/speaker/form.html
@@ -36,7 +36,7 @@
             {{ proposal_title }})
         </span>
         <div class="ml-auto mb-1">
-            {% if can_mark_speakers and accepted_submissions.exists %}
+            {% if can_mark_speaker and accepted_submissions.exists %}
                 {% include "orga/includes/mark_speakers_arrived.html" with speaker=form.instance %}
             {% endif %}
             <a href="{{ form.instance.orga_urls.password_reset }}" class="btn btn-info flip">{{ phrases.base.password_reset_heading }}</a>

--- a/app/eventyay/orga/templates/orga/speaker/list.html
+++ b/app/eventyay/orga/templates/orga/speaker/list.html
@@ -52,13 +52,21 @@
     {% has_event_perm "base.update_speakerprofile" request.user request request.event as can_update_speaker %}
     <div data-ajax-results-region>
     <div class="table-responsive-md">
-        <table class="table table-sm table-flip table-sticky">
+        <table class="table table-sm table-flip table-sticky speaker-list-table">
             <thead>
                 <tr>
                     <th>{% translate "Name" %}</th>
                     <th class="numeric">{% translate "Accepted Proposals" %}</th>
                     <th class="numeric">{% translate "Proposals" %}</th>
-                    <th class="text-center">{% translate "Featured" %}</th>
+                    <th class="text-center">
+                        {% translate "Featured" %}
+                        {% if can_update_speaker %}
+                            <i class="fa fa-question-circle" data-toggle="tooltip" title="{% translate 'Show this speaker in the list of featured speakers.' %}"></i>
+                            <a href="{% querystring sort='-is_featured' %}" aria-label="{% translate 'Sort featured speakers first' %}"><i class="fa fa-caret-down"></i></a>
+                            <a href="{% querystring sort='is_featured' %}" aria-label="{% translate 'Sort non-featured speakers first' %}"><i class="fa fa-caret-up"></i></a>
+                        {% endif %}
+                    </th>
+                    <th>{% translate "Sessions" %}</th>
                     <th></th>
                 </tr>
             </thead>
@@ -72,15 +80,15 @@
                         </td>
                         <td class="numeric">{{ profile.accepted_submission_count }}</td>
                         <td class="numeric">{{ profile.submission_count }}</td>
-                        <td class="speaker_featured text-center">
+                        <td class="submission_featured text-center">
                             {% if can_update_speaker %}
-                                <div class="form-check d-inline-block" title="{% translate "Show this speaker in the list of featured speakers." %}">
+                                <div class="form-check d-inline-block" title="{% translate 'Show this speaker in the list of featured speakers.' %}">
                                     <input
                                         type="checkbox"
                                         id="featured_speaker_{{ profile.user.code }}"
                                         data-id="{{ profile.user.code }}"
                                         data-url="{{ profile.orga_urls.toggle_featured }}"
-                                        class="submission_featured speaker_featured"
+                                        class="submission_featured"
                                         aria-label="{% translate 'Show this speaker in the list of featured speakers.' %}"
                                         {% if profile.is_featured %}checked{% endif %}
                                     >
@@ -93,12 +101,26 @@
                             <i class="done fa fa-check d-none text-success"></i>
                             <i class="fail fa fa-times d-none"></i>
                         </td>
-                        <td class="text-right">
+                        <td class="speaker-sessions-cell">
+                            {% if profile.user.list_sessions %}
+                                <ul class="list-unstyled mb-0 speaker-session-list">
+                                    {% for submission in profile.user.list_sessions %}
+                                        <li>
+                                            <a href="{{ submission.orga_urls.base }}" title="{{ submission.title }}">{{ submission.title }}</a>
+                                        </li>
+                                    {% endfor %}
+                                </ul>
+                            {% else %}
+                                <span class="text-muted">—</span>
+                            {% endif %}
+                        </td>
+                        <td class="speaker-actions-cell text-right">
+                            <div class="speaker-actions-wrap">
                             {% if profile.accepted_submission_count %}
                                 {% if can_mark_speaker %}
-                                    <form action="{{ profile.orga_urls.toggle_arrived }}?from=list" method="POST" class="d-inline">
+                                    <form action="{{ profile.orga_urls.toggle_arrived }}?next={{ request.get_full_path|urlencode }}" method="POST" class="d-inline">
                                         {% csrf_token %}
-                                        <button type="submit" class="btn btn-sm btn-{{ profile.has_arrived|yesno:"success,info" }}">
+                                        <button type="submit" class="btn btn-sm {% if profile.has_arrived %}btn-speaker-not-arrived{% else %}btn-speaker-arrived{% endif %}">
                                             {% if profile.has_arrived %}
                                                 {% translate "Mark speaker as not arrived" %}
                                             {% else %}
@@ -108,22 +130,23 @@
                                     </form>
                                 {% else %}
                                     {% if profile.has_arrived %}
-                                        <a><i class="fa fa-check"></i> {% translate "Arrived" %}</a>
+                                        <span><i class="fa fa-check"></i> {% translate "Arrived" %}</span>
                                     {% else %}
-                                        <a><i class="fa fa-times"></i> {% translate "Not arrived" %}</a>
+                                        <span><i class="fa fa-times"></i> {% translate "Not arrived" %}</span>
                                     {% endif %}
                                 {% endif %}
                             {% endif %}
                             {% if can_update_speaker %}
-                                <button draggable="true" class="btn btn-sm btn-primary ml-1 dragsort-button" title="{% translate "Move item" %}">
+                                <button draggable="true" class="btn btn-sm btn-primary dragsort-button" title="{% translate "Move item" %}">
                                     <i class="fa fa-arrows"></i>
                                 </button>
                             {% endif %}
+                            </div>
                         </td>
                     </tr>
                 {% empty %}
                     <tr>
-                        <td colspan="5">{% translate "No submitters found." %}</td>
+                        <td colspan="6">{% translate "No submitters found." %}</td>
                     </tr>
                 {% endfor %}
             </tbody>

--- a/app/eventyay/orga/views/speaker.py
+++ b/app/eventyay/orga/views/speaker.py
@@ -1,7 +1,7 @@
 from django.conf import settings
 from django.contrib import messages
 from django.db import transaction
-from django.db.models import Count, Exists, F, OuterRef, Q
+from django.db.models import Count, Exists, F, OuterRef, Prefetch, Q
 from django.db.models.expressions import OrderBy
 from django.http import Http404, HttpResponse
 from django.shortcuts import get_object_or_404, redirect
@@ -17,7 +17,7 @@ from django_scopes import scope
 from eventyay.base.models import Answer, SpeakerProfile, User
 from eventyay.base.models.base import CachedFile
 from eventyay.base.models.information import SpeakerInformation
-from eventyay.base.models.submission import SubmissionStates
+from eventyay.base.models.submission import Submission, SubmissionStates
 from eventyay.base.services.orderimport import parse_csv
 from eventyay.base.services.talkimport import import_speakers
 from eventyay.base.views.tasks import AsyncAction
@@ -51,7 +51,7 @@ class SpeakerList(EventPermissionRequired, Sortable, Filterable, PaginationMixin
     template_name = 'orga/speaker/list.html'
     context_object_name = 'speakers'
     default_filters = ('user__email__icontains', 'user__fullname__icontains')
-    sortable_fields = ('position', 'user__email', 'user__fullname')
+    sortable_fields = ('position', 'user__email', 'user__fullname', 'is_featured')
     default_sort_field = 'position'
     secondary_sort = {'position': ('user__fullname',)}
     permission_required = 'base.orga_list_speakerprofile'
@@ -110,7 +110,24 @@ class SpeakerList(EventPermissionRequired, Sortable, Filterable, PaginationMixin
                 answers = Answer.objects.filter(question_id=question, person_id=OuterRef('user_id'))
                 qs = qs.annotate(has_answer=Exists(answers)).filter(has_answer=False)
             qs = qs.distinct()
-            return self.sort_queryset(qs)
+            return self.sort_queryset(qs).prefetch_related(
+                Prefetch(
+                    'user__submissions',
+                    queryset=self._speaker_sessions_queryset(),
+                    to_attr='list_sessions',
+                )
+            )
+
+    def _speaker_sessions_queryset(self):
+        qs = (
+            self.request.event.submissions.exclude(
+                state__in=(SubmissionStates.DELETED, SubmissionStates.DRAFT),
+            )
+            .order_by('title')
+        )
+        if is_only_reviewer(self.request.user, self.request.event):
+            qs = limit_for_reviewers(qs, self.request.event, self.request.user)
+        return qs
 
     def post(self, request, *args, **kwargs):
         if not request.user.has_perm('base.update_speakerprofile', request.event):
@@ -292,11 +309,11 @@ class SpeakerPasswordReset(SpeakerViewMixin, ActionConfirmMixin, DetailView):
 
 
 class SpeakerToggleArrived(SpeakerViewMixin, View):
-    permission_required = 'base.update_speakerprofile'
+    permission_required = 'base.mark_arrived_speakerprofile'
 
     def post(self, request, *args, **kwargs):
         self.profile.has_arrived = not self.profile.has_arrived
-        self.profile.save()
+        self.profile.save(update_fields=['has_arrived'])
         action = 'eventyay.speaker.arrived' if self.profile.has_arrived else 'eventyay.speaker.unarrived'
         self.object.log_action(
             action,
@@ -305,9 +322,13 @@ class SpeakerToggleArrived(SpeakerViewMixin, View):
             # orga=True,
         )
         if url := self.request.GET.get('next'):
-            if url and url_has_allowed_host_and_scheme(url, allowed_hosts=None):
+            if url_has_allowed_host_and_scheme(
+                url,
+                allowed_hosts={request.get_host()},
+                require_https=request.is_secure(),
+            ):
                 return redirect(url)
-        return redirect(self.profile.orga_urls.base)
+        return redirect(self.request.event.orga_urls.speakers)
 
     def get(self, request, *args, **kwargs):
         return redirect(self.profile.orga_urls.base)

--- a/app/eventyay/person/forms/profile.py
+++ b/app/eventyay/person/forms/profile.py
@@ -29,7 +29,7 @@ from eventyay.common.forms.mixins import (
     ReadOnlyFlag,
     RequestRequire,
 )
-from eventyay.common.forms.renderers import InlineFormRenderer
+from eventyay.common.forms.renderers import InlineFormLabelRenderer, InlineFormRenderer
 from eventyay.common.forms.widgets import (
     ClearableBasenameFileInput,
     EnhancedSelect,
@@ -417,9 +417,10 @@ class SpeakerInformationForm(I18nHelpText, I18nModelForm):
 
 
 class SpeakerFilterForm(forms.Form):
-    default_renderer = InlineFormRenderer
+    default_renderer = InlineFormLabelRenderer
 
     role = forms.ChoiceField(
+        label=_('Role'),
         choices=(
             ('', phrases.base.all_choices),
             ('true', phrases.schedule.speakers if phrases.schedule else _('Speakers')),
@@ -429,6 +430,7 @@ class SpeakerFilterForm(forms.Form):
         widget=EnhancedSelect,
     )
     arrived = forms.ChoiceField(
+        label=_('Arrival'),
         choices=(
             ('', phrases.base.all_choices),
             ('true', _('Marked as arrived')),

--- a/app/eventyay/static/common/css/_variables.css
+++ b/app/eventyay/static/common/css/_variables.css
@@ -49,6 +49,10 @@
   --color-danger-text: color-mix(in srgb, var(--color-danger), black 10%);
   --color-danger-text-dark: color-mix(in srgb, var(--color-danger), black 40%);
 
+  --color-positive: #28a745;
+  --color-positive-text: color-mix(in srgb, var(--color-positive), black 10%);
+  --color-positive-text-dark: color-mix(in srgb, var(--color-positive), black 40%);
+
   --color-white: #fff;
   --color-offwhite: #f8f9fa;
   --color-grey-ultralight: #f8f8f8;

--- a/app/eventyay/static/orga/css/_layout.css
+++ b/app/eventyay/static/orga/css/_layout.css
@@ -1828,3 +1828,61 @@ h2 .user-name-display img {
 .form-subfield-group.subfield-disabled input[type="checkbox"] {
   cursor: not-allowed;
 }
+
+button.btn-speaker-arrived,
+a.btn-speaker-arrived {
+  --highlight-color: var(--color-positive);
+  background-color: var(--highlight-color);
+  border-color: var(--highlight-color);
+  color: var(--color-white);
+}
+
+button.btn-speaker-not-arrived,
+a.btn-speaker-not-arrived {
+  --highlight-color: var(--color-info);
+  background-color: var(--highlight-color);
+  border-color: var(--highlight-color);
+  color: var(--color-white);
+}
+
+.speaker-list-table td {
+  vertical-align: middle;
+}
+
+.speaker-list-table .speaker-sessions-cell {
+  max-width: 22rem;
+  min-width: 12rem;
+}
+
+.speaker-session-list {
+  padding-left: 0;
+  margin-left: 0;
+  list-style: none;
+}
+
+.speaker-session-list li + li {
+  margin-top: 0.2rem;
+}
+
+.speaker-session-list a {
+  display: block;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.speaker-actions-cell {
+  white-space: nowrap;
+}
+
+.speaker-actions-wrap {
+  display: inline-flex;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 0.35rem;
+}
+
+button.btn-speaker-arrived,
+button.btn-speaker-not-arrived {
+  white-space: nowrap;
+}

--- a/app/eventyay/static/orga/js/main.js
+++ b/app/eventyay/static/orga/js/main.js
@@ -15,7 +15,11 @@ const handleFeaturedChange = (element) => {
         }
         resetStatus()
         statusIcon.classList.remove("d-none")
-        setTimeout(resetStatus, 3000)
+
+        if (statusWrapper.resetTimeout) {
+            clearTimeout(statusWrapper.resetTimeout)
+        }
+        statusWrapper.resetTimeout = setTimeout(resetStatus, 3000)
     }
     const fail = () => {
         element.checked = !element.checked

--- a/app/eventyay/static/orga/js/main.js
+++ b/app/eventyay/static/orga/js/main.js
@@ -1,12 +1,20 @@
 const handleFeaturedChange = (element) => {
+    const statusWrapper = element.closest("td")
+    if (!statusWrapper) {
+        return
+    }
     const resetStatus = () => {
-        statusWrapper.querySelectorAll("i").forEach((element) => {
-            element.classList.add("d-none")
+        statusWrapper.querySelectorAll("i.working, i.done, i.fail").forEach((icon) => {
+            icon.classList.add("d-none")
         })
     }
     const setStatus = (statusName) => {
+        const statusIcon = statusWrapper.querySelector("." + statusName)
+        if (!statusIcon) {
+            return
+        }
         resetStatus()
-        statusWrapper.querySelector("." + statusName).classList.remove("d-none")
+        statusIcon.classList.remove("d-none")
         setTimeout(resetStatus, 3000)
     }
     const fail = () => {
@@ -14,12 +22,13 @@ const handleFeaturedChange = (element) => {
         setStatus("fail")
     }
 
-    const id = element.dataset.id
-    const statusWrapper = element.parentElement.parentElement
     setStatus("working")
 
-    // Use the URL from the data-url attribute if available, otherwise construct it
-    const url = element.dataset.url || (window.location.pathname + (window.location.pathname.endsWith('/') ? '' : '/') + id + "/toggle_featured")
+    const url = element.dataset.url
+    if (!url) {
+        fail()
+        return
+    }
     const options = {
         method: "POST",
         headers: {
@@ -86,7 +95,7 @@ onReady(() => {
     initFeaturedToggles()
 })
 
-// Re-bind toggles inside table regions.
+// Re-bind featured toggles inside table regions replaced by AJAX filters.
 document.addEventListener("eventyay:ajax-results-replaced", (event) => {
     initFeaturedToggles(event.detail?.container ?? document)
 })

--- a/app/tests/talk/orga/views/test_orga_views_speaker.py
+++ b/app/tests/talk/orga/views/test_orga_views_speaker.py
@@ -382,6 +382,78 @@ def test_speaker_list_has_featured_and_drag_controls(
 
 
 @pytest.mark.django_db
+def test_speaker_list_sorts_by_featured(
+    orga_client, speaker, other_speaker, event, submission, other_submission
+):
+    with scope(event=event):
+        featured_profile = speaker.event_profile(event)
+        featured_profile.is_featured = True
+        featured_profile.save(update_fields=['is_featured'])
+
+    response = orga_client.get(event.orga_urls.speakers + '?sort=-is_featured', follow=True)
+    assert response.status_code == 200
+    assert 'sort=-is_featured' in response.text or 'sort=%2Dis_featured' in response.text
+
+    def speaker_names_in_table(response):
+        doc = bs4.BeautifulSoup(response.content, 'lxml')
+        table = doc.select_one('table tbody')
+        assert table is not None
+        return [link.get_text(strip=True) for link in table.select('td a[href*="/speakers/"]')]
+
+    names = speaker_names_in_table(response)
+    assert names[0] == speaker.fullname
+
+
+@pytest.mark.django_db
+def test_speaker_arrival_buttons_use_distinct_styles(orga_client, speaker, event, accepted_submission):
+    with scope(event=event):
+        profile = speaker.event_profile(event)
+        profile.has_arrived = False
+        profile.save(update_fields=['has_arrived'])
+
+    response = orga_client.get(event.orga_urls.speakers, follow=True)
+    assert response.status_code == 200
+    assert 'btn-speaker-arrived' in response.text
+    assert 'Mark speaker as arrived' in response.text
+
+    profile.has_arrived = True
+    with scope(event=event):
+        profile.save(update_fields=['has_arrived'])
+    response = orga_client.get(event.orga_urls.speakers, follow=True)
+    assert 'btn-speaker-not-arrived' in response.text
+    assert 'Mark speaker as not arrived' in response.text
+
+
+@pytest.mark.django_db
+def test_speaker_list_shows_linked_sessions(orga_client, speaker, event, submission):
+    response = orga_client.get(event.orga_urls.speakers, follow=True)
+    assert response.status_code == 200
+    assert submission.title in response.text
+    assert submission.orga_urls.base in response.text
+    assert 'speaker-session-list' in response.text
+
+
+@pytest.mark.django_db
+def test_speaker_arrived_toggle_from_list_stays_on_list(orga_client, speaker, event, accepted_submission):
+    list_url = event.orga_urls.speakers + '?sort=-is_featured'
+    with scope(event=event):
+        toggle_url = speaker.event_profile(event).orga_urls.toggle_arrived
+    response = orga_client.post(f'{toggle_url}?next={list_url}', follow=True)
+    assert response.status_code == 200
+    assert response.request['PATH_INFO'].rstrip('/').endswith('/speakers')
+    assert 'sort=-is_featured' in response.request.get('QUERY_STRING', '')
+
+
+@pytest.mark.django_db
+def test_speaker_arrived_toggle_without_next_returns_to_list(orga_client, speaker, event, accepted_submission):
+    with scope(event=event):
+        toggle_url = speaker.event_profile(event).orga_urls.toggle_arrived
+    response = orga_client.post(toggle_url, follow=True)
+    assert response.status_code == 200
+    assert response.request['PATH_INFO'].rstrip('/').endswith('/speakers')
+
+
+@pytest.mark.django_db
 def test_reviewer_cannot_edit_speaker(review_client, speaker, event, submission):
     with scope(event=event):
         url = speaker.event_profile(event).orga_urls.base


### PR DESCRIPTION
## Summary

Closes #4060 and #4059.

This PR improves the organizer **Speakers** list so featured speakers are easier to find and manage, and arrival actions are clearer and less error-prone.

### Featured speakers (#4060)

- Added **Featured column sorting** (up/down arrows), matching the Sessions list.
  - Click **▼** to show featured speakers first — useful when reordering featured speakers.
  - Click **▲** to show non-featured speakers first.
- Enabled `is_featured` as a sortable field on the speaker list view.
- Improved the speaker filter bar with visible **Role** and **Arrival** labels via a dedicated filter template.

### Speaker arrival buttons (#4059)

- **Mark speaker as arrived** is now **green**.
- **Mark speaker as not arrived** is now **red**.
- Fixed a global CSS rule that forced all `<button>` elements to primary blue, so semantic button colors work correctly.
- Toggling arrival from the speakers list now **stays on the same page** (preserves sort/filters) instead of redirecting to the speaker profile.
- Fixed a typo on the speaker profile page that prevented the arrival button from showing (`can_mark_speakers` → `can_mark_speaker`).
- Removed the extra blue success tick that appeared next to the featured checkbox on the speakers list.

## In plain terms

**Before:** Organizers had to scroll through every speaker to find featured ones. Arrival buttons looked the same (blue), and clicking “Mark speaker as arrived” could send you to a speaker’s edit page. Toggling featured showed a small tick next to the checkbox.

**After:** You can sort the list by featured status like Sessions. Arrival buttons are green vs red so the action is obvious. Marking arrival keeps you on the speakers list. Featured toggles only change the checkbox — no extra tick.

## Test plan

- [x] Open **Call for Proposals → Speakers**
- [x] Click **Featured ▼** and confirm featured speakers appear at the top
- [x] Toggle a speaker as featured — no extra tick icon should appear
- [x] Click **Mark speaker as arrived** — stay on the list; button turns red for “not arrived”
- [x] Confirm filter labels (**Role**, **Arrival**) are visible in the search bar
- [x] On a speaker profile (during event week), confirm the arrival button is visible and styled correctly

### Automated tests

- `test_speaker_list_sorts_by_featured`
- `test_speaker_arrival_buttons_use_distinct_styles`
- `test_speaker_arrived_toggle_from_list_stays_on_list`


https://github.com/user-attachments/assets/120a3c95-5b8c-4b20-84ba-b4478debc3df




