### PR TITLE
fix: resolve admin user list emails for video JWT personas

### DIFF
--- a/app/eventyay/base/migrations/0044_clear_video_user_emails.py
+++ b/app/eventyay/base/migrations/0044_clear_video_user_emails.py
@@ -1,0 +1,17 @@
+from django.db import migrations
+
+
+def clear_video_user_emails(apps, schema_editor):
+    """Event-scoped video personas must not use User.email (platform accounts only)."""
+    User = apps.get_model('base', 'User')
+    User.objects.filter(event__isnull=False).exclude(email__isnull=True).update(email=None)
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ('base', '0043_remove_sendmail_from_plugins'),
+    ]
+
+    operations = [
+        migrations.RunPython(clear_video_user_emails, migrations.RunPython.noop),
+    ]

--- a/app/eventyay/base/services/user.py
+++ b/app/eventyay/base/services/user.py
@@ -7,7 +7,9 @@ from channels.db import database_sync_to_async
 from channels.layers import get_channel_layer
 from django.core.cache import cache
 from django.core.paginator import InvalidPage, Paginator
-from django.db.models import Q
+from django.db.models import Exists, OuterRef, Q
+from django.db.models.fields.json import KeyTextTransform
+from django.db.models.functions import Lower
 from django.db.transaction import atomic
 from django.utils.timezone import now
 from django_scopes import scopes_disabled
@@ -94,19 +96,84 @@ def _unresolved_hash_tokens(token_ids, ticket_by_token):
     ]
 
 
+def video_contact_email_from_profile(profile):
+    return ((profile or {}).get("contact_email") or "").strip()
+
+
+def video_display_name_from_profile(profile):
+    return ((profile or {}).get("display_name") or "").strip()
+
+
+def admin_users_list_q():
+    """Platform accounts plus ticket-only video personas (no duplicate platform email)."""
+    contact_email_ref = KeyTextTransform("contact_email", OuterRef("profile"))
+    platform_email_match = (
+        User.objects.filter(event__isnull=True)
+        .exclude(email="")
+        .annotate(lower_email=Lower("email"))
+        .filter(lower_email=Lower(contact_email_ref))
+    )
+    return Q(event__isnull=True) | (
+        Q(event__isnull=False)
+        & ~Q(profile__contact_email="")
+        & ~Exists(platform_email_match)
+    )
+
+
+def resolve_video_display_names_by_contact_emails(emails):
+    """Map platform contact email to the latest video display name from event personas."""
+    uniq = list(dict.fromkeys((e or "").strip().lower() for e in emails if e))
+    if not uniq:
+        return {}
+    email_conditions = reduce(
+        operator.or_, (Q(profile__contact_email__iexact=e) for e in uniq), Q()
+    )
+    result = {}
+    with scopes_disabled():
+        for row in (
+            User.objects.filter(event__isnull=False)
+            .filter(email_conditions)
+            .order_by("-last_login", "-id")
+            .values("profile")
+        ):
+            profile = row.get("profile") or {}
+            email = video_contact_email_from_profile(profile).lower()
+            if not email or email in result:
+                continue
+            display_name = video_display_name_from_profile(profile)
+            if display_name:
+                result[email] = display_name
+    return result
+
+
+def platform_user_video_display_name(platform_user, video_names_by_email):
+    """Display name for admin user list: video persona, then Wikimedia, then nick."""
+    email = (platform_user.email or "").strip().lower()
+    if email:
+        video_name = (video_names_by_email.get(email) or "").strip()
+        if video_name:
+            return video_name
+    wikimedia = (platform_user.wikimedia_username or "").strip()
+    if wikimedia:
+        return wikimedia
+    return (platform_user.nick or "").strip()
+
+
 def admin_public_fields_from_user_row(user_row, ticket_by_token, account_by_token=None):
     """Admin-only list fields derived from a User values() row and ticket lookup."""
     tid = user_row["token_id"]
     ticket = _ticket_lookup(ticket_by_token, tid)
     account = _ticket_lookup(account_by_token, tid)
+    profile = user_row.get("profile") or {}
     return {
         "moderation_state": user_row["moderation_state"],
         "token_id": tid,
-        "email": (user_row.get("email") or "").strip()
+        "email": video_contact_email_from_profile(profile)
+        or (user_row.get("email") or "").strip()
         or ticket.get("contact_email", "")
         or account.get("email", ""),
         "wikimedia_username": display_wikimedia_username_from_profile(
-            user_row["profile"],
+            profile,
             user_row.get("wikimedia_username") or account.get("wikimedia_username"),
         ),
         "order_code": ticket.get("order_code"),
@@ -172,6 +239,46 @@ def resolve_account_fields_by_token_ids(token_ids):
         if token.upper() in result
     }
     return keyed
