### PR TITLE
fix(orga): prevent text overlapping in mobile tables

### DIFF
--- a/app/eventyay/static/common/css/base.css
+++ b/app/eventyay/static/common/css/base.css
@@ -1143,10 +1143,7 @@ a.event-public-text-link:visited {
     color: var(--color-text-muted, #6c757d);
     margin-right: auto;
   }
-  /* Let long textual values (e.g. session titles, speaker names) shrink and
-     wrap instead of overflowing onto the ::before label. Scoped to text-value
-     cells only; control cells (buttons, icons, checkboxes, badges) are excluded
-     so their children keep their intrinsic sizing. */
+
   .table-flip tbody td:not(.numeric):not(.text-right):not(.action-column):not(.submission_featured):not(.speaker-actions-cell):not(.col-tags):not(.col-state) > * {
     min-width: 0;
     max-width: 100%;

--- a/app/eventyay/static/common/css/base.css
+++ b/app/eventyay/static/common/css/base.css
@@ -1143,13 +1143,14 @@ a.event-public-text-link:visited {
     color: var(--color-text-muted, #6c757d);
     margin-right: auto;
   }
-  /* Prevent long values (session titles, speaker names) from overflowing
-     onto the ::before label: let the value shrink and wrap instead. */
-  .table-flip tbody td > * {
+  /* Let long textual values (e.g. session titles, speaker names) shrink and
+     wrap instead of overflowing onto the ::before label. Scoped to text-value
+     cells only; control cells (buttons, icons, checkboxes, badges) are excluded
+     so their children keep their intrinsic sizing. */
+  .table-flip tbody td:not(.numeric):not(.text-right):not(.action-column):not(.submission_featured):not(.speaker-actions-cell):not(.col-tags):not(.col-state) > * {
     min-width: 0;
     max-width: 100%;
-    overflow-wrap: break-word;
-    word-break: break-word;
+    overflow-wrap: anywhere;
   }
   .table-flip tbody td:not([data-label])::before,
   .table-flip tbody td[data-label=""]::before {

--- a/app/eventyay/static/common/css/base.css
+++ b/app/eventyay/static/common/css/base.css
@@ -1123,6 +1123,7 @@ a.event-public-text-link:visited {
     border-bottom: 1px solid var(--color-grey-light);
     display: flex;
     align-items: center;
+    flex-wrap: wrap;
     padding: 0.55rem 0.75rem;
     text-align: right;
     justify-content: flex-end;
@@ -1133,7 +1134,7 @@ a.event-public-text-link:visited {
   }
   .table-flip tbody td::before {
     content: attr(data-label);
-    flex: 0 1 auto;
+    flex: 0 0 auto;
     min-width: 0;
     max-width: 50%;
     text-align: left;
@@ -1141,6 +1142,14 @@ a.event-public-text-link:visited {
     font-weight: 600;
     color: var(--color-text-muted, #6c757d);
     margin-right: auto;
+  }
+  /* Prevent long values (session titles, speaker names) from overflowing
+     onto the ::before label: let the value shrink and wrap instead. */
+  .table-flip tbody td > * {
+    min-width: 0;
+    max-width: 100%;
+    overflow-wrap: break-word;
+    word-break: break-word;
   }
   .table-flip tbody td:not([data-label])::before,
   .table-flip tbody td[data-label=""]::before {


### PR DESCRIPTION
This PR fixes a layout issue where long text values in mobile tables (like speaker names and question titles) overlap with the label.

## Before 
<img width="1920" height="1080" alt="1" src="https://github.com/user-attachments/assets/965dd4f0-010c-4832-8202-8f9937c137a8" />
<img width="1920" height="1080" alt="3" src="https://github.com/user-attachments/assets/a7655819-dd55-4d12-affc-72ae4c2c0305" />
<img width="1920" height="1080" alt="2" src="https://github.com/user-attachments/assets/f7b38a8d-5f8c-49de-97c2-f31bbe0ae1f0" />


## After


https://github.com/user-attachments/assets/f5498905-6f4c-4948-82d4-717060854a4a

## Summary by Sourcery

Bug Fixes:
- Ensure mobile table cells wrap flexibly so long labels and values no longer overlap or overflow.