### PR TITLE
Fix: Signup with existing email leaks account existence

### DIFF
--- a/app/eventyay/config/settings.py
+++ b/app/eventyay/config/settings.py
@@ -1257,6 +1257,7 @@ LOGGING = {
 
 # NOTE: django-allauth changed some settings name. Check https://docs.allauth.org/en/dev/release-notes/recent.html
 ACCOUNT_LOGIN_METHODS = {'email'}
+ACCOUNT_PREVENT_ENUMERATION = "strict"
 ACCOUNT_SIGNUP_FIELDS = ['email*', 'password1*', 'password2*']
 ACCOUNT_USER_MODEL_USERNAME_FIELD = None
 # 'mandatory' means allauth's own login view (/accounts/login/) will block unverified users.

--- a/app/eventyay/jinja-templates/account/messages/email_confirmation_sent.txt
+++ b/app/eventyay/jinja-templates/account/messages/email_confirmation_sent.txt
@@ -1,0 +1,1 @@
+Confirmation email sent.


### PR DESCRIPTION
This PR resolves the account enumeration vulnerability in the signup flow outlined in #4016.

### Changes Made:
- Enabled `ACCOUNT_PREVENT_ENUMERATION = "strict"` in the `django-allauth` configuration to ensure that signup attempts with both existing and non-existing emails result in the exact same application flow and redirect behavior.
- Overrode the default `email_confirmation_sent.txt` flash message template. It now generically displays `"Confirmation email sent."` instead of echoing the submitted email address back to the user, completely obfuscating the account's existence.

Fixes #4016
