### PR TITLE
fix: replace .format() in logger calls with f-strings

### DIFF
--- a/app/eventyay/api/views/oauth.py
+++ b/app/eventyay/api/views/oauth.py
@@ -85,7 +85,7 @@ class AuthorizationView(BaseAuthorizationView):
             return self.error_response(error, application)
 
         self.success_url = uri
-        logger.debug('Success url for the request: {0}'.format(self.success_url))
+        logger.debug(f'Success url for the request: {self.success_url}')
 
         msgs = [
             _('The application "{application_name}" has been authorized to access your account.').format(

--- a/app/eventyay/base/forms/questions.py
+++ b/app/eventyay/base/forms/questions.py
@@ -1050,7 +1050,7 @@ class BaseInvoiceAddressForm(forms.ModelForm):
             except (vat_moss_lite.errors.InvalidError, ValueError):
                 raise ValidationError(_('This VAT ID is not valid. Please re-check your input.'))
             except vat_moss_lite.errors.WebServiceUnavailableError:
-                logger.exception('VAT ID checking failed for country {}'.format(data.get('country')))
+                logger.exception(f'VAT ID checking failed for country {data.get("country")}')
                 self.instance.vat_id_validated = False
                 if self.request and self.vat_warning:
                     messages.warning(
@@ -1063,7 +1063,7 @@ class BaseInvoiceAddressForm(forms.ModelForm):
                         ),
                     )
             except (vat_moss_lite.errors.WebServiceError, HTTPError):
-                logger.exception('VAT ID checking failed for country {}'.format(data.get('country')))
+                logger.exception(f'VAT ID checking failed for country {data.get("country")}')
                 self.instance.vat_id_validated = False
                 if self.request and self.vat_warning:
                     messages.warning(

--- a/app/eventyay/base/models/orders.py
+++ b/app/eventyay/base/models/orders.py
@@ -1829,7 +1829,7 @@ class OrderPayment(models.Model):
         )
 
         if self.order.status in (Order.STATUS_PAID, Order.STATUS_CANCELED):
-            logger.info('Confirmed payment {} but order is in status {}.'.format(self.full_id, self.order.status))
+            logger.info(f'Confirmed payment {self.full_id} but order is in status {self.order.status}.')
             return
 
         payment_sum = self.order.payments.filter(

--- a/app/eventyay/base/pdf.py
+++ b/app/eventyay/base/pdf.py
@@ -894,7 +894,7 @@ class Renderer:
         try:
             text = '<br/>'.join(get_display(reshaper.reshape(l)) for l in text.split('<br/>'))
         except Exception:
-            logger.exception('Reshaping/Bidi fixes failed on string {}'.format(repr(text)))
+            logger.exception(f'Reshaping/Bidi fixes failed on string {repr(text)}')
 
         p = Paragraph(text, style=style)
         w, h = p.wrapOn(canvas, float(o['width']) * mm, 1000 * mm)

--- a/app/eventyay/control/views/orders.py
+++ b/app/eventyay/control/views/orders.py
@@ -1709,7 +1709,7 @@ class OrderCheckVATID(OrderView):
             except vat_moss_lite.errors.InvalidError:
                 messages.error(self.request, _('This VAT ID is not valid.'))
             except vat_moss_lite.errors.WebServiceUnavailableError:
-                logger.exception('VAT ID checking failed for country {}'.format(ia.country))
+                logger.exception(f'VAT ID checking failed for country {ia.country}')
                 messages.error(
                     self.request,
                     _(

--- a/app/eventyay/plugins/banktransfer/tasks.py
+++ b/app/eventyay/plugins/banktransfer/tasks.py
@@ -230,7 +230,7 @@ def _get_unknown_transactions(job: BankImportJob, data: list, event: Event = Non
             try:
                 amount = Decimal(amount)
             except:
-                logger.exception('Could not parse amount of transaction: {}'.format(amount))
+                logger.exception(f'Could not parse amount of transaction: {amount}')
                 amount = Decimal('0.00')
 
         trans = BankTransaction(

--- a/app/eventyay/presale/views/user.py
+++ b/app/eventyay/presale/views/user.py
@@ -66,7 +66,7 @@ class ResendLinkView(EventViewMixin, TemplateView):
             )
         except SendMailException:
             logger = logging.getLogger('pretix.presale.user')
-            logger.exception('A mail resending order links to {} could not be sent.'.format(user))
+            logger.exception(f'A mail resending order links to {user} could not be sent.')
             messages.error(
                 self.request,
                 _('We have trouble sending emails right now, please check back later.'),


### PR DESCRIPTION
## Summary

This PR replaces old-style `.format()` string formatting in logger calls with Python f-strings across the codebase.

F-strings improve readability, reduce unnecessary verbosity, and align the code with modern Python best practices while preserving the existing functionality.

## Changes

Updated logger calls in the following files:

- `api/views/oauth.py`
- `control/views/orders.py`
- `presale/views/user.py`
- `base/models/orders.py`
- `base/forms/questions.py` (2 occurrences)
- `base/pdf.py`
- `plugins/banktransfer/tasks.py`

## Testing

- Verified that all modified logger messages preserve the original output.
- No functional changes were introduced.

Closes #4290

## Summary by Sourcery

Enhancements:
- Modernize logging statements by converting string .format() calls to f-strings across API, control, presale, base, and plugin modules.