### PR TITLE
fix(i18n): restore Tamil format placeholders from Weblate PR #4064

### DIFF
--- a/app/eventyay/locale/ta/LC_MESSAGES/django.po
+++ b/app/eventyay/locale/ta/LC_MESSAGES/django.po
@@ -212,7 +212,7 @@ msgstr "காலநீளம்"
 #: agenda/templates/agenda/talk_review.html:24
 #, python-format
 msgid "%(minutes)s min"
-msgstr "%(நிமிடங்கள்) மணித்துளி"
+msgstr "%(minutes)s நிமி"
 
 #: agenda/templates/agenda/talk_review.html:31 base/models/access_code.py:30
 #: base/models/submission.py:193
@@ -25204,14 +25204,14 @@ msgstr "குழுவை உருவாக்கு"
 msgid "%(count)s member"
 msgid_plural "%(count)s members"
 msgstr[0] "%(count)s உறுப்பினர்"
-msgstr[1] "%(எண்ணிக்கை) உறுப்பினர்கள்"
+msgstr[1] "%(count)s உறுப்பினர்கள்"
 
 #: eventyay_common/templates/eventyay_common/organizers/edit.html:65
 #, python-format
 msgid "%(count)s event"
 msgid_plural "%(count)s events"
 msgstr[0] "%(count)s நிகழ்வு"
-msgstr[1] "%(எண்ணிக்கை) நிகழ்வுகள்"
+msgstr[1] "%(count)s நிகழ்வுகள்"
 
 #: eventyay_common/templates/eventyay_common/organizers/edit.html:78
 #, python-format


### PR DESCRIPTION
## Summary

Fixes three Tamil (`ta`) translation entries introduced in #4064 where Weblate translated Python format placeholder names into Tamil text. That breaks `msgfmt --check-format`, prevents `compilemessages` from succeeding for Tamil, and causes `KeyError` at runtime when those strings are interpolated.

## Changes

- `"%(minutes)s min"`: restore placeholder `%(minutes)s` (was `%(நிமிடங்கள்)`)
- `"%(count)s members"` plural: restore `%(count)s` in `msgstr[1]` (was `%(எண்ணிக்கை)`)
- `"%(count)s events"` plural: restore `%(count)s` in `msgstr[1]` (was `%(எண்ணிக்கை)`)

## Test plan

- [x] `msgfmt --check-format app/eventyay/locale/ta/LC_MESSAGES/django.po -o /dev/null`
- [x] `cd app && uv run manage.py compilemessages -l ta`