### PR TITLE
fix: display pending email count in ticket outbox sidebar

### DIFF
--- a/app/eventyay/plugins/sendmail/signals.py
+++ b/app/eventyay/plugins/sendmail/signals.py
@@ -11,9 +11,18 @@ def control_nav_import(sender, request=None, **kwargs):
     url = resolve(request.path_info)
     if not request.user.has_event_permission(request.organizer, request.event, 'can_change_orders', request=request):
         return []
+    from eventyay.plugins.sendmail.models import EmailQueue
+    pending_mails = EmailQueue.objects.filter(event=request.event, sent_at__isnull=True).count()
+    
+    if pending_mails > 0:
+        from django.utils.html import format_html
+        label = format_html('{} <span class="badge" style="background-color: #f0ad4e; margin-left: 5px;">{}</span>', _('Message center'), pending_mails)
+    else:
+        label = _('Message center')
+
     return [
         {
-            'label': _('Message center'),
+            'label': label,
             'url': reverse(
                 'plugins:sendmail:outbox',
                 kwargs={

--- a/app/eventyay/plugins/sendmail/signals.py
+++ b/app/eventyay/plugins/sendmail/signals.py
@@ -1,9 +1,11 @@
 from django.dispatch import receiver
 from django.urls import resolve, reverse
+from django.utils.html import format_html
 from django.utils.translation import gettext_lazy as _
 
 from eventyay.base.signals import logentry_display
 from eventyay.control.signals import nav_event
+from eventyay.plugins.sendmail.models import EmailQueue
 
 
 @receiver(nav_event, dispatch_uid='sendmail_nav')
@@ -11,18 +13,15 @@ def control_nav_import(sender, request=None, **kwargs):
     url = resolve(request.path_info)
     if not request.user.has_event_permission(request.organizer, request.event, 'can_change_orders', request=request):
         return []
-    from eventyay.plugins.sendmail.models import EmailQueue
     pending_mails = EmailQueue.objects.filter(event=request.event, sent_at__isnull=True).count()
-    
-    if pending_mails > 0:
-        from django.utils.html import format_html
-        label = format_html('{} <span class="badge" style="background-color: #f0ad4e; margin-left: 5px;">{}</span>', _('Message center'), pending_mails)
-    else:
-        label = _('Message center')
 
     return [
         {
-            'label': label,
+            'label': format_html(
+                '{} <span class="badge badge-warning">{}</span>',
+                _('Message center'),
+                pending_mails,
+            ) if pending_mails > 0 else _('Message center'),
             'url': reverse(
                 'plugins:sendmail:outbox',
                 kwargs={


### PR DESCRIPTION
Close : #4073

Added logic to accurately calculate and display the number of pending emails for the Ticket Outbox in the sidebar by querying the EmailQueue model instead of QueuedMails.

<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/1521cb98-f784-4d43-bbba-10672b768414" />


## Summary by Sourcery

Bug Fixes:
- Correct the pending email count in the Ticket Outbox sidebar by querying the EmailQueue model instead of QueuedMails.