### PR TITLE
Collapse long product lists in Order Forms attendee data

### DIFF
--- a/app/eventyay/api/models.py
+++ b/app/eventyay/api/models.py
@@ -120,6 +120,9 @@ class WebHook(models.Model):
     class Meta:
         ordering = ('id',)
 
+    def __str__(self):
+        return self.target_url
+
     @property
     def action_types(self):
         return [l.action_type for l in self.listeners.all()]
@@ -131,6 +134,9 @@ class WebHookEventListener(models.Model):
 
     class Meta:
         ordering = ('action_type',)
+
+    def __str__(self):
+        return self.action_type
 
 
 class WebHookCall(models.Model):
@@ -148,6 +154,9 @@ class WebHookCall(models.Model):
     class Meta:
         ordering = ('-datetime',)
 
+    def __str__(self):
+        return f"{self.action_type} @ {self.target_url}"
+
 
 class ApiCall(models.Model):
     idempotency_key = models.CharField(max_length=190, db_index=True)
@@ -164,3 +173,6 @@ class ApiCall(models.Model):
 
     class Meta:
         unique_together = (('idempotency_key', 'auth_hash'),)
+
+    def __str__(self):
+        return f"{self.request_method} {self.request_path}"

--- a/app/eventyay/control/templates/pretixcontrol/items/orderforms.html
+++ b/app/eventyay/control/templates/pretixcontrol/items/orderforms.html
@@ -212,7 +212,7 @@
                                 </ul>
                                 {% with count=system_field_products.attendee_name_parts|length %}
                                     {% if count > 5 %}
-                                        <button type="button" class="btn btn-default btn-sm" data-products-toggle
+                                        <button type="button" class="btn btn-default btn-sm" data-products-toggle aria-expanded="false"
                                             data-show-more="{% blocktranslate trimmed with remaining=count|add:"-5" %}Show more (+{{ remaining }}){% endblocktranslate %}"
                                             data-show-less="{% translate "Show less" %}">
                                             {% blocktranslate trimmed with remaining=count|add:"-5" %}Show more (+{{ remaining }}){% endblocktranslate %}

--- a/app/eventyay/control/templates/pretixcontrol/items/orderforms.html
+++ b/app/eventyay/control/templates/pretixcontrol/items/orderforms.html
@@ -14,6 +14,24 @@
     {% compress js %}
         <script defer src="{% static 'pretixcontrol/js/orderFormToggles.js' %}"></script>
     {% endcompress %}
+    <script>
+        (function() {
+            document.addEventListener('click', function(e) {
+                var btn = e.target.closest('[data-products-toggle]');
+                if (!btn) return;
+                var ul = btn.previousElementSibling;
+                var extras = [].slice.call(ul.querySelectorAll('[data-product-extra]'));
+                var expanded = btn.getAttribute('aria-expanded') === 'true';
+                extras.forEach(function(el) {
+                    el.classList.toggle('d-none', expanded);
+                });
+                btn.textContent = expanded
+                    ? btn.getAttribute('data-show-more')
+                    : btn.getAttribute('data-show-less');
+                btn.setAttribute('aria-expanded', String(!expanded));
+            });
+        })();
+    </script>
 {% endblock %}
 {% block inside %}
     <nav id="event-nav" class="header-nav">
@@ -185,13 +203,22 @@
                             <td class="text-center">
                                 <ul class="list-unstyled products-list">
                                     {% for product in system_field_products.attendee_name_parts %}
-                                        <li>
+                                        <li{% if forloop.counter > 5 %} class="d-none" data-product-extra{% endif %}>
                                             <a href="{% url 'control:event.product' organizer=request.event.organizer.slug event=request.event.slug product=product.id %}">{{ product }}</a>
                                         </li>
                                     {% empty %}
                                         <li class="text-muted">{% translate "No products" %}</li>
                                     {% endfor %}
                                 </ul>
