### PR TITLE
fix(schedule): show all event days when toolbar space allows

### DIFF
--- a/app/eventyay/webapp/schedule/src/App.vue
+++ b/app/eventyay/webapp/schedule/src/App.vue
@@ -299,6 +299,8 @@ export default {
 			now: moment(),
 			currentDay: null,
 			forceScrollDay: 0,
+			userNavigatingToDay: null,
+			_dayNavTimeout: null,
 			currentTimezone: null,
 			favs: [],
 			userCode: null,
@@ -861,11 +863,35 @@ export default {
 			}
 		},
 		setCurrentDay (day) {
-			// Find best match among days, because timezones can muddle this
-			const matchingDays = this.days.filter(d => d.format('YYYY-MM-DD') === day.format('YYYY-MM-DD'))
-			if (matchingDays.length) {
-				this.currentDay = matchingDays[0].format('YYYY-MM-DD')
+			const dayStr = day.format('YYYY-MM-DD')
+			if (this.userNavigatingToDay && dayStr !== this.userNavigatingToDay) {
+				return
 			}
+			const matchingDays = this.days.filter(d => d.format('YYYY-MM-DD') === dayStr)
+			if (!matchingDays.length) return
+			const nextDay = matchingDays[0].format('YYYY-MM-DD')
+			if (nextDay === this.currentDay) {
+				if (this.userNavigatingToDay === nextDay) {
+					this.clearDayNavigationLock()
+				}
+				return
+			}
+			this.currentDay = nextDay
+			if (this.userNavigatingToDay === nextDay) {
+				this.clearDayNavigationLock()
+			}
+		},
+		clearDayNavigationLock () {
+			if (this._dayNavTimeout) {
+				clearTimeout(this._dayNavTimeout)
+				this._dayNavTimeout = null
+			}
+			this.userNavigatingToDay = null
+		},
+		beginDayNavigation (dayId) {
+			this.clearDayNavigationLock()
+			this.userNavigatingToDay = dayId
+			this._dayNavTimeout = setTimeout(() => this.clearDayNavigationLock(), 2000)
 		},
 		changeDay (day) {
 			if (day.clone().startOf('day').format('YYYY-MM-DD') === this.currentDay) return
@@ -882,11 +908,14 @@ export default {
 			} catch (e) {
 				window.location.hash = dayId
 			}
-			if (dayId === this.currentDay) {
-				this.forceScrollDay++
-				return
+			if (dayId !== this.currentDay) {
+				this.beginDayNavigation(dayId)
+				this.currentDay = dayId
 			}
-			this.currentDay = dayId
+			// Always scroll on toolbar click. When the day is already visible,
+			// scroll-sync may have set currentDay with _scrollDayUpdate, which
+			// skips the currentDay watcher — forceScrollDay handles that case.
+			this.forceScrollDay++
 		},
 		onWindowResize () {
 			this.scrollParentWidth = document.body.offsetWidth

--- a/app/eventyay/webapp/schedule/src/components/GridSchedule.vue
+++ b/app/eventyay/webapp/schedule/src/components/GridSchedule.vue
@@ -532,7 +532,7 @@ export default {
 		},
 		scrollToDayStart (day) {
 			const dayStr = moment.isMoment(day) ? day.clone().tz(this.timezone).startOf('day').format('YYYY-MM-DD') : day
-			const el = this.$el.querySelector(`[data-slice-day="${dayStr}"]`)
+			const el = this.$el.querySelector(`.timeslice.datebreak[data-slice-day="${dayStr}"]`)
 			if (!el) return
 			this.scrollElementIntoViewWithClearance(el)
 		},
@@ -608,8 +608,9 @@ export default {
 			document.addEventListener('mouseup', onMouseUp)
 		},
 		onIntersect (entries) {
-			const entry = entries.sort((a, b) => b.ts - a.ts).find(entry => entry.isIntersecting)
-			if (!entry) return
+			const intersecting = entries.filter(entry => entry.isIntersecting)
+			if (!intersecting.length) return
+			const entry = intersecting.sort((a, b) => a.boundingClientRect.top - b.boundingClientRect.top)[0]
 			const dayStr = entry.target.dataset.sliceDay
 			if (!dayStr || dayStr === this.currentDay) return
 			// Only update the active day indicator — don't trigger a scroll jump.

--- a/app/eventyay/webapp/schedule/src/components/ScheduleToolbar.vue
+++ b/app/eventyay/webapp/schedule/src/components/ScheduleToolbar.vue
@@ -647,16 +647,18 @@ export default {
 			this._onStackedToolbarMqChange = () => {
 				this.$nextTick(() => this.updateDayNavigation())
 			}
-			this._stackedToolbarMq.addEventListener('change', this._onStackedToolbarMqChange)
+			if (typeof this._stackedToolbarMq.addEventListener === 'function') {
+				this._stackedToolbarMq.addEventListener('change', this._onStackedToolbarMqChange)
+			} else if (typeof this._stackedToolbarMq.addListener === 'function') {
+				this._stackedToolbarMq.addListener(this._onStackedToolbarMqChange)
+			}
 		}
 		this.$nextTick(() => {
 			this.updateVersionBannerHeight()
 			this.updateToolbarHeight()
 			if (typeof ResizeObserver !== 'undefined') {
 				this._versionBannerResizeObserver = new ResizeObserver(() => {
-					this.updateVersionBannerHeight()
-					this.updateToolbarHeight()
-					this.updateDayNavigation()
+					this.scheduleToolbarLayoutUpdate()
 				})
 				if (this.$refs.versionBanner) this._versionBannerResizeObserver.observe(this.$refs.versionBanner)
 				this._versionBannerResizeObserver.observe(this.$el)
@@ -674,15 +676,28 @@ export default {
 	beforeUnmount() {
 		document.removeEventListener('click', this.outsideClick, true)
 		document.removeEventListener('fullscreenchange', this.onFullscreenChange)
-		this._stackedToolbarMq?.removeEventListener('change', this._onStackedToolbarMqChange)
+		if (this._stackedToolbarMq && this._onStackedToolbarMqChange) {
+			if (typeof this._stackedToolbarMq.removeEventListener === 'function') {
+				this._stackedToolbarMq.removeEventListener('change', this._onStackedToolbarMqChange)
+			} else if (typeof this._stackedToolbarMq.removeListener === 'function') {
+				this._stackedToolbarMq.removeListener(this._onStackedToolbarMqChange)
+			}
+		}
+		if (this._toolbarLayoutRaf) {
+			cancelAnimationFrame(this._toolbarLayoutRaf)
+			this._toolbarLayoutRaf = null
+		}
 		this._versionBannerResizeObserver?.disconnect?.()
 	},
 	methods: {
-		isStackedToolbarLayout() {
-			if (typeof window === 'undefined' || typeof window.matchMedia !== 'function') {
-				return false
-			}
-			return window.matchMedia(`(max-width: ${STACKED_TOOLBAR_MAX_WIDTH}px)`).matches
+		scheduleToolbarLayoutUpdate() {
+			if (this._toolbarLayoutRaf) return
+			this._toolbarLayoutRaf = requestAnimationFrame(() => {
+				this._toolbarLayoutRaf = null
+				this.updateVersionBannerHeight()
+				this.updateToolbarHeight()
+				this.updateDayNavigation()
+			})
 		},
 		updateVersionBannerHeight() {
 			const host = this.$el?.parentElement
@@ -936,16 +951,23 @@ export default {
 					return
 				}
 
-				for (let count = this.days.length - 1; count >= 1; count--) {
-					this.maxVisibleDays = count
+				let lo = 1
+				let hi = this.days.length - 1
+				let bestFit = 1
+				while (lo <= hi) {
+					const mid = Math.floor((lo + hi) / 2)
+					this.maxVisibleDays = mid
 					await this.$nextTick()
 					if (fits()) {
-						this.ensureCurrentDayVisible()
-						return
+						bestFit = mid
+						lo = mid + 1
+					} else {
+						hi = mid - 1
 					}
 				}
 
-				this.maxVisibleDays = 1
+				this.maxVisibleDays = bestFit
+				await this.$nextTick()
 				this.ensureCurrentDayVisible()
 			} finally {
 				this._updatingDayNav = false

--- a/app/eventyay/webapp/schedule/src/components/ScheduleToolbar.vue
+++ b/app/eventyay/webapp/schedule/src/components/ScheduleToolbar.vue
@@ -4,7 +4,7 @@
 		span.version-warning-text {{ versionWarningText }}
 		a.current-version-link(v-if="currentScheduleUrl && !isWipPreview", :href="currentScheduleUrl")
 			|  {{ t.go_to_current_version }}
-	.toolbar-row
+	.toolbar-row(ref="toolbarRow")
 		.toolbar-left
 			button.toolbar-btn.mobile-toggle-btn.mobile-filter-toggle.icon-only(
 				class="tooltip-align-left"
@@ -148,8 +148,8 @@
 						line(x1="3", y1="12", x2="3.01", y2="12")
 						line(x1="3", y1="18", x2="3.01", y2="18")
 				span.sessions-toggle-label {{ sessionsMode ? t.cal : t.list }}
-		.toolbar-center(v-if="!isListView && days && days.length > 1")
-			button.day-arrow(:disabled="dayWindowStart <= 0", @click="shiftDays(-2)", :title="t.previous_days", :aria-label="t.previous_days")
+		.toolbar-center(v-if="!isListView && days && days.length > 1", ref="dayNavCenter")
+			button.day-arrow(v-if="showDayArrows", :disabled="dayWindowStart <= 0", @click="shiftDays(-1)", :title="t.previous_days", :aria-label="t.previous_days")
 				svg(viewBox="0 0 24 24", fill="none", stroke="currentColor", stroke-width="2")
 					path(d="M15 18l-6-6 6-6")
 			button.day-btn(
@@ -158,7 +158,7 @@
 				:class="{active: currentDay === day.id}",
 				@click="$emit('selectDay', day.id)")
 				| {{ day.label }}
-			button.day-arrow(:disabled="dayWindowStart + 3 >= days.length", @click="shiftDays(2)", :title="t.next_days", :aria-label="t.next_days")
+			button.day-arrow(v-if="showDayArrows", :disabled="dayWindowStart + dayWindowSize >= days.length", @click="shiftDays(1)", :title="t.next_days", :aria-label="t.next_days")
 				svg(viewBox="0 0 24 24", fill="none", stroke="currentColor", stroke-width="2")
 					path(d="M9 18l6-6-6-6")
 		.toolbar-right
@@ -324,7 +324,6 @@
 </template>
 
 <script>
-// FA icon name → inline SVG path mapping (shadow DOM blocks external CSS)
 const FA_SVG_MAP = {
 	'fa-calendar': '<rect x="3" y="4" width="18" height="18" rx="2" ry="2"/><line x1="16" y1="2" x2="16" y2="6"/><line x1="8" y1="2" x2="8" y2="6"/><line x1="3" y1="10" x2="21" y2="10"/>',
 	'fa-code': '<polyline points="16 18 22 12 16 6"/><polyline points="8 6 2 12 8 18"/>',
@@ -333,6 +332,8 @@ const FA_SVG_MAP = {
 	'fa-question-circle': '<circle cx="12" cy="12" r="10"/><path d="M9.09 9a3 3 0 015.83 1c0 2-3 3-3 3"/><line x1="12" y1="17" x2="12.01" y2="17"/>',
 	'fa-question-circle-o': '<circle cx="12" cy="12" r="10"/><path d="M9.09 9a3 3 0 015.83 1c0 2-3 3-3 3"/><line x1="12" y1="17" x2="12.01" y2="17"/>',
 }
+
+const STACKED_TOOLBAR_MAX_WIDTH = 1024
 
 export default {
 	name: 'ScheduleToolbar',
@@ -388,6 +389,7 @@ export default {
 			isFullscreen: false,
 			openFilterDropdowns: {},
 			dayWindowStart: 0,
+			maxVisibleDays: Infinity,
 			recordingOpen: false,
 			sortOpen: false,
 			densityOpen: false,
@@ -600,10 +602,20 @@ export default {
 			get() { return this.recordingFilter || 'all' },
 			set(value) { this.$emit('update:recordingFilter', value) }
 		},
+		dayWindowSize() {
+			if (!this.days || this.days.length <= 1) return 0
+			if (!Number.isFinite(this.maxVisibleDays) || this.maxVisibleDays >= this.days.length) {
+				return this.days.length
+			}
+			return Math.max(1, this.maxVisibleDays)
+		},
+		showDayArrows() {
+			return Boolean(this.days && this.days.length > 1 && this.days.length > this.dayWindowSize)
+		},
 		visibleDays() {
 			if (!this.days || this.days.length <= 1) return []
 			return this.days
-				.slice(this.dayWindowStart, this.dayWindowStart + 3)
+				.slice(this.dayWindowStart, this.dayWindowStart + this.dayWindowSize)
 				.map(day => ({
 					id: day.format('YYYY-MM-DD'),
 					label: day.format('ddd D MMM')
@@ -611,30 +623,32 @@ export default {
 		}
 	},
 	watch: {
-		currentDay(newDay) {
-			if (!this.days || this.days.length <= 1) return
-			const idx = this.days.findIndex(d => d.format('YYYY-MM-DD') === newDay)
-			if (idx < 0) return
-			if (idx < this.dayWindowStart) {
-				this.dayWindowStart = Math.max(0, idx)
-			} else if (idx >= this.dayWindowStart + 3) {
-				this.dayWindowStart = Math.min(this.days.length - 3, idx - 2)
-			}
+		currentDay() {
+			this.ensureCurrentDayVisible()
 		},
 		days: {
 			immediate: true,
-			handler(newDays) {
-				if (!newDays || newDays.length <= 1) return
-				const idx = newDays.findIndex(d => d.format('YYYY-MM-DD') === this.currentDay)
-				if (idx >= 0) {
-					this.dayWindowStart = Math.max(0, Math.min(idx, newDays.length - 3))
-				}
+			handler() {
+				this.$nextTick(() => this.updateDayNavigation())
 			}
+		},
+		showDayArrows() {
+			this.ensureCurrentDayVisible()
+		},
+		searchExpanded() {
+			this.$nextTick(() => this.updateDayNavigation())
 		}
 	},
 	mounted() {
 		document.addEventListener('click', this.outsideClick, true)
 		document.addEventListener('fullscreenchange', this.onFullscreenChange)
+		if (typeof window !== 'undefined' && typeof window.matchMedia === 'function') {
+			this._stackedToolbarMq = window.matchMedia(`(max-width: ${STACKED_TOOLBAR_MAX_WIDTH}px)`)
+			this._onStackedToolbarMqChange = () => {
+				this.$nextTick(() => this.updateDayNavigation())
+			}
+			this._stackedToolbarMq.addEventListener('change', this._onStackedToolbarMqChange)
+		}
 		this.$nextTick(() => {
 			this.updateVersionBannerHeight()
 			this.updateToolbarHeight()
@@ -642,18 +656,34 @@ export default {
 				this._versionBannerResizeObserver = new ResizeObserver(() => {
 					this.updateVersionBannerHeight()
 					this.updateToolbarHeight()
+					this.updateDayNavigation()
 				})
 				if (this.$refs.versionBanner) this._versionBannerResizeObserver.observe(this.$refs.versionBanner)
 				this._versionBannerResizeObserver.observe(this.$el)
+				if (this.$refs.toolbarRow) {
+					this._versionBannerResizeObserver.observe(this.$refs.toolbarRow)
+					for (const selector of ['.toolbar-left', '.toolbar-center', '.toolbar-right']) {
+						const el = this.$refs.toolbarRow.querySelector(selector)
+						if (el) this._versionBannerResizeObserver.observe(el)
+					}
+				}
 			}
+			this.updateDayNavigation()
 		})
 	},
 	beforeUnmount() {
 		document.removeEventListener('click', this.outsideClick, true)
 		document.removeEventListener('fullscreenchange', this.onFullscreenChange)
+		this._stackedToolbarMq?.removeEventListener('change', this._onStackedToolbarMqChange)
 		this._versionBannerResizeObserver?.disconnect?.()
 	},
 	methods: {
+		isStackedToolbarLayout() {
+			if (typeof window === 'undefined' || typeof window.matchMedia !== 'function') {
+				return false
+			}
+			return window.matchMedia(`(max-width: ${STACKED_TOOLBAR_MAX_WIDTH}px)`).matches
+		},
 		updateVersionBannerHeight() {
 			const host = this.$el?.parentElement
 			if (!host) return
@@ -867,8 +897,69 @@ export default {
 			item.selected = !item.selected
 			this.$emit('filterToggle', item)
 		},
-		shiftDays(delta) {
-			const max = Math.max(0, this.days.length - 3)
+		ensureCurrentDayVisible() {
+			if (!this.days || this.days.length <= 1) return
+			if (!this.showDayArrows) {
+				this.dayWindowStart = 0
+				return
+			}
+			const idx = this.days.findIndex(d => d.format('YYYY-MM-DD') === this.currentDay)
+			if (idx < 0) return
+			const size = this.dayWindowSize
+			if (idx < this.dayWindowStart) {
+				this.dayWindowStart = Math.max(0, idx)
+			} else if (idx >= this.dayWindowStart + size) {
+				this.dayWindowStart = Math.min(this.days.length - size, idx - size + 1)
+			}
+		},
+		async updateDayNavigation() {
+			if (this._updatingDayNav) return
+			const center = this.$refs.dayNavCenter
+			if (!center || !this.days?.length || this.days.length <= 1) {
+				this.maxVisibleDays = Infinity
+				return
+			}
+
+			this._updatingDayNav = true
+			try {
+				const fits = () => {
+					const available = this.getDayNavAvailableWidth()
+					if (available <= 0) return false
+					return center.scrollWidth <= available + 1
+				}
+
+				this.maxVisibleDays = this.days.length
+				await this.$nextTick()
+				await new Promise(resolve => requestAnimationFrame(resolve))
+				if (fits()) {
+					this.dayWindowStart = 0
+					return
+				}
+
+				for (let count = this.days.length - 1; count >= 1; count--) {
+					this.maxVisibleDays = count
+					await this.$nextTick()
+					if (fits()) {
+						this.ensureCurrentDayVisible()
+						return
+					}
+				}
+
+				this.maxVisibleDays = 1
+				this.ensureCurrentDayVisible()
+			} finally {
+				this._updatingDayNav = false
+			}
+		},
+		getDayNavAvailableWidth() {
+			const center = this.$refs.dayNavCenter
+			if (!center) return 0
+			return Math.max(0, center.clientWidth)
+		},
+		shiftDays(direction) {
+			const step = Math.max(1, this.dayWindowSize - 1)
+			const delta = direction < 0 ? -step : step
+			const max = Math.max(0, this.days.length - this.dayWindowSize)
 			this.dayWindowStart = Math.max(0, Math.min(max, this.dayWindowStart + delta))
 		},
 		toggleSearch() {
@@ -1165,6 +1256,7 @@ export default {
 			font-size: 13px
 			font-weight: 500
 			white-space: nowrap
+			flex-shrink: 0
 			color: #555
 			&:hover
 				background-color: rgba(0, 0, 0, 0.05)
@@ -1595,60 +1687,28 @@ export default {
 	&.open
 		transform: rotate(180deg)
 
-@media (max-width: 600px)
+@media (min-width: 1025px)
 	.c-schedule-toolbar
-		.filter-title,
-		.filter-title-text,
-		.filter-dot,
-		.filter-dropdown-label,
-		label.filter-dropdown-item,
-		button.toolbar-btn,
-		button.toolbar-btn span,
-		button.toolbar-btn .filter-title,
-		button.toolbar-btn .filter-title-text {
-			color: #111
-		}
-		svg.tb-icon,
-		svg.chevron-icon {
-			stroke: #111
-			color: #111
-			fill: none
-		}
-		.language-filter-area svg.tb-icon {
-			fill: #111
-			color: #111
-			stroke: none
-		}
-		.sessions-toggle-label
-			display: none
-		.sessions-toggle[aria-label]
-			position: relative
-			&::after
-				content: attr(aria-label)
-				position: absolute
-				left: 50%
-				top: calc(100% + 6px)
-				transform: translateX(-50%) translateY(-2px)
-				opacity: 0
-				pointer-events: none
-				background-color: rgba(0, 0, 0, 0.87)
-				color: #fff
-				padding: 4px 8px
-				border-radius: 4px
-				font-size: 12px
-				line-height: 1.2
-				white-space: nowrap
-				z-index: 1000
-			&:hover::after, &:focus-visible::after
-				opacity: 1
-				transform: translateX(-50%) translateY(0)
-				transition: opacity 0.05s ease, transform 0.05s ease
+		.toolbar-row
+			display: grid
+			grid-template-columns: auto minmax(0, 1fr) auto
+			align-items: center
+			gap: 8px
+		.toolbar-left
+			flex: none
+			min-width: 0
+		.toolbar-center
+			flex: none
+			justify-content: center
+			min-width: 0
+			max-width: 100%
 		.toolbar-right
-			.fullscreen-quick
-				display: inline-flex
-				order: 98
-		.toolbar-btn.icon-only[aria-label]::after
-			display: none
+			flex: none
+			min-width: 0
+			justify-self: end
+
+@media (max-width: 1024px)
+	.c-schedule-toolbar
 		.toolbar-row
 			display: grid
 			grid-template-columns: minmax(0, 1fr) auto
@@ -1656,11 +1716,14 @@ export default {
 			align-items: center
 			height: auto
 			min-height: 40px
-			padding: 6px
+			padding: 6px 8px
 			gap: 6px
 			.toolbar-left
 				grid-area: left
 				position: relative
+				flex: none
+				min-width: 0
+				max-width: 100%
 				gap: 4px
 				.language-filter-area
 					display: inline-flex
@@ -1718,34 +1781,36 @@ export default {
 							height: 14px
 			.toolbar-center
 				grid-area: center
+				flex: none
 				width: 100%
+				max-width: 100%
 				justify-content: center
 				padding-top: 2px
 				.day-btn
 					padding: 4px 8px
-					font-size: 13px
+					font-size: 12px
 			.day-arrow svg
 				width: 16px
 				height: 16px
 		.toolbar-right
 			grid-area: right
 			flex: 0 0 auto
+			flex-wrap: nowrap
 			gap: 4px
 			align-items: center
 			justify-content: flex-end
-			.search-area .search-compact .search-input
-				width: 130px
-				font-size: 13px
-			.toolbar-right-quick
-				display: flex
-				align-items: center
-				gap: 2px
-				.timezone-label
-					display: none
+			max-width: 100%
+			.fullscreen-quick
+				display: inline-flex
+				order: 98
 			.mobile-toggle-btn
 				display: inline-flex
 				order: 99
 				margin-left: 2px
+			.toolbar-right-quick
+				display: flex
+				align-items: center
+				gap: 2px
 			.toolbar-secondary
 				display: none
 				position: absolute
@@ -1811,6 +1876,73 @@ export default {
 				.sessions-toggle-menu
 					display: flex
 					justify-content: flex-start
+
+@media (max-width: 600px)
+	.c-schedule-toolbar
+		.filter-title,
+		.filter-title-text,
+		.filter-dot,
+		.filter-dropdown-label,
+		label.filter-dropdown-item,
+		button.toolbar-btn,
+		button.toolbar-btn span,
+		button.toolbar-btn .filter-title,
+		button.toolbar-btn .filter-title-text {
+			color: #111
+		}
+		svg.tb-icon,
+		svg.chevron-icon {
+			stroke: #111
+			color: #111
+			fill: none
+		}
+		.language-filter-area svg.tb-icon {
+			fill: #111
+			color: #111
+			stroke: none
+		}
+		.sessions-toggle-label
+			display: none
+		.sessions-toggle[aria-label]
+			position: relative
+			&::after
+				content: attr(aria-label)
+				position: absolute
+				left: 50%
+				top: calc(100% + 6px)
+				transform: translateX(-50%) translateY(-2px)
+				opacity: 0
+				pointer-events: none
+				background-color: rgba(0, 0, 0, 0.87)
+				color: #fff
+				padding: 4px 8px
+				border-radius: 4px
+				font-size: 12px
+				line-height: 1.2
+				white-space: nowrap
+				z-index: 1000
+			&:hover::after, &:focus-visible::after
+				opacity: 1
+				transform: translateX(-50%) translateY(0)
+				transition: opacity 0.05s ease, transform 0.05s ease
+		.toolbar-right
+			.fullscreen-quick
+				display: inline-flex
+				order: 98
+		.toolbar-btn.icon-only[aria-label]::after
+			display: none
+		.toolbar-row
+			padding: 6px
+			.toolbar-center
+				.day-btn
+					font-size: 13px
+		.toolbar-right
+			.search-area .search-compact .search-input
+				width: 130px
+				font-size: 13px
+			.toolbar-right-quick
+				.timezone-label
+					display: none
 			.toolbar-btn,
 			.toolbar-btn.icon-only,
 			button.toolbar-btn,


### PR DESCRIPTION
## Summary

- Fixes #4162 by replacing the hardcoded three-day schedule toolbar window with responsive day navigation that measures available width and only paginates when tabs no longer fit.
- Uses a three-column grid on desktop (`>1024px`) so filters, day tabs, and utility controls stay in separate columns and no longer overlap.
- On tablet and mobile (`≤1024px`), reuses the collapsed filter and more menus so crowded toolbars do not push day tabs below or into other controls.

## Test plan

- [ ] Open a multi-day schedule (e.g. 5–10 days) on a wide desktop viewport and confirm all day tabs are visible without arrows when they fit.
- [ ] Narrow the viewport and confirm day tabs paginate with arrows only when space runs out.
- [ ] At tablet width (`≤1024px`), confirm filter and more menus collapse into hamburger controls and day tabs sit on their own row.
- [ ] At mobile width (`≤600px`), confirm existing mobile toolbar behavior still works (filter/more dropdowns, search, timezone).
- [ ] Verify other toolbar actions are unchanged: filters, search, timezone, export, version, density, print, fullscreen, sessions/list toggle.