+
+
+def resolve_video_jwt_contact_email(event_id, token_id):
+    """
+    Resolve the contact email for an event-scoped user created from a video JWT uid.
+
+    Order ticket links use ``encode_email(order.email)`` or a position pseudonym;
+    logged-in organisers and talk users use ``encode_email(platform_user.email)``.
+    """
+    normalized_token = (token_id or "").strip()
+    if not normalized_token:
+        return None
+
+    ticket_rows = build_admin_ticket_rows_by_token(event_id, [normalized_token])
+    ticket = _ticket_lookup(ticket_rows, normalized_token)
+    email = (ticket.get("contact_email") or "").strip()
+    if email:
+        return email.lower()
+
+    if _is_email_hash_uid_token(normalized_token):
+        accounts = resolve_account_fields_by_token_ids([normalized_token])
+        for key, account in accounts.items():
+            if key.upper() == normalized_token.upper():
+                email = (account.get("email") or "").strip()
+                if email:
+                    return email.lower()
+    return None
+
+
+def apply_video_jwt_contact_to_profile(user, event_id, token_id):
+    """Store resolved contact email on an event-scoped user's profile (not User.email)."""
+    contact_email = resolve_video_jwt_contact_email(event_id, token_id)
+    if not contact_email:
+        return
+    profile = dict(user.profile or {})
+    if profile.get("contact_email") == contact_email:
+        return
+    profile["contact_email"] = contact_email
+    user.profile = profile
+    user.save(update_fields=["profile"])
 
 
 def _latest_paid_ticket_row_for_email(event_id, email):
@@ -537,10 +644,13 @@ def get_user(
         )
 
     if user:
-        if with_token and (user.traits != with_token.get("traits")):
-            traits = with_token["traits"]
-            update_user(event.id, id=user.id, traits=traits)
-            user = get_user_by_id(event.id, user.id)
+        if with_token:
+            if user.traits != with_token.get("traits"):
+                traits = with_token["traits"]
+                update_user(event.id, id=user.id, traits=traits)
+                user = get_user_by_id(event.id, user.id)
+            if token_id:
+                apply_video_jwt_contact_to_profile(user, event.id, token_id)
         return user
 
     traits = with_token.get("traits") if with_token else None
