### PR TITLE
Update uv.lock for exhibition commit sha

### DIFF
--- a/app/uv.lock
+++ b/app/uv.lock
@@ -1684,7 +1684,7 @@ wheels = [
 [[package]]
 name = "exhibition"
 version = "1.0.0"
-source = { git = "https://github.com/fossasia/eventyay-exhibition.git?rev=main#a46d7c2949513df6a8754b6381ae8617fc77236d" }
+source = { git = "https://github.com/fossasia/eventyay-exhibition.git?rev=main#77b60a9986bf262d7906cd1fd5d8eb0168408440" }
 dependencies = [
     { name = "flake8" },
 ]


### PR DESCRIPTION
## Summary by Sourcery

Build:
- Regenerate uv.lock to align dependencies with the updated exhibition commit.