### PR TITLE
fix: Resolve LSP signature and protobuf attribute mismatch in Sig1TicketSecretGenerator

### DIFF
--- a/app/eventyay/base/secrets.py
+++ b/app/eventyay/base/secrets.py
@@ -190,6 +190,7 @@ class Sig1TicketSecretGenerator(BaseTicketSecretGenerator):
         product: Product,
         variation: ProductVariation = None,
         subevent: SubEvent = None,
+        attendee_name: str = None,
         current_secret: str = None,
         force_invalidate=False,
     ):
@@ -197,7 +198,7 @@ class Sig1TicketSecretGenerator(BaseTicketSecretGenerator):
             ticket = self._parse(current_secret)
             if ticket:
                 unchanged = (
-                    ticket.product == product.pk
+                    ticket.item == product.pk
                     and ticket.variation == (variation.pk if variation else 0)
                     and ticket.subevent == (subevent.pk if subevent else 0)
                 )
@@ -206,7 +207,7 @@ class Sig1TicketSecretGenerator(BaseTicketSecretGenerator):
 
         t = pretix_sig1_pb2.Ticket()
         t.seed = get_random_string(9)
-        t.product = product.pk
+        t.item = product.pk
         t.variation = variation.pk if variation else 0
         t.subevent = subevent.pk if subevent else 0
         payload = t.SerializeToString()


### PR DESCRIPTION
### Describe the bug
This is the updated and complete fix for the issue originally attempted in PR#3895.

The `Sig1TicketSecretGenerator` was completely broken due to two distinct issues:
1. It violated the Liskov Substitution Principle (LSP) by omitting the `attendee_name` argument from its overridden `generate_secret` method, throwing a `TypeError` if a caller provided it.
2. Even if called correctly, it crashed at runtime with an `AttributeError` because it attempted to read/assign `t.product` on the underlying protobuf message object, but the `pretix_sig1_pb2.Ticket` schema explicitly defines that field as `item`.

This PR comprehensively addresses both the signature mismatch and the internal runtime logic error, making the generator fully functional again without introducing out-of-scope type hints. Closes #3871.

### Expected behavior
- `Sig1TicketSecretGenerator.generate_secret` correctly implements the base class signature by including `attendee_name: str = None`.
- The generator safely constructs and parses the protobuf payloads using `t.item` mapping to `product.pk`, executing without runtime exceptions.

### Before
```python
# Calling it with attendee_name caused:
TypeError: generate_secret() got an unexpected keyword argument 'attendee_name'

# Or, if attendee_name was omitted, it caused a runtime crash inside the generator:
AttributeError: Assignment not allowed to unknown field "product" in protocol message object.
```

### After
The generator accepts the ```attendee_name``` parameter silently (satisfying the LSP) and generates/validates signed ticket secrets flawlessly using the correct ```item``` protobuf attribute.

### Related to issue : #3871 