### PR TITLE
fix: replace debug print statements with proper logging

### DIFF
--- a/app/eventyay/base/services/connections.py
+++ b/app/eventyay/base/services/connections.py
@@ -1,8 +1,12 @@
+
+import logging
 import time
 
 from django.conf import settings
 
 from eventyay.core.utils.redis import aredis
+
+logger = logging.getLogger(__name__)
 
 
 async def register_connection():
@@ -55,15 +59,9 @@ async def unregister_user_connection(user_id, channel_name):
 
 async def get_user_connection_count(user_id):
     async with aredis() as redis:
-        print(
-            f"connections.list.user:{user_id}",
-            await redis.llen(
-                f"connections.list.user:{user_id}",
-            ),
-        )
-        return await redis.llen(
-            f"connections.list.user:{user_id}",
-        )
+        count = await redis.llen(f"connections.list.user:{user_id}")
+        logger.debug("connections.list.user:%s count=%s", user_id, count)
+        return count
 
 
 async def ping_connection(last_ping, user=None):

--- a/app/eventyay/plugins/badges/apps.py
+++ b/app/eventyay/plugins/badges/apps.py
@@ -1,4 +1,5 @@
 import json
+import logging
 import os
 
 from django.apps import AppConfig
@@ -9,6 +10,8 @@ from django.utils.translation import gettext_lazy as _
 from rest_framework.renderers import BaseRenderer
 
 from eventyay import __version__ as version
+
+logger = logging.getLogger(__name__)
 
 
 class PDFRenderer(BaseRenderer):
@@ -61,7 +64,7 @@ class BadgesApp(AppConfig):
                 default=True,
             )
             media_dir = os.path.join(os.path.dirname(__file__), 'media')
-            print("\n\n\n", media_dir, "\n\n\n")
+            logger.debug("Badge media directory: %s", media_dir)
             templates_path = os.path.join(
                 os.path.dirname(__file__),
                 'templates',


### PR DESCRIPTION
## Problem
Two files contained debug `print()` statements accidentally left in  production code.

## Why print() in production is harmful
- Cannot be silenced — unlike loggers, there's no log level to filter them
- Leaks internal paths and user IDs to server stdout
- Blocks async I/O — especially dangerous in async functions like
  `get_user_connection_count()`
- No context — no timestamp, module name, or severity level

## Changes

| File | Issue | Fix |
|------|-------|-----|
| `base/services/connections.py` | `print()` in async function + duplicate `redis.llen()` call | Replaced with `logger.debug()`, removed duplicate DB call |
| `plugins/badges/apps.py` | `print()` leaking internal file path | Replaced with `logger.debug()` |

## Bonus fix
In `connections.py`, the original code called `redis.llen()` **twice**  unnecessarily. The refactor removes the duplicate call, making the  function more efficient.

## Testing
No behaviour change — debug output is now routed through Python's  logging system and only appears when DEBUG log level is enabled.