### PR TITLE
fix: replace % string formatting in logger calls with lazy arguments

### DIFF
--- a/app/eventyay/base/views/tasks.py
+++ b/app/eventyay/base/views/tasks.py
@@ -137,7 +137,7 @@ class AsyncMixin:
         elif exception.__class__.__name__ in self.known_errortypes:
             return str(exception)
         else:
-            logger.error('Unexpected exception: %r' % exception)
+            logger.error('Unexpected exception: %r', exception)
             return _('An unexpected error has occurred, please try again later.')
 
     def get_success_message(self, value):

--- a/app/eventyay/control/views/pdf.py
+++ b/app/eventyay/control/views/pdf.py
@@ -165,7 +165,7 @@ class BaseEditorView(EventPermissionRequiredMixin, TemplateView):
             try:
                 default_storage.delete(fexisting.name)
             except OSError:  # pragma: no cover
-                logger.error('Deleting file %s failed.' % fexisting.name)
+                logger.error('Deleting file %s failed.', fexisting.name)
 
         # Create new file
         nonce = get_random_string(length=8)

--- a/app/eventyay/plugins/sendmail/mixins.py
+++ b/app/eventyay/plugins/sendmail/mixins.py
@@ -77,7 +77,7 @@ class CopyDraftMixin:
 
 
             except (EmailQueue.DoesNotExist, ValueError, TypeError) as e:
-                logger.warning('Failed to load EmailQueue for copyToDraft: %s' % e)
+                logger.warning('Failed to load EmailQueue for copyToDraft: %s', e)
 
 
 class QueryFilterOrderingMixin:


### PR DESCRIPTION
## What

Replace old-style `%` string formatting in 3 logger calls  with lazy argument passing across 3 files.

Closes #4278

## Why

Using `%` formatting eagerly builds the string before passing  to the logger — even if the message will never be displayed  due to log level settings. This wastes CPU unnecessarily.

Passing format arguments separately means the string is only  built when the log level requires it.

This also fixes pylint `W1201/W1202` warnings.

## Files Changed

- `app/eventyay/control/views/pdf.py`
- `app/eventyay/base/views/tasks.py`
- `app/eventyay/plugins/sendmail/mixins.py`

## Before vs After

```python
# Before
logger.error('Deleting file %s failed.' % fexisting.name)

# After  
logger.error('Deleting file %s failed.', fexisting.name)
```

## Summary by Sourcery

Replace eager percent-style string formatting in logger calls with lazy argument-based logging to avoid unnecessary string construction and satisfy logging lint rules.

Bug Fixes:
- Prevent unnecessary work when logging messages that may be skipped due to log level by deferring string interpolation to the logger.

Chores:
- Address logging style lint warnings by switching from percent-style string formatting to argument-based logging in error messages.