### PR TITLE
fix: mark name field as required in Track and SubmissionType forms

### DIFF
--- a/app/eventyay/orga/forms/cfp.py
+++ b/app/eventyay/orga/forms/cfp.py
@@ -590,6 +590,7 @@ class SubmissionTypeForm(ReadOnlyFlag, I18nHelpText, I18nModelForm):
     def __init__(self, *args, event=None, **kwargs):
         self.event = event
         super().__init__(*args, **kwargs)
+        self.fields['name'].required = True
 
     def clean_name(self):
         name = self.cleaned_data['name']
@@ -636,6 +637,7 @@ class TrackForm(ReadOnlyFlag, I18nHelpText, I18nModelForm):
                         pass
             kwargs['initial'] = initial
         super().__init__(*args, **kwargs)
+        self.fields['name'].required = True
         if self.instance.pk:
             url = f'{event.cfp.urls.new_access_code}?track={self.instance.pk}'
             self.fields['requires_access_code'].help_text += ' ' + _(

--- a/app/eventyay/orga/forms/cfp.py
+++ b/app/eventyay/orga/forms/cfp.py
@@ -586,11 +586,17 @@ class AnswerOptionForm(ReadOnlyFlag, I18nHelpText, I18nModelForm):
         }
 
 
-class SubmissionTypeForm(ReadOnlyFlag, I18nHelpText, I18nModelForm):
+class NameRequiredMixin:
+    """Mixin to ensure the name field is always marked as required in the UI."""
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.fields['name'].required = True
+
+
+class SubmissionTypeForm(NameRequiredMixin, ReadOnlyFlag, I18nHelpText, I18nModelForm):
     def __init__(self, *args, event=None, **kwargs):
         self.event = event
         super().__init__(*args, **kwargs)
-        self.fields['name'].required = True
 
     def clean_name(self):
         name = self.cleaned_data['name']
@@ -616,7 +622,7 @@ class SubmissionTypeForm(ReadOnlyFlag, I18nHelpText, I18nModelForm):
         }
 
 
-class TrackForm(ReadOnlyFlag, I18nHelpText, I18nModelForm):
+class TrackForm(NameRequiredMixin, ReadOnlyFlag, I18nHelpText, I18nModelForm):
     def __init__(self, *args, event=None, **kwargs):
         self.event = event
         # Set initial color for new tracks (when creating, not editing)
@@ -637,7 +643,6 @@ class TrackForm(ReadOnlyFlag, I18nHelpText, I18nModelForm):
                         pass
             kwargs['initial'] = initial
         super().__init__(*args, **kwargs)
-        self.fields['name'].required = True
         if self.instance.pk:
             url = f'{event.cfp.urls.new_access_code}?track={self.instance.pk}'
             self.fields['requires_access_code'].help_text += ' ' + _(


### PR DESCRIPTION
## Problem
Closes #4328

The `Name` field in **New Track** and **New Session Type** forms was  labeled as `Optional` in the UI, but submitting without a name  triggered: `"This field is required."`

## Root Cause
The `name` field is required at model level but `TrackForm` and  `SubmissionTypeForm` did not explicitly set `required=True` after 
`super().__init__()`.

## Fix
Added `self.fields['name'].required = True` in both form `__init__`  methods after `super().__init__()`.

## Screenshots

### New Track — After Fix
<img width="1920" height="1020" alt="Screenshot 2026-07-11 115715" src="https://github.com/user-attachments/assets/d26e1aef-6332-4e2d-8595-9ac0bbf92520" />


### New Track — Validation works
<img width="1920" height="1020" alt="Screenshot 2026-07-11 115819" src="https://github.com/user-attachments/assets/195dbc7d-6edb-47a5-9e80-2b93042b3dc6" />


### New Session Type — After Fix  
<img width="1920" height="1020" alt="Screenshot 2026-07-11 115846" src="https://github.com/user-attachments/assets/7890a38c-2044-499d-b5a2-7c8b4d7bb86f" />

## Summary by Sourcery

Bug Fixes:
- Fix inconsistent behavior where the name field appeared optional in New Track and New Session Type forms but was still required on submission.