### PR TITLE
fix(email): align join online video token with presale flow

### DIFF
--- a/app/eventyay/multidomain/urlreverse.py
+++ b/app/eventyay/multidomain/urlreverse.py
@@ -1,7 +1,7 @@
 import datetime
 import logging
 from typing import cast
-from urllib.parse import urljoin, urlsplit
+from urllib.parse import urljoin, urlsplit, urlparse, urlunparse
 
 import jwt
 from django.conf import settings
@@ -9,6 +9,7 @@ from django.db.models import Q
 from django.urls import reverse
 
 from eventyay.base.models import Event, Order, OrderPosition, Organizer
+from eventyay.eventyay_common.utils import encode_email
 
 from .models import KnownDomain
 
@@ -185,22 +186,22 @@ def build_join_video_url(event: Event, order: Order) -> str:
 
 
 def generate_video_token_url_from_order(event: Event, order: Order, position: OrderPosition | None) -> str:
-    # If customer has account, use customer code to generate token
-    if hasattr(order, 'customer') and order.customer:
-        video_url = generate_video_token_url(event, order.customer.identifier, position)
-    else:
-        # else user position Id to generate token
-        video_url = generate_video_token_url(event, None, position)
-    return video_url
+    if not position:
+        position = order.positions.first()
+    uid_token = encode_email(order.email) if order.email else (position.pseudonymization_id if position else None)
+    return generate_video_token_url(event, uid_token, position)
 
 
-def generate_video_token_url(event: Event, customer_code: str, position: OrderPosition | None) -> str:
+def generate_video_token_url(event: Event, uid_token: str | None, position: OrderPosition | None) -> str:
     iat = datetime.datetime.now(tz=datetime.UTC)
     exp = iat + datetime.timedelta(days=30)
-    if not customer_code and not position:
-        logger.error('No customer code or position provided for generating video token URL.')
+    if not uid_token:
+        logger.error('No uid provided for generating video token URL.')
         return ''
-    uid = customer_code if customer_code else position.pseudonymization_id
+    if not position:
+        logger.error('No position provided for generating video token URL.')
+        return ''
+    uid = uid_token
     profile = {'fields': {}}
     if position and position.attendee_name:
         profile['display_name'] = position.attendee_name
