### PR TITLE
fix: correct checkinlog exporter lookup attribute from item_id to product_id

### DIFF
--- a/app/eventyay/plugins/checkinlists/exporters.py
+++ b/app/eventyay/plugins/checkinlists/exporters.py
@@ -690,7 +690,7 @@ class CheckinLogList(ListExporter):
         if form_data.get('list'):
             qs = qs.filter(list_id=form_data.get('list'))
         if form_data.get('products'):
-            qs = qs.filter(position__item_id__in=form_data['products'])
+            qs = qs.filter(position__product_id__in=form_data['products'])
 
         yield self.ProgressSetTotal(total=qs.count())
 


### PR DESCRIPTION
### Description

This PR fixes a bug in the 'Check-in log' data exporter where filtering by products resulted in a Django ORM `FieldError`: `Unsupported lookup 'item_id__in' for ForeignKey`.

The `OrderPosition` model in Eventyay uses a ForeignKey relation to `Product`, not `Item`. This updates the queryset filter to use the correct `product_id__in` lookup.

https://github.com/user-attachments/assets/0bda86e1-8b94-4120-8986-938b653b386d

## Summary by Sourcery

Bug Fixes:
- Correct check-in log exporter queryset to filter by position.product_id instead of the invalid position.item_id lookup.