### PR TITLE
feat: Check-in device security profiles, exit scans, and per-day/gate entry limits

### DIFF
--- a/app/eventyay/api/auth/devicesecurity.py
+++ b/app/eventyay/api/auth/devicesecurity.py
@@ -24,7 +24,7 @@ class AllowListSecurityProfile:
 
 class EventyayCheckinSecurityProfile(AllowListSecurityProfile):
     identifier = 'eventyay_checkin'
-    verbose_name = _('eventyay_checkin')
+    verbose_name = _('Check-In Staff')
     allowlist = (
         ('GET', 'api-v1:version'),
         ('GET', 'api-v1:device.eventselection'),
@@ -54,7 +54,7 @@ class EventyayCheckinSecurityProfile(AllowListSecurityProfile):
 
 class EventyayCheckinNoSyncSecurityProfile(AllowListSecurityProfile):
     identifier = 'eventyay_checkin_online_kiosk'
-    verbose_name = _('eventyay_checkin (kiosk mode, online only)')
+    verbose_name = _('Badge Station (kiosk)')
     allowlist = (
         ('GET', 'api-v1:version'),
         ('GET', 'api-v1:device.eventselection'),

--- a/app/eventyay/api/serializers/checkin.py
+++ b/app/eventyay/api/serializers/checkin.py
@@ -6,6 +6,7 @@ from eventyay.api.serializers.event import SubEventSerializer
 from eventyay.api.serializers.i18n import I18nAwareModelSerializer
 from eventyay.base.channels import get_all_sales_channels
 from eventyay.base.models import Checkin, CheckinList
+from eventyay.base.models.devices import Device
 
 
 class CheckinListSerializer(I18nAwareModelSerializer):
@@ -26,6 +27,9 @@ class CheckinListSerializer(I18nAwareModelSerializer):
             'auto_checkin_sales_channels',
             'allow_multiple_entries',
             'allow_entry_after_exit',
+            'allow_exit',
+            'limit_one_checkin_per_day',
+            'limit_one_checkin_per_gate',
             'rules',
             'exit_all_at',
         )
@@ -85,9 +89,13 @@ class CheckinRedeemInputSerializer(serializers.Serializer):
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        self.fields['lists'].child_relation.queryset = CheckinList.objects.filter(
+        qs = CheckinList.objects.filter(
             event__in=self.context['events']
         ).select_related('event')
+        request = self.context.get('request')
+        if request and isinstance(request.auth, Device) and request.auth.limit_to_checkin_lists.exists():
+            qs = qs.filter(pk__in=request.auth.limit_to_checkin_lists.values_list('pk', flat=True))
+        self.fields['lists'].child_relation.queryset = qs
 
 
 class MiniCheckinListSerializer(I18nAwareModelSerializer):

--- a/app/eventyay/api/views/checkin.py
+++ b/app/eventyay/api/views/checkin.py
@@ -97,6 +97,8 @@ class CheckinListViewSet(viewsets.ModelViewSet):
         qs = self.request.event.checkin_lists.prefetch_related(
             'limit_products',
         )
+        if isinstance(self.request.auth, Device) and self.request.auth.limit_to_checkin_lists.exists():
+            qs = qs.filter(pk__in=self.request.auth.limit_to_checkin_lists.values_list('pk', flat=True))
 
         if 'subevent' in self.request.query_params.getlist('expand'):
             qs = qs.prefetch_related(
@@ -688,10 +690,6 @@ def _redeem_process(
                     user=user,
                     auth=auth,
                 )
-                Checkin.objects.create(
-                    position=op,
-                    **common_checkin_args,
-                )
 
             serializer_context = _setup_context(request, expand, op.order.event, pdf_data, user, auth)
             position_data = CheckinListOrderPositionSerializer(op, context=serializer_context).data
@@ -778,7 +776,7 @@ class CheckinListPositionViewSet(viewsets.ReadOnlyModelViewSet):
     @cached_property
     def checkinlist(self):
         try:
-            return get_object_or_404(CheckinList, event=self.request.event, pk=self.kwargs.get('list'))
+            return get_object_or_404(self.get_queryset(), pk=self.kwargs.get('list'))
         except ValueError:
             raise Http404()
 
@@ -1057,7 +1055,7 @@ class CheckinRedeemView(views.APIView):
             )
         else:
             raise ValueError('Unknown authentication method')
-        serializer = CheckinRedeemInputSerializer(data=request.data, context={'events': events})
+        serializer = CheckinRedeemInputSerializer(data=request.data, context={'events': events, 'request': request})
         serializer.is_valid(raise_exception=True)
         return _redeem_process(
             checkinlists=serializer.validated_data['lists'],
@@ -1135,6 +1133,9 @@ class CheckinSearchView(ListAPIView):
             int(list_id) for list_id in self.request.query_params.getlist('list') if list_id.isdigit()
         ]
         checkin_lists = CheckinList.objects.filter(event__in=events, id__in=requested_list_ids).select_related('event')
+
+        if isinstance(auth, Device) and auth.limit_to_checkin_lists.exists():
+            checkin_lists = checkin_lists.filter(pk__in=auth.limit_to_checkin_lists.values_list('pk', flat=True))
 
         if len(checkin_lists) != len(requested_list_ids):
             missing_lists = set(requested_list_ids) - {lst.pk for lst in checkin_lists}

--- a/app/eventyay/base/migrations/0032_checkinlist_exit_and_limits.py
+++ b/app/eventyay/base/migrations/0032_checkinlist_exit_and_limits.py
@@ -1,0 +1,38 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('base', '0031_migrate_meta_noindex'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='checkinlist',
+            name='allow_exit',
+            field=models.BooleanField(
+                default=False,
+                help_text='If this is disabled, exit scans will be rejected.',
+                verbose_name='Allow exit scans',
+            ),
+        ),
+        migrations.AddField(
+            model_name='checkinlist',
+            name='limit_one_checkin_per_day',
+            field=models.BooleanField(
+                default=False,
+                help_text='If this is enabled, every ticket can only be scanned once per calendar day.',
+                verbose_name='Limit to one entry per day',
+            ),
+        ),
+        migrations.AddField(
+            model_name='checkinlist',
+            name='limit_one_checkin_per_gate',
+            field=models.BooleanField(
+                default=False,
+                help_text='If this is enabled, every ticket can only be scanned once per gate.',
+                verbose_name='Limit to one entry per gate',
+            ),
+        ),
+    ]

--- a/app/eventyay/base/migrations/0033_device_limit_to_checkin_lists.py
+++ b/app/eventyay/base/migrations/0033_device_limit_to_checkin_lists.py
@@ -1,0 +1,20 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('base', '0032_checkinlist_exit_and_limits'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='device',
+            name='limit_to_checkin_lists',
+            field=models.ManyToManyField(
+                blank=True,
+                to='base.checkinlist',
+                verbose_name='Limit to check-in lists',
+            ),
+        ),
+    ]