@@ -553,10 +663,15 @@ def get_user(
         return
 
     if token_id:
+        contact_email = resolve_video_jwt_contact_email(event.id, token_id)
+        profile = with_token.get("profile") if with_token else None
+        if contact_email:
+            profile = dict(profile or {})
+            profile["contact_email"] = contact_email
         user = create_user(
             event_id=event.id,
             token_id=token_id,
-            profile=with_token.get("profile") if with_token else None,
+            profile=profile,
             traits=traits,
             pretalx_id=with_token.get("pretalx_id") if with_token else None,
         )

--- a/app/eventyay/control/forms/filter.py
+++ b/app/eventyay/control/forms/filter.py
@@ -1523,10 +1523,28 @@ class UserFilterForm(FilterForm):
             qs = qs.filter(is_spam=False)
 
         if fdata.get('query'):
-            qs = qs.filter(Q(email__icontains=fdata.get('query')) | Q(fullname__icontains=fdata.get('query')))
+            query = fdata.get('query')
+            qs = qs.filter(
+                Q(email__icontains=query)
+                | Q(profile__contact_email__icontains=query)
+                | Q(fullname__icontains=query)
+                | Q(profile__display_name__icontains=query)
+                | Q(wikimedia_username__icontains=query)
+                | Q(nick__icontains=query)
+            )
 
         if fdata.get('ordering'):
-            qs = qs.order_by(self.get_order_by())
+            ordering = self.get_order_by()
+            if 'admin_list_email' in qs.query.annotations:
+                if ordering == 'email':
+                    ordering = 'admin_list_email'
+                elif ordering == '-email':
+                    ordering = '-admin_list_email'
+                elif ordering == 'fullname':
+                    ordering = 'admin_list_fullname'
+                elif ordering == '-fullname':
+                    ordering = '-admin_list_fullname'
+            qs = qs.order_by(ordering)
 
         return qs
 

--- a/app/eventyay/control/templates/pretixcontrol/admin/users/index.html
+++ b/app/eventyay/control/templates/pretixcontrol/admin/users/index.html
@@ -53,6 +53,7 @@
                         <a href="?{% url_replace request 'ordering' '-fullname' %}"><i class="fa fa-caret-down"></i></a>
                         <a href="?{% url_replace request 'ordering' 'fullname' %}"><i class="fa fa-caret-up"></i></a>
                     </th>
+                    <th>{% trans "Video username" %}</th>
                     <th class="text-center">{% trans "Active" %}</th>
                     <th class="text-center">{% trans "Verified" %}</th>
                     <th class="text-center">{% trans "Admin" %}</th>
@@ -72,11 +73,16 @@
                 <tbody>
                 {% trans 'No email' as no_email %}
                 {% for u in users %}
-                    <tr data-user-id="{{ u.pk }}">
+                    <tr data-user-id="{{ u.pk }}"{% if u.event_id %} class="text-muted"{% endif %}>
                         <td><strong>
-                            <a href='{% url "eventyay_admin:admin.users.edit" id=u.pk %}'>{{ u.email|default:no_email }}</a>
+                            {% if u.event_id %}
+                                {{ u.admin_list_email|default:no_email }}
+                            {% else %}
+                                <a href='{% url "eventyay_admin:admin.users.edit" id=u.pk %}'>{{ u.admin_list_email|default:no_email }}</a>
+                            {% endif %}
                         </strong></td>
-                        <td>{{ u.fullname|default_if_none:"" }}</td>
+                        <td>{{ u.admin_list_fullname|default_if_none:"" }}</td>
+                        <td>{{ u.video_username|default_if_none:"" }}</td>
 
                         {# Active column #}
                         <td class="text-center">
@@ -99,8 +105,8 @@
                                 {% csrf_token %}
                                 <input type="hidden" name="user_id" value="{{ u.pk }}">
                                 <input type="hidden" name="action" value="toggle_verified">
-                                {% if not u.email %}
-                                    <label class="toggle-switch always-on" title="{% trans 'Users without an email address cannot be verified.' %}">
+                                {% if u.event_id or not u.email %}
+                                    <label class="toggle-switch always-on" title="{% if u.event_id %}{% trans 'Ticket-only video attendees cannot be verified here.' %}{% else %}{% trans 'Users without an email address cannot be verified.' %}{% endif %}">
                                         <input
                                             type="checkbox"
                                             class="js-user-toggle"
@@ -134,8 +140,8 @@
                                 {% csrf_token %}
                                 <input type="hidden" name="user_id" value="{{ u.pk }}">
                                 <input type="hidden" name="action" value="toggle_admin">
-                                {% if u.pk == request.user.pk %}
-                                    <label class="toggle-switch always-on" title="{% trans 'You cannot change your own admin status.' %}">
+                                {% if u.event_id or u.pk == request.user.pk %}
+                                    <label class="toggle-switch always-on" title="{% if u.event_id %}{% trans 'Ticket-only video attendees cannot be made admin here.' %}{% else %}{% trans 'You cannot change your own admin status.' %}{% endif %}">
                                         <input
                                             type="checkbox"
                                             class="js-user-toggle"
@@ -169,8 +175,8 @@
                                 {% csrf_token %}
                                 <input type="hidden" name="user_id" value="{{ u.pk }}">
                                 <input type="hidden" name="action" value="toggle_spam">
-                                {% if u.is_staff or u.is_superuser or u.pk == request.user.pk %}
-                                    <label class="toggle-switch always-on" title="{% if u.pk == request.user.pk %}{% trans 'You cannot mark yourself as spam.' %}{% else %}{% trans 'Administrators cannot be marked as spam.' %}{% endif %}">
+                                {% if u.event_id or u.is_staff or u.is_superuser or u.pk == request.user.pk %}
+                                    <label class="toggle-switch always-on" title="{% if u.event_id %}{% trans 'Ticket-only video attendees cannot be marked as spam here.' %}{% elif u.pk == request.user.pk %}{% trans 'You cannot mark yourself as spam.' %}{% else %}{% trans 'Administrators cannot be marked as spam.' %}{% endif %}">
                                         <input
                                             type="checkbox"
                                             class="js-user-toggle"
@@ -214,7 +220,7 @@
 
                         {# Actions column #}
                         <td class="text-right flip">
-                            {% if u.email and u.auth_backend == "native" %}
+                            {% if not u.event_id and u.email and u.auth_backend == "native" %}
                                 <div class="btn-group">
                                     <button type="button" class="btn btn-default btn-sm dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
                                         <span class="fa fa-envelope"></span>
@@ -259,9 +265,11 @@
 
                         {# Edit column #}
                         <td class="text-right">
-                            <a href='{% url "eventyay_admin:admin.users.edit" id=u.pk %}' class="btn btn-default btn-sm" title="{% trans 'Edit user' %}">
-                                <i class="fa fa-edit"></i>
-                            </a>
+                            {% if not u.event_id %}
+                                <a href='{% url "eventyay_admin:admin.users.edit" id=u.pk %}' class="btn btn-default btn-sm" title="{% trans 'Edit user' %}">
+                                    <i class="fa fa-edit"></i>
+                                </a>
+                            {% endif %}
                         </td>
                     </tr>
                 {% endfor %}

--- a/app/eventyay/control/views/users.py
+++ b/app/eventyay/control/views/users.py
@@ -13,7 +13,9 @@ from django.contrib.auth import (
 )
 from django.contrib.auth.mixins import LoginRequiredMixin
 from django.db import DatabaseError, transaction
-from django.db.models import Exists, OuterRef
+from django.db.models import CharField, Exists, OuterRef, Value
+from django.db.models.fields.json import KeyTextTransform
+from django.db.models.functions import Coalesce
 from django.http import JsonResponse
 from django.shortcuts import get_object_or_404, redirect
 from django.urls import reverse
@@ -33,6 +35,11 @@ from eventyay.base.models import User
 from eventyay.base.services.mail import SendMailException
 from eventyay.base.settings import GlobalSettingsObject
 from eventyay.control.forms.filter import UserFilterForm
+from eventyay.base.services.user import (
+    admin_users_list_q,
+    platform_user_video_display_name,
+    resolve_video_display_names_by_contact_emails,
+)
 from eventyay.control.forms.users import UserEditForm
 from eventyay.control.permissions import AdministratorPermissionRequiredMixin
 from eventyay.control.views import CreateView, UpdateView
@@ -72,9 +79,24 @@ class UserListView(AdministratorPermissionRequiredMixin, ListView):
     }
 
     def get_queryset(self):
-        qs = User.objects.all().annotate(
-            is_email_verified=Exists(
-                EmailAddress.objects.filter(user=OuterRef('pk'), primary=True, verified=True)
+        qs = (
+            User.objects.filter(admin_users_list_q())
+            .annotate(
+                is_email_verified=Exists(
+                    EmailAddress.objects.filter(user=OuterRef('pk'), primary=True, verified=True)
+                ),
+                admin_list_email=Coalesce(
+                    'email',
+                    KeyTextTransform('contact_email', 'profile'),
+                    Value(''),
+                    output_field=CharField(),
+                ),
+                admin_list_fullname=Coalesce(
+                    'fullname',
+                    KeyTextTransform('display_name', 'profile'),
+                    Value(''),
+                    output_field=CharField(),
+                ),
             )
         )
         if self.filter_form.is_valid():
@@ -84,6 +106,18 @@ class UserListView(AdministratorPermissionRequiredMixin, ListView):
     def get_context_data(self, **kwargs):
         ctx = super().get_context_data(**kwargs)
         ctx['filter_form'] = self.filter_form
+        users = ctx[self.context_object_name]
+        emails = [
+            (u.admin_list_email or '').strip().lower()
+            for u in users
+            if u.admin_list_email and not u.event_id
+        ]
+        video_names = resolve_video_display_names_by_contact_emails(emails)
+        for user in users:
+            if user.event_id:
+                user.video_username = ''
+            else:
+                user.video_username = platform_user_video_display_name(user, video_names)
         return ctx
 
     @cached_property
@@ -118,7 +152,7 @@ class UserListView(AdministratorPermissionRequiredMixin, ListView):
             return redirect(reverse('eventyay_admin:admin.users'))
 
         try:
-            target_user = User.objects.get(pk=user_id)
+            target_user = User.objects.get(pk=user_id, event__isnull=True)
         except User.DoesNotExist:
             msg = str(_('User not found.'))
             if request.headers.get('x-requested-with') == 'XMLHttpRequest':
@@ -388,7 +422,7 @@ class UserEditView(AdministratorPermissionRequiredMixin, RecentAuthenticationReq
     form_class = UserEditForm
 
     def get_object(self, queryset=None):
-        return get_object_or_404(User, pk=self.kwargs.get('id'))
+        return get_object_or_404(User, pk=self.kwargs.get('id'), event__isnull=True)
 
     def get_context_data(self, **kwargs):
         ctx = super().get_context_data(**kwargs)


### PR DESCRIPTION
## Summary
- Store video JWT contact emails on event-scoped user profiles (`profile.contact_email`) instead of `User.email`, resolving order/platform email on presale, control, and talk video join flows.
- Update `/admin/users/` to list platform accounts plus ticket-only presale video attendees (order email + attendee name), add a Video username column for linked platform users, and restrict edit/toggle actions to platform accounts.
- Add migration `0044_clear_video_user_emails` to clear legacy emails incorrectly set on video personas.

Fixes #4078

## Test plan
- [ ] Run `python manage.py migrate` and confirm `0044_clear_video_user_emails` applies cleanly
- [ ] Open `/admin/users/` as site admin — no rows show "No email" for video personas; platform users still editable
- [ ] Join video from a presale order (e.g. dev order `DEV01`) and confirm ticket-only row appears with order email and attendee name (grey row, toggles disabled)
- [ ] Join video as a logged-in organiser/speaker and confirm one platform row with Video username populated
- [ ] Search admin users by order email, display name, Wikimedia username, or nick