### PR TITLE
Fix featured speakers and schedule caches not clearing correctly

### DIFF
--- a/app/eventyay/agenda/apps.py
+++ b/app/eventyay/agenda/apps.py
@@ -37,7 +37,7 @@ class AgendaConfig(AppConfig):
             except Exception:
                 LOGGER.exception('Failed to enqueue warm_schedule_caches for schedule pk=%s', schedule.pk)
 
-        schedule_release.connect(on_schedule_release, dispatch_uid='agenda.on_schedule_release')
+        schedule_release.connect(on_schedule_release, dispatch_uid='agenda.on_schedule_release', weak=False)
 
         from eventyay.base.models import SubmissionStates
         from eventyay.submission.signals import submission_state_change
@@ -56,6 +56,7 @@ class AgendaConfig(AppConfig):
         submission_state_change.connect(
             on_submission_state_change,
             dispatch_uid='agenda.on_submission_state_change',
+            weak=False,
         )
 
 


### PR DESCRIPTION
Set weak=False on submission_state_change and schedule_release signal receivers in AgendaConfig.ready to prevent garbage collection.

fixes #4048

## Summary by Sourcery

Ensure agenda-related signal handlers are connected with strong references so their cache-warming callbacks are not garbage-collected, restoring correct cache invalidation for featured speakers and schedules.

Bug Fixes:
- Prevent agenda schedule release cache-warming handler from being garbage-collected by connecting the signal receiver with a strong reference.
- Prevent submission state change cache-warming handler from being garbage-collected by connecting the signal receiver with a strong reference.