### PR TITLE
Fix : Dont show error when user logged in on Schedule Page

### DIFF
--- a/app/eventyay/agenda/views/schedule.py
+++ b/app/eventyay/agenda/views/schedule.py
@@ -384,7 +384,7 @@ def schedule_messages(request, **kwargs):
             'we are not responsible for data loss in this case.'
         ),
         'favs_not_saved': _(
-            'Could not sync favourites to your account. They remain stored locally in this browser.'
+            'Could not save favourites in this browser. Please check your browser storage settings.'
         ),
         'no_matching_options': _('Sorry, no matching options.'),
         'view_changelog': _('View Changelog'),

--- a/app/eventyay/multidomain/views.py
+++ b/app/eventyay/multidomain/views.py
@@ -157,7 +157,7 @@ class VideoSPAView(View):
                         'we are not responsible for data loss in this case.'
                     )),
                     'favs_not_saved': str(_(
-                        'Could not sync favourites to your account. They remain stored locally in this browser.'
+                        'Could not save favourites in this browser. Please check your browser storage settings.'
                     )),
                     'no_matching_options': str(_('Sorry, no matching options.')),
                     'view_changelog': str(_('View Changelog')),

--- a/app/eventyay/webapp/schedule/src/App.vue
+++ b/app/eventyay/webapp/schedule/src/App.vue
@@ -628,7 +628,10 @@ export default {
 			}
 		},
 		loggedIn () {
-			if (!this.schedule) return
+			if (!this.schedule || !this.remoteApiUrl) return
+			if (!this.apiUrl) {
+				this.apiUrl = this.remoteApiUrl
+			}
 			this.loadFavs().then((favs) => {
 				this.favs = this.pruneFavs(favs, this.schedule)
 			})
@@ -662,6 +665,7 @@ export default {
 		if (messagesEl) {
 			this.onHomeServer = true
 			this.userCode = messagesEl.dataset.userCode ?? null
+			this.apiUrl = this.remoteApiUrl
 			if (messagesEl.dataset.loggedIn === 'true') {
 				this.loggedIn = true
 			}
@@ -717,7 +721,7 @@ export default {
 			this.currentTimezone = [this.schedule.timezone, this.userTimezone].includes(this.currentTimezone) ? this.currentTimezone : this.schedule.timezone
 			this.now = moment.tz(this.currentTimezone)
 			setInterval(() => this.now = moment.tz(this.currentTimezone), 30000)
-			this.apiUrl = window.location.origin + '/api/v1/events/' + this.eventSlug + '/'
+			this.apiUrl = this.remoteApiUrl || (window.location.origin + '/api/v1/events/' + this.eventSlug + '/')
 			if (this.publicFavsUrl) {
 				this.favsReadOnly = true
 				this.onlyFavs = true
@@ -783,7 +787,7 @@ export default {
 		})
 
 		// set API URL before loading favs
-		this.apiUrl = window.location.origin + '/api/v1/events/' + this.eventSlug + '/'
+		this.apiUrl = this.remoteApiUrl || (window.location.origin + '/api/v1/events/' + this.eventSlug + '/')
 		if (this.publicFavsUrl) {
 			this.favsReadOnly = true
 			this.onlyFavs = true
@@ -932,7 +936,10 @@ export default {
 			return this.apiRequest(path, method, data, baseUrl)
 		},
 		async apiRequest (path, method, data, baseUrl) {
-			const base = baseUrl || this.apiUrl
+			const base = baseUrl || this.apiUrl || this.remoteApiUrl
+			if (!base) {
+				throw new Error('API base URL is not configured')
+			}
 			const url = `${base}${path}`
 			const headers = new Headers()
 			if (this.onHomeServer) {
@@ -965,15 +972,16 @@ export default {
 				const merged = await this.apiRequest(
 					'submissions/favourites/merge/',
 					'POST',
-					mergedLocal
+					mergedLocal,
+					this.remoteApiUrl
 				)
 				if (Array.isArray(merged)) {
 					localStorage.setItem(userStorageKey, JSON.stringify(merged))
 					localStorage.removeItem(anonymousStorageKey)
 					return merged
 				}
-			} catch (error) {
-				console.warn('Failed to merge favourites with server, using local copy:', error)
+			} catch {
+				// Server sync is optional; local favourites are already loaded.
 			}
 			return mergedLocal
 		},
@@ -1043,9 +1051,9 @@ export default {
 				return
 			}
 			try {
-				await this.apiRequest(`submissions/${id}/favourite/`, 'POST')
-			} catch (error) {
-				console.warn('Failed to sync favourite to account:', error)
+				await this.apiRequest(`submissions/${id}/favourite/`, 'POST', undefined, this.remoteApiUrl)
+			} catch {
+				// Local favourite is already saved.
 			}
 		},
 		async unfav (id) {
@@ -1067,9 +1075,9 @@ export default {
 				return
 			}
 			try {
-				await this.apiRequest(`submissions/${id}/favourite/`, 'DELETE')
-			} catch (error) {
-				console.warn('Failed to sync favourite removal to account:', error)
+				await this.apiRequest(`submissions/${id}/favourite/`, 'DELETE', undefined, this.remoteApiUrl)
+			} catch {
+				// Local favourite is already saved.
 			}
 			if (!this.favs.length) this.onlyFavs = false
 		},

--- a/app/eventyay/webapp/schedule/src/App.vue
+++ b/app/eventyay/webapp/schedule/src/App.vue
@@ -973,7 +973,7 @@ export default {
 					return merged
 				}
 			} catch (error) {
-				console.error('Failed to merge favourites: %s', error)
+				console.warn('Failed to merge favourites with server, using local copy:', error)
 			}
 			return mergedLocal
 		},
@@ -1008,8 +1008,11 @@ export default {
 			const storageKey = this.getFavStorageKey(this.loggedIn ? this.userCode : null)
 			try {
 				localStorage.setItem(storageKey, JSON.stringify(this.favs))
+				return true
 			} catch (error) {
-				console.error('Failed to save favourites locally: %s', error)
+				console.error('Failed to save favourites locally:', error)
+				this.pushErrorMessage(this.translationMessages.favs_not_saved)
+				return false
 			}
 		},
 		toggleSessionModalFav (id) {
@@ -1023,12 +1026,18 @@ export default {
 		async fav (id) {
 			if (this.favsReadOnly) return
 			if (this.favSet.has(id)) return
+			const previousFavs = [...this.favs]
 			this.favs.push(id)
 			const talk = this.schedule?.talks?.find(t => t.code === id)
+			const previousFavCount = talk ? Number(talk.fav_count || 0) : 0
 			if (talk) {
-				talk.fav_count = Math.max(0, Number(talk.fav_count || 0) + 1)
+				talk.fav_count = Math.max(0, previousFavCount + 1)
 			}
-			this.saveFavs()
+			if (!this.saveFavs()) {
+				this.favs = previousFavs
+				if (talk) talk.fav_count = previousFavCount
+				return
+			}
 			if (!this.loggedIn) {
 				this.showAnonymousFavsInfo()
 				return
@@ -1036,22 +1045,31 @@ export default {
 			try {
 				await this.apiRequest(`submissions/${id}/favourite/`, 'POST')
 			} catch (error) {
-				console.error('Failed to save favourite: %s', error)
+				console.warn('Failed to sync favourite to account:', error)
 			}
 		},
 		async unfav (id) {
 			if (this.favsReadOnly) return
+			const previousFavs = [...this.favs]
 			this.favs = this.favs.filter(elem => elem !== id)
 			const talk = this.schedule?.talks?.find(t => t.code === id)
+			const previousFavCount = talk ? Number(talk.fav_count || 0) : 0
 			if (talk) {
-				talk.fav_count = Math.max(0, Number(talk.fav_count || 0) - 1)
+				talk.fav_count = Math.max(0, previousFavCount - 1)
 			}
-			this.saveFavs()
-			if (!this.loggedIn) return
+			if (!this.saveFavs()) {
+				this.favs = previousFavs
+				if (talk) talk.fav_count = previousFavCount
+				return
+			}
+			if (!this.loggedIn) {
+				if (!this.favs.length) this.onlyFavs = false
+				return
+			}
 			try {
 				await this.apiRequest(`submissions/${id}/favourite/`, 'DELETE')
 			} catch (error) {
-				console.error('Failed to remove favourite: %s', error)
+				console.warn('Failed to sync favourite removal to account:', error)
 			}
 			if (!this.favs.length) this.onlyFavs = false
 		},

--- a/app/eventyay/webapp/schedule/src/App.vue
+++ b/app/eventyay/webapp/schedule/src/App.vue
@@ -943,8 +943,8 @@ export default {
 					localStorage.removeItem(anonymousStorageKey)
 					return merged
 				}
-			} catch {
-				this.pushErrorMessage(this.translationMessages.favs_not_saved)
+			} catch (error) {
+				console.error('Failed to merge favourites: %s', error)
 			}
 			return mergedLocal
 		},
@@ -979,8 +979,8 @@ export default {
 			const storageKey = this.getFavStorageKey(this.loggedIn ? this.userCode : null)
 			try {
 				localStorage.setItem(storageKey, JSON.stringify(this.favs))
-			} catch {
-				this.pushErrorMessage(this.translationMessages.favs_not_saved)
+			} catch (error) {
+				console.error('Failed to save favourites locally: %s', error)
 			}
 		},
 		toggleSessionModalFav (id) {
@@ -1008,7 +1008,6 @@ export default {
 				await this.apiRequest(`submissions/${id}/favourite/`, 'POST')
 			} catch (error) {
 				console.error('Failed to save favourite: %s', error)
-				this.pushErrorMessage(this.translationMessages.favs_not_saved)
 			}
 		},
 		async unfav (id) {
@@ -1024,7 +1023,6 @@ export default {
 				await this.apiRequest(`submissions/${id}/favourite/`, 'DELETE')
 			} catch (error) {
 				console.error('Failed to remove favourite: %s', error)
-				this.pushErrorMessage(this.translationMessages.favs_not_saved)
 			}
 			if (!this.favs.length) this.onlyFavs = false
 		},


### PR DESCRIPTION
https://github.com/user-attachments/assets/3bc5278e-e1b5-4f71-89a4-3436c0038f31

## Summary by Sourcery

Adjust favourites error handling on the schedule page to avoid showing user-facing errors when persistence fails.

Bug Fixes:
- Stop displaying error messages when a logged-in user's favourites fail to sync or persist on the schedule page.

Enhancements:
- Log failures to merge, save, or update favourites to the console instead of surfacing them as user-visible errors.