+                                {% with count=system_field_products.attendee_name_parts|length %}
+                                    {% if count > 5 %}
+                                        <button type="button" class="btn btn-default btn-sm" data-products-toggle
+                                            data-show-more="{% blocktranslate trimmed with remaining=count|add:"-5" %}Show more (+{{ remaining }}){% endblocktranslate %}"
+                                            data-show-less="{% translate "Show less" %}">
+                                            {% blocktranslate trimmed with remaining=count|add:"-5" %}Show more (+{{ remaining }}){% endblocktranslate %}
+                                        </button>
+                                    {% endif %}
+                                {% endwith %}
                             </td>
                             <td class="dnd-container text-center text-nowrap">
                                 <a href="{% url 'control:event.products.orderforms.defaultfield' organizer=request.event.organizer.slug event=request.event.slug field='attendee_name_parts' %}" class="btn btn-default btn-sm" aria-label="{% translate 'Settings for Attendee names' %}" title="{% translate 'Settings for Attendee names' %}"><i class="fa fa-cog fa-fw"></i></a>
@@ -250,13 +277,22 @@
                             <td class="text-center">
                                 <ul class="list-unstyled products-list">
                                     {% for product in system_field_products.attendee_email %}
-                                        <li>
+                                        <li{% if forloop.counter > 5 %} class="d-none" data-product-extra{% endif %}>
                                             <a href="{% url 'control:event.product' organizer=request.event.organizer.slug event=request.event.slug product=product.id %}">{{ product }}</a>
                                         </li>
                                     {% empty %}
                                         <li class="text-muted">{% translate "No products" %}</li>
                                     {% endfor %}
                                 </ul>
+                                {% with count=system_field_products.attendee_email|length %}
+                                    {% if count > 5 %}
+                                        <button type="button" class="btn btn-default btn-sm" data-products-toggle
+                                            data-show-more="{% blocktranslate trimmed with remaining=count|add:"-5" %}Show more (+{{ remaining }}){% endblocktranslate %}"
+                                            data-show-less="{% translate "Show less" %}">
+                                            {% blocktranslate trimmed with remaining=count|add:"-5" %}Show more (+{{ remaining }}){% endblocktranslate %}
+                                        </button>
+                                    {% endif %}
+                                {% endwith %}
                             </td>
                             <td class="dnd-container text-center text-nowrap">
                                 <a href="{% url 'control:event.products.orderforms.defaultfield' organizer=request.event.organizer.slug event=request.event.slug field='attendee_email' %}" class="btn btn-default btn-sm" aria-label="{% translate 'Settings for Attendee emails' %}" title="{% translate 'Settings for Attendee emails' %}"><i class="fa fa-cog fa-fw"></i></a>
@@ -296,13 +332,22 @@
                             <td class="text-center">
                                 <ul class="list-unstyled products-list">
                                     {% for product in system_field_products.company %}
-                                        <li>
+                                        <li{% if forloop.counter > 5 %} class="d-none" data-product-extra{% endif %}>
                                             <a href="{% url 'control:event.product' organizer=request.event.organizer.slug event=request.event.slug product=product.id %}">{{ product }}</a>
                                         </li>
                                     {% empty %}
                                         <li class="text-muted">{% translate "No products" %}</li>
                                     {% endfor %}
                                 </ul>
+                                {% with count=system_field_products.company|length %}
+                                    {% if count > 5 %}
+                                        <button type="button" class="btn btn-default btn-sm" data-products-toggle
+                                            data-show-more="{% blocktranslate trimmed with remaining=count|add:"-5" %}Show more (+{{ remaining }}){% endblocktranslate %}"
+                                            data-show-less="{% translate "Show less" %}">
+                                            {% blocktranslate trimmed with remaining=count|add:"-5" %}Show more (+{{ remaining }}){% endblocktranslate %}
+                                        </button>
+                                    {% endif %}
+                                {% endwith %}
                             </td>
                             <td class="dnd-container text-center text-nowrap">
                                 <a href="{% url 'control:event.products.orderforms.defaultfield' organizer=request.event.organizer.slug event=request.event.slug field='company' %}" class="btn btn-default btn-sm" aria-label="{% translate 'Settings for Company' %}" title="{% translate 'Settings for Company' %}"><i class="fa fa-cog fa-fw"></i></a>
@@ -342,13 +387,22 @@
                             <td class="text-center">
                                 <ul class="list-unstyled products-list">
                                     {% for product in system_field_products.job_title %}
-                                        <li>
+                                        <li{% if forloop.counter > 5 %} class="d-none" data-product-extra{% endif %}>
                                             <a href="{% url 'control:event.product' organizer=request.event.organizer.slug event=request.event.slug product=product.id %}">{{ product }}</a>
                                         </li>
                                     {% empty %}
                                         <li class="text-muted">{% translate "No products" %}</li>
                                     {% endfor %}
                                 </ul>
