### PR TITLE
Enhancement: Make "Join online event" label translatable in emails

### DIFF
--- a/app/eventyay/base/email.py
+++ b/app/eventyay/base/email.py
@@ -518,8 +518,7 @@ def base_placeholders(sender: Event, **kwargs):
     )
     def render_video_join_link(event: Event, order) -> str:
         url = build_join_video_url(event, order)
-        # TODO: Make the label translatable.
-        return f'<a href="{url}" class="button">Join online event</a>'
+        return f'<a href="{url}" class="button">{_("Join online event")}</a>'
     ph = [
         SimpleFunctionalMailTextPlaceholder('event', ['event'], lambda event: event.name, lambda event: event.name),
         SimpleFunctionalMailTextPlaceholder(


### PR DESCRIPTION
This PR makes the "Join online event" label in email templates translatable by wrapping it in Django's translation function.

Fixes #4233

## Summary by Sourcery

Enhancements:
- Localize the "Join online event" label in video join links within email templates so it can be translated.