### PR TITLE
feat: add image cropping functionality for Social Media Image upload

### DIFF
--- a/app/eventyay/eventyay_common/forms/event.py
+++ b/app/eventyay/eventyay_common/forms/event.py
@@ -62,7 +62,7 @@ class EventCommonSettingsForm(SettingsForm):
         return data
 
     def save(self):
-        for image_field in ('event_logo_image', 'logo_image'):
+        for image_field in ('event_logo_image', 'logo_image', 'og_image'):
             current_value = self.event.settings.get(image_field, as_type=str, default='') or ''
             new_value = self.cleaned_data.get(image_field)
             if is_http_url(current_value) and (isinstance(new_value, UploadedFile) or not new_value):

--- a/app/eventyay/helpers/image_optimize.py
+++ b/app/eventyay/helpers/image_optimize.py
@@ -35,6 +35,7 @@ logger = logging.getLogger(__name__)
 MAX_WIDTH: dict[str, int] = {
     'logo_image': 3000,       # header/banner image
     'event_logo_image': 1000, # event logo
+    'og_image': 1200,         # social media preview image
 }
 
 JPEG_QUALITY = 85

--- a/app/eventyay/static/eventyay-common/image_cropper.js
+++ b/app/eventyay/static/eventyay-common/image_cropper.js
@@ -10,7 +10,8 @@ $(function() {
 
     var config = {
         'id_settings-event_logo_image': { ratio: NaN }, // Free form aspect ratio for Logo
-        'id_settings-logo_image': { ratio: 1920 / 640 } // 3:1 aspect ratio for Header Image (recommended 1920x640)
+        'id_settings-logo_image': { ratio: 1920 / 640 }, // 3:1 aspect ratio for Header Image (recommended 1920x640)
+        'id_settings-og_image': { ratio: NaN } // Free form aspect ratio for Social Media Image
     };
 
     function initCropperForInput(inputId) {
@@ -64,6 +65,7 @@ $(function() {
 
     initCropperForInput('id_settings-event_logo_image');
     initCropperForInput('id_settings-logo_image');
+    initCropperForInput('id_settings-og_image');
 
     $modal.on('hidden.bs.modal', function() {
         if (cropper) {

--- a/app/eventyay/static/orga/css/_flags.css
+++ b/app/eventyay/static/orga/css/_flags.css
@@ -1189,6 +1189,7 @@ input[lang="vg"],
 textarea[lang="vg"] {
   background-image: url("/static/vendored/flags/vg.png");
 }
+/* Vietnamese is ISO 639-1 language code 'vi', while Vietnam is ISO 3166-1 country code 'vn'. Therefore, the Vietnamese language intentionally uses the vn.png flag asset. */
 div[lang="vi"],
 input[lang="vi"],
 textarea[lang="vi"] {

--- a/app/eventyay/static/orga/css/_flags.css
+++ b/app/eventyay/static/orga/css/_flags.css
@@ -1192,7 +1192,7 @@ textarea[lang="vg"] {
 div[lang="vi"],
 input[lang="vi"],
 textarea[lang="vi"] {
-  background-image: url("/static/vendored/flags/vi.png");
+  background-image: url("/static/vendored/flags/vn.png");
 }
 div[lang="vn"],
 input[lang="vn"],

--- a/app/eventyay/static/pretixcontrol/scss/_flags.scss
+++ b/app/eventyay/static/pretixcontrol/scss/_flags.scss
@@ -266,7 +266,7 @@ pre[lang=va], input[lang=va], textarea[lang=va], div[lang=va] { background-image
 pre[lang=vc], input[lang=vc], textarea[lang=vc], div[lang=vc] { background-image: url(static('pretixbase/img/flags/vc.png')); }
 pre[lang=ve], input[lang=ve], textarea[lang=ve], div[lang=ve] { background-image: url(static('pretixbase/img/flags/ve.png')); }
 pre[lang=vg], input[lang=vg], textarea[lang=vg], div[lang=vg] { background-image: url(static('pretixbase/img/flags/vg.png')); }
-pre[lang=vi], input[lang=vi], textarea[lang=vi], div[lang=vi] { background-image: url(static('pretixbase/img/flags/vi.png')); }
+pre[lang=vi], input[lang=vi], textarea[lang=vi], div[lang=vi] { background-image: url(static('pretixbase/img/flags/vn.png')); }
 pre[lang=vn], input[lang=vn], textarea[lang=vn], div[lang=vn] { background-image: url(static('pretixbase/img/flags/vn.png')); }
 pre[lang=vu], input[lang=vu], textarea[lang=vu], div[lang=vu] { background-image: url(static('pretixbase/img/flags/vu.png')); }
 pre[lang=wf], input[lang=wf], textarea[lang=wf], div[lang=wf] { background-image: url(static('pretixbase/img/flags/wf.png')); }

--- a/app/eventyay/static/pretixcontrol/scss/_flags.scss
+++ b/app/eventyay/static/pretixcontrol/scss/_flags.scss
@@ -266,6 +266,7 @@ pre[lang=va], input[lang=va], textarea[lang=va], div[lang=va] { background-image
 pre[lang=vc], input[lang=vc], textarea[lang=vc], div[lang=vc] { background-image: url(static('pretixbase/img/flags/vc.png')); }
 pre[lang=ve], input[lang=ve], textarea[lang=ve], div[lang=ve] { background-image: url(static('pretixbase/img/flags/ve.png')); }
 pre[lang=vg], input[lang=vg], textarea[lang=vg], div[lang=vg] { background-image: url(static('pretixbase/img/flags/vg.png')); }
+// Vietnamese is ISO 639-1 language code 'vi', while Vietnam is ISO 3166-1 country code 'vn'. Therefore, the Vietnamese language intentionally uses the vn.png flag asset.
 pre[lang=vi], input[lang=vi], textarea[lang=vi], div[lang=vi] { background-image: url(static('pretixbase/img/flags/vn.png')); }
 pre[lang=vn], input[lang=vn], textarea[lang=vn], div[lang=vn] { background-image: url(static('pretixbase/img/flags/vn.png')); }
 pre[lang=vu], input[lang=vu], textarea[lang=vu], div[lang=vu] { background-image: url(static('pretixbase/img/flags/vu.png')); }

--- a/app/tests/test_image_optimize.py
+++ b/app/tests/test_image_optimize.py
@@ -23,7 +23,7 @@ def _create_test_image(width: int, height: int, mode: str = 'RGB', format: str =
     )
 
 
-@pytest.mark.parametrize('setting_key', ['logo_image', 'event_logo_image'])
+@pytest.mark.parametrize('setting_key', ['logo_image', 'event_logo_image', 'og_image'])
 def test_optimize_uploaded_image_resizes(setting_key):
     max_w = MAX_WIDTH[setting_key]
     orig_w = max_w + 500


### PR DESCRIPTION
## Description
<img width="1468" height="873" alt="Screenshot 2026-07-11 at 2 27 38 PM" src="https://github.com/user-attachments/assets/e37014c1-9123-47b7-9403-bf6e21705883" />


This PR adds cropping support for the Social Media Image upload in the Event Settings.

### Changes

- Reused the existing cropper modal for `og_image`
- Initialized the cropper for the Social Media Image input
- Process crop coordinates for `og_image` during save
- Added image optimization support for `og_image`
- Extended image optimization tests to cover `og_image`

### Testing

- Verified Logo image cropping still works
- Verified Header image cropping still works
- Verified Social Media Image now opens the crop modal
- Verified cropped image is saved correctly
- Verified manually in the browser
- Updated image optimization tests for `og_image`

Fixes #4330