### PR TITLE
Fix: Update requests User-Agent for external storage fetches

### DIFF
--- a/app/eventyay/base/services/geo.py
+++ b/app/eventyay/base/services/geo.py
@@ -8,6 +8,7 @@ from django.core.cache import cache
 
 from eventyay.base.settings import GlobalSettingsObject
 from eventyay.common.utils.language import localize_event_text
+from eventyay.helpers.http import get_default_user_agent
 
 
 logger = logging.getLogger(__name__)
@@ -300,7 +301,7 @@ def _geocode_with_nominatim(query: str) -> list[dict]:
             'limit': 5,
         },
         headers={
-            'User-Agent': f'{django_settings.INSTANCE_NAME}/1.0 ({django_settings.SITE_URL})',
+            'User-Agent': get_default_user_agent(),
         },
         timeout=10,
     )

--- a/app/eventyay/helpers/http.py
+++ b/app/eventyay/helpers/http.py
@@ -1,6 +1,7 @@
 import random
 import socket
 
+import eventyay
 from django.conf import settings
 from django.core.cache import cache
 from django.http import HttpResponsePermanentRedirect, HttpResponseRedirect, StreamingHttpResponse
@@ -56,3 +57,11 @@ def smtp_reachable(host: str | None, port: int | None, timeout: int | float | No
     )
     cache.set(cache_key, reachable, timeout=cache_ttl)
     return reachable
+
+
+def get_default_user_agent() -> str:
+    """Return a consistent User-Agent string for outgoing HTTP requests."""
+    instance_name = getattr(settings, 'INSTANCE_NAME', '') or 'eventyay'
+    site_url = getattr(settings, 'SITE_URL', '') or 'https://eventyay.com'
+    version = getattr(eventyay, '__version__', '') or 'unknown'
+    return f'{instance_name}/{version} ({site_url})'

--- a/app/eventyay/storage/external.py
+++ b/app/eventyay/storage/external.py
@@ -60,7 +60,10 @@ def store_image(response, event):  # TODO deduplicate
 
 
 def retrieve_url(url):
-    response = requests.get(url, timeout=10)  # TODO: user agent
+    headers = {
+        'User-Agent': f'{settings.INSTANCE_NAME}/1.0 ({settings.SITE_URL})',
+    }
+    response = requests.get(url, headers=headers, timeout=10)
     if response.status_code == 200:
         return response
 

--- a/app/eventyay/storage/external.py
+++ b/app/eventyay/storage/external.py
@@ -10,6 +10,7 @@ from django.utils.timezone import now
 
 from eventyay.base.models.storage_model import StoredFile
 from eventyay.consts import SizeKey
+from eventyay.helpers.http import get_default_user_agent
 
 
 def get_extension_from_response(response):
@@ -61,7 +62,7 @@ def store_image(response, event):  # TODO deduplicate
 
 def retrieve_url(url):
     headers = {
-        'User-Agent': f'{settings.INSTANCE_NAME}/1.0 ({settings.SITE_URL})',
+        'User-Agent': get_default_user_agent(),
     }
     response = requests.get(url, headers=headers, timeout=10)
     if response.status_code == 200:


### PR DESCRIPTION
Fixes #4276

### Describe the PR
This PR replaces the default `python-requests` User-Agent string used in `app/eventyay/storage/external.py` with a custom identifying User-Agent (`settings.INSTANCE_NAME` combined with `settings.SITE_URL`), addressing an existing codebase `TODO`.

### Why is this necessary?
The default Python User-Agent is frequently blocked by external web servers and CDNs that have simple bot protection enabled, which causes preview image and metadata fetching to fail. Using a custom User-Agent ensures our legitimate outbound requests are not blocked as malicious scrapers. This also aligns the behavior with other similar requests in the codebase (e.g., in `base/services/geo.py`).

### Testing
- [x] Verified code adheres to PEP 8 standards.
- [x] Verified `settings` is correctly imported and utilized in the scope.

## Summary by Sourcery

Bug Fixes:
- Prevent external image/metadata fetches from being blocked due to the default python-requests User-Agent.