### PR TITLE
chore(teamshifts): update uv.lock

### DIFF
--- a/app/uv.lock
+++ b/app/uv.lock
@@ -1199,7 +1199,7 @@ dependencies = [
 [[package]]
 name = "eventyay-teamshifts"
 version = "0.1.0"
-source = { git = "https://github.com/fossasia/eventyay-teamshifts.git?rev=main#fc1baff07687d03d08baf36fd51775eb02dc5a21" }
+source = { git = "https://github.com/fossasia/eventyay-teamshifts.git?rev=main#7f709ae9bf60b9c458bebb59b8e962f7ecadf289" }
 
 [[package]]
 name = "eventyay-unified"


### PR DESCRIPTION
Updates uv.lock to pin eventyay-teamshifts to [7f709ae](https://github.com/fossasia/eventyay-teamshifts.git?rev=main#7f709ae9bf60b9c458bebb59b8e962f7ecadf289)

Brings in the merged organizer and public views.

## Summary by Sourcery

Build:
- Regenerate uv.lock to reference the updated eventyay-teamshifts revision.