### PR TITLE
Fix conditional questions not working with checkbox values

### DIFF
--- a/app/eventyay/presale/checkoutflowstep/questions_step.py
+++ b/app/eventyay/presale/checkoutflowstep/questions_step.py
@@ -8,7 +8,7 @@ from django.utils.functional import cached_property
 from django.utils.translation import gettext_lazy as _
 from django.utils.translation import pgettext_lazy
 
-from eventyay.base.models import TaxRule
+from eventyay.base.models import Question, TaxRule
 from eventyay.base.services.cart import update_tax_rates
 from eventyay.base.services.system_questions import (
     get_system_question_asked_required,
@@ -267,6 +267,12 @@ class QuestionsStep(QuestionsViewMixin, CartMixin, TemplateFlowStep):
                 ):
                     return False
                 if parentid not in answ:
+                    # A TYPE_BOOLEAN parent that was left unchecked has no stored
+                    # QuestionAnswer (save() deletes empty answers). Treat absence
+                    # as a 'False' answer so children with dependency_values=['False']
+                    # are still considered visible and validated.
+                    if parentq.type == Question.TYPE_BOOLEAN:
+                        return 'False' in qvals
                     return False
                 return (
                     ('True' in qvals and answ[parentid].answer == 'True')

--- a/app/eventyay/presale/checkoutflowstep/questions_step.py
+++ b/app/eventyay/presale/checkoutflowstep/questions_step.py
@@ -32,6 +32,25 @@ from eventyay.presale.views.cart import get_or_create_cart_id
 from eventyay.presale.views.questions import QuestionsViewMixin
 
 
+def question_is_visible_for_stored_answers(parentid, qvals, question_cache, answ):
+    if parentid not in question_cache:
+        return False
+    parentq = question_cache[parentid]
+    if parentq.dependency_question_id and not question_is_visible_for_stored_answers(
+        parentq.dependency_question_id, parentq.dependency_values, question_cache, answ
+    ):
+        return False
+    if parentid not in answ:
+        if parentq.type == Question.TYPE_BOOLEAN:
+            return 'False' in qvals
+        return False
+    return (
+        ('True' in qvals and answ[parentid].answer == 'True')
+        or ('False' in qvals and answ[parentid].answer == 'False')
+        or (any(qval in [o.identifier for o in answ[parentid].options.all()] for qval in qvals))
+    )
+
+
 class QuestionsStep(QuestionsViewMixin, CartMixin, TemplateFlowStep):
     priority = 50
     identifier = 'questions'
@@ -259,26 +278,7 @@ class QuestionsStep(QuestionsViewMixin, CartMixin, TemplateFlowStep):
             question_cache = {q.pk: q for q in cp.product.questions_to_ask}
 
             def question_is_visible(parentid, qvals):
-                if parentid not in question_cache:
-                    return False
-                parentq = question_cache[parentid]
-                if parentq.dependency_question_id and not question_is_visible(
-                    parentq.dependency_question_id, parentq.dependency_values
-                ):
-                    return False
-                if parentid not in answ:
-                    # A TYPE_BOOLEAN parent that was left unchecked has no stored
-                    # QuestionAnswer (save() deletes empty answers). Treat absence
-                    # as a 'False' answer so children with dependency_values=['False']
-                    # are still considered visible and validated.
-                    if parentq.type == Question.TYPE_BOOLEAN:
-                        return 'False' in qvals
-                    return False
-                return (
-                    ('True' in qvals and answ[parentid].answer == 'True')
-                    or ('False' in qvals and answ[parentid].answer == 'False')
-                    or (any(qval in [o.identifier for o in answ[parentid].options.all()] for qval in qvals))
-                )
+                return question_is_visible_for_stored_answers(parentid, qvals, question_cache, answ)
 
             def question_is_required(q):
                 return q.required and (

--- a/app/eventyay/static/pretixcontrol/js/ui/question.js
+++ b/app/eventyay/static/pretixcontrol/js/ui/question.js
@@ -144,8 +144,8 @@ $(function () {
             type: 'GET',
             success: function (data) {
                 if (data.type === "B") {
-                    $val.append($("<option>").attr("value", "True").text(gettext("Yes")));
-                    $val.append($("<option>").attr("value", "False").text(gettext("No")));
+                    $val.append($("<option>").attr("value", "True").text(gettext("is checked")));
+                    $val.append($("<option>").attr("value", "False").text(gettext("is not checked")));
                 } else {
                     for (var i = 0; i < data.options.length; i++) {
                         var opt = data.options[i];

--- a/app/eventyay/static/pretixpresale/js/ui/questions.js
+++ b/app/eventyay/static/pretixpresale/js/ui/questions.js
@@ -1,4 +1,15 @@
 /*global $,safeSelector */
+function _css_escape_value(v) {
+    var s = String(v);
+    if (typeof window !== 'undefined' && window.CSS && typeof window.CSS.escape === 'function') {
+        return window.CSS.escape(s);
+    }
+    return s.replace(/(["\\])/g, '\\$1');
+}
+
+function _attr_sel(name, value) {
+    return '[' + name + '="' + _css_escape_value(value) + '"]';
+}
 
 function questions_toggle_dependent(ev) {
     function q_should_be_shown($el) {
@@ -6,75 +17,107 @@ function questions_toggle_dependent(ev) {
             return true;
         }
 
-        var dependency_name = $el.attr("name").split("_")[0] + "_" + $el.attr("data-question-dependency");
-        var dependency_values = JSON.parse($el.attr("data-question-dependency-values"));
+        var name = $el.attr('name') || '';
+        var dep_id = $el.attr('data-question-dependency');
+        var dependency_name = name.replace(/question_\d+(?:_\d+)?$/, 'question_' + dep_id);
+        if (dependency_name === name) {
+            dependency_name = name.split('_')[0] + '_' + dep_id;
+        }
+
+        var dependency_values;
+        try {
+            dependency_values = JSON.parse($el.attr('data-question-dependency-values'));
+        } catch (e) {
+            return true;
+        }
+        if (!Array.isArray(dependency_values)) {
+            return true;
+        }
+
+        var nameSel = _attr_sel('name', dependency_name);
         var $dependency_el;
 
-        if ($("select[name=" + dependency_name + "]").length) {
-            $dependency_el = $("select[name=" + dependency_name + "]");
-            if (!$dependency_el.closest(".form-group").hasClass("dependency-hidden")) {  // do not show things that depend on hidden things
-                return q_should_be_shown($dependency_el) && $.inArray($dependency_el.val(), dependency_values) > -1;
+        $dependency_el = $('select' + nameSel);
+        if ($dependency_el.length) {
+            if ($dependency_el.closest('.form-group').hasClass('dependency-hidden')) {
+                return false;
             }
-        } else if ($("input[type=radio][name=" + dependency_name + "]").length) {
-            $dependency_el = $("input[type=radio][name=" + dependency_name + "]");
-            if (!$dependency_el.closest(".form-group").hasClass("dependency-hidden")) {  // do not show things that depend on hidden things
-                return q_should_be_shown($dependency_el.first())
-                    && $.inArray($dependency_el.filter(":checked").val(), dependency_values) > -1;
-            }
-        } else if ($("input[type=checkbox][name=" + dependency_name + "]").length) {
-            // dependency type is B or M
-            if ($.inArray("True", dependency_values) > -1 || $.inArray("False", dependency_values) > -1) {
-                $dependency_el = $("input[name=" + dependency_name + "]");
-                if (!$dependency_el.closest(".form-group").hasClass("dependency-hidden")) {  // do not show things that depend on hidden things
-                    return q_should_be_shown($dependency_el) && (
-                        ($.inArray("True", dependency_values) > -1 && $dependency_el.prop('checked'))
-                        || ($.inArray("False", dependency_values) > -1 && !$dependency_el.prop('checked'))
-                    );
-                }
-            } else {
-                var filter = "";
-                for (var i = 0; i < dependency_values.length; i++) {
-                    if (filter) filter += ", ";
-                    filter += "input[value=" + dependency_values[i] + "][name=" + dependency_name + "]:checked";
-                }
-                $dependency_el = $("input[value=" + dependency_values[0] + "][name=" + dependency_name + "]");
-                if (!$dependency_el.closest(".form-group").hasClass("dependency-hidden")) {  // do not show things that depend on hidden things
-                    return q_should_be_shown($dependency_el) && safeSelector(filter).length;
-                }
-            }
+            return q_should_be_shown($dependency_el) &&
+                $.inArray($dependency_el.val(), dependency_values) > -1;
         }
+
+        $dependency_el = $('input[type="radio"]' + nameSel);
+        if ($dependency_el.length) {
+            if ($dependency_el.closest('.form-group').hasClass('dependency-hidden')) {
+                return false;
+            }
+            return q_should_be_shown($dependency_el.first()) &&
+                $.inArray($dependency_el.filter(':checked').val(), dependency_values) > -1;
+        }
+
+        $dependency_el = $('input[type="checkbox"]' + nameSel);
+        if ($dependency_el.length) {
+            if ($dependency_el.closest('.form-group').hasClass('dependency-hidden')) {
+                return false;
+            }
+
+            var has_true = $.inArray('True', dependency_values) > -1;
+            var has_false = $.inArray('False', dependency_values) > -1;
+
+            if ($dependency_el.length === 1 && (has_true || has_false)) {
+                if (!q_should_be_shown($dependency_el)) {
+                    return false;
+                }
+                var checked = $dependency_el.prop('checked');
+                return (has_true && checked) || (has_false && !checked);
+            }
+
+            if (!q_should_be_shown($dependency_el.first())) {
+                return false;
+            }
+            for (var i = 0; i < dependency_values.length; i++) {
+                var sel = 'input[type="checkbox"]' +
+                    _attr_sel('value', dependency_values[i]) +
+                    nameSel + ':checked';
+                if (safeSelector(sel).length) {
+                    return true;
+                }
+            }
+            return false;
+        }
+
+        return false;
     }
 
-    $("[data-question-dependency]").each(function () {
-        var $dependent = $(this).closest(".form-group");
-        var is_shown = !$dependent.hasClass("dependency-hidden");
+    $('[data-question-dependency]').each(function () {
+        var $dependent = $(this).closest('.form-group');
+        var is_shown = !$dependent.hasClass('dependency-hidden');
         var should_be_shown = q_should_be_shown($(this));
 
         if (should_be_shown && !is_shown) {
-            $dependent.stop().removeClass("dependency-hidden");
+            $dependent.stop().removeClass('dependency-hidden');
             if (!ev) {
                 $dependent.show();
             } else {
                 $dependent.slideDown();
             }
-            $dependent.find("input.required-hidden, select.required-hidden, textarea.required-hidden").each(function () {
-                $(this).prop("required", true).removeClass("required-hidden");
+            $dependent.find('input.required-hidden, select.required-hidden, textarea.required-hidden').each(function () {
+                $(this).prop('required', true).removeClass('required-hidden');
             });
         } else if (!should_be_shown && is_shown) {
-            if ($dependent.hasClass("has-error") || $dependent.find(".has-error").length) {
+            if ($dependent.hasClass('has-error') || $dependent.find('.has-error').length) {
                 // Do not hide things with invalid validation
                 return;
             }
-            $dependent.stop().addClass("dependency-hidden");
+            $dependent.stop().addClass('dependency-hidden');
             if (!ev) {
                 $dependent.hide();
             } else {
                 $dependent.slideUp();
             }
-            $dependent.find("input[required], select[required], textarea[required]").each(function () {
-                $(this).prop("required", false).addClass("required-hidden");
+            $dependent.find('input[required], select[required], textarea[required]').each(function () {
+                $(this).prop('required', false).addClass('required-hidden');
             });
         }
-
     });
 }

--- a/app/tests/tickets/presale/test_question_checkbox_dependency.py
+++ b/app/tests/tickets/presale/test_question_checkbox_dependency.py
@@ -10,7 +10,11 @@ from eventyay.base.models import (
     Organizer,
     Product,
     Question,
+    QuestionAnswer,
     Quota,
+)
+from eventyay.presale.checkoutflowstep.questions_step import (
+    question_is_visible_for_stored_answers,
 )
 
 
@@ -51,6 +55,8 @@ def _add_to_ask(product, *questions):
 def _build_form(env, data):
     prefix = str(env['cart'].id)
     payload = {f'{prefix}-{k}': v for k, v in data.items()}
+    with scopes_disabled():
+        env['cart'].answerlist = list(env['cart'].answers.all())
     return BaseQuestionsForm(
         data=payload,
         event=env['event'],
@@ -280,3 +286,127 @@ def test_multi_checkbox_nothing_selected_skips_followup(env):
 
     form = _build_form(env, {})
     assert form.is_valid(), form.errors
+
+
+def _make_boolean_parent_and_child(env, dep_values):
+    with scopes_disabled():
+        parent = env['event'].questions.create(
+            question='I have dietary restrictions',
+            type=Question.TYPE_BOOLEAN,
+            required=False,
+        )
+        child = env['event'].questions.create(
+            question='Please describe',
+            type=Question.TYPE_TEXT,
+            required=True,
+            dependency_question=parent,
+            dependency_values=dep_values,
+        )
+        env['product'].questions.add(parent, child)
+    return parent, child
+
+
+@pytest.mark.django_db
+def test_stored_answers_boolean_unchecked_shows_false_child(env):
+    parent, child = _make_boolean_parent_and_child(env, ['False'])
+    assert question_is_visible_for_stored_answers(
+        parent.pk, child.dependency_values, {parent.pk: parent, child.pk: child}, {}
+    ) is True
+
+
+@pytest.mark.django_db
+def test_stored_answers_boolean_unchecked_hides_true_child(env):
+    parent, child = _make_boolean_parent_and_child(env, ['True'])
+    assert question_is_visible_for_stored_answers(
+        parent.pk, child.dependency_values, {parent.pk: parent, child.pk: child}, {}
+    ) is False
+
+
+@pytest.mark.django_db
+def test_stored_answers_boolean_checked_shows_true_child(env):
+    parent, child = _make_boolean_parent_and_child(env, ['True'])
+    with scopes_disabled():
+        answer = QuestionAnswer.objects.create(
+            cartposition=env['cart'], question=parent, answer='True'
+        )
+    assert question_is_visible_for_stored_answers(
+        parent.pk,
+        child.dependency_values,
+        {parent.pk: parent, child.pk: child},
+        {parent.pk: answer},
+    ) is True
+
+
+@pytest.mark.django_db
+def test_stored_answers_boolean_checked_hides_false_child(env):
+    parent, child = _make_boolean_parent_and_child(env, ['False'])
+    with scopes_disabled():
+        answer = QuestionAnswer.objects.create(
+            cartposition=env['cart'], question=parent, answer='True'
+        )
+    assert question_is_visible_for_stored_answers(
+        parent.pk,
+        child.dependency_values,
+        {parent.pk: parent, child.pk: child},
+        {parent.pk: answer},
+    ) is False
+
+
+@pytest.mark.django_db
+def test_stored_answers_multi_checkbox_selected_option_matches(env):
+    with scopes_disabled():
+        parent = env['event'].questions.create(
+            question='Workshops?',
+            type=Question.TYPE_CHOICE_MULTIPLE,
+            required=False,
+        )
+        opt_a = parent.options.create(answer='A', identifier='WSA')
+        parent.options.create(answer='B', identifier='WSB')
+        child = env['event'].questions.create(
+            question='Workshop A details',
+            type=Question.TYPE_TEXT,
+            required=True,
+            dependency_question=parent,
+            dependency_values=['WSA'],
+        )
+        env['product'].questions.add(parent, child)
+        answer = QuestionAnswer.objects.create(
+            cartposition=env['cart'], question=parent, answer='A'
+        )
+        answer.options.add(opt_a)
+    assert question_is_visible_for_stored_answers(
+        parent.pk,
+        child.dependency_values,
+        {parent.pk: parent, child.pk: child},
+        {parent.pk: answer},
+    ) is True
+
+
+@pytest.mark.django_db
+def test_stored_answers_multi_checkbox_other_option_hides_child(env):
+    with scopes_disabled():
+        parent = env['event'].questions.create(
+            question='Workshops?',
+            type=Question.TYPE_CHOICE_MULTIPLE,
+            required=False,
+        )
+        parent.options.create(answer='A', identifier='WSA')
+        opt_b = parent.options.create(answer='B', identifier='WSB')
+        child = env['event'].questions.create(
+            question='Workshop A details',
+            type=Question.TYPE_TEXT,
+            required=True,
+            dependency_question=parent,
+            dependency_values=['WSA'],
+        )
+        env['product'].questions.add(parent, child)
+        answer = QuestionAnswer.objects.create(
+            cartposition=env['cart'], question=parent, answer='B'
+        )
+        answer.options.add(opt_b)
+    assert question_is_visible_for_stored_answers(
+        parent.pk,
+        child.dependency_values,
+        {parent.pk: parent, child.pk: child},
+        {parent.pk: answer},
+    ) is False

--- a/app/tests/tickets/presale/test_question_checkbox_dependency.py
+++ b/app/tests/tickets/presale/test_question_checkbox_dependency.py
@@ -1,0 +1,282 @@
+from datetime import datetime, timedelta, timezone
+
+import pytest
+from django_scopes import scopes_disabled
+
+from eventyay.base.forms.questions import BaseQuestionsForm
+from eventyay.base.models import (
+    CartPosition,
+    Event,
+    Organizer,
+    Product,
+    Question,
+    Quota,
+)
+
+
+@pytest.fixture
+def env(db):
+    with scopes_disabled():
+        orga = Organizer.objects.create(name='Org', slug='org')
+        event = Event.objects.create(
+            organizer=orga,
+            name='Conf',
+            slug='conf',
+            date_from=datetime(2030, 12, 26, tzinfo=timezone.utc),
+            plugins='eventyay.plugins.banktransfer',
+        )
+        product = Product.objects.create(
+            event=event,
+            name='Ticket',
+            default_price=0,
+            admission=True,
+        )
+        quota = Quota.objects.create(event=event, name='Quota', size=200)
+        quota.products.add(product)
+        cp = CartPosition.objects.create(
+            event=event,
+            cart_id='test-cart',
+            product=product,
+            price=0,
+            expires=datetime.now(timezone.utc) + timedelta(minutes=10),
+        )
+    return {'event': event, 'product': product, 'cart': cp}
+
+
+def _add_to_ask(product, *questions):
+    """Mimic the ``questions_to_ask`` prefetch attribute expected by the form."""
+    product.questions_to_ask = list(questions)
+
+
+def _build_form(env, data):
+    prefix = str(env['cart'].id)
+    payload = {f'{prefix}-{k}': v for k, v in data.items()}
+    return BaseQuestionsForm(
+        data=payload,
+        event=env['event'],
+        cartpos=env['cart'],
+        all_optional=False,
+        prefix=prefix,
+    )
+
+
+@pytest.mark.django_db
+def test_boolean_checked_makes_followup_required(env):
+    with scopes_disabled():
+        parent = env['event'].questions.create(
+            question='I have dietary restrictions',
+            type=Question.TYPE_BOOLEAN,
+            required=False,
+        )
+        child = env['event'].questions.create(
+            question='Please describe',
+            type=Question.TYPE_TEXT,
+            required=True,
+            dependency_question=parent,
+            dependency_values=['True'],
+        )
+        env['product'].questions.add(parent, child)
+        _add_to_ask(env['product'], parent, child)
+
+    form = _build_form(env, {f'question_{parent.id}': 'on'})
+    assert not form.is_valid()
+    assert f'question_{child.id}' in form.errors
+
+
+@pytest.mark.django_db
+def test_boolean_checked_followup_provided_passes(env):
+    with scopes_disabled():
+        parent = env['event'].questions.create(
+            question='I have dietary restrictions',
+            type=Question.TYPE_BOOLEAN,
+            required=False,
+        )
+        child = env['event'].questions.create(
+            question='Please describe',
+            type=Question.TYPE_TEXT,
+            required=True,
+            dependency_question=parent,
+            dependency_values=['True'],
+        )
+        env['product'].questions.add(parent, child)
+        _add_to_ask(env['product'], parent, child)
+
+    form = _build_form(
+        env,
+        {
+            f'question_{parent.id}': 'on',
+            f'question_{child.id}': 'No nuts please',
+        },
+    )
+    assert form.is_valid(), form.errors
+
+
+@pytest.mark.django_db
+def test_boolean_unchecked_followup_not_required(env):
+    """A hidden required follow-up must not block submission."""
+    with scopes_disabled():
+        parent = env['event'].questions.create(
+            question='I have dietary restrictions',
+            type=Question.TYPE_BOOLEAN,
+            required=False,
+        )
+        child = env['event'].questions.create(
+            question='Please describe',
+            type=Question.TYPE_TEXT,
+            required=True,
+            dependency_question=parent,
+            dependency_values=['True'],
+        )
+        env['product'].questions.add(parent, child)
+        _add_to_ask(env['product'], parent, child)
+
+    form = _build_form(env, {})
+    assert form.is_valid(), form.errors
+
+
+@pytest.mark.django_db
+def test_boolean_inverse_dependency_unchecked_requires_followup(env):
+    """dependency_values=['False'] means follow-up is shown when the parent is unchecked."""
+    with scopes_disabled():
+        parent = env['event'].questions.create(
+            question='I have already shared this info',
+            type=Question.TYPE_BOOLEAN,
+            required=False,
+        )
+        child = env['event'].questions.create(
+            question='How should we contact you?',
+            type=Question.TYPE_TEXT,
+            required=True,
+            dependency_question=parent,
+            dependency_values=['False'],
+        )
+        env['product'].questions.add(parent, child)
+        _add_to_ask(env['product'], parent, child)
+
+    form = _build_form(env, {})
+    assert not form.is_valid()
+    assert f'question_{child.id}' in form.errors
+
+
+@pytest.mark.django_db
+def test_boolean_inverse_dependency_checked_skips_followup(env):
+    with scopes_disabled():
+        parent = env['event'].questions.create(
+            question='I have already shared this info',
+            type=Question.TYPE_BOOLEAN,
+            required=False,
+        )
+        child = env['event'].questions.create(
+            question='How should we contact you?',
+            type=Question.TYPE_TEXT,
+            required=True,
+            dependency_question=parent,
+            dependency_values=['False'],
+        )
+        env['product'].questions.add(parent, child)
+        _add_to_ask(env['product'], parent, child)
+
+    form = _build_form(env, {f'question_{parent.id}': 'on'})
+    assert form.is_valid(), form.errors
+
+
+@pytest.mark.django_db
+def test_multi_checkbox_matching_option_requires_followup(env):
+    with scopes_disabled():
+        parent = env['event'].questions.create(
+            question='Which workshops?',
+            type=Question.TYPE_CHOICE_MULTIPLE,
+            required=False,
+        )
+        parent.options.create(answer='Workshop A', identifier='WSA')
+        parent.options.create(answer='Workshop B', identifier='WSB')
+        child = env['event'].questions.create(
+            question='Workshop A: prior experience?',
+            type=Question.TYPE_TEXT,
+            required=True,
+            dependency_question=parent,
+            dependency_values=['WSA'],
+        )
+        env['product'].questions.add(parent, child)
+        _add_to_ask(env['product'], parent, child)
+
+    form = _build_form(env, {f'question_{parent.id}': ['WSA']})
+    assert not form.is_valid()
+    assert f'question_{child.id}' in form.errors
+
+
+@pytest.mark.django_db
+def test_multi_checkbox_matching_option_followup_provided_passes(env):
+    with scopes_disabled():
+        parent = env['event'].questions.create(
+            question='Which workshops?',
+            type=Question.TYPE_CHOICE_MULTIPLE,
+            required=False,
+        )
+        parent.options.create(answer='Workshop A', identifier='WSA')
+        parent.options.create(answer='Workshop B', identifier='WSB')
+        child = env['event'].questions.create(
+            question='Workshop A: prior experience?',
+            type=Question.TYPE_TEXT,
+            required=True,
+            dependency_question=parent,
+            dependency_values=['WSA'],
+        )
+        env['product'].questions.add(parent, child)
+        _add_to_ask(env['product'], parent, child)
+
+    form = _build_form(
+        env,
+        {
+            f'question_{parent.id}': ['WSA'],
+            f'question_{child.id}': 'Yes, attended last year',
+        },
+    )
+    assert form.is_valid(), form.errors
+
+
+@pytest.mark.django_db
+def test_multi_checkbox_other_option_skips_followup(env):
+    with scopes_disabled():
+        parent = env['event'].questions.create(
+            question='Which workshops?',
+            type=Question.TYPE_CHOICE_MULTIPLE,
+            required=False,
+        )
+        parent.options.create(answer='Workshop A', identifier='WSA')
+        parent.options.create(answer='Workshop B', identifier='WSB')
+        child = env['event'].questions.create(
+            question='Workshop A: prior experience?',
+            type=Question.TYPE_TEXT,
+            required=True,
+            dependency_question=parent,
+            dependency_values=['WSA'],
+        )
+        env['product'].questions.add(parent, child)
+        _add_to_ask(env['product'], parent, child)
+
+    form = _build_form(env, {f'question_{parent.id}': ['WSB']})
+    assert form.is_valid(), form.errors
+
+
+@pytest.mark.django_db
+def test_multi_checkbox_nothing_selected_skips_followup(env):
+    with scopes_disabled():
+        parent = env['event'].questions.create(
+            question='Which workshops?',
+            type=Question.TYPE_CHOICE_MULTIPLE,
+            required=False,
+        )
+        parent.options.create(answer='Workshop A', identifier='WSA')
+        child = env['event'].questions.create(
+            question='Workshop A: prior experience?',
+            type=Question.TYPE_TEXT,
+            required=True,
+            dependency_question=parent,
+            dependency_values=['WSA'],
+        )
+        env['product'].questions.add(parent, child)
+        _add_to_ask(env['product'], parent, child)
+
+    form = _build_form(env, {})
+    assert form.is_valid(), form.errors


### PR DESCRIPTION
Fixes #4167 

### Summary
Conditional (dependent) questions in ticketing forms did not show or hide correctly when the controlling question was a checkbox — either a single confirm checkbox or a multi-option checkbox. Radio buttons and dropdowns worked as parents; checkboxes did not.

### Root causes:
- `questions_toggle_dependent` (presale JS) built CSS attribute selectors by string concatenation. Field names are prefixed with the cart position id (e.g. `5-question_42`), and `document.querySelectorAll` rejects selectors built from unescaped values starting with a digit. Multi-option checkbox parents therefore never matched, so dependents stayed hidden regardless of what was selected.
- The same function had branches that returned `undefined` instead of an explicit `true`/`false` (e.g. when the parent element wasn't found, or was itself hidden), so visibility decisions were inconsistent.
- Server-side, `QuestionsStep.is_completed` treated an unchecked `TYPE_BOOLEAN` parent (which has no stored `QuestionAnswer`, since empty answers are deleted) as "unknown/hidden" rather than "False". This let a required follow-up question with `dependency_values=['False']` bypass validation.

### Changes
- Rewrote `questions_toggle_dependent` in `app/eventyay/static/pretixpresale/js/ui/questions.js` to build properly
  escaped CSS attribute selectors, scope the single-checkbox lookup to `input[type="checkbox"]`, and return an explicit boolean from every branch.
- Fixed `QuestionsStep.is_completed` in `app/eventyay/presale/checkoutflowstep/questions_step.py` to treat a missing answer on a `TYPE_BOOLEAN` parent as `'False'`.
- Reworded the organiser-facing dependency value labels in `app/eventyay/static/pretixcontrol/js/ui/question.js` from "Yes"/"No" to "is checked"/"is not checked" for clearer condition semantics.
- Added `app/tests/tickets/presale/test_question_checkbox_dependency.py` covering single checkbox and multi-option checkbox parents, both checked and unchecked directions, and the "hidden required question must not block submission" case.

https://github.com/user-attachments/assets/4d325a74-f010-4c63-a060-04b579efc057


### Risk and Rollback
Low risk — changes are scoped to conditional-question display/validation logic for ticketing forms only (not the CfP/talk dependency system, which is a separate implementation). Revert by reverting this branch/commit; no migrations or data changes involved.