### PR TITLE
Fix Netlify Cors so that deployment preview works for access

### DIFF
--- a/deployment/nginx/enext-direct
+++ b/deployment/nginx/enext-direct
@@ -21,7 +21,7 @@ server {
 	
 	set $cors_origin "";
 	set $cors_allowed_origin 0;
-	if ($http_origin ~* ^https://access\.eventyay\.com$) {
+	if ($http_origin ~* ^https://(access\.eventyay\.com|app\.netlify\.com|.*\.netlify\.app)$) {
 		set $cors_origin $http_origin;
 		set $cors_allowed_origin 1;
 	}


### PR DESCRIPTION
## Summary by Sourcery

Deployment:
- Adjust Nginx settings in the enext-direct deployment config to allow Netlify preview requests without CORS failures.