### PR TITLE
fix: prevent resource leak from unclosed file handles

### DIFF
--- a/app/eventyay/agenda/views/widget.py
+++ b/app/eventyay/agenda/views/widget.py
@@ -274,10 +274,9 @@ def widget_schedule_chunk(request, organizer=None, event=None, filename=None, **
     if not file_path:
         raise Http404
     try:
-        f = open(file_path, 'rb')
+        response = FileResponse(open(file_path, 'rb'), content_type='application/javascript; charset=utf-8')
     except OSError:
         raise Http404
-    response = FileResponse(f, content_type='application/javascript; charset=utf-8')
     response['Cache-Control'] = 'public, max-age=86400'
     response['Access-Control-Allow-Origin'] = '*'
     return response

--- a/app/eventyay/common/views/helpers.py
+++ b/app/eventyay/common/views/helpers.py
@@ -16,4 +16,7 @@ def get_static(request, path, content_type, organizer=None, event=None, **kwargs
         logger.warning("Static asset %s not found", path)
         raise Http404()
     logger.debug("Serving static asset %s", path)
-    return FileResponse(open(path, 'rb'), content_type=content_type, as_attachment=False)
+    try:
+        return FileResponse(open(path, 'rb'), content_type=content_type, as_attachment=False)
+    except OSError:
+        raise Http404()


### PR DESCRIPTION
close #4204 

## Problem
Two views opened file handles that could be leaked under certain  conditions, causing resource exhaustion on busy production servers.

## Why This Is Dangerous
On Linux, each process has a limit on open file descriptors (typically  1024). If file handles are not properly closed, they accumulate. On a  busy server this causes:
- `OSError: [Errno 24] Too many open files`
- The entire application process crashes
- All active users get 500 errors

## Changes

### `agenda/views/widget.py`
The original code stored the file handle in `f` before passing it to  `FileResponse`. If anything between `open()` and `FileResponse()`  raised an exception, `f` would never be closed.

**Fix:** Pass `open()` directly into `FileResponse()` — Django's  `FileResponse` is designed to accept and close file objects after  streaming is complete.

### `common/views/helpers.py`
Same pattern — `open()` passed directly but without any error handling  for the case where the file disappears between the `path.exists()`  check and the actual `open()` call (a TOCTOU race condition).

**Fix:** Wrap in `try/except OSError` to handle this race condition  cleanly.

## References
- [Django FileResponse docs](https://docs.djangoproject.com/en/stable/ref/request-response/#fileresponse objects)
- [Python file handle best practices](https://docs.python.org/3/tutorial/inputoutput.html#reading-and-writing-files)