+                                {% with count=system_field_products.job_title|length %}
+                                    {% if count > 5 %}
+                                        <button type="button" class="btn btn-default btn-sm" data-products-toggle
+                                            data-show-more="{% blocktranslate trimmed with remaining=count|add:"-5" %}Show more (+{{ remaining }}){% endblocktranslate %}"
+                                            data-show-less="{% translate "Show less" %}">
+                                            {% blocktranslate trimmed with remaining=count|add:"-5" %}Show more (+{{ remaining }}){% endblocktranslate %}
+                                        </button>
+                                    {% endif %}
+                                {% endwith %}
                             </td>
                             <td class="dnd-container text-center text-nowrap">
                                 <a href="{% url 'control:event.products.orderforms.defaultfield' organizer=request.event.organizer.slug event=request.event.slug field='job_title' %}" class="btn btn-default btn-sm" aria-label="{% translate 'Settings for Job title' %}" title="{% translate 'Settings for Job title' %}"><i class="fa fa-cog fa-fw" aria-hidden="true"></i></a>
@@ -388,13 +442,22 @@
                             <td class="text-center">
                                 <ul class="list-unstyled products-list">
                                     {% for product in system_field_products.street %}
-                                        <li>
+                                        <li{% if forloop.counter > 5 %} class="d-none" data-product-extra{% endif %}>
                                             <a href="{% url 'control:event.product' organizer=request.event.organizer.slug event=request.event.slug product=product.id %}">{{ product }}</a>
                                         </li>
                                     {% empty %}
                                         <li class="text-muted">{% translate "No products" %}</li>
                                     {% endfor %}
                                 </ul>
+                                {% with count=system_field_products.street|length %}
+                                    {% if count > 5 %}
+                                        <button type="button" class="btn btn-default btn-sm" data-products-toggle
+                                            data-show-more="{% blocktranslate trimmed with remaining=count|add:"-5" %}Show more (+{{ remaining }}){% endblocktranslate %}"
+                                            data-show-less="{% translate "Show less" %}">
+                                            {% blocktranslate trimmed with remaining=count|add:"-5" %}Show more (+{{ remaining }}){% endblocktranslate %}
+                                        </button>
+                                    {% endif %}
+                                {% endwith %}
                             </td>
                             <td class="dnd-container text-center text-nowrap">
                                 <a href="{% url 'control:event.products.orderforms.defaultfield' organizer=request.event.organizer.slug event=request.event.slug field='street' %}" class="btn btn-default btn-sm" aria-label="{% translate 'Settings for Postal addresses' %}"><i class="fa fa-cog fa-fw" aria-hidden="true"></i></a>
@@ -448,13 +511,22 @@
                             <td class="text-center">
                                 <ul class="list-unstyled products-list">
                                     {% for product in q.products.all %}
-                                        <li>
+                                        <li{% if forloop.counter > 5 %} class="d-none" data-product-extra{% endif %}>
                                             <a href="{% url "control:event.product" organizer=request.event.organizer.slug event=request.event.slug product=product.id %}">{{ product }}</a>
                                         </li>
                                     {% empty %}
                                         <li class="text-muted">{% translate "All products" %}</li>
                                     {% endfor %}
                                 </ul>
+                                {% with count=q.products.all|length %}
+                                    {% if count > 5 %}
+                                        <button type="button" class="btn btn-default btn-sm" data-products-toggle
+                                            data-show-more="{% blocktranslate trimmed with remaining=count|add:"-5" %}Show more (+{{ remaining }}){% endblocktranslate %}"
+                                            data-show-less="{% translate "Show less" %}">
+                                            {% blocktranslate trimmed with remaining=count|add:"-5" %}Show more (+{{ remaining }}){% endblocktranslate %}
+                                        </button>
+                                    {% endif %}
+                                {% endwith %}
                             </td>
                             <td class="dnd-container text-center text-nowrap">
                                 {% if q.type == "DES" %}


### PR DESCRIPTION
## Summary

This PR improves the Products column in the Order Forms → Attendee Data page by preventing long product lists from expanding the table indefinitely.

### Changes

- Display the first five associated products by default.
- Add a "Show more (+X)" button when additional products exist.
- Allow users to expand and collapse the full product list inline.
- Apply the same behavior to both system fields and custom questions.

This keeps the table compact while still allowing users to view all associated products without leaving the page.

Closes #4210