### PR TITLE
fix: skip role-less mail templates during locale backfill

### DIFF
--- a/app/eventyay/base/models/event.py
+++ b/app/eventyay/base/models/event.py
@@ -1050,11 +1050,10 @@ class Event(
 
     def _backfill_all_mail_template_locales(self):
         """Backfill all existing mail templates with newly added locales."""
-        from eventyay.base.models import MailTemplate
-        
         with scope(event=self):
             for template in self.mail_templates.all():
-                self._ensure_mail_template_locales(template, template.role)
+                if template.role:
+                    self._ensure_mail_template_locales(template, template.role)
 
     def get_plugins(self):
         """
@@ -2832,6 +2831,9 @@ class Event(
 
     def _ensure_mail_template_locales(self, template, role):
         from eventyay.mail.default_templates import get_default_template
+
+        if role is None:
+            return template
 
         default_subject, default_text = get_default_template(role)
         

--- a/app/tests/talk/event/test_event_model.py
+++ b/app/tests/talk/event/test_event_model.py
@@ -7,7 +7,7 @@ from django.utils.timezone import now
 from django_scopes import scope, scopes_disabled
 from i18nfield.strings import LazyI18nString
 
-from eventyay.base.models import Event
+from eventyay.base.models import Event, MailTemplate
 
 
 @pytest.fixture
@@ -85,6 +85,18 @@ def test_default_mail_template_backfills_missing_locale_entries(event):
         assert template.text.data['en'] == 'custom text'
         assert 'de' in template.subject.data
         assert 'de' in template.text.data
+
+
+@pytest.mark.django_db
+def test_event_save_with_custom_mail_template_and_locale_change(event):
+    with scope(event=event):
+        MailTemplate.objects.create(
+            event=event,
+            subject='Custom subject',
+            text='Custom text',
+        )
+        event.locale_array = 'en,de,fr'
+        event.save()
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary
- Fix `KeyError: None` when saving event settings if the event has custom mail templates (`role=None`) and locales change
- Skip role-less templates during mail template locale backfill, matching existing behavior in orga mail views
- Add regression test for saving an event with a custom template when locales change

## Test plan
- [x] Added `test_event_save_with_custom_mail_template_and_locale_change`
- [ ] Save event settings on an event that has a custom mail template and change locales — should no longer 500

## Summary by Sourcery

Skip role-less mail templates when backfilling locales on event save to avoid errors with custom templates.

Bug Fixes:
- Avoid KeyError when saving events that have custom mail templates without a role during locale backfill.

Tests:
- Add regression test covering saving an event with a custom mail template while changing locales.