### PR TITLE
Fix video frame offline error message overflow

### DIFF
--- a/app/eventyay/webapp/video/src/components/JanusCall.vue
+++ b/app/eventyay/webapp/video/src/components/JanusCall.vue
@@ -66,6 +66,7 @@ export default {
 	display: flex
 	flex-direction: column
 	position: relative
+	overflow: hidden
 
 	&.size-tiny
 		height: 48px

--- a/app/eventyay/webapp/video/src/components/Livestream.vue
+++ b/app/eventyay/webapp/video/src/components/Livestream.vue
@@ -723,6 +723,7 @@ export default {
 		justify-content: center
 		align-items: center
 		background-color: $clr-blue-grey-200
+		overflow: hidden
 		.offline-message
 			font-size: 36px
 		.offline-image

--- a/app/eventyay/webapp/video/src/components/MediaSource.vue
+++ b/app/eventyay/webapp/video/src/components/MediaSource.vue
@@ -655,6 +655,7 @@ iframe.iframe-media-source
 	align-items: center
 	background-color: $clr-blue-grey-200
 	z-index: 1
+	overflow: hidden
 	// Fallbacks prevent the overlay from shrinking to its text when
 	// --mediasource-placeholder-* are not yet available.
 	&:not(.size-tiny):not(.background)


### PR DESCRIPTION
Fixes #4140 

Added ``overflow: hidden`` to the main flex containers responsible for rendering the offline/error messages across video components:
 ``.c-januscall in JanusCall.vue``
  ``.iframe-error in MediaSource.vue``
  ``.offline in Livestream.vue``
This cleanly ensures that any long error text is neatly contained and clipped within the video frame at all widths, preventing it from breaking the UI layout.


<img width="409" height="379" alt="Screenshot From 2026-06-29 16-52-43" src="https://github.com/user-attachments/assets/7090ef1d-272a-4e07-9863-dd3ca991fba6" />

