### PR TITLE
fix: renumber conflicting base migration 0037 to 0038

### DIFF
--- a/app/eventyay/base/migrations/0038_team_force_hide_speaker_emails_and_more.py
+++ b/app/eventyay/base/migrations/0038_team_force_hide_speaker_emails_and_more.py
@@ -6,7 +6,7 @@ from django.db import migrations, models
 class Migration(migrations.Migration):
 
     dependencies = [
-        ('base', '0036_orderposition_search_trigram_indexes'),
+        ('base', '0037_device_checkin_lists_and_security'),
     ]
 
     operations = [


### PR DESCRIPTION
## Summary
- Resolves duplicate `base` migration number `0037` after device check-in and team speaker-email migrations both claimed that slot.
- Keeps `0037_device_checkin_lists_and_security` and renumbers the team migration to `0038`, depending on the device migration.