### PR TITLE
feat: add video support for interpretation channels

### DIFF
--- a/app/eventyay/webapp/video/src/components/AudioTranslationDropdown.vue
+++ b/app/eventyay/webapp/video/src/components/AudioTranslationDropdown.vue
@@ -42,6 +42,7 @@ export default {
 		sendLanguageChange() {
 			const selected = this.languages.find(item => item.language === this.selectedLanguage)
 			const audioSource = selected?.youtube_id || null
+			const useVideo = selected?.use_video || false
 			
 			let normalizedSource = null
 			if (audioSource) {
@@ -56,7 +57,7 @@ export default {
 				}
 			}
 			
-			this.$emit('languageChanged', normalizedSource)
+			this.$emit('languageChanged', { url: normalizedSource, useVideo })
 		}
 	}
 }

--- a/app/eventyay/webapp/video/src/components/MediaSource.vue
+++ b/app/eventyay/webapp/video/src/components/MediaSource.vue
@@ -78,7 +78,7 @@ const janus = ref(null);
 
 // Mapped state/getters
 const streamingRoom = computed(() => store.state.streamingRoom);
-const youtubeTransUrl = computed(() => store.state.youtubeTransUrl);
+const youtubeTranslation = computed(() => store.state.youtubeTranslation);
 const autoplay = computed(() => store.getters.autoplay);
 
 const module = computed(() => {
@@ -209,7 +209,9 @@ watch(
 	}
 )
 
-watch(youtubeTransUrl, async (audioSource) => {
+const isPlayingTranslationVideo = ref(false);
+
+watch(youtubeTranslation, async (transConfig) => {
 	if (!props.room) return;
 	const isScheduleDriven = module.value && getStagePlaybackMode(module.value) === PLAYBACK_MODE_SCHEDULE_DRIVEN;
 	const streamType = isScheduleDriven ? props.room?.currentStream?.stream_type : null;
@@ -220,6 +222,21 @@ watch(youtubeTransUrl, async (audioSource) => {
 	if (whepClient) {
 		whepClient.disconnect();
 		whepClient = null;
+	}
+
+	const audioSource = transConfig?.url || null;
+	const useVideo = transConfig?.useVideo || false;
+
+	if (useVideo) {
+		isPlayingTranslationVideo.value = true;
+		languageIframeUrl.value = null; // Clear any audio iframe
+		destroyIframe();
+		await initializeIframe(false);
+		return;
+	} else if (isPlayingTranslationVideo.value) {
+		isPlayingTranslationVideo.value = false;
+		destroyIframe();
+		await initializeIframe(false);
 	}
 
 	// Handle translation: mute main player and connect audio source
@@ -366,7 +383,9 @@ async function initializeIframe(mute, skipConsentCheck = false) {
 			case 'livestream.youtube': {
 				isYouTube = true;
 				let ytid;
-				if (streamType === STREAM_TYPE_YOUTUBE && currentStream?.url) {
+				if (youtubeTranslation.value?.useVideo && youtubeTranslation.value?.url) {
+					ytid = normalizeYoutubeVideoId(youtubeTranslation.value.url);
+				} else if (streamType === STREAM_TYPE_YOUTUBE && currentStream?.url) {
 					ytid = normalizeYoutubeVideoId(currentStream.url);
 				} else if (!isScheduleDriven && module.value.type === 'livestream.youtube' && module.value.config?.ytid) {
 					ytid = normalizeYoutubeVideoId(module.value.config.ytid);
@@ -447,8 +466,8 @@ async function initializeIframe(mute, skipConsentCheck = false) {
 		// Wait for iframe to load before sending postMessage commands
 		if (isYouTube) {
 			iframe.onload = () => {
-				// If translation is already selected, mute the main player
-				if (youtubeTransUrl.value) {
+				// If translation is already selected, mute the main player (if audio-only)
+				if (youtubeTranslation.value?.url && !youtubeTranslation.value?.useVideo) {
 					setTimeout(() => muteYouTubePlayer(), 1000);
 				}
 			};

--- a/app/eventyay/webapp/video/src/components/MediaSource.vue
+++ b/app/eventyay/webapp/video/src/components/MediaSource.vue
@@ -225,7 +225,8 @@ watch(youtubeTranslation, async (transConfig) => {
 	}
 
 	const audioSource = transConfig?.url || null;
-	const useVideo = transConfig?.useVideo || false;
+	const requestedUseVideo = transConfig?.useVideo || false;
+	const useVideo = requestedUseVideo && !!(audioSource && normalizeYoutubeVideoId(audioSource));
 
 	if (useVideo) {
 		isPlayingTranslationVideo.value = true;
@@ -383,7 +384,7 @@ async function initializeIframe(mute, skipConsentCheck = false) {
 			case 'livestream.youtube': {
 				isYouTube = true;
 				let ytid;
-				if (youtubeTranslation.value?.useVideo && youtubeTranslation.value?.url) {
+				if (youtubeTranslation.value?.useVideo && youtubeTranslation.value?.url && normalizeYoutubeVideoId(youtubeTranslation.value.url)) {
 					ytid = normalizeYoutubeVideoId(youtubeTranslation.value.url);
 				} else if (streamType === STREAM_TYPE_YOUTUBE && currentStream?.url) {
 					ytid = normalizeYoutubeVideoId(currentStream.url);

--- a/app/eventyay/webapp/video/src/store/index.js
+++ b/app/eventyay/webapp/video/src/store/index.js
@@ -43,7 +43,7 @@ export default new Vuex.Store({
 				.map((d) => normalizeIframeConsentDomain(d))
 				.filter(Boolean)
 		),
-		youtubeTransUrl: null
+		youtubeTranslation: null
 	},
 	getters: {
 		hasPermission(state) {
@@ -104,8 +104,8 @@ export default new Vuex.Store({
 		updateNow(state) {
 			state.now = moment()
 		},
-		updateYoutubeTransAudio(state, youtubeTransUrl) {
-			state.youtubeTransUrl = youtubeTransUrl
+		updateYoutubeTransAudio(state, youtubeTranslation) {
+			state.youtubeTranslation = youtubeTranslation
 		},
 		setStreamPollInterval(state, streamPollInterval) {
 			state.streamPollInterval = streamPollInterval

--- a/app/eventyay/webapp/video/src/views/admin/rooms/types-edit/stage.vue
+++ b/app/eventyay/webapp/video/src/views/admin/rooms/types-edit/stage.vue
@@ -35,6 +35,7 @@
 			.language-url-entry(v-for="(entry, index) in modules['livestream.youtube'].config.languageUrls" :key="index")
 				bunt-select(name="language", v-model="entry.language", :options="ISO_LANGUAGE_OPTIONS", label="Language")
 				bunt-input(name="youtube_id" v-model="entry.youtube_id" label="Audio Source (YouTube ID or WHEP URL)" @blur="normalizeLanguageYoutubeId(entry)")
+				bunt-switch(name="use_video" v-model="entry.use_video" label="Use video from this interpretation channel" hint="If enabled, attendees will see both the audio and video from this interpretation channel. If disabled, attendees will hear the interpretation audio while continuing to see the original main video.")
 				bunt-icon-button(@click="deleteLanguageUrl(index)") delete-outline
 			bunt-button(@click="addLanguageUrl") + Add Language and Audio Source
 			// Switch button for no-cookies domain
@@ -290,7 +291,7 @@ export default defineComponent({
 			if (!this.modules['livestream.youtube'].config.languageUrls) {
 				this.modules['livestream.youtube'].config.languageUrls = []
 			}
-			this.modules['livestream.youtube'].config.languageUrls.push({ language: '', youtube_id: '' })
+			this.modules['livestream.youtube'].config.languageUrls.push({ language: '', youtube_id: '', use_video: false })
 		},
 		deleteLanguageUrl(index) {
 			if (!this.modules['livestream.youtube']?.config.languageUrls) return

--- a/app/eventyay/webapp/video/src/views/rooms/item.vue
+++ b/app/eventyay/webapp/video/src/views/rooms/item.vue
@@ -128,8 +128,8 @@ export default {
 			if (tab === this.activeSidebarTab) return
 			this.unreadTabs[tab] = true
 		},
-		handleLanguageChange(languageUrl) {
-			this.$store.commit('updateYoutubeTransAudio', languageUrl)
+		handleLanguageChange(translationConfig) {
+			this.$store.commit('updateYoutubeTransAudio', translationConfig)
 		},
 		initializeLanguages() {
 			this.languages = []
@@ -137,7 +137,7 @@ export default {
 				this.languages = this.modules['livestream.youtube'].config.languageUrls
 			}
 			if (!this.languages.find(lang => lang.language === 'Original')) {
-				this.languages.unshift({language: 'Original', youtube_id: null})
+				this.languages.unshift({language: 'Original', youtube_id: null, use_video: false})
 			}
 			// Reset translation only when actually changing rooms, not on component remount
 			const currentRoomId = this.room?.id


### PR DESCRIPTION
This pull request enhances the audio translation feature in the video module by allowing admins to specify whether an interpretation channel should use both audio and video, or audio only. It introduces a new `use_video` flag to the language configuration, updates related state management, and ensures the UI and playback logic respect this option. The most important changes are grouped below:

**Feature Enhancement: Audio/Video Selection for Interpretation Channels**
- Added a `use_video` boolean option to each language entry in the admin stage editor, allowing admins to specify if attendees should see both audio and video from an interpretation channel, or just hear the audio while watching the main video. (`stage.vue`, language entry form and default object) [[1]](diffhunk://#diff-739d678f074aa8621f34b96b7a4f6d26e95fef71cd310eddcad503ef5cfd2c49R38) [[2]](diffhunk://#diff-739d678f074aa8621f34b96b7a4f6d26e95fef71cd310eddcad503ef5cfd2c49L293-R294)

**State Management Updates**
- Changed the Vuex store state and mutation from `youtubeTransUrl` (string) to `youtubeTranslation` (object containing `url` and `useVideo`), and updated all related code to use the new structure. (`store/index.js`, `MediaSource.vue`, `item.vue`) [[1]](diffhunk://#diff-d04bfc965fca090604ad9178c6de40b00d9dfedd923dda0020fa8231b598c9efL46-R46) [[2]](diffhunk://#diff-d04bfc965fca090604ad9178c6de40b00d9dfedd923dda0020fa8231b598c9efL107-R108) [[3]](diffhunk://#diff-4c11794ba55b5744a940f40a9f863a741c8a63258e42712d6c6489db24adf6e7L81-R81) [[4]](diffhunk://#diff-b27a672cdf662113ba48f1f76d900d28be304d501e6fee1f17ac40df0eb3121fL131-R140)

**Component and Playback Logic Adjustments**
- Modified the language change event and handler to emit and accept the new translation config object, ensuring the selected mode (`useVideo`) is respected throughout the playback flow. (`AudioTranslationDropdown.vue`, `item.vue`) [[1]](diffhunk://#diff-72ad36718be0ed0f3e37ff8c6c742dbb1daa010e7df1ac928449eb315eec9f4bR45) [[2]](diffhunk://#diff-72ad36718be0ed0f3e37ff8c6c742dbb1daa010e7df1ac928449eb315eec9f4bL59-R60) [[3]](diffhunk://#diff-b27a672cdf662113ba48f1f76d900d28be304d501e6fee1f17ac40df0eb3121fL131-R140)
- Updated the main video playback logic to switch between showing the interpretation video or just playing its audio, based on the `useVideo` flag. This includes toggling iframes and muting logic in `MediaSource.vue`. [[1]](diffhunk://#diff-4c11794ba55b5744a940f40a9f863a741c8a63258e42712d6c6489db24adf6e7L212-R214) [[2]](diffhunk://#diff-4c11794ba55b5744a940f40a9f863a741c8a63258e42712d6c6489db24adf6e7R227-R241) [[3]](diffhunk://#diff-4c11794ba55b5744a940f40a9f863a741c8a63258e42712d6c6489db24adf6e7L369-R388) [[4]](diffhunk://#diff-4c11794ba55b5744a940f40a9f863a741c8a63258e42712d6c6489db24adf6e7L450-R470)

These changes provide greater flexibility for event organizers and improve the attendee experience when multiple interpretation channels are available.

Fixes #3874 


# Demo
https://drive.google.com/file/d/1TlFLt5cnG1fN8N5n8dd93KS2i91Wxsbe/view?usp=sharing