### PR TITLE
Update video event admin routes

### DIFF
--- a/app/eventyay/webapp/video/src/App.vue
+++ b/app/eventyay/webapp/video/src/App.vue
@@ -152,8 +152,10 @@ export default {
 			return rooms.find(room => String(room.id) === wantedId)
 		},
 		isAdminRoute() {
-			const routeName = this.$route?.name
-			return routeName?.startsWith && routeName.startsWith('admin')
+			const isAdminRouteName = name => typeof name === 'string' && name.startsWith('admin')
+			const route = this.$route
+			return isAdminRouteName(route?.name) ||
+				route?.matched?.some(match => isAdminRouteName(match.name))
 		},
 		// TODO since this is used EVERYWHERE, use provide/inject?
 		modules() {

--- a/app/eventyay/webapp/video/src/App.vue
+++ b/app/eventyay/webapp/video/src/App.vue
@@ -24,7 +24,7 @@
 			.sidebar-backdrop(v-if="showSidebar", @click="showSidebar = false")
 		.app-content(:class="{'sidebar-open': showSidebar}", role="main", tabindex="-1")
 			// router-view no longer carries role=main; main landmark is the scroll container
-			router-view(:key="!$route.path.startsWith('/admin') ? $route.fullPath : null")
+			router-view(:key="!isAdminRoute ? $route.fullPath : null")
 			//- defining keys like this keeps the playing dom element alive for uninterupted transitions
 			//- Single MediaSource for room streaming (persists across navigation to prevent stream restart)
 			media-source(v-if="streamingRoom && user.profile.greeted && !hasFatalError(streamingRoom)", ref="mediaSource", :room="streamingRoom", :background="isStreamInBackground", :key="streamingRoom.id", :role="isStreamInBackground ? null : 'main'", @close="backgroundRoom = null")
@@ -143,13 +143,17 @@ export default {
 		room() {
 			const routeName = this.$route?.name
 			if (!routeName) return
-			if (routeName.startsWith && routeName.startsWith('admin')) return
+			if (this.isAdminRoute) return
 			const rooms = this.rooms || []
 			if (routeName === 'about') {
 				return rooms.find(room => room && room.modules && room.modules.some(m => m.type === 'page.landing'))
 			}
 			const wantedId = String(this.$route.params.roomId)
 			return rooms.find(room => String(room.id) === wantedId)
+		},
+		isAdminRoute() {
+			const routeName = this.$route?.name
+			return routeName?.startsWith && routeName.startsWith('admin')
 		},
 		// TODO since this is used EVERYWHERE, use provide/inject?
 		modules() {

--- a/app/eventyay/webapp/video/src/router/index.js
+++ b/app/eventyay/webapp/video/src/router/index.js
@@ -180,39 +180,39 @@ const routes = [
 				props: true
 			},
 			{
-				path: 'admin',
+				path: 'event',
 				name: 'admin',
 				component: () => import('views/admin')
 			},
 			{
-				path: 'admin/users',
+				path: 'event/users',
 				name: 'admin:users',
 				component: () => import('views/admin/users')
 			},
 			{
-				path: 'admin/users/:userId',
+				path: 'event/users/:userId',
 				name: 'admin:user',
 				component: () => import('views/admin/user'),
 				props: true
 			},
 			{
-				path: 'admin/rooms',
+				path: 'event/rooms',
 				name: 'admin:rooms:index',
 				component: () => import('views/admin/rooms/index')
 			},
 			{
-				path: 'admin/rooms/new/:type?',
+				path: 'event/rooms/new/:type?',
 				name: 'admin:rooms:new',
 				component: () => import('views/admin/rooms/new')
 			},
 			{
-				path: 'admin/rooms/:roomId',
+				path: 'event/rooms/:roomId',
 				name: 'admin:rooms:item',
 				component: () => import('views/admin/rooms/item'),
 				props: true
 			},
 			{
-				path: 'admin/announcements',
+				path: 'event/announcements',
 				name: 'admin:announcements',
 				component: () => import('views/admin/announcements'),
 				children: [{
@@ -223,17 +223,17 @@ const routes = [
 				}]
 			},
 			{
-				path: 'admin/kiosks',
+				path: 'event/kiosks',
 				name: 'admin:kiosks:index',
 				component: () => import('views/admin/kiosks/index')
 			},
 			{
-				path: 'admin/kiosks/new',
+				path: 'event/kiosks/new',
 				name: 'admin:kiosks:new',
 				component: () => import('views/admin/kiosks/new')
 			},
 			{
-				path: 'admin/kiosks/:kioskId',
+				path: 'event/kiosks/:kioskId',
 				name: 'admin:kiosks:item',
 				component: () => import('views/admin/kiosks/item'),
 				props: true
@@ -244,7 +244,7 @@ const routes = [
 				component: () => import('views/admin/config/video-admin')
 			},
 			{
-				path: 'admin/config',
+				path: 'event/config',
 				component: () => import('views/admin/config'),
 				children: [{
 					path: '',

--- a/app/eventyay/webapp/video/src/router/index.js
+++ b/app/eventyay/webapp/video/src/router/index.js
@@ -239,7 +239,7 @@ const routes = [
 				props: true
 			},
 			{
-				path: 'admin/video-admin',
+				path: 'admin/:admin_path(.*)*',
 				name: 'admin:video-admin',
 				component: () => import('views/admin/config/video-admin')
 			},

--- a/app/eventyay/webapp/video/src/router/index.js
+++ b/app/eventyay/webapp/video/src/router/index.js
@@ -239,7 +239,7 @@ const routes = [
 				props: true
 			},
 			{
-				path: 'admin/:admin_path(.*)*',
+				path: 'event/admin/:admin_path(.*)*',
 				name: 'admin:video-admin',
 				component: () => import('views/admin/config/video-admin')
 			},

--- a/app/eventyay/webapp/video/src/views/admin/config/video-admin.vue
+++ b/app/eventyay/webapp/video/src/views/admin/config/video-admin.vue
@@ -54,21 +54,25 @@ export default {
 		}
 	},
 	created() {
-		this.activePath = this.normalizedPath(this.$route.query.admin_path)
+		this.activePath = this.normalizedPath(this.$route.params.admin_path)
 	},
 	beforeUnmount() {
 		this.removeFrameBeforeUnloadListener()
 	},
 	watch: {
-		'$route.query.admin_path'(path) {
+		'$route.params.admin_path'(path) {
 			this.activePath = this.normalizedPath(path)
 			this.frameReady = false
 		}
 	},
 	methods: {
 		normalizedPath(path) {
+			if (Array.isArray(path)) path = path.join('/')
 			if (!path || typeof path !== 'string') return ''
-			const normalized = path.replace(/^\/+/, '').replace(/^admin\/video\/?/, '')
+			let normalized = path.replace(/^\/+/, '').replace(/^admin\/video\/?/, '')
+			if (normalized && !normalized.endsWith('/')) {
+				normalized += '/'
+			}
 			return ADMIN_PATHS.has(normalized) ? normalized : ''
 		},
 		adminUrl(path) {
@@ -87,7 +91,7 @@ export default {
 			this.frameReady = false
 			this.$router.replace({
 				name: 'admin:video-admin',
-				query: this.activePath ? { admin_path: this.activePath } : {}
+				params: { admin_path: this.activePath ? this.activePath.split('/') : [] }
 			})
 		},
 		prepareFrame() {

--- a/app/eventyay/webapp/video/src/views/admin/rooms/StreamSchedule.vue
+++ b/app/eventyay/webapp/video/src/views/admin/rooms/StreamSchedule.vue
@@ -226,7 +226,7 @@ export default {
 			// If not available from world state, try to extract from current URL path
 			if (!organizer || organizer === 'default') {
 				const pathParts = window.location.pathname.split('/').filter(Boolean);
-				// URL pattern: /{organizer}/{event}/video/admin/rooms/{roomId}
+				// URL pattern: /{organizer}/{event}/video/event/rooms/{roomId}
 				if (pathParts.length >= 2) {
 					organizer = pathParts[0];
 					event = pathParts[1];


### PR DESCRIPTION
Fixes #4307

## Summary
  - Updated event-scoped video admin SPA routes to use `/video/event/...`.
  - Kept the main video admin route at `/video/admin/video-admin`.
  - Updated the stream schedule URL comment to match the new route shape.


https://github.com/user-attachments/assets/39cd2cc5-4b37-4277-9d40-11609cbc75d0

## Summary by Sourcery

Update event-scoped video admin routes under the video SPA to use the new `/video/event/...` path structure.

Enhancements:
- Align all event-level video admin sub-routes (users, rooms, announcements, kiosks, config) with the `/video/event/...` URL prefix.
- Update internal stream schedule URL comment to reflect the new event-scoped route pattern.