### PR TITLE
ci: separate dev and main branches for eventyay-exhibition deployments

### DIFF
--- a/.github/workflows/enext-docker-pr.yml
+++ b/.github/workflows/enext-docker-pr.yml
@@ -46,6 +46,15 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@2b51285047da1547ffb1b2203d8be4c0af6b1f20
 
+      - name: Swap exhibition plugin branch for environment
+        working-directory: app
+        run: |
+          if [ "${{ github.ref_name }}" = "dev" ] || [ "${{ github.base_ref }}" = "dev" ]; then
+            sed -i 's/eventyay-exhibition.git@[a-zA-Z0-9_-]*/eventyay-exhibition.git@dev/' pyproject.toml
+            pip install uv
+            uv lock
+          fi
+
       - name: Build Docker image
         uses: docker/build-push-action@5cd11c3a4ced054e52742c5fd54dca954e0edd85
         with:

--- a/.github/workflows/enext-docker.yml
+++ b/.github/workflows/enext-docker.yml
@@ -24,6 +24,15 @@ jobs:
         with:
           images: eventyay/eventyay-next
 
+      - name: Swap exhibition plugin branch for environment
+        working-directory: app
+        run: |
+          if [ "${{ github.ref_name }}" = "dev" ] || [ "${{ github.base_ref }}" = "dev" ]; then
+            sed -i 's/eventyay-exhibition.git@[a-zA-Z0-9_-]*/eventyay-exhibition.git@dev/' pyproject.toml
+            pip install uv
+            uv lock
+          fi
+
       - name: Build and push Docker image
         uses: docker/build-push-action@ad44023a93711e3deb337508980b4b5e9bcdc5dc
         with:

--- a/.github/workflows/video-backend-ci.yml
+++ b/.github/workflows/video-backend-ci.yml
@@ -44,6 +44,14 @@ jobs:
       - name: Install uv
         run: pip install uv
 
+      - name: Swap exhibition plugin branch for environment
+        working-directory: app
+        run: |
+          if [ "${{ github.ref_name }}" = "dev" ] || [ "${{ github.base_ref }}" = "dev" ]; then
+            sed -i 's/eventyay-exhibition.git@[a-zA-Z0-9_-]*/eventyay-exhibition.git@dev/' pyproject.toml
+            uv lock
+          fi
+
       - name: Sync dependencies
         run: uv sync --directory app
 
@@ -117,6 +125,14 @@ jobs:
 
       - name: Install uv
         run: pip install uv
+
+      - name: Swap exhibition plugin branch for environment
+        working-directory: app
+        run: |
+          if [ "${{ github.ref_name }}" = "dev" ] || [ "${{ github.base_ref }}" = "dev" ]; then
+            sed -i 's/eventyay-exhibition.git@[a-zA-Z0-9_-]*/eventyay-exhibition.git@dev/' pyproject.toml
+            uv lock
+          fi
 
       - name: Sync dependencies (including test group)
         run: uv sync --directory app --group test
@@ -192,6 +208,14 @@ jobs:
 
       - name: Install uv
         run: pip install uv
+
+      - name: Swap exhibition plugin branch for environment
+        working-directory: app
+        run: |
+          if [ "${{ github.ref_name }}" = "dev" ] || [ "${{ github.base_ref }}" = "dev" ]; then
+            sed -i 's/eventyay-exhibition.git@[a-zA-Z0-9_-]*/eventyay-exhibition.git@dev/' pyproject.toml
+            uv lock
+          fi
 
       - name: Sync dependencies
         run: uv sync --directory app


### PR DESCRIPTION
**Fixes:** #4139

### Description
This PR updates the deployment configuration to ensure that the `eventyay-exhibition` plugin tracks the correct branch depending on the environment being deployed:
- `dev.eventyay.com` tracks the `dev` branch of the plugin.
- `eventyay.com` (production) tracks the `main` branch.

To achieve this cleanly without causing hardcoded branch-name conflicts during future merges between the core `dev` and `main` branches, this PR introduces an environment-aware pre-build step in the GitHub Actions workflows.

### Changes Made:
- **`enext-docker.yml` & `enext-docker-pr.yml`**: Added a bash step before the Docker image builds that dynamically checks if the workflow is targeting the `dev` branch (`github.ref_name` or `github.base_ref`). If it is, it uses `sed` to update `pyproject.toml` to point the `eventyay-exhibition` Git dependency to `@dev` and runs `uv lock` to update the lockfile before Docker consumes it.
- **`video-backend-ci.yml`**: Added the same plugin resolution step before the backend `pytest` jobs are executed, ensuring PRs and tests on `dev` run against the `dev` branch of the plugin.

### Acceptance Criteria Met:
- [x] `dev.eventyay.com` uses the `dev` branch of `eventyay-exhibition`.
- [x] `eventyay.com` uses the `main` branch of `eventyay-exhibition`.
- [x] Deployment configuration explicitly defines the branch per environment.
- [x] Production deployment is not triggered by changes to the `dev` branch.
- [x] Development deployment can be tested independently.
