### PR TITLE
fix: voucher bulk delete button visibility 

### DIFF
--- a/app/eventyay/static/pretixcontrol/js/ui/main.js
+++ b/app/eventyay/static/pretixcontrol/js/ui/main.js
@@ -1025,7 +1025,7 @@ $(function () {
     // Only run this behavior on the voucher list (other pages also use .table-quotas + a delete button).
     if ($vouchersCheckboxes.length) {
         var updateVouchersDeleteBtn = function () {
-            $vouchersDeleteBtn.toggle($vouchersCheckboxes.filter(':checked').length > 0);
+            $vouchersDeleteBtn.toggleClass('hidden', $vouchersCheckboxes.filter(':checked').length === 0);
         };
 
         $vouchersForm.on('change', 'input[name="voucher"], input[data-toggle-table]', function () {


### PR DESCRIPTION
## Description
This PR fixes single line change missing from code that was merged which breaks the edge case of `delete button`  visibility when selecting a voucher.

### Before

https://github.com/user-attachments/assets/b138b1fb-f21f-4727-b2bc-21b3f8367723


### After

https://github.com/user-attachments/assets/19af304d-5152-4b3f-8cb6-877bb40b0763

## Summary by Sourcery

Bug Fixes:
- Ensure the voucher bulk delete button only becomes visible when at least one voucher is selected and remains hidden otherwise.