### PR TITLE
fix: replace generic Exception with ValidationError in check_access_permissions

### DIFF
--- a/app/eventyay/base/models/organizer.py
+++ b/app/eventyay/base/models/organizer.py
@@ -7,6 +7,7 @@ from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
 
 from django.conf import settings
 from django.core.validators import MinLengthValidator, RegexValidator
+from django.core.exceptions import ValidationError
 from django.db import models, transaction
 from django.db.models import Exists, OuterRef, Q
 from django.urls import reverse
@@ -46,8 +47,7 @@ def check_access_permissions(organizer):
     warnings = []
     teams = organizer.teams.all().annotate(member_count=models.Count('members')).filter(member_count__gt=0)
     if not [t for t in teams if t.can_change_teams]:
-        # TODO: Should use a concrete exception type
-        raise Exception(
+        raise ValidationError(
             _(
                 'There must be at least one team with the permission to change teams, '
                 'as otherwise nobody can create new teams or grant permissions to existing teams.'
@@ -71,8 +71,7 @@ def check_access_permissions(organizer):
     for event in organizer.events.all():
         event_teams = teams.filter(models.Q(limit_events=event) | models.Q(all_events=True)).distinct()
         if not event_teams:
-            # TODO: Should use a concrete exception type
-            raise Exception(
+            raise ValidationError(
                 str(
                     _(
                         'There must be at least one team with access to every event. '


### PR DESCRIPTION
## What

Replace two generic `Exception` raises with `ValidationError`  in `check_access_permissions` in `organizer.py`.

Fixes #3353

## Why

The `check_access_permissions` function performs data/business  rule validation (checking team permission invariants), not  user authorization. Therefore `ValidationError` is more semantically appropriate than generic `Exception`.

This also aligns with how `TeamForm.clean` in  `control/forms/organizer_forms/team_form.py` handles 
the same validation check.

The TODO comments requesting this change are also removed.

## Changes

- Added `ValidationError` import from `django.core.exceptions`
- Replaced `Exception` with `ValidationError` on lines 50 and 75
- Removed TODO comments