### PR TITLE
Docs: Clarify why request.get_host() is not used in MultiDomainMiddleware

### DIFF
--- a/app/eventyay/multidomain/middlewares.py
+++ b/app/eventyay/multidomain/middlewares.py
@@ -29,7 +29,22 @@ LOCAL_HOST_NAMES = ('testserver', 'localhost')
 
 class MultiDomainMiddleware(MiddlewareMixin):
     def process_request(self, request):
-        host = request.get_host()
+        # We cannot use request.get_host() here because Django's get_host() validates
+        # against settings.ALLOWED_HOSTS. In a multi-tenant environment, organizers
+        # can use custom domains that are not explicitly listed in ALLOWED_HOSTS.
+        # Therefore, we manually extract the host and validate it against the KnownDomain
+        # model below to prevent DisallowedHost exceptions for valid custom domains.
+
+        if settings.USE_X_FORWARDED_HOST and ('X-Forwarded-Host' in request.headers):
+            host = request.headers['X-Forwarded-Host']
+        elif 'Host' in request.headers:
+            host = request.headers['Host']
+        else:
+            # Reconstruct the host using the algorithm from PEP 333.
+            host = request.META['SERVER_NAME']
+            server_port = str(request.META['SERVER_PORT'])
+            if server_port != ('443' if request.is_secure() else '80'):
+                host = '%s:%s' % (host, server_port)
 
         domain, port = split_domain_port(host)
         default_domain, default_port = split_domain_port(urlparse(settings.SITE_URL).netloc)

--- a/app/eventyay/multidomain/middlewares.py
+++ b/app/eventyay/multidomain/middlewares.py
@@ -29,20 +29,7 @@ LOCAL_HOST_NAMES = ('testserver', 'localhost')
 
 class MultiDomainMiddleware(MiddlewareMixin):
     def process_request(self, request):
-        # TODO: Don't know why this code is complicated, why just not use request.get_host()?
-        # May improve later.
-
-        # We try three options, in order of decreasing preference.
-        if settings.USE_X_FORWARDED_HOST and ('X-Forwarded-Host' in request.headers):
-            host = request.headers['X-Forwarded-Host']
-        elif 'Host' in request.headers:
-            host = request.headers['Host']
-        else:
-            # Reconstruct the host using the algorithm from PEP 333.
-            host = request.META['SERVER_NAME']
-            server_port = str(request.META['SERVER_PORT'])
-            if server_port != ('443' if request.is_secure() else '80'):
-                host = '%s:%s' % (host, server_port)
+        host = request.get_host()
 
         domain, port = split_domain_port(host)
         default_domain, default_port = split_domain_port(urlparse(settings.SITE_URL).netloc)


### PR DESCRIPTION
Fixes #4270 

### Description
This PR replaces a misleading `TODO` in `MultiDomainMiddleware` (`eventyay/multidomain/middlewares.py`) with an explanatory comment.

The original `TODO` suggested simplifying the manual host extraction block (around line 32) by using Django's native `request.get_host()`. However, `request.get_host()` internally validates against `settings.ALLOWED_HOSTS`. 

Because Eventyay is a multi-tenant platform where organizers can connect dynamic custom domains, these domains are not listed in `ALLOWED_HOSTS`. Swapping to `request.get_host()` would cause Django to instantly raise a `DisallowedHost` error for valid custom domains before the middleware has a chance to validate them against the `KnownDomain` model. 

This PR adds a comment to clarify this behavior and prevent future developers from introducing this bug.

### Testing
- CI should pass as this is purely a documentation/comment change with no code behavior changes.
