### PR TITLE
fix: CfP.max_deadline only looked at submission types that had an

### DIFF
--- a/app/eventyay/base/models/cfp.py
+++ b/app/eventyay/base/models/cfp.py
@@ -248,21 +248,26 @@ class CfP(PretalxModel):
     def is_open(self) -> bool:
         """``True`` if ``max_deadline`` is not over yet, or if no deadline is
         set."""
-        if self.deadline is None:
-            return True
         return self.max_deadline >= now() if self.max_deadline else True
 
     @cached_property
     def max_deadline(self) -> dt.datetime:
         """Returns the latest date any submission is possible.
 
-        This includes the deadlines set on any submission type for this
-        event.
+        A submission type without its own deadline falls back to the
+        global CfP deadline, just like ``Submission.cfp_open`` does. If
+        any submission type (or the CfP itself, if there are no
+        submission types) ends up without a deadline, submissions never
+        stop being possible for that type, so there is no overall
+        deadline and ``None`` is returned.
         """
-        deadlines = list(self.event.submission_types.filter(deadline__isnull=False).values_list('deadline', flat=True))
-        if self.deadline:
-            deadlines.append(self.deadline)
-        return max(deadlines) if deadlines else None
+        effective_deadlines = [
+            submission_type.deadline or self.deadline
+            for submission_type in self.event.submission_types.all()
+        ] or [self.deadline]
+        if any(deadline is None for deadline in effective_deadlines):
+            return None
+        return max(effective_deadlines)
 
     @property
     def enable_gravatar(self) -> bool:

--- a/app/tests/talk/submission/test_cfp_model.py
+++ b/app/tests/talk/submission/test_cfp_model.py
@@ -68,3 +68,23 @@ def test_cfp_model_is_open(event, deadline, deadlines, is_open):
             )
 
         assert event.cfp.is_open == is_open
+
+
+@pytest.mark.django_db
+def test_cfp_model_max_deadline_ignores_expired_type_deadline_when_others_are_open(event):
+    """Regression test for #4229: a single, already expired submission type
+    deadline must not make the CfP look closed (nor make ``max_deadline``
+    report a past date) while other submission types (with no deadline of
+    their own, and no global CfP deadline) are still open."""
+    with scope(event=event):
+        event.cfp.deadline = None
+        event.cfp.save()
+
+        SubmissionType.objects.create(
+            event=event,
+            name='Expired talk',
+            deadline=dt.datetime(year=2000, month=11, day=20, tzinfo=event.tz),
+        )
+
+        assert event.cfp.max_deadline is None
+        assert event.cfp.is_open is True


### PR DESCRIPTION
Fixes #4229

## Summary
CfP.max_deadline only looked at submission types that had an explicit deadline set, ignoring that a type with no deadline falls back to the global CfP deadline (same rule Submission.cfp_open already uses); when the global deadline was unset, a single expired session-type deadline was wrongly surfaced as 'the' CFP deadline on the public page even though other types were still open indefinitely. Fixed max_deadline to compute each type's effective deadline (type.deadline or cfp.deadline) and return None (no message) when any type is unbounded, and simplified is_open accordingly; added a regression test for the exact scenario.

## Changes
- `app/eventyay/base/models/cfp.py`
- `app/tests/talk/submission/test_cfp_model.py`

## How this was tested
Ran `pytest tests/` locally.
