### PR TITLE
fix(video): keep avatar dialog actions visible within the viewport

### DIFF
--- a/app/eventyay/webapp/video/src/components/Prompt.vue
+++ b/app/eventyay/webapp/video/src/components/Prompt.vue
@@ -55,17 +55,28 @@ export default {
 	background-color: $clr-secondary-text-light
 	display: flex
 	justify-content: center
-	align-items: center
+	align-items: safe center
+	overflow-y: auto
+	padding: 16px 0
+	box-sizing: border-box
 	.prompt-wrapper
 		card()
 		display: flex
 		flex-direction: column
 		width: 480px
-		max-height: 80vh
+		max-height: calc(var(--vh100) - 32px)
+		min-height: 0
+		flex-shrink: 1
 		position: relative
 		+below('m')
 			width: 100vw
-			max-height: 95vh
+			max-height: calc(var(--vh100) - 32px)
+		> .content
+			display: flex
+			flex-direction: column
+			flex: 1 1 auto
+			min-height: 0
+			overflow: hidden
 		#btn-close
 			icon-button-style(style: clear)
 			position: absolute

--- a/app/eventyay/webapp/video/src/components/profile/ChangeAvatar.vue
+++ b/app/eventyay/webapp/video/src/components/profile/ChangeAvatar.vue
@@ -217,6 +217,10 @@ defineExpose({ update })
 .c-change-avatar
 	display: flex
 	flex-direction: column
+	flex: 1 1 auto
+	min-height: 0
+	overflow-y: auto
+	align-items: center
 	.upload-info
 		font-size: 12px
 		color: rgba(0, 0, 0, 0.6)
@@ -226,7 +230,6 @@ defineExpose({ update })
 		border-left: 3px solid var(--clr-primary, #2185d0)
 		border-radius: 2px
 		line-height: 1.5
-	align-items: center
 	.c-identicon
 		cursor: pointer
 		height: 128px
@@ -243,16 +246,11 @@ defineExpose({ update })
 	.btn-upload .bunt-button
 		themed-button-primary()
 	.image-wrapper
-		flex: auto
+		flex: 0 0 auto
 		display: flex
 		flex-direction: column
 		align-items: center
 		justify-content: center
-		height: calc(80vh - 230px) // HACK approx. shrinking to avoid top down constraints
-		max-height: 320px
-		min-height: 160px
-		+below('m')
-			height: calc(95vh - 230px)
 	.file-error
 		width: 320px
 		height: 320px
@@ -261,10 +259,17 @@ defineExpose({ update })
 		color: $clr-danger
 		align-items: center
 		justify-content: center
+		+below('m')
+			width: 280px
+			height: 280px
 		.mdi
 			font-size: 64px
 	.cropper
 		width: 320px
 		height: 320px
+		flex-shrink: 0
 		background-color: $clr-grey-900
+		+below('m')
+			width: 280px
+			height: 280px
 </style>

--- a/app/eventyay/webapp/video/src/components/profile/GreetingPrompt.vue
+++ b/app/eventyay/webapp/video/src/components/profile/GreetingPrompt.vue
@@ -178,6 +178,7 @@ export default {
 		align-items: center
 		position: relative
 		padding: 16px
+		min-height: 0
 		h1
 			margin: 8px 0
 			text-align: center
@@ -189,6 +190,10 @@ export default {
 			display: flex
 			flex-direction: column
 			align-items: center
+			flex: 1 1 auto
+			min-height: 0
+			overflow-y: auto
+			width: 100%
 		.step-connect-social
 			margin-bottom: 16px
 			.social-connection
@@ -224,6 +229,7 @@ export default {
 			align-self: stretch
 			display: flex
 			justify-content: flex-end
+			flex-shrink: 0
 		#btn-back
 			themed-button-secondary()
 			margin-right: 8px

--- a/app/eventyay/webapp/video/src/views/admin/user.vue
+++ b/app/eventyay/webapp/video/src/views/admin/user.vue
@@ -158,11 +158,13 @@ export default {
 			display: flex
 			flex-direction: column
 			padding: 48px 32px 32px
+			min-height: 0
 		.actions
 			margin-top: 32px
 			align-self: stretch
 			display: flex
 			justify-content: flex-end
+			flex-shrink: 0
 		#btn-cancel
 			themed-button-secondary()
 			margin-right: 8px

--- a/app/eventyay/webapp/video/src/views/preferences/index.vue
+++ b/app/eventyay/webapp/video/src/views/preferences/index.vue
@@ -160,11 +160,13 @@ export default {
 			display: flex
 			flex-direction: column
 			padding: 48px 32px 32px
+			min-height: 0
 		.actions
 			margin-top: 32px
 			align-self: stretch
 			display: flex
 			justify-content: flex-end
+			flex-shrink: 0
 		#btn-cancel
 			themed-button-secondary()
 			margin-right: 8px


### PR DESCRIPTION
## Summary

Fixes #3894

During first-login profile setup and the video-area Change Avatar dialog, the modal could grow taller than the viewport and cut off Save/Cancel at the bottom—especially after uploading or randomizing an avatar when the cropper appears.

This constrains prompt modals to the viewport and keeps action buttons pinned while allowing step content to scroll when needed.

## Changes

- **`Prompt.vue`**: Cap modal height to the viewport, use safe vertical centering, and allow the overlay to scroll when content is tall.
- **`GreetingPrompt.vue`**: Make onboarding step content scrollable while keeping Back/Continue/Finish buttons visible.
- **`ChangeAvatar.vue`**: Remove viewport-based height hack; keep a fixed 320×320 cropper (280×280 on mobile) so the cropper renders correctly.
- **`preferences/index.vue`** and **`admin/user.vue`**: Pin Save/Cancel in the Change Avatar prompt.

## Test plan

- [ ] Create a new account and reach the "Choose your look" onboarding step
- [ ] Click **Randomize** or **Upload** an image — confirm Save/Cancel (or Continue/Back) stay visible without clipping
- [ ] Open **Change Avatar** from video preferences on a shorter viewport — confirm cropper looks correct and buttons remain reachable
- [ ] Verify existing prompts (e.g. room edit) still display and scroll correctly