### PR TITLE
fix: replace bare except clauses with Exception in helpers

### DIFF
--- a/app/eventyay/helpers/periodic.py
+++ b/app/eventyay/helpers/periodic.py
@@ -43,20 +43,20 @@ def minimum_interval(minutes_after_success, minutes_after_error=0, minutes_runni
             except Exception as e:
                 try:
                     cache.set(key_result, 'error', timeout=minutes_after_error * 60)
-                except:
+                except Exception:
                     logger.exception('Could not store result')
                 raise e
             else:
                 try:
                     cache.set(key_result, 'success', timeout=minutes_after_success * 60)
-                except:
+                except Exception:
                     logger.exception('Could not store result')
                 return retval
             finally:
                 try:
                     if cache.get(key_running) == uniqid:
                         cache.delete(key_running)
-                except:
+                except Exception:
                     logger.exception('Could not release lock')
 
         return wrapper

--- a/app/eventyay/helpers/templatetags/thumb.py
+++ b/app/eventyay/helpers/templatetags/thumb.py
@@ -16,6 +16,6 @@ def thumb(source, arg):
         source = source.name
     try:
         return get_thumbnail(source, arg).thumb.url
-    except:
+    except Exception:
         logger.exception('Failed to create thumbnail')
         return default_storage.url(source)


### PR DESCRIPTION
## What

Replace 4 bare `except:` clauses with `except Exception:` across two files in the helpers module.

## Why

A bare `except:` catches all `BaseException` subclasses including `KeyboardInterrupt` and `SystemExit`. This can silently interfere
with process shutdown and hide real errors from developers.

## Files changed

- `helpers/templatetags/thumb.py` — thumbnail generation fallback
- `helpers/periodic.py` — cache set/delete in periodic task scheduler (3 places)

## Note

`except Exception:` is used here (rather than a more specific type) because these blocks already log the exception and continue — they are intentional catch-all fallbacks, but should not catch system-level signals like KeyboardInterrupt.

## Summary by Sourcery

Bug Fixes:
- Limit previously bare exception handlers in thumbnail generation and periodic task caching helpers to catch only standard exceptions, preventing unintended interception of system-exiting signals.