@@ -219,6 +220,7 @@ def generate_video_token_url(event: Event, customer_code: str, position: OrderPo
         'profile': profile,
         'traits': list(
             {
+                'attendee',
                 'eventyay-video-event-{}'.format(event.slug),
                 'eventyay-video-subevent-{}'.format(position.subevent_id),
                 'eventyay-video-product-{}'.format(position.product_id),
@@ -235,6 +237,17 @@ def generate_video_token_url(event: Event, customer_code: str, position: OrderPo
         ),
     }
     token = jwt.encode(payload, event.settings.venueless_secret, algorithm='HS256')
-    url = urlsplit(cast(str, event.settings.venueless_url))
-    url = url._replace(fragment=f'token={token}')
-    return url.geturl()
+    baseurl = cast(str, event.settings.venueless_url)
+    if '{token}' in baseurl:
+        return baseurl.format(token=token)
+
+    video_path = reverse(
+        'video.spa',
+        kwargs={
+            'organizer': event.organizer.slug,
+            'event': event.slug,
+        },
+    )
+    parsed = urlparse(baseurl)
+    baseurl = urlunparse((parsed.scheme, parsed.netloc, video_path, '', '', ''))
+    return f'{baseurl}/#token={token}'.replace('//#', '/#')

--- a/app/tests/tickets/multidomain/test_urlreverse.py
+++ b/app/tests/tickets/multidomain/test_urlreverse.py
@@ -1,23 +1,12 @@
-import datetime
-from decimal import Decimal
-
-import jwt
 import pytest
 from django.conf import settings
 from django.test import override_settings
 from django.utils.timezone import now
 from django_scopes import scopes_disabled
 
-from eventyay.base.models import Event, Order, OrderPosition, Organizer, Product
-from eventyay.eventyay_common.utils import encode_email
+from eventyay.base.models import Event, Organizer
 from eventyay.multidomain.models import KnownDomain
-from eventyay.multidomain.urlreverse import (
-    build_absolute_uri,
-    build_join_video_url,
-    eventreverse,
-    generate_video_token_url,
-)
-from eventyay.presale.views.event import JoinOnlineVideoView
+from eventyay.multidomain.urlreverse import build_absolute_uri, eventreverse
 from tests.tickets import assert_num_queries
 
 
@@ -209,100 +198,3 @@ def test_event_custom_domain_absolute(env):
 def test_event_org_domain_absolute(env):
     KnownDomain.objects.create(domainname='foobar', organizer=env[0])
     assert build_absolute_uri(env[1], 'presale:event.index') == 'http://foobar/2015/'
-
-
-@pytest.fixture
-def video_event(env):
-    organizer, event = env
-    ticket = Product.objects.create(
-        event=event,
-        name='Ticket',
-        default_price=Decimal('10.00'),
-        admission=True,
-    )
-    event.settings.set('venueless_url', 'http://video.example.com/')
-    event.settings.set('venueless_issuer', 'test-issuer')
-    event.settings.set('venueless_audience', 'test-audience')
-    event.settings.set('venueless_secret', 'test-secret')
-    event.settings.set('venueless_all_products', True)
-    order = Order.objects.create(
-        event=event,
-        email='attendee@example.com',
-        status=Order.STATUS_PAID,
-        total=Decimal('10.00'),
-        datetime=now(),
-        expires=now() + datetime.timedelta(days=1),
-    )
-    position = OrderPosition.objects.create(
-        order=order,
-        product=ticket,
-        price=Decimal('10.00'),
-        positionid=1,
-        attendee_name_parts={'full_name': 'Jane Doe'},
-    )
-    return event, order, position
-
-
-@pytest.mark.django_db
-@scopes_disabled()
-def test_build_join_video_url_matches_presale_token(video_event):
-    event, order, position = video_event
-    email_url = build_join_video_url(event, order)
-
-    view = JoinOnlineVideoView()
-    view.request = type('Request', (), {'event': event})()
-    presale_url = view.generate_token_url(view.request, position, order)
-
-    email_token = email_url.split('#token=')[1]
-    presale_token = presale_url.split('#token=')[1]
-    decode_kwargs = {
-        'algorithms': ['HS256'],
-        'audience': 'test-audience',
-        'issuer': 'test-issuer',
-    }
-    email_payload = jwt.decode(email_token, 'test-secret', **decode_kwargs)
-    presale_payload = jwt.decode(presale_token, 'test-secret', **decode_kwargs)
-
-    assert email_payload['uid'] == presale_payload['uid'] == encode_email('attendee@example.com')
-    assert 'attendee' in email_payload['traits']
-    assert set(email_payload['traits']) == set(presale_payload['traits'])
-    assert email_url.split('#')[0] == presale_url.split('#')[0]
-    assert f'/{event.organizer.slug}/{event.slug}/video/' in email_url
-
-
-@pytest.mark.django_db
-@scopes_disabled()
-def test_build_join_video_url_returns_empty_without_allowed_products(video_event):
-    event, order, _position = video_event
-    event.settings.set('venueless_all_products', False)
-    event.settings.set('venueless_products', [])
-
-    assert build_join_video_url(event, order) == ''
-
-
-@pytest.mark.django_db
-@scopes_disabled()
-def test_generate_video_token_url_returns_empty_without_position(video_event):
-    event, order, _position = video_event
-
-    assert generate_video_token_url(event, encode_email(order.email), None) == ''
-
-
-@pytest.mark.django_db
-@scopes_disabled()
-def test_generate_video_token_url_supports_legacy_token_placeholder(video_event):
-    event, order, _position = video_event
-    event.settings.set('venueless_url', 'http://video.example.com/join?token={token}')
-
-    url = build_join_video_url(event, order)
-
-    assert '#token=' not in url
-    assert 'token=' in url
-    token = url.split('token=')[1]
-    jwt.decode(
-        token,
-        'test-secret',
-        algorithms=['HS256'],
-        audience='test-audience',
-        issuer='test-issuer',
-    )

--- a/app/tests/tickets/multidomain/test_urlreverse.py
+++ b/app/tests/tickets/multidomain/test_urlreverse.py
@@ -1,12 +1,23 @@
+import datetime
+from decimal import Decimal
+
+import jwt
 import pytest
 from django.conf import settings
 from django.test import override_settings
 from django.utils.timezone import now
 from django_scopes import scopes_disabled
 
-from eventyay.base.models import Event, Organizer
+from eventyay.base.models import Event, Order, OrderPosition, Organizer, Product
+from eventyay.eventyay_common.utils import encode_email
 from eventyay.multidomain.models import KnownDomain
-from eventyay.multidomain.urlreverse import build_absolute_uri, eventreverse
+from eventyay.multidomain.urlreverse import (
+    build_absolute_uri,
+    build_join_video_url,
+    eventreverse,
+    generate_video_token_url,
+)
+from eventyay.presale.views.event import JoinOnlineVideoView
 from tests.tickets import assert_num_queries
 
 
@@ -198,3 +209,100 @@ def test_event_custom_domain_absolute(env):
 def test_event_org_domain_absolute(env):
     KnownDomain.objects.create(domainname='foobar', organizer=env[0])
     assert build_absolute_uri(env[1], 'presale:event.index') == 'http://foobar/2015/'
+
+
+@pytest.fixture
+def video_event(env):
+    organizer, event = env
+    ticket = Product.objects.create(
+        event=event,
+        name='Ticket',
+        default_price=Decimal('10.00'),
+        admission=True,
+    )
+    event.settings.set('venueless_url', 'http://video.example.com/')
+    event.settings.set('venueless_issuer', 'test-issuer')
+    event.settings.set('venueless_audience', 'test-audience')
+    event.settings.set('venueless_secret', 'test-secret')
+    event.settings.set('venueless_all_products', True)
+    order = Order.objects.create(
+        event=event,
+        email='attendee@example.com',
+        status=Order.STATUS_PAID,
+        total=Decimal('10.00'),
+        datetime=now(),
+        expires=now() + datetime.timedelta(days=1),
+    )
+    position = OrderPosition.objects.create(
+        order=order,
+        product=ticket,
+        price=Decimal('10.00'),
+        positionid=1,
+        attendee_name_parts={'full_name': 'Jane Doe'},
+    )
+    return event, order, position
+
+
+@pytest.mark.django_db
+@scopes_disabled()
+def test_build_join_video_url_matches_presale_token(video_event):
+    event, order, position = video_event
+    email_url = build_join_video_url(event, order)
+
+    view = JoinOnlineVideoView()
+    view.request = type('Request', (), {'event': event})()
+    presale_url = view.generate_token_url(view.request, position, order)
+
+    email_token = email_url.split('#token=')[1]
+    presale_token = presale_url.split('#token=')[1]
+    decode_kwargs = {
+        'algorithms': ['HS256'],
+        'audience': 'test-audience',
+        'issuer': 'test-issuer',
+    }
+    email_payload = jwt.decode(email_token, 'test-secret', **decode_kwargs)
+    presale_payload = jwt.decode(presale_token, 'test-secret', **decode_kwargs)
+
+    assert email_payload['uid'] == presale_payload['uid'] == encode_email('attendee@example.com')
+    assert 'attendee' in email_payload['traits']
+    assert set(email_payload['traits']) == set(presale_payload['traits'])
+    assert email_url.split('#')[0] == presale_url.split('#')[0]
+    assert f'/{event.organizer.slug}/{event.slug}/video/' in email_url
+
+
+@pytest.mark.django_db
+@scopes_disabled()
+def test_build_join_video_url_returns_empty_without_allowed_products(video_event):
+    event, order, _position = video_event
+    event.settings.set('venueless_all_products', False)
+    event.settings.set('venueless_products', [])
+
+    assert build_join_video_url(event, order) == ''
+
+
+@pytest.mark.django_db
+@scopes_disabled()
+def test_generate_video_token_url_returns_empty_without_position(video_event):
+    event, order, _position = video_event
+
+    assert generate_video_token_url(event, encode_email(order.email), None) == ''
+
+
+@pytest.mark.django_db
+@scopes_disabled()
+def test_generate_video_token_url_supports_legacy_token_placeholder(video_event):
+    event, order, _position = video_event
+    event.settings.set('venueless_url', 'http://video.example.com/join?token={token}')
+
+    url = build_join_video_url(event, order)
+
+    assert '#token=' not in url
+    assert 'token=' in url
+    token = url.split('token=')[1]
+    jwt.decode(
+        token,
+        'test-secret',
+        algorithms=['HS256'],
+        audience='test-audience',
+        issuer='test-issuer',
+    )


### PR DESCRIPTION
## Summary
- Fix the `{join_online_event}` email placeholder so it generates the same video access token as the presale "Join online video" button.
- Use `encode_email(order.email)` for the JWT `uid`, include the `attendee` trait, and build the redirect URL via `video.spa`.
- Add regression tests to ensure email and presale tokens stay in sync.

## Test plan
- [x] Added tests in `tests/tickets/multidomain/test_urlreverse.py` for token parity, empty fallback, and legacy `{token}` URL format
- [ ] Run `pytest tests/tickets/multidomain/test_urlreverse.py -k video -v`
- [ ] Send a test order email with `{join_online_event}` and confirm the link opens video successfully
- [ ] Confirm presale "Join online video" button still works unchanged