### PR TITLE
feat: Add 'Product' column to Event Orders overview table

### DIFF
--- a/app/eventyay/control/templates/pretixcontrol/orders/index.html
+++ b/app/eventyay/control/templates/pretixcontrol/orders/index.html
@@ -168,15 +168,19 @@
                                 {{ o.datetime|date:"SHORT_DATETIME_FORMAT" }}
                             </td>
                             <td>
-                                <ul class="list-unstyled">
-                                {% for pos in o.active_positions|slice:":2" %}
-                                    <li>{{ pos.product.name }}</li>
+                                <ul class="list-unstyled order-product-list">
+                                {% for pos in o.active_positions %}
+                                    {% if forloop.counter <= 2 %}
+                                        <li>
+                                            {{ pos.product.name }}
+                                            {% if forloop.counter == 2 and not forloop.last %}
+                                                <span class="product-ellipsis">&hellip;</span>
+                                            {% endif %}
+                                        </li>
+                                    {% else %}
+                                        <li class="product-hidden" style="display: none;">{{ pos.product.name }}</li>
+                                    {% endif %}
                                 {% endfor %}
-                                {% if o.active_positions|length > 2 %}
-                                    <li>
-                                        <a href="#" data-toggle="tooltip" title="{% for pos in o.active_positions|slice:"2:" %}{{ pos.product.name }}{% if not forloop.last %}, {% endif %}{% endfor %}">&hellip;</a>
-                                    </li>
-                                {% endif %}
                                 </ul>
                             </td>
                             <td class="text-right flip">
@@ -282,4 +286,12 @@
 {% endblock %}
 {% block custom_header %}
     <script type="module" src="{% static 'common/js/timezone.js' %}" defer></script>
+    <style>
+        .order-product-list:hover .product-hidden {
+            display: list-item !important;
+        }
+        .order-product-list:hover .product-ellipsis {
+            display: none !important;
+        }
+    </style>
 {% endblock %}

--- a/app/eventyay/control/templates/pretixcontrol/orders/index.html
+++ b/app/eventyay/control/templates/pretixcontrol/orders/index.html
@@ -169,11 +169,14 @@
                             </td>
                             <td>
                                 <ul class="list-unstyled">
-                                {% for pos in o.all_positions.all %}
-                                    {% if not pos.canceled %}
-                                        <li>{{ pos.product.name }}</li>
-                                    {% endif %}
+                                {% for pos in o.active_positions|slice:":2" %}
+                                    <li>{{ pos.product.name }}</li>
                                 {% endfor %}
+                                {% if o.active_positions|length > 2 %}
+                                    <li>
+                                        <a href="#" data-toggle="tooltip" title="{% for pos in o.active_positions|slice:"2:" %}{{ pos.product.name }}{% if not forloop.last %}, {% endif %}{% endfor %}">&hellip;</a>
+                                    </li>
+                                {% endif %}
                                 </ul>
                             </td>
                             <td class="text-right flip">

--- a/app/eventyay/control/templates/pretixcontrol/orders/index.html
+++ b/app/eventyay/control/templates/pretixcontrol/orders/index.html
@@ -128,6 +128,7 @@
                             <a href="?{% url_replace request 'ordering' '-datetime' %}"><i class="fa fa-caret-down"></i></a>
                             <a href="?{% url_replace request 'ordering' 'datetime' %}"><i class="fa fa-caret-up"></i></a>
                         </th>
+                        <th>{% trans "Products" %}</th>
                         <th class="text-right flip">{% trans "Order paid / total" %}
                             <a href="?{% url_replace request 'ordering' '-total' %}"><i class="fa fa-caret-down"></i></a>
                             <a href="?{% url_replace request 'ordering' 'total' %}"><i class="fa fa-caret-up"></i></a></th>
@@ -165,6 +166,15 @@
                                 <span class="fa fa-{{ o.sales_channel_obj.icon }} text-muted"
                                       data-toggle="tooltip" title="{% trans o.sales_channel_obj.verbose_name %}"></span>
                                 {{ o.datetime|date:"SHORT_DATETIME_FORMAT" }}
+                            </td>
+                            <td>
+                                <ul class="list-unstyled">
+                                {% for pos in o.all_positions.all %}
+                                    {% if not pos.canceled %}
+                                        <li>{{ pos.product.name }}</li>
+                                    {% endif %}
+                                {% endfor %}
+                                </ul>
                             </td>
                             <td class="text-right flip">
                                 {% if o.has_cancellation_request %}
@@ -213,6 +223,7 @@
                                     {{ s }} orders
                                 {% endblocktrans %}
                             </th>
+                            <th></th>
                             <th class="text-right flip">
                                 {% if sums.s|default_if_none:"none" != "none" %}
                                     {{ sums.s|money:request.event.currency }}

--- a/app/eventyay/control/views/orders.py
+++ b/app/eventyay/control/views/orders.py
@@ -195,7 +195,7 @@ class OrderList(OrderSearchMixin, EventPermissionRequiredMixin, PaginationMixin,
     permission = 'can_view_orders'
 
     def get_queryset(self):
-        qs = Order.objects.filter(event=self.request.event).select_related('invoice_address')
+        qs = Order.objects.filter(event=self.request.event).select_related('invoice_address').prefetch_related('all_positions__product')
 
         if self.filter_form.is_valid():
             qs = self.filter_form.filter_qs(qs)

--- a/app/eventyay/control/views/orders.py
+++ b/app/eventyay/control/views/orders.py
@@ -195,7 +195,13 @@ class OrderList(OrderSearchMixin, EventPermissionRequiredMixin, PaginationMixin,
     permission = 'can_view_orders'
 
     def get_queryset(self):
-        qs = Order.objects.filter(event=self.request.event).select_related('invoice_address').prefetch_related('all_positions__product')
+        qs = Order.objects.filter(event=self.request.event).select_related('invoice_address').prefetch_related(
+            Prefetch(
+                'all_positions',
+                queryset=OrderPosition.objects.filter(canceled=False).select_related('product'),
+                to_attr='active_positions'
+            )
+        )
 
         if self.filter_form.is_valid():
             qs = self.filter_form.filter_qs(qs)


### PR DESCRIPTION
Close : #4183


https://github.com/user-attachments/assets/7d9194f9-88fd-4552-bdad-eb8a15c0b223



## Summary by Sourcery

Add a products column to the event orders overview and optimize the orders query for related product data.

New Features:
- Display a products column in the event orders overview table showing non-cancelled line items for each order.

Enhancements:
- Prefetch order positions and their products in the orders list view to avoid additional queries when rendering the products column.