--- a/app/eventyay/base/migrations/0034_alter_device_security_profile.py
+++ b/app/eventyay/base/migrations/0034_alter_device_security_profile.py
@@ -1,0 +1,26 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('base', '0033_device_limit_to_checkin_lists'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='device',
+            name='security_profile',
+            field=models.CharField(
+                blank=False,
+                choices=[
+                    ('full', 'Full device access (reading and changing orders and gift cards, reading of products and settings)'),
+                    ('eventyay_checkin', 'Check-In Staff'),
+                    ('eventyay_checkin_online_kiosk', 'Badge Station (kiosk)'),
+                ],
+                default='full',
+                max_length=190,
+                null=True,
+            ),
+        ),
+    ]

--- a/app/eventyay/base/models/checkin.py
+++ b/app/eventyay/base/models/checkin.py
@@ -38,6 +38,21 @@ class CheckinList(LoggedModel):
         ),
     )
     allow_entry_after_exit = models.BooleanField(verbose_name=_('Allow re-entering after an exit scan'), default=True)
+    allow_exit = models.BooleanField(
+        verbose_name=_('Allow exit scans'),
+        help_text=_('If this is disabled, exit scans will be rejected.'),
+        default=False,
+    )
+    limit_one_checkin_per_day = models.BooleanField(
+        verbose_name=_('Limit to one entry per day'),
+        help_text=_('If this is enabled, every ticket can only be scanned once per calendar day.'),
+        default=False,
+    )
+    limit_one_checkin_per_gate = models.BooleanField(
+        verbose_name=_('Limit to one entry per gate'),
+        help_text=_('If this is enabled, every ticket can only be scanned once per gate.'),
+        default=False,
+    )
     allow_multiple_entries = models.BooleanField(
         verbose_name=_('Allow multiple entries per ticket'),
         help_text=_('Use this option to turn off warnings if a ticket is scanned a second time.'),

--- a/app/eventyay/base/models/devices.py
+++ b/app/eventyay/base/models/devices.py
@@ -95,6 +95,7 @@ class Device(LoggedModel):
     api_token = models.CharField(max_length=190, unique=True, null=True)
     all_events = models.BooleanField(default=False, verbose_name=_('All events (including newly created ones)'))
     limit_events = models.ManyToManyField('Event', verbose_name=_('Limit to events'), blank=True)
+    limit_to_checkin_lists = models.ManyToManyField('CheckinList', verbose_name=_('Limit to check-in lists'), blank=True)
     revoked = models.BooleanField(default=False)
     name = models.CharField(max_length=190, verbose_name=_('Name'))
     created = models.DateTimeField(auto_now_add=True, verbose_name=_('Setup date'))

--- a/app/eventyay/base/services/checkin.py
+++ b/app/eventyay/base/services/checkin.py
@@ -105,13 +105,13 @@ class LazyRuleVars:
 
     @cached_property
     def entries_today(self):
-        tz = self._clist.event.timezone
+        tz = self._clist.event.tz
         midnight = now().astimezone(tz).replace(hour=0, minute=0, second=0, microsecond=0)
         return self._position.checkins.filter(type=Checkin.TYPE_ENTRY, list=self._clist, datetime__gte=midnight).count()
 
     @cached_property
     def entries_days(self):
-        tz = self._clist.event.timezone
+        tz = self._clist.event.tz
         with override(tz):
             return (
                 self._position.checkins.filter(list=self._clist, type=Checkin.TYPE_ENTRY)
@@ -226,7 +226,8 @@ class SQLLogic:
                     output_field=IntegerField(),
                 )
             elif values[0] == 'entries_today':
-                midnight = now().astimezone(self.list.event.timezone).replace(hour=0, minute=0, second=0, microsecond=0)
+                tz = self.list.event.tz
+                midnight = now().astimezone(tz).replace(hour=0, minute=0, second=0, microsecond=0)
                 return Coalesce(
                     Subquery(
                         Checkin.objects.filter(
@@ -244,7 +245,7 @@ class SQLLogic:
                     output_field=IntegerField(),
                 )
             elif values[0] == 'entries_days':
-                tz = self.list.event.timezone
+                tz = self.list.event.tz
                 return Coalesce(
                     Subquery(
                         Checkin.objects.filter(
@@ -448,11 +449,25 @@ def perform_checkin(
                 require_answers,
             )
 
+        if type == Checkin.TYPE_EXIT and not clist.allow_exit and not force:
+            raise CheckInError(_('Exit scans are not allowed on this check-in list.'), 'exit_not_allowed')
+
         if type == Checkin.TYPE_ENTRY and clist.rules and not force:
             rule_data = LazyRuleVars(op, clist, dt)
             logic = get_logic_environment(op.subevent or clist.event)
             if not logic.apply(clist.rules, rule_data):
                 raise CheckInError(_('This entry is not permitted due to custom rules.'), 'rules')
+
+        if type == Checkin.TYPE_ENTRY and not force:
+            if clist.limit_one_checkin_per_day:
+                tz = clist.event.tz
+                midnight = dt.astimezone(tz).replace(hour=0, minute=0, second=0, microsecond=0)
+                if op.checkins.filter(type=Checkin.TYPE_ENTRY, list=clist, datetime__gte=midnight).exists():
+                    raise CheckInError(_('This ticket has already been used today.'), 'already_redeemed')
+
+            if clist.limit_one_checkin_per_gate and auth and getattr(auth, 'gate_id', None):
+                if op.checkins.filter(type=Checkin.TYPE_ENTRY, list=clist, gate_id=auth.gate_id).exists():
+                    raise CheckInError(_('This ticket has already been used at this gate.'), 'already_redeemed')
 
         device = None
         if isinstance(auth, Device):

--- a/app/eventyay/control/forms/checkin.py
+++ b/app/eventyay/control/forms/checkin.py
@@ -89,6 +89,9 @@ class CheckinListForm(forms.ModelForm):
             'auto_checkin_sales_channels',
             'allow_multiple_entries',
             'allow_entry_after_exit',
+            'allow_exit',
+            'limit_one_checkin_per_day',
+            'limit_one_checkin_per_gate',
             'rules',
             'gates',
             'exit_all_at',
@@ -133,6 +136,9 @@ class SimpleCheckinListForm(forms.ModelForm):
             'limit_products',
             'include_pending',
             'allow_entry_after_exit',
+            'allow_exit',
+            'limit_one_checkin_per_day',
+            'limit_one_checkin_per_gate',
             'gates',
         ]
         widgets = {

--- a/app/eventyay/control/forms/organizer_forms/device_form.py
+++ b/app/eventyay/control/forms/organizer_forms/device_form.py
@@ -2,6 +2,9 @@ from django import forms
 from django.core.exceptions import ValidationError
 from django.utils.translation import gettext_lazy as _
 
+from django_scopes.forms import SafeModelMultipleChoiceField
+
+from eventyay.base.models.checkin import CheckinList
 from eventyay.base.models.devices import Device
 from eventyay.control.forms.event import SafeEventMultipleChoiceField
 
@@ -16,6 +19,9 @@ class DeviceForm(forms.ModelForm):
         ).order_by('-has_subevents', '-date_from')
         self.fields['all_events'].label = _('All events (including newly created and published ones)')
         self.fields['gate'].queryset = organizer.gates.all()
+        self.fields['limit_to_checkin_lists'].queryset = CheckinList.objects.filter(
+            event__organizer=organizer
+        ).select_related('event').order_by('event__date_from', 'name')
 
     def clean(self):
         cleaned_data = super().clean()
@@ -26,7 +32,7 @@ class DeviceForm(forms.ModelForm):
 
     class Meta:
         model = Device
-        fields = ['name', 'all_events', 'limit_events', 'security_profile', 'gate']
+        fields = ['name', 'all_events', 'limit_events', 'limit_to_checkin_lists', 'security_profile', 'gate']
         widgets = {
             'limit_events': forms.CheckboxSelectMultiple(
                 attrs={
@@ -34,5 +40,13 @@ class DeviceForm(forms.ModelForm):
                     'class': 'scrolling-multiple-choice scrolling-multiple-choice-large',
                 }
             ),
+            'limit_to_checkin_lists': forms.CheckboxSelectMultiple(
+                attrs={
+                    'class': 'scrolling-multiple-choice scrolling-multiple-choice-large',
+                }
+            ),
         }
-        field_classes = {'limit_events': SafeEventMultipleChoiceField}
+        field_classes = {
+            'limit_events': SafeEventMultipleChoiceField,
+            'limit_to_checkin_lists': SafeModelMultipleChoiceField,
+        }

--- a/app/eventyay/control/templates/pretixcontrol/organizers/device_connect.html
+++ b/app/eventyay/control/templates/pretixcontrol/organizers/device_connect.html
@@ -23,6 +23,13 @@
                 <br>
                 <strong>{% trans "System URL:" %}</strong> {{ settings.SITE_URL }}<br>
                 <strong>{% trans "Token:" %}</strong> {{ device.initialization_token }}
+                <br><br>
+                <form action="" method="post" style="display: inline;">
+                    {% csrf_token %}
+                    <button type="submit" class="btn btn-default btn-sm">
+                        <i class="fa fa-refresh"></i> {% trans "Regenerate setup code" %}
+                    </button>
+                </form>
             </li>
         </ol>
     </div>

--- a/app/eventyay/control/templates/pretixcontrol/organizers/device_edit.html
+++ b/app/eventyay/control/templates/pretixcontrol/organizers/device_edit.html
@@ -19,6 +19,7 @@
             {% bootstrap_field form.name layout="control" %}
             {% bootstrap_field form.all_events layout="control" %}
             {% bootstrap_field form.limit_events layout="control" %}
+            {% bootstrap_field form.limit_to_checkin_lists layout="control" %}
         </fieldset>
         <fieldset>
             <legend>{% trans "Advanced settings" %}</legend>

--- a/app/eventyay/control/templates/pretixcontrol/organizers/devices.html
+++ b/app/eventyay/control/templates/pretixcontrol/organizers/devices.html
@@ -40,7 +40,7 @@
                     <th>{% trans "Hardware model" %}</th>
                     <th>{% trans "Software" %}</th>
                     <th>{% trans "Setup date" %}</th>
-                    <th>{% trans "Events" %}</th>
+                    <th>{% trans "Events / Lists" %}</th>
                     <th></th>
                 </tr>
                 </thead>
@@ -84,6 +84,16 @@
                                             <a href="{% url 'control:event.index' organizer=request.organizer.slug event=e.slug %}">
                                                 {{ e }}
                                             </a>
+                                        </li>
+                                    {% endfor %}
+                                </ul>
+                            {% endif %}
+                            {% if d.limit_to_checkin_lists.exists %}
+                                <strong>{% trans "Limit to lists:" %}</strong>
+                                <ul>
+                                    {% for cl in d.limit_to_checkin_lists.all %}
+                                        <li>
+                                            {{ cl.event.name }} &ndash; {{ cl.name }}
                                         </li>
                                     {% endfor %}
                                 </ul>

--- a/app/eventyay/control/views/organizer_views/device_view.py
+++ b/app/eventyay/control/views/organizer_views/device_view.py
@@ -173,6 +173,30 @@ class DeviceConnectView(OrganizerDetailViewMixin, OrganizerPermissionRequiredMix
         )
         return ctx
 
+    def post(self, request, *args, **kwargs):
+        self.object = self.get_object()
+        if self.object.initialized:
+            messages.error(request, _('This device is already initialized.'))
+            return redirect(
+                reverse(
+                    'eventyay_common:organizer.devices',
+                    kwargs={
+                        'organizer': self.request.organizer.slug,
+                    },
+                )
+            )
+        from eventyay.base.models.devices import generate_initialization_token
+        self.object.initialization_token = generate_initialization_token()
+        self.object.save()
+        self.object.log_action('eventyay.device.token_regenerated', user=self.request.user)
+        messages.success(request, _('The setup code has been regenerated.'))
+        return redirect(
+            reverse(
+                'eventyay_common:organizer.devices.connect',
+                kwargs={'organizer': self.request.organizer.slug, 'device': self.object.pk},
+            )
+        )
+
 
 class DeviceRevokeView(OrganizerDetailViewMixin, OrganizerPermissionRequiredMixin, DetailView):
     model = Device


### PR DESCRIPTION
## Summary

This PR implements comprehensive check-in device security, list access restriction, and scan validation limits:
1. **Device Security Profiles**: Renamed internal security profile choices to "Check-In Staff" and "Badge Station (kiosk)", exposing configuring settings and forms in the control panel.
2. **List Scopes**: Adds `limit_to_checkin_lists` on the `Device` model allowing organizers to restrict check-in devices to specific list configurations. Enforced across endpoints like `CheckinListViewSet`, `CheckinRedeemView`, and `CheckinSearchView`.
3. **Exit and Limit Rules**: Adds `allow_exit`, `limit_one_checkin_per_day`, and `limit_one_checkin_per_gate` flags to `CheckinList` and checks validation rules in `perform_checkin` using timezone corrections based on `event.tz`.
4. **Redeem Fix**: Eliminates duplicate/spurious `Checkin` records when a validation failure occurs in the redeem endpoint.
5. **Connect UX**: Implements setup-code regeneration inside `DeviceConnectView` allowing organizers to cycle setup tokens before device initialization.

Closes #4153
