### PR TITLE
fix: add missing __str__ methods to API models

### DIFF
--- a/app/eventyay/api/models.py
+++ b/app/eventyay/api/models.py
@@ -120,6 +120,9 @@ class WebHook(models.Model):
     class Meta:
         ordering = ('id',)
 
+    def __str__(self):
+        return f'WebHook {self.pk} -> {self.target_url}'
+
     @property
     def action_types(self):
         return [l.action_type for l in self.listeners.all()]
@@ -131,6 +134,9 @@ class WebHookEventListener(models.Model):
 
     class Meta:
         ordering = ('action_type',)
+
+    def __str__(self):
+        return f'WebHookEventListener {self.pk}: {self.action_type}'
 
 
 class WebHookCall(models.Model):
@@ -148,6 +154,9 @@ class WebHookCall(models.Model):
     class Meta:
         ordering = ('-datetime',)
 
+    def __str__(self):
+        return f'WebHookCall {self.pk} [{self.action_type}] -> {self.return_code}'
+
 
 class ApiCall(models.Model):
     idempotency_key = models.CharField(max_length=190, db_index=True)
@@ -164,3 +173,6 @@ class ApiCall(models.Model):
 
     class Meta:
         unique_together = (('idempotency_key', 'auth_hash'),)
+
+    def __str__(self):
+        return f'ApiCall {self.request_method} {self.request_path} ({self.response_code})'


### PR DESCRIPTION
## What

Add `__str__` methods to 4 models in `app/eventyay/api/models.py`  that were missing them.

Closes #4272

## Why

Without `__str__`, Django displays unhelpful output like  `WebHook object (1)` in the admin interface and shell.

This is a Django best practice for all models.

## Models Fixed

- `WebHook` → shows pk and target URL
- `WebHookEventListener` → shows pk and action type
- `WebHookCall` → shows pk, action type and return code
- `ApiCall` → shows method, path and response code