### PR TITLE
fix: pin exhibition deployment branches

### DIFF
--- a/.github/workflows/enext-docker-pr.yml
+++ b/.github/workflows/enext-docker-pr.yml
@@ -55,5 +55,6 @@ jobs:
           tags: eventyay-next:${{ github.sha }}
           build-args: |
             GITHUB_TOKEN=${{ secrets.EVENTYAY_TOKEN }}
+            EVENTYAY_EXHIBITION_BRANCH=${{ github.base_ref }}
           cache-from: type=gha
           cache-to: type=gha,mode=max

--- a/.github/workflows/enext-docker.yml
+++ b/.github/workflows/enext-docker.yml
@@ -32,4 +32,6 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
-          build-args: GITHUB_TOKEN=${{ secrets.EVENTYAY_TOKEN }}
+          build-args: |
+            GITHUB_TOKEN=${{ secrets.EVENTYAY_TOKEN }}
+            EVENTYAY_EXHIBITION_BRANCH=${{ github.ref_name }}

--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -152,6 +152,35 @@ fi
 
 Change at least `SERVER_NAME` and the `CHANGEME` entries.
 
+## Branch based exhibition plugin deployment
+
+The `eventyay/eventyay-next` Docker images install `fossasia/eventyay-exhibition`
+from the same deployment branch as the Eventyay image:
+
+| Environment | Domain | Image tag | eventyay-exhibition branch |
+|---|---|---|---|
+| Development | `dev.eventyay.com` | `dev` | `dev` |
+| Production | `eventyay.com` | `main` | `main` |
+
+The Docker publish workflow passes the Git branch name to
+`EVENTYAY_EXHIBITION_BRANCH` while building the image. Pull requests against
+`dev` test the development branch, and pushes to `main` build the production
+image. The production deployment should keep `TAG=main`; development should
+keep `TAG=dev`.
+
+To verify a deployed container, inspect the baked branch value:
+
+```$USER@server
+docker compose exec web sh -c 'echo "$EVENTYAY_EXHIBITION_BRANCH"'
+```
+
+Rollback by changing `TAG` in `.env` to the last known good image tag, then run:
+
+```$USER@server
+docker compose pull
+docker compose up -d
+```
+
 ## Install the nginx entry
 
 ```root@server

--- a/app/Dockerfile
+++ b/app/Dockerfile
@@ -31,9 +31,15 @@ RUN apt-get update && apt-get install --no-install-recommends -y \
 # copy project files
 COPY . .
 
+ARG EVENTYAY_EXHIBITION_BRANCH=dev
+
 # install dependencies (using build tools)
 RUN --mount=type=cache,target=/root/.cache/uv \
     uv sync --all-extras --all-groups
+
+RUN case "$EVENTYAY_EXHIBITION_BRANCH" in dev|main) ;; *) echo "Unsupported eventyay-exhibition branch: $EVENTYAY_EXHIBITION_BRANCH" >&2; exit 1 ;; esac && \
+    uv pip install --python /usr/src/app/.venv/bin/python --force-reinstall \
+      "exhibition @ git+https://github.com/fossasia/eventyay-exhibition.git@${EVENTYAY_EXHIBITION_BRANCH}"
 
 # Run npm stuff (needs nodejs)
 RUN make npminstall
@@ -86,6 +92,8 @@ COPY --from=builder /bin/uv /bin/uv
 # Expose virtual env
 ENV VIRTUAL_ENV=/usr/src/app/.venv
 ENV PATH="/usr/src/app/.venv/bin:$PATH"
+ARG EVENTYAY_EXHIBITION_BRANCH=dev
+ENV EVENTYAY_EXHIBITION_BRANCH=${EVENTYAY_EXHIBITION_BRANCH}
 
 # Create .secrets to suppress warnings about missing directory
 RUN mkdir -p /usr/src/app/.secrets

--- a/app/Dockerfile.prod
+++ b/app/Dockerfile.prod
@@ -25,10 +25,15 @@ RUN apt-get update && \
 
 # install python dependencies
 # Ref: https://docs.astral.sh/uv/guides/integration/docker/#non-editable-installs
+ARG EVENTYAY_EXHIBITION_BRANCH=main
 RUN --mount=type=cache,target=/root/.cache/uv \
     --mount=type=bind,source=uv.lock,target=uv.lock \
     --mount=type=bind,source=pyproject.toml,target=pyproject.toml \
     uv sync --locked --no-install-project --no-editable
+
+RUN case "$EVENTYAY_EXHIBITION_BRANCH" in dev|main) ;; *) echo "Unsupported eventyay-exhibition branch: $EVENTYAY_EXHIBITION_BRANCH" >&2; exit 1 ;; esac && \
+    uv pip install --python $APP_HOME/.venv/bin/python --force-reinstall \
+      "exhibition @ git+https://github.com/fossasia/eventyay-exhibition.git@${EVENTYAY_EXHIBITION_BRANCH}"
 
 COPY Makefile Makefile
 
@@ -100,6 +105,8 @@ USER app
 ENV VIRTUAL_ENV="$APP_HOME/.venv"
 ENV PATH="$APP_HOME/.venv/bin:$PATH"
 ENV EVY_RUNNING_ENVIRONMENT=production
+ARG EVENTYAY_EXHIBITION_BRANCH=main
+ENV EVENTYAY_EXHIBITION_BRANCH=${EVENTYAY_EXHIBITION_BRANCH}
 
 
 RUN python manage.py compilemessages -i .venv

--- a/deployment/env.dev.sample
+++ b/deployment/env.dev.sample
@@ -2,6 +2,8 @@
 # - main for images build from the main branch
 # - dev for images build from the dev branch
 TAG=dev
+# The Docker development build installs this branch of fossasia/eventyay-exhibition.
+EVENTYAY_EXHIBITION_BRANCH=dev
 
 # EVY_ variables are loaded into the django configuration
 EVY_DEBUG=1

--- a/deployment/env.sample
+++ b/deployment/env.sample
@@ -10,6 +10,8 @@
 # - main for images build from the main branch
 # - dev for images build from the dev branch
 TAG=main
+# eventyay.com should run images built with eventyay-exhibition from main.
+EVENTYAY_EXHIBITION_BRANCH=main
 # Set path to a directory which will contain data for static pages, postgres, and general app data.
 # This directory can be relative, in which case it is relative to the location of the docker-compose.yml file.
 # This directory must contain:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,10 @@ name: eventyay-next
 
 services:
   web:
-    build: ./app
+    build:
+      context: ./app
+      args:
+        EVENTYAY_EXHIBITION_BRANCH: dev
     platform: linux/amd64
     container_name: eventyay-next-web
     command: python manage.py runserver 0.0.0.0:8000
@@ -29,7 +32,10 @@ services:
       - redis
 
   worker:
-    build: ./app
+    build:
+      context: ./app
+      args:
+        EVENTYAY_EXHIBITION_BRANCH: dev
     platform: linux/amd64
     container_name: eventyay-next-worker
     entrypoint: celery -A eventyay worker -l info


### PR DESCRIPTION
Fixes #4139

## Description

  This separates the `eventyay-exhibition` branch used by development and production Docker builds. Development builds now install `fossasia/eventyay-exhibition` from `dev`, while production builds install it from `main`.

## Changes

  - Pass `EVENTYAY_EXHIBITION_BRANCH` into Docker builds from the GitHub Actions branch context.
  - Set the local Docker development build to use the `dev` exhibition branch.
  - Keep production deployment samples on `TAG=main` and `EVENTYAY_EXHIBITION_BRANCH=main`.
  - Document the dev/prod branch model, deployment verification, and rollback steps.

## Test plan

  - [x] `git diff --check`
  - [x] Parsed `.github/workflows/enext-docker.yml`, `.github/workflows/enext-docker-pr.yml`, and `docker-compose.yml` with PyYAML.
  - [x] `docker compose config` using `deployment/env.dev.sample` as a temporary `.env.dev`.
  - [ ] Full Docker image build was not run locally because Docker Desktop is not running.
  - [ ] Full test suite was not run locally because this clone has no `uv`/Python 3.12 environment.