### PR TITLE
fix: add missing __str__ methods to PlannedUsage and WorldView models

### DIFF
--- a/app/eventyay/base/models/world.py
+++ b/app/eventyay/base/models/world.py
@@ -495,6 +495,9 @@ class PlannedUsage(models.Model):
     class Meta:
         ordering = ("start",)
 
+    def __str__(self):
+        return f'PlannedUsage {self.pk}: {self.world} ({self.start} - {self.end})'
+
     def as_ical(self):
         event = icalendar.Event()
         event["uid"] = f"{self.world.id}-{self.id}"
@@ -519,6 +522,9 @@ class WorldView(models.Model):
     user = models.ForeignKey(
         to="user", related_name="world_views", on_delete=models.CASCADE
     )
+
+    def __str__(self):
+        return f'WorldView {self.pk}: {self.world} by {self.user}'
 
     class Meta:
         indexes = [


### PR DESCRIPTION
## What

Add `__str__` methods to 2 models in  `app/eventyay/base/models/world.py` that were missing them.

Closes #4280

## Why

Without `__str__`, Django displays unhelpful output like  `PlannedUsage object (1)` in the admin interface and shell.

## Models Fixed

- `PlannedUsage` → shows pk, world and date range
- `WorldView` → shows pk, world and user

## Summary by Sourcery

Add human-readable string representations to selected Django models to improve their display in the admin and other interfaces.

Enhancements:
- Add a descriptive __str__ implementation to the PlannedUsage model to show its primary key, world, and date range.
- Add a descriptive __str__ implementation to the WorldView model to show its primary key, world, and user.