### PR TITLE
fix: unescape markdown escaped underscores in placeholders

### DIFF
--- a/app/eventyay/base/forms/validators.py
+++ b/app/eventyay/base/forms/validators.py
@@ -32,7 +32,9 @@ class PlaceholderValidator(BaseValidator):
         data_placeholders = list(re.findall(r'({[^}]*})', value, re.X))
         invalid_placeholders = []
         for placeholder in data_placeholders:
-            if placeholder not in self.limit_value:
+            # Clean backslashes that might be added by markdown editors (e.g. {join\_online\_event})
+            clean_placeholder = placeholder.replace('\\_', '_')
+            if clean_placeholder not in self.limit_value:
                 invalid_placeholders.append(placeholder)
         if invalid_placeholders:
             raise ValidationError(

--- a/app/eventyay/base/services/mail.py
+++ b/app/eventyay/base/services/mail.py
@@ -62,13 +62,11 @@ INVALID_ADDRESS = 'invalid-eventyay-mail-address'
 
 class TolerantDict(dict):
     def __missing__(self, key):
+        if isinstance(key, str) and '\\_' in key:
+            clean_key = key.replace('\\_', '_')
+            if clean_key in self:
+                return super().__getitem__(clean_key)
         return key
-
-    def __getitem__(self, key):
-        clean_key = key.replace('\\_', '_')
-        if clean_key in self:
-            return super().__getitem__(clean_key)
-        return self.__missing__(key)
 
 
 class SendMailException(Exception):  # NOQA: N818

--- a/app/eventyay/base/services/mail.py
+++ b/app/eventyay/base/services/mail.py
@@ -64,6 +64,12 @@ class TolerantDict(dict):
     def __missing__(self, key):
         return key
 
+    def __getitem__(self, key):
+        clean_key = key.replace('\\_', '_')
+        if clean_key in self:
+            return super().__getitem__(clean_key)
+        return self.__missing__(key)
+
 
 class SendMailException(Exception):  # NOQA: N818
     pass

--- a/app/eventyay/common/mail.py
+++ b/app/eventyay/common/mail.py
@@ -34,13 +34,11 @@ class CustomSMTPBackend(EmailBackend):
 class TolerantDict(dict):
     def __missing__(self, key):
         """Don't fail when formatting strings with a dict with missing keys."""
+        if isinstance(key, str) and '\\_' in key:
+            clean_key = key.replace('\\_', '_')
+            if clean_key in self:
+                return super().__getitem__(clean_key)
         return key
-
-    def __getitem__(self, key):
-        clean_key = key.replace('\\_', '_')
-        if clean_key in self:
-            return super().__getitem__(clean_key)
-        return self.__missing__(key)
 
 
 DEBUG_DOMAINS = [

--- a/app/eventyay/common/mail.py
+++ b/app/eventyay/common/mail.py
@@ -36,6 +36,12 @@ class TolerantDict(dict):
         """Don't fail when formatting strings with a dict with missing keys."""
         return key
 
+    def __getitem__(self, key):
+        clean_key = key.replace('\\_', '_')
+        if clean_key in self:
+            return super().__getitem__(clean_key)
+        return self.__missing__(key)
+
 
 DEBUG_DOMAINS = [
     'localhost',

--- a/app/eventyay/mail/context.py
+++ b/app/eventyay/mail/context.py
@@ -48,7 +48,7 @@ def get_used_placeholders(text):
     if not text:
         return set()
     if isinstance(text, str):
-        return {element[1] for element in string.Formatter().parse(text) if element[1]}
+        return {element[1].replace('\\_', '_') for element in string.Formatter().parse(text) if element[1]}
     if getattr(text, 'data', None):
         return get_used_placeholders(text.data)
     if isinstance(text, dict):


### PR DESCRIPTION
This fixes an issue where markdown editors escape underscores in placeholders like {join\_online\_event}, causing validation and email rendering errors.


<img width="5088" height="3108" alt="image" src="https://github.com/user-attachments/assets/01a8a8ed-3cf4-4ecf-997f-594fb25d4789" />
