### PR TITLE
fix(badges): repair multi-badge-per-page PDF rendering

### DIFF
--- a/app/eventyay/base/pdf.py
+++ b/app/eventyay/base/pdf.py
@@ -723,6 +723,7 @@ class Renderer:
         if self.background_file:
             self.bg_bytes = self.background_file.read()
             self.bg_pdf = PdfReader(BytesIO(self.bg_bytes), strict=False)
+            correct_page_media_box(self.bg_pdf.pages[0])
         else:
             self.bg_bytes = None
             self.bg_pdf = None
@@ -908,6 +909,15 @@ class Renderer:
         canvas.restoreState()
 
     def draw_page(self, canvas: Canvas, order: Order, op: OrderPosition, show_page=True):
+        if self.bg_pdf:
+            bg_page = self.bg_pdf.pages[0]
+            page_size = (
+                bg_page.mediabox[2] - bg_page.mediabox[0],
+                bg_page.mediabox[3] - bg_page.mediabox[1],
+            )
+            if bg_page.get('/Rotate') in (90, 270):
+                page_size = page_size[::-1]
+            canvas.setPageSize(page_size)
         for o in self.layout:
             if o['type'] == 'barcodearea':
                 self._draw_barcodearea(canvas, op, o)
@@ -917,10 +927,18 @@ class Renderer:
                 self._draw_textarea(canvas, op, order, o)
             elif o['type'] == 'poweredby':
                 self._draw_poweredby(canvas, op, o)
-            if self.bg_pdf:
-                canvas.setPageSize((self.bg_pdf.pages[0].mediabox[2], self.bg_pdf.pages[0].mediabox[3]))
         if show_page:
             canvas.showPage()
+
+    def merge_foreground_buffer(self, buffer):
+        buffer.seek(0)
+        fg_pdf = PdfReader(buffer, strict=False)
+        if not self.bg_pdf:
+            return list(fg_pdf.pages)
+        bg_page = self.bg_pdf.pages[0]
+        for page in fg_pdf.pages:
+            page.merge_page(bg_page, over=False)
+        return list(fg_pdf.pages)
 
     def render_background(self, buffer, title=_('Ticket')):
         if settings.PDFTK:
@@ -945,16 +963,11 @@ class Renderer:
                 with open(os.path.join(d, 'out.pdf'), 'rb') as f:
                     return BytesIO(f.read())
         else:
-            from pypdf import PdfReader, PdfWriter
+            from pypdf import PdfWriter
 
-            buffer.seek(0)
-            new_pdf = PdfReader(buffer)
             output = PdfWriter()
