### PR TITLE
fix: enable attendee DMs and deduplicate order video panel

### DIFF
--- a/app/eventyay/base/models/event.py
+++ b/app/eventyay/base/models/event.py
@@ -62,7 +62,7 @@ from eventyay.core.permissions import (
     traits_match_required,
 )
 from eventyay.core.utils.json import CustomJSONEncoder
-from eventyay.eventyay_common.video.permissions import VIDEO_PERMISSION_BY_FIELD, VIDEO_TRAIT_ROLE_MAP
+from eventyay.eventyay_common.video.permissions import VIDEO_TRAIT_ROLE_MAP
 from eventyay.helpers.database import GroupConcat
 from eventyay.helpers.daterange import daterange
 from eventyay.helpers.http import smtp_reachable
@@ -99,6 +99,7 @@ def default_roles():
     attendee = [
         Permission.EVENT_VIEW,
         Permission.EVENT_EXHIBITION_CONTACT,
+        Permission.EVENT_CHAT_DIRECT,
     ]
     viewer = attendee + [Permission.ROOM_VIEW, Permission.ROOM_CHAT_READ]
     participant = viewer + [
@@ -1454,24 +1455,6 @@ class Event(
             augmented.setdefault(role, [f'eventyay-video-event-{slug}-{trait_name.replace("_", "-")}'])
         return augmented
 
-    def _remove_direct_messaging_if_unauthorized(self, result, user_traits):
-        """Remove EVENT_CHAT_DIRECT permission if user doesn't have the direct messaging trait.
-
-        Args:
-            result: Permission result dictionary to modify
-            user_traits: List of user traits
-        """
-        direct_messaging_def = VIDEO_PERMISSION_BY_FIELD.get('can_video_direct_message')
-        if not direct_messaging_def:
-            return
-
-        direct_messaging_trait = direct_messaging_def.trait_value(self.slug)
-        has_direct_messaging_trait = direct_messaging_trait in user_traits
-
-        if not has_direct_messaging_trait:
-            direct_message_value = Permission.EVENT_CHAT_DIRECT.value
-            result[self] = {p for p in result[self] if normalize_permission_value(p) != direct_message_value}
-
     def has_permission_implicit(
         self,
         *,
@@ -1588,10 +1571,10 @@ class Event(
             for role_name in ORGANIZER_ROLES:
                 role_perms = event_roles.get(role_name, SYSTEM_ROLES.get(role_name, []))
                 result[self].update(role_perms)
-        else:
-            # Remove EVENT_CHAT_DIRECT from ALL users unless they have the direct messaging trait.
-            # Only users with can_video_direct_message team permission get the video_direct_messaging trait.
-            self._remove_direct_messaging_if_unauthorized(result, user_traits)
+
+        attendee_traits = event_trait_grants.get('attendee', ['attendee'])
+        if traits_match_required(user_traits, attendee_traits) and (attendee_traits or allow_empty_traits):
+            result[self].add(Permission.EVENT_CHAT_DIRECT)
 
         for room in self.rooms.all():
             room_trait_grants = room.trait_grants if room.trait_grants is not None else {}

--- a/app/eventyay/base/models/event.py
+++ b/app/eventyay/base/models/event.py
@@ -1463,14 +1463,35 @@ class Event(
         room=None,
         allow_empty_traits=True,
     ):
-        # Ensure trait_grants and roles are not None - use defaults if missing
         event_trait_grants = self._get_trait_grants_with_defaults()
         event_roles = self.roles if self.roles is not None else default_roles()
 
+        if allow_empty_traits and not traits:
+            traits = ['attendee']
+
+        admin_mode_active = 'admin' in traits
+        if admin_mode_active:
+            for role_name in ORGANIZER_ROLES:
+                role_permissions = event_roles.get(role_name, SYSTEM_ROLES.get(role_name, []))
+                role_permissions_str = [normalize_permission_value(rp) for rp in role_permissions]
+                if any(normalize_permission_value(p) in role_permissions_str for p in permissions):
+                    return True
+
+        attendee_traits = event_trait_grants.get('attendee', ['attendee'])
+        if traits_match_required(traits, attendee_traits) and (attendee_traits or allow_empty_traits):
+            role_permissions = event_roles.get('attendee', SYSTEM_ROLES.get('attendee', []))
+            role_permissions_str = [normalize_permission_value(rp) for rp in role_permissions]
+            role_permissions_str.append(normalize_permission_value(Permission.EVENT_CHAT_DIRECT))
+            if any(normalize_permission_value(p) in role_permissions_str for p in permissions):
+                return True
+
         for role, required_traits in event_trait_grants.items():
+            if role == 'attendee':
+                continue
             if traits_match_required(traits, required_traits) and (required_traits or allow_empty_traits):
                 role_permissions = event_roles.get(role, SYSTEM_ROLES.get(role, []))
-                if any(normalize_permission_value(p) in role_permissions for p in permissions):
+                role_permissions_str = [normalize_permission_value(rp) for rp in role_permissions]
+                if any(normalize_permission_value(p) in role_permissions_str for p in permissions):
                     return True
 
         if room:
@@ -1478,7 +1499,8 @@ class Event(
             for role, required_traits in room_trait_grants.items():
                 if traits_match_required(traits, required_traits) and (required_traits or allow_empty_traits):
                     role_permissions = event_roles.get(role, SYSTEM_ROLES.get(role, []))
-                    if any(normalize_permission_value(p) in role_permissions for p in permissions):
+                    role_permissions_str = [normalize_permission_value(rp) for rp in role_permissions]
+                    if any(normalize_permission_value(p) in role_permissions_str for p in permissions):
                         return True
 
         # Return False if no permission was granted
@@ -1511,7 +1533,8 @@ class Event(
         event_roles = self.roles if self.roles is not None else default_roles()
         for r in roles:
             role_perms = event_roles.get(r, SYSTEM_ROLES.get(r, []))
-            if any(normalize_permission_value(p) in role_perms for p in permission):
+            role_perms_str = [normalize_permission_value(rp) for rp in role_perms]
+            if any(normalize_permission_value(p) in role_perms_str for p in permission):
                 return True
 
     async def has_permission_async(self, *, user, permission: Permission, room=None):
@@ -1541,7 +1564,8 @@ class Event(
         event_roles = self.roles if self.roles is not None else default_roles()
         for r in roles:
             role_perms = event_roles.get(r, SYSTEM_ROLES.get(r, []))
-            if any(normalize_permission_value(p) in role_perms for p in permission):
+            role_perms_str = [normalize_permission_value(rp) for rp in role_perms]
+            if any(normalize_permission_value(p) in role_perms_str for p in permission):
                 return True
 
     def get_all_permissions(self, user):
@@ -1556,6 +1580,8 @@ class Event(
         event_roles = self.roles if self.roles is not None else default_roles()
 
         user_traits = user.traits or []
+        if allow_empty_traits and not user_traits:
+            user_traits = ['attendee']
 
         for role, required_traits in event_trait_grants.items():
             if traits_match_required(user_traits, required_traits) and (required_traits or allow_empty_traits):

--- a/app/eventyay/base/models/world.py
+++ b/app/eventyay/base/models/world.py
@@ -34,6 +34,7 @@ def default_roles():
     attendee = [
         Permission.EVENT_VIEW,
         Permission.EVENT_EXHIBITION_CONTACT,
+        Permission.EVENT_CHAT_DIRECT,
     ]
     viewer = attendee + [Permission.ROOM_VIEW, Permission.ROOM_CHAT_READ]
     participant = viewer + [

--- a/app/eventyay/base/services/chat.py
+++ b/app/eventyay/base/services/chat.py
@@ -434,7 +434,7 @@ class ChatService:
         with transaction.atomic():
             users = list(
                 User.objects.prefetch_related("blocked_users").filter(
-                    event_id=self.event.id, id__in=user_ids
+                    id__in=user_ids
                 )
             )
             if (

--- a/app/eventyay/base/services/event.py
+++ b/app/eventyay/base/services/event.py
@@ -162,6 +162,7 @@ async def notify_schedule_change(event_id):
 
 
 def get_room_config(room, permissions):
+    str_permissions = [p if isinstance(p, str) else getattr(p, "value", p) for p in permissions]
     room_config = {
         "id": str(room.id),
         "name": room.name,
@@ -169,7 +170,7 @@ def get_room_config(room, permissions):
         "picture": room.picture.url if room.picture else None,
         "import_id": room.import_id,
         "pretalx_id": room.pretalx_id,
-        "permissions": [p for p in permissions if not p.startswith("event:")],
+        "permissions": [p for p in str_permissions if not p.startswith("event:")],
         "force_join": room.force_join,
         "modules": [],
         "schedule_data": room.schedule_data or None,

--- a/app/eventyay/presale/templates/pretix_venueless/order_info.html
+++ b/app/eventyay/presale/templates/pretix_venueless/order_info.html
@@ -9,20 +9,22 @@
         </h3>
     </div>
     <ul class="list-group">
-        {% for p in positions %}
+        {% if positions %}
             <li class="list-group-item">
-                <p>
-                    {{ p.item.name }}
-                    {% if p.variation %}
-                        – {{ p.variation.value }}
-                    {% endif %}
-                    {% if p.subevent %}
-                        – {{ p.subevent }}
-                    {% endif %}
-                    {% if p.attendee_name %}
-                        – {{ p.attendee_name }}
-                    {% endif %}
-                </p>
+                {% for p in positions %}
+                    <p>
+                        {{ p.item.name }}
+                        {% if p.variation %}
+                            – {{ p.variation.value }}
+                        {% endif %}
+                        {% if p.subevent %}
+                            – {{ p.subevent }}
+                        {% endif %}
+                        {% if p.attendee_name %}
+                            – {{ p.attendee_name }}
+                        {% endif %}
+                    </p>
+                {% endfor %}
                 {% if request.event.settings.venueless_text %}
                     {{ request.event.settings.venueless_text|rich_text }}
                 {% else %}
@@ -32,30 +34,32 @@
                         {% endblocktrans %}
                     </p>
                 {% endif %}
-                <div class="form-inline text-center">
-                    <div class="form-group" style="display: inline-block; margin-right: 10px;">
-                        <form method="post" target="_blank"
-                              action="{% eventurl event 'presale:event.venueless.join' order=order.code position=p.positionid secret=p.web_secret view_schedule=False %}">
-                            {% csrf_token %}
-                            <button class="btn btn-primary btn-lg">
-                                {% trans "Join online event stream" %}
-                            </button>
-                        </form>
-                    </div>
-                    {% if request.event.settings.venueless_talk_schedule_url %}
-                        <div class="form-group" style="display: inline-block;">
+                {% with join_position=positions.0 %}
+                    <div class="form-inline text-center">
+                        <div class="form-group" style="display: inline-block; margin-right: 10px;">
                             <form method="post" target="_blank"
-                                  action="{% eventurl event 'presale:event.venueless.join' order=order.code position=p.positionid secret=p.web_secret view_schedule=True %}">
+                                  action="{% eventurl event 'presale:event.venueless.join' order=order.code position=join_position.positionid secret=join_position.web_secret view_schedule=False %}">
                                 {% csrf_token %}
                                 <button class="btn btn-primary btn-lg">
-                                    {% trans "View schedule" %}
+                                    {% trans "Join online event stream" %}
                                 </button>
                             </form>
                         </div>
-                    {% endif %}
-                </div>
+                        {% if request.event.settings.venueless_talk_schedule_url %}
+                            <div class="form-group" style="display: inline-block;">
+                                <form method="post" target="_blank"
+                                      action="{% eventurl event 'presale:event.venueless.join' order=order.code position=join_position.positionid secret=join_position.web_secret view_schedule=True %}">
+                                    {% csrf_token %}
+                                    <button class="btn btn-primary btn-lg">
+                                        {% trans "View schedule" %}
+                                    </button>
+                                </form>
+                            </div>
+                        {% endif %}
+                    </div>
+                {% endwith %}
             </li>
-        {% empty %}
+        {% else %}
             <li class="list-group-item">
                 <p>
                     {% blocktrans trimmed %}
@@ -63,6 +67,6 @@
                     {% endblocktrans %}
                 </p>
             </li>
-        {% endfor %}
+        {% endif %}
     </ul>
 </div>

--- a/app/eventyay/webapp/video/src/components/CreateDmPrompt.vue
+++ b/app/eventyay/webapp/video/src/components/CreateDmPrompt.vue
@@ -47,6 +47,9 @@ export default {
 		position: relative
 		box-sizing: border-box
 		min-height: 0
+		.c-user-select
+			flex: 1
+			min-height: 0
 		#btn-close
 			icon-button-style(style: clear)
 			position: absolute

--- a/app/eventyay/webapp/video/src/components/UserSelect.vue
+++ b/app/eventyay/webapp/video/src/components/UserSelect.vue
@@ -62,22 +62,38 @@ export default {
 	},
 	watch: {
 		search() {
+			this.reloadResults()
+		}
+	},
+	created() {
+		this.reloadResults()
+	},
+	methods: {
+		async reloadResults() {
 			this.loading = false
 			this.results = []
 			this.nextPage = 1
-		}
-	},
-	methods: {
+			await this.loadPage()
+		},
 		async loadPage() {
+			if (!this.nextPage || this.loading) return
 			this.loading = true
 			const search = this.search
-			const newPage = (await api.call('user.list.search', {search_term: this.search, page: this.nextPage}))
-			if (search !== this.search) return
+			const page = this.nextPage
+			const newPage = (await api.call('user.list.search', {
+				search_term: this.search,
+				page,
+				include_banned: false,
+			}))
+			if (search !== this.search) {
+				this.loading = false
+				return
+			}
 			this.results.push(...newPage.results.filter(e => !this.exclude.includes(e.id)))
 			if (newPage.isLastPage) {
 				this.nextPage = null
 			} else {
-				this.nextPage++
+				this.nextPage = page + 1
 			}
 			this.loading = false
 		},
@@ -160,6 +176,8 @@ export default {
 	.bunt-button
 		themed-button-primary()
 	.search-results
+		flex: 1
+		min-height: 0
 		.user
 			display: flex
 			align-items: center

--- a/app/tests/stable/test_attendee_direct_message_permission.py
+++ b/app/tests/stable/test_attendee_direct_message_permission.py
@@ -1,0 +1,22 @@
+import pytest
+
+from eventyay.base.models.auth import User
+from eventyay.core.permissions import Permission
+
+
+@pytest.mark.django_db
+def test_attendee_gets_direct_message_permission(event):
+    user = User.objects.create(event=event, profile={}, traits=['attendee'])
+    perms = event.get_all_permissions(user)[event]
+    assert Permission.EVENT_CHAT_DIRECT in perms
+
+
+@pytest.mark.django_db
+def test_attendee_without_admin_trait_keeps_direct_message(event):
+    user = User.objects.create(
+        event=event,
+        profile={},
+        traits=['attendee', f'eventyay-video-event-{event.slug}'],
+    )
+    perms = event.get_all_permissions(user)[event]
+    assert Permission.EVENT_CHAT_DIRECT in perms

--- a/app/tests/tickets/presale/test_orders.py
+++ b/app/tests/tickets/presale/test_orders.py
@@ -239,6 +239,29 @@ class OrdersTest(BaseOrdersTest):
         assert response.status_code == 200
         assert 'Join online event stream' in response.content.decode()
 
+    def test_order_detail_shows_online_stream_intro_and_button_once_for_multiple_positions(self):
+        self.order.status = Order.STATUS_PAID
+        self.order.save(update_fields=['status'])
+        self.event.settings.set('venueless_secret', 'secret')
+        self.event.settings.set('venueless_show_public_link', True)
+        self.event.settings.set('venueless_all_products', True)
+        OrderPosition.objects.create(
+            order=self.order,
+            item=self.ticket,
+            variation=None,
+            price=Decimal('23'),
+            attendee_name_parts={'full_name': 'Anna'},
+        )
+
+        response = self.client.get(
+            '/%s/%s/order/%s/%s/' % (self.orga.slug, self.event.slug, self.order.code, self.order.secret)
+        )
+
+        content = response.content.decode()
+        assert response.status_code == 200
+        assert content.count('You can now join the event using the following button:') == 1
+        assert content.count('Join online event stream') == 2  # panel title + one join button
+
     def test_ticket_detail(self):
         response = self.client.get(
             '/%s/%s/ticket/%s/%s/%s/'


### PR DESCRIPTION
## Summary
- Grant `event:chat.direct` to attendees so the Video component Direct Messages section and DM creation work for regular ticket holders, not only admins.
- Load the user list when opening the DM picker and restore a stable prompt layout.
- Show the order-page “Join online event stream” intro text and join button once per order, even when multiple admission tickets are present.

Fixes #4337

## Test plan
- [ ] Log in as an attendee and confirm the Direct Messages section appears in the Video sidebar.
- [ ] Open the DM picker and verify users load immediately; create a DM successfully.
- [ ] Open a paid order with multiple admission tickets and confirm the join intro and button appear only once.
- [ ] Run `pytest tests/stable/test_attendee_direct_message_permission.py tests/tickets/presale/test_orders.py -k online_stream`