### PR TITLE
Revert "chore(teamshifts): update to latest main"

### DIFF
--- a/app/uv.lock
+++ b/app/uv.lock
@@ -1199,7 +1199,7 @@ dependencies = [
 [[package]]
 name = "eventyay-teamshifts"
 version = "0.1.0"
-source = { git = "https://github.com/fossasia/eventyay-teamshifts.git?rev=main#195fa557f37cf67ba12d572bce42da83ba0fa8a6" }
+source = { git = "https://github.com/fossasia/eventyay-teamshifts.git?rev=main#fc1baff07687d03d08baf36fd51775eb02dc5a21" }
 
 [[package]]
 name = "eventyay-unified"


### PR DESCRIPTION
Reverts fossasia/eventyay#3908

## Summary by Sourcery

Enhancements:
- Restore the prior uv.lock dependency snapshot by reverting the latest main-based update.