-
-            for page in new_pdf.pages:
-                bg_page = copy.copy(self.bg_pdf.pages[0])
-                bg_page.merge_page(page)
-                output.add_page(bg_page)
+            for page in self.merge_foreground_buffer(buffer):
+                output.add_page(page)
 
             output.add_metadata(
                 {
@@ -966,3 +979,30 @@ class Renderer:
             output.write(outbuffer)
             outbuffer.seek(0)
             return outbuffer
+
+
+def correct_page_media_box(page):
+    import pypdf
+    from pypdf.generic import NameObject, RectangleObject
+
+    if page.rotation != 0:
+        page.transfer_rotation_to_content()
+    media_box = page.mediabox
+    trsf = pypdf.Transformation()
+    if media_box.bottom != 0:
+        trsf = trsf.translate(0, -media_box.bottom)
+    if media_box.left != 0:
+        trsf = trsf.translate(-media_box.left, 0)
+    page.add_transformation(trsf, False)
+    for box in ('/MediaBox', '/CropBox', '/BleedBox', '/TrimBox', '/ArtBox'):
+        if box in page:
+            rect = RectangleObject(page[box])
+            pt1 = trsf.apply_on(rect.lower_left)
+            pt2 = trsf.apply_on(rect.upper_right)
+            page[NameObject(box)] = RectangleObject((
+                min(pt1[0], pt2[0]),
+                min(pt1[1], pt2[1]),
+                max(pt1[0], pt2[0]),
+                max(pt1[1], pt2[1]),
+            ))
+

--- a/app/eventyay/base/pdf.py
+++ b/app/eventyay/base/pdf.py
@@ -722,6 +722,11 @@ class Renderer:
         self.event = event
         if self.background_file:
             self.bg_bytes = self.background_file.read()
+            try:
+                self.background_file.close()
+            except OSError:
+                pass
+            self.background_file = None
             self.bg_pdf = PdfReader(BytesIO(self.bg_bytes), strict=False)
             correct_page_media_box(self.bg_pdf.pages[0])
         else:

--- a/app/eventyay/plugins/badges/apps.py
+++ b/app/eventyay/plugins/badges/apps.py
@@ -77,7 +77,7 @@ class BadgesApp(AppConfig):
             for template_name, template_data in templates.items():
                 design_name = template_data['name']
                 template_path = os.path.join(media_dir, f'{design_name}.pdf')
-                if os.path.exists(templates_path):
+                if os.path.exists(template_path):
                     with open(template_path, 'rb') as f:
                         content = f.read()
                     content_file = ContentFile(content, name=f'{design_name}.pdf')

--- a/app/eventyay/plugins/badges/exporters.py
+++ b/app/eventyay/plugins/badges/exporters.py
@@ -1,8 +1,13 @@
-import copy
 import json
+import os
+import subprocess
+import tempfile
 from collections import OrderedDict
+from decimal import Decimal
 from io import BytesIO
-from typing import Tuple
+from typing import BinaryIO, List, Tuple
+
+from pathlib import Path
 
 from django import forms
 from django.conf import settings
@@ -13,7 +18,7 @@ from django.db.models import Exists, OuterRef, Q
 from django.db.models.functions import Coalesce
 from django.utils.translation import gettext as _
 from django.utils.translation import gettext_lazy
-from pypdf import Transformation
+from pypdf import PdfReader, PdfWriter, Transformation
 from reportlab.lib import pagesizes
 from reportlab.lib.units import mm
 from reportlab.pdfgen import canvas
@@ -53,13 +58,49 @@ class BadgeRenderer(Renderer):
         return super()._get_text_content(op, order, o, inner=inner)
 
 
+def _is_placeholder_pdf(bgf):
+    pos = bgf.tell()
+    try:
+        bgf.seek(0, os.SEEK_END)
+        size = bgf.tell()
+        bgf.seek(pos)
+        if size < 1_000:
+            return True
+        if size < 15_000:
+            header = bgf.read(200)
+            return b'ReportLab Generated PDF' in header
+        return False
+    finally:
+        bgf.seek(pos)
+
+
+def _bundled_background_for_layout(layout):
+    media_dir = Path(settings.BASE_DIR) / 'plugins/badges/media'
+    if not media_dir.is_dir():
+        return None
+    name_lower = layout.name.lower()
+    for pdf_path in sorted(media_dir.glob('*.pdf')):
+        if pdf_path.stem.lower() in name_lower:
+            return open(pdf_path, 'rb')
+    return None
+
+
+def _open_layout_background(layout):
+    if isinstance(layout.background, File) and layout.background.name:
+        bgf = default_storage.open(layout.background.name, 'rb')
+        if not _is_placeholder_pdf(bgf):
+            return bgf
+        bgf.close()
+    bundled = _bundled_background_for_layout(layout)
+    if bundled:
+        return bundled
+    return open(finders.find('pretixplugins/badges/badge_default_a6l.pdf'), 'rb')
+
+
 def _renderer(event, layout):
     if layout is None:
         return None
-    if isinstance(layout.background, File) and layout.background.name:
-        bgf = default_storage.open(layout.background.name, 'rb')
-    else:
-        bgf = open(finders.find('pretixplugins/badges/badge_default_a6l.pdf'), 'rb')
+    bgf = _open_layout_background(layout)
     return BadgeRenderer(
         event,
         layout.layout_data,
@@ -104,7 +145,7 @@ OPTIONS = OrderedDict(
                 'margins': [0 * mm, 0 * mm, 0 * mm, 0 * mm],
                 'offsets': [
                     pagesizes.portrait(pagesizes.A4)[0] / 2,
-                    pagesizes.portrait(pagesizes.A4)[0] / 2,
+                    pagesizes.portrait(pagesizes.A4)[1] / 2,
                 ],
                 'pagesize': pagesizes.portrait(pagesizes.A4),
             },
@@ -132,7 +173,7 @@ OPTIONS = OrderedDict(
                 'margins': [0 * mm, 0 * mm, 0 * mm, 0 * mm],
                 'offsets': [
                     pagesizes.landscape(pagesizes.A4)[0] / 4,
-                    pagesizes.landscape(pagesizes.A4)[0] / 2,
+                    pagesizes.landscape(pagesizes.A4)[1] / 2,
                 ],
                 'pagesize': pagesizes.landscape(pagesizes.A4),
             },
@@ -196,11 +237,124 @@ OPTIONS = OrderedDict(
 )
 
 
-def render_pdf(event, positions, opt):
-    from pypdf import PdfReader, PdfWriter
+def chunks(items, size):
+    for i in range(0, len(items), size):
+        yield items[i : i + size]
 
-    Renderer._register_fonts()
 
+def _fit_badge_to_slot(page, slot_width, slot_height):
+    page_width = float(page.mediabox.width)
+    page_height = float(page.mediabox.height)
+    if page_width <= 0 or page_height <= 0:
+        return None
+
+    scale = min(slot_width / page_width, slot_height / page_height)
+    writer = PdfWriter()
+    fitted = writer.add_blank_page(
+        width=Decimal('%.5f' % slot_width),
+        height=Decimal('%.5f' % slot_height),
+    )
+    fitted.merge_transformed_page(
+        page,
+        Transformation().scale(scale, scale),
+        expand=False,
+    )
+    return fitted
+
+
+def render_nup_page(nup_pdf: PdfWriter, input_pages, opt: dict):
+    badges_per_page = opt['cols'] * opt['rows']
+    slot_width = float(opt['offsets'][0])
+    slot_height = float(opt['offsets'][1])
+    nup_page = nup_pdf.add_blank_page(
+        width=Decimal('%.5f' % (opt['pagesize'][0])),
+        height=Decimal('%.5f' % (opt['pagesize'][1])),
+    )
+    for i, page in enumerate(input_pages):
+        slot = i % badges_per_page
+        tx = float(opt['margins'][3] + (slot % opt['cols']) * opt['offsets'][0])
+        ty = float(opt['margins'][2] + (opt['rows'] - 1 - (slot // opt['cols'])) * opt['offsets'][1])
+        fitted = _fit_badge_to_slot(page, slot_width, slot_height)
+        if fitted is None:
+            continue
+        nup_page.merge_transformed_page(
+            fitted,
+            Transformation().translate(tx, ty),
+            expand=False,
+        )
+    return nup_page
+
+
+def merge_pages(file_paths: List[str], output_file: BinaryIO):
+    if settings.PDFTK:
+        subprocess.run(
+            [settings.PDFTK, *file_paths, 'cat', 'output', '-', 'compress'],
+            check=True,
+            stdout=output_file,
+        )
+    else:
+        merger = PdfWriter()
+        merger.add_metadata({
+            '/Title': 'Badges',
+            '/Creator': 'eventyay',
+        })
+        for pdf in file_paths:
+            merger.append(pdf)
+        merger.write(output_file)
+
+
+def render_nup(input_files: List[str], num_pages: int, output_file: BinaryIO, opt: dict):
+    badges_per_page = opt['cols'] * opt['rows']
+    max_nup_pages = 20
+    nup_pdf_files = []
+    temp_dir = None
+    if num_pages > badges_per_page * max_nup_pages:
+        try:
+            temp_dir = tempfile.TemporaryDirectory()
+        except OSError:
+            pass
+
+    try:
+        badges_pdf = PdfReader(input_files.pop(0))
+        offset = 0
+        for i, chunk_indices in enumerate(chunks(list(range(num_pages)), badges_per_page * max_nup_pages)):
+            chunk = []
+            for j in chunk_indices:
+                if j - offset >= len(badges_pdf.pages):
+                    offset += len(badges_pdf.pages)
+                    badges_pdf = PdfReader(input_files.pop(0))
+                chunk.append(badges_pdf.pages[j - offset])
+            badges_pdf.flattened_pages = None
+
+            nup_pdf = PdfWriter()
+            nup_pdf.add_metadata({
+                '/Title': 'Badges',
+                '/Creator': 'eventyay',
+            })
+
+            for page_chunk in chunks(chunk, badges_per_page):
+                render_nup_page(nup_pdf, page_chunk, opt)
+
+            if temp_dir:
+                file_path = os.path.join(temp_dir.name, f'badges-{i}.pdf')
+                nup_pdf.write(file_path)
+                nup_pdf_files.append(file_path)
+            else:
+                nup_pdf.write(output_file)
+                return
+
+        if temp_dir:
+            file_paths = [os.path.join(temp_dir.name, fp) for fp in nup_pdf_files]
+            merge_pages(file_paths, output_file)
+    finally:
+        if temp_dir:
+            try:
+                temp_dir.cleanup()
+            except OSError:
+                pass
+
+
+def render_badges(event, positions, opt, apply_output_pagesize=False):
     renderermap = {
         bi.product_id: _renderer(event, bi.layout)
         for bi in BadgeProduct.objects.select_related('layout').filter(product__event=event)
@@ -209,64 +363,58 @@ def render_pdf(event, positions, opt):
         default_renderer = _renderer(event, event.badge_layouts.get(default=True))
     except BadgeLayout.DoesNotExist:
         default_renderer = None
-    output_pdf_writer = PdfWriter()
 
-    any = False
-    npp = opt['cols'] * opt['rows']
-
-    def render_page(positions):
-        buffer = BytesIO()
-        p = canvas.Canvas(buffer, pagesize=pagesizes.A4)
-        for i, (op, r) in enumerate(positions):
-            offsetx = opt['margins'][3] + (i % opt['cols']) * opt['offsets'][0]
-            offsety = opt['margins'][2] + (opt['rows'] - 1 - i // opt['cols']) * opt['offsets'][1]
-            p.translate(offsetx, offsety)
-            with language(op.order.locale, op.order.event.settings.region):
-                r.draw_page(p, op.order, op, show_page=False)
-            p.translate(-offsetx, -offsety)
-
-        if opt['pagesize']:
-            p.setPageSize(opt['pagesize'])
-        p.showPage()
-        p.save()
-        buffer.seek(0)
-        canvas_pdf_reader = PdfReader(buffer)
-        empty_pdf_page = output_pdf_writer.add_blank_page(
-            width=opt['pagesize'][0] if opt['pagesize'] else positions[0][1].bg_pdf.pages[0].mediabox[2],
-            height=opt['pagesize'][1] if opt['pagesize'] else positions[0][1].bg_pdf.pages[0].mediabox[3],
-        )
-        for i, (op, r) in enumerate(positions):
-            bg_page = copy.copy(r.bg_pdf.pages[0])
-            offsetx = opt['margins'][3] + (i % opt['cols']) * opt['offsets'][0]
-            offsety = opt['margins'][2] + (opt['rows'] - 1 - i // opt['cols']) * opt['offsets'][1]
-            bg_page.add_transformation(Transformation().translate(offsetx, offsety))
-            empty_pdf_page.merge_page(bg_page)
-        empty_pdf_page.merge_page(canvas_pdf_reader.pages[0])
-
-    pagebuffer = []
-    outbuffer = BytesIO()
-    for op in positions:
-        r = renderermap.get(op.product_id, default_renderer)
-        if not r:
-            continue
-        any = True
-        pagebuffer.append((op, r))
-        if len(pagebuffer) == npp:
-            render_page(pagebuffer)
-            pagebuffer.clear()
-
-    if pagebuffer:
-        render_page(pagebuffer)
-
-    if not any:
+    op_renderers = [
+        (op, renderermap.get(op.product_id, default_renderer))
+        for op in positions
+        if renderermap.get(op.product_id, default_renderer)
+    ]
+    if not op_renderers:
         raise OrderError(_('None of the selected products is configured to print badges.'))
-    output_pdf_writer.add_metadata(
-        {
-            '/Title': 'Badges',
-            '/Creator': 'eventyay',
-        }
-    )
-    output_pdf_writer.write(outbuffer)
+
+    badge_pdf = PdfWriter()
+    badge_pdf.add_metadata({
+        '/Title': 'Badges',
+        '/Creator': 'eventyay',
+    })
+    for op, renderer in op_renderers:
+        buffer = BytesIO()
+        page = canvas.Canvas(buffer, pagesize=pagesizes.A4)
+        with language(op.order.locale, op.order.event.settings.region):
+            renderer.draw_page(page, op.order, op, show_page=False)
+        if apply_output_pagesize and opt['pagesize']:
+            page.setPageSize(opt['pagesize'])
+        page.showPage()
+        page.save()
+        for merged_page in renderer.merge_foreground_buffer(buffer):
+            badge_pdf.add_page(merged_page)
+
+    return badge_pdf, len(badge_pdf.pages)
+
+
+def render_pdf(event, positions, opt):
+    Renderer._register_fonts()
+    badges_per_page = opt['cols'] * opt['rows']
+    outbuffer = BytesIO()
+
+    if badges_per_page == 1:
+        badge_pdf, _ = render_badges(event, positions, opt, apply_output_pagesize=True)
+        badge_pdf.write(outbuffer)
+    else:
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            page_pdfs = []
+            total_num_pages = 0
+            for position_chunk in chunks(list(positions), 200):
+                badge_pdf, num_pages = render_badges(event, position_chunk, opt)
+                out_pdf_name = os.path.join(tmp_dir, f'chunk-{len(page_pdfs)}.pdf')
+                with open(out_pdf_name, 'wb') as out_pdf:
+                    badge_pdf.write(out_pdf)
+                page_pdfs.append(out_pdf_name)
+                total_num_pages += num_pages
+                del badge_pdf
+
+            render_nup(page_pdfs, total_num_pages, outbuffer, opt)
+
     outbuffer.seek(0)
     return outbuffer
 

--- a/app/eventyay/plugins/badges/exporters.py
+++ b/app/eventyay/plugins/badges/exporters.py
@@ -248,6 +248,8 @@ def _fit_badge_to_slot(page, slot_width, slot_height):
         return None
 
     scale = min(slot_width / page_width, slot_height / page_height)
+    offset_x = (slot_width - page_width * scale) / 2
+    offset_y = (slot_height - page_height * scale) / 2
     writer = PdfWriter()
     fitted = writer.add_blank_page(
         width=Decimal('%.5f' % slot_width),
@@ -255,7 +257,7 @@ def _fit_badge_to_slot(page, slot_width, slot_height):
     )
     fitted.merge_transformed_page(
         page,
-        Transformation().scale(scale, scale),
+        Transformation().scale(scale, scale).translate(offset_x, offset_y),
         expand=False,
     )
     return fitted

--- a/app/eventyay/plugins/badges/exporters.py
+++ b/app/eventyay/plugins/badges/exporters.py
@@ -324,7 +324,6 @@ def render_nup(input_files: List[str], num_pages: int, output_file: BinaryIO, op
                     offset += len(badges_pdf.pages)
                     badges_pdf = PdfReader(input_files.pop(0))
                 chunk.append(badges_pdf.pages[j - offset])
-            badges_pdf.flattened_pages = None
 
             nup_pdf = PdfWriter()
             nup_pdf.add_metadata({
@@ -344,8 +343,7 @@ def render_nup(input_files: List[str], num_pages: int, output_file: BinaryIO, op
                 return
 
         if temp_dir:
-            file_paths = [os.path.join(temp_dir.name, fp) for fp in nup_pdf_files]
-            merge_pages(file_paths, output_file)
+            merge_pages(nup_pdf_files, output_file)
     finally:
         if temp_dir:
             try:

--- a/app/eventyay/plugins/badges/exporters.py
+++ b/app/eventyay/plugins/badges/exporters.py
@@ -1,6 +1,5 @@
 import json
 import os
-import subprocess
 import tempfile
 from collections import OrderedDict
 from decimal import Decimal
@@ -286,21 +285,14 @@ def render_nup_page(nup_pdf: PdfWriter, input_pages, opt: dict):
 
 
 def merge_pages(file_paths: List[str], output_file: BinaryIO):
-    if settings.PDFTK:
-        subprocess.run(
-            [settings.PDFTK, *file_paths, 'cat', 'output', '-', 'compress'],
-            check=True,
-            stdout=output_file,
-        )
-    else:
-        merger = PdfWriter()
-        merger.add_metadata({
-            '/Title': 'Badges',
-            '/Creator': 'eventyay',
-        })
-        for pdf in file_paths:
-            merger.append(pdf)
-        merger.write(output_file)
+    merger = PdfWriter()
+    merger.add_metadata({
+        '/Title': 'Badges',
+        '/Creator': 'eventyay',
+    })
+    for pdf in file_paths:
+        merger.append(pdf)
+    merger.write(output_file)
 
 
 def render_nup(input_files: List[str], num_pages: int, output_file: BinaryIO, opt: dict):

--- a/app/eventyay/plugins/badges/views.py
+++ b/app/eventyay/plugins/badges/views.py
@@ -3,7 +3,6 @@ from datetime import timedelta
 from io import BytesIO
 
 from django.contrib import messages
-from django.contrib.staticfiles import finders
 from django.core.files import File
 from django.core.files.storage import default_storage
 from django.db import transaction
@@ -29,7 +28,7 @@ from eventyay.plugins.badges.forms import BadgeLayoutForm, BadgeLayoutSettingsFo
 from eventyay.plugins.badges.tasks import badges_create_pdf
 from eventyay.plugins.badges.utils import clear_badge_layout_cache
 
-from .exporters import BadgeRenderer
+from .exporters import BadgeRenderer, _open_layout_background
 from .models import BadgeLayout
 
 
@@ -322,10 +321,8 @@ class LayoutEditorView(BaseEditorView):
         buffer = BytesIO()
         if override_background:
             bgf = default_storage.open(override_background.name, 'rb')
-        elif isinstance(self.layout.background, File) and self.layout.background.name:
-            bgf = default_storage.open(self.layout.background.name, 'rb')
         else:
-            bgf = open(finders.find('pretixplugins/badges/badge_default_a6l.pdf'), 'rb')
+            bgf = _open_layout_background(self.layout)
         r = BadgeRenderer(
             self.request.event,
             override_layout or self.get_current_layout(),
@@ -351,6 +348,19 @@ class LayoutEditorView(BaseEditorView):
         )
 
     def save_background(self, f: CachedFile):
+        # The editor creates a blank placeholder PDF for on-canvas sizing. Do not
+        # replace the layout artwork when the user only saves field positions.
+        if not f.file:
+            return
+        if f.file.name.endswith('empty.pdf'):
+            return
+        try:
+            if f.file.size < 15_000:
+                with f.file.open('rb') as handle:
+                    if b'ReportLab Generated PDF' in handle.read(120):
+                        return
+        except OSError:
+            pass
         if self.layout.background:
             self.layout.background.delete()
         self.layout.background.save('background.pdf', f.file)

--- a/app/eventyay/static/pretixcontrol/js/ui/editor.js
+++ b/app/eventyay/static/pretixcontrol/js/ui/editor.js
@@ -1137,11 +1137,14 @@ var editor = {
         }
         $btn.prop("disabled", true).prepend('<span class="fa fa-cog fa-spin"></span> ');
         editor._sync_active_text_object_from_toolbox();
-        $.post(window.location.href, {
+        var payload = {
             data: JSON.stringify(editor.dump()),
             csrfmiddlewaretoken: editor._csrf_token(),
-            background: editor.uploaded_file_id,
-        }, function (data) {
+        };
+        if (editor.uploaded_file_id) {
+            payload.background = editor.uploaded_file_id;
+        }
+        $.post(window.location.href, payload, function (data) {
             editor._finish_save_button($btn, defaultLabel, data.status === "ok");
         }, "json").fail(function () {
             editor._finish_save_button($btn, defaultLabel, false);

--- a/app/tests/tickets/plugins/badges/test_pdf.py
+++ b/app/tests/tickets/plugins/badges/test_pdf.py
@@ -5,7 +5,7 @@ from io import BytesIO
 import pytest
 from django.utils.timezone import now
 from django_scopes import scope
-from pypdf import PdfReader
+from pypdf import PdfReader, PdfWriter
 
 from eventyay.base.models import (
     Event,
@@ -16,7 +16,13 @@ from eventyay.base.models import (
     Organizer,
 )
 from eventyay.base.services.orders import OrderError
-from eventyay.plugins.badges.exporters import BadgeExporter
+from eventyay.plugins.badges.exporters import BadgeExporter, OPTIONS, render_nup
+
+
+def _render_form(shirt, **kwargs):
+    defaults = {'products': [shirt.pk], 'include_pending': True}
+    defaults.update(kwargs)
+    return defaults
 
 
 @pytest.fixture
@@ -60,12 +66,12 @@ def test_generate_pdf(env):
     event.badge_layouts.create(name='Default', default=True)
     e = BadgeExporter(event)
     with pytest.raises(OrderError):
-        e.render({'items': [shirt.pk], 'rendering': 'one', 'include_pending': False})
+        e.render(_render_form(shirt, include_pending=False, rendering='one'))
 
     with pytest.raises(OrderError):
-        e.render({'items': [], 'rendering': 'one', 'include_pending': True})
+        e.render({'products': [], 'rendering': 'one', 'include_pending': True})
 
-    fname, ftype, buf = e.render({'items': [shirt.pk], 'rendering': 'one', 'include_pending': True})
+    fname, ftype, buf = e.render(_render_form(shirt, rendering='one'))
     assert ftype == 'application/pdf'
     pdf = PdfReader(BytesIO(buf))
     assert len(pdf.pages) == 2
@@ -76,7 +82,29 @@ def test_generate_pdf_multi(env):
     event, order, shirt = env
     event.badge_layouts.create(name='Default', default=True)
     e = BadgeExporter(event)
-    fname, ftype, buf = e.render({'items': [shirt.pk], 'rendering': 'a4_a6l', 'include_pending': True})
+    fname, ftype, buf = e.render(_render_form(shirt, rendering='a4_a6l'))
     assert ftype == 'application/pdf'
     pdf = PdfReader(BytesIO(buf))
     assert len(pdf.pages) == 1
+    expected_size = OPTIONS['a4_a6l']['pagesize']
+    page = pdf.pages[0].mediabox
+    assert float(page.width) == pytest.approx(float(expected_size[0]), rel=0.01)
+    assert float(page.height) == pytest.approx(float(expected_size[1]), rel=0.01)
+
+
+def test_render_nup_large_export_merge(tmp_path):
+    badges_per_page = OPTIONS['a4_a6l']['cols'] * OPTIONS['a4_a6l']['rows']
+    num_badges = badges_per_page * 20 + 1
+
+    badge_pdf_path = tmp_path / 'badges.pdf'
+    writer = PdfWriter()
+    for _ in range(num_badges):
+        writer.add_blank_page(width=200, height=200)
+    with badge_pdf_path.open('wb') as handle:
+        writer.write(handle)
+
+    outbuffer = BytesIO()
+    render_nup([str(badge_pdf_path)], num_badges, outbuffer, OPTIONS['a4_a6l'])
+
+    pdf = PdfReader(outbuffer)
+    assert len(pdf.pages) == (num_badges + badges_per_page - 1) // badges_per_page


### PR DESCRIPTION
## Summary
- Fix multi-badge-per-page export by rendering each badge individually, then tiling scaled pages onto the sheet with proper clipping.
- Fix repeated attendee text when reusing badge renderers by merging backgrounds under foreground pages without mutating shared PDF state.
- Prevent the layout editor from overwriting real badge artwork with placeholder PDFs on layout-only saves, and recover bundled template backgrounds when stored files are corrupted.

Fixes #4203

## Test plan
- [x] Export badges with "One badge per page" — backgrounds and attendee fields render correctly
- [x] Export badges with `4 landscape A6`, `4 portrait A6`, `8 landscape A7`, and `8 portrait A7` options — no overlap, bleed, or missing backgrounds
- [x] Verify alternating Standard/VIP attendees each show only their own name/email/company/job title
- [x] Save badge layout field positions without uploading a new background — existing artwork is preserved
- [ ] Run `pytest tests/tickets/plugins/badges/test_pdf.py` in CI