### PR TITLE
fix: Replaced the unbounded per-field products <ul> in orderforms.html

### DIFF
--- a/app/eventyay/control/templates/pretixcontrol/items/_orderform_products_cell.html
+++ b/app/eventyay/control/templates/pretixcontrol/items/_orderform_products_cell.html
@@ -1,0 +1,26 @@
+{% load i18n %}
+{% with total=products|length %}
+<ul class="list-unstyled products-list">
+    {% for product in products|slice:":5" %}
+        <li>
+            <a href="{% url 'control:event.product' organizer=request.event.organizer.slug event=request.event.slug product=product.id %}">{{ product }}</a>
+        </li>
+    {% empty %}
+        <li class="text-muted">
+            {% if empty_means_all %}{% translate "All products" %}{% else %}{% translate "No products" %}{% endif %}
+        </li>
+    {% endfor %}
+</ul>
+{% if total > 5 %}
+    <details class="products-list-more">
+        <summary>{% blocktranslate count counter=total|add:"-5" %}+{{ counter }} more product{% plural %}+{{ counter }} more products{% endblocktranslate %}</summary>
+        <ul class="list-unstyled products-list-extra">
+            {% for product in products|slice:"5:" %}
+                <li>
+                    <a href="{% url 'control:event.product' organizer=request.event.organizer.slug event=request.event.slug product=product.id %}">{{ product }}</a>
+                </li>
+            {% endfor %}
+        </ul>
+    </details>
+{% endif %}
+{% endwith %}

--- a/app/eventyay/control/templates/pretixcontrol/items/orderforms.html
+++ b/app/eventyay/control/templates/pretixcontrol/items/orderforms.html
@@ -183,15 +183,7 @@
                                 </div>
                             </td>
                             <td class="text-center">
-                                <ul class="list-unstyled products-list">
-                                    {% for product in system_field_products.attendee_name_parts %}
-                                        <li>
-                                            <a href="{% url 'control:event.product' organizer=request.event.organizer.slug event=request.event.slug product=product.id %}">{{ product }}</a>
-                                        </li>
-                                    {% empty %}
-                                        <li class="text-muted">{% translate "No products" %}</li>
-                                    {% endfor %}
-                                </ul>
+                                {% include "pretixcontrol/items/_orderform_products_cell.html" with products=system_field_products.attendee_name_parts %}
                             </td>
                             <td class="dnd-container text-center text-nowrap">
                                 <a href="{% url 'control:event.products.orderforms.defaultfield' organizer=request.event.organizer.slug event=request.event.slug field='attendee_name_parts' %}" class="btn btn-default btn-sm" aria-label="{% translate 'Settings for Attendee names' %}" title="{% translate 'Settings for Attendee names' %}"><i class="fa fa-cog fa-fw"></i></a>
@@ -248,15 +240,7 @@
                                 </div>
                             </td>
                             <td class="text-center">
-                                <ul class="list-unstyled products-list">
-                                    {% for product in system_field_products.attendee_email %}
-                                        <li>
-                                            <a href="{% url 'control:event.product' organizer=request.event.organizer.slug event=request.event.slug product=product.id %}">{{ product }}</a>
-                                        </li>
-                                    {% empty %}
-                                        <li class="text-muted">{% translate "No products" %}</li>
-                                    {% endfor %}
-                                </ul>
+                                {% include "pretixcontrol/items/_orderform_products_cell.html" with products=system_field_products.attendee_email %}
                             </td>
                             <td class="dnd-container text-center text-nowrap">
                                 <a href="{% url 'control:event.products.orderforms.defaultfield' organizer=request.event.organizer.slug event=request.event.slug field='attendee_email' %}" class="btn btn-default btn-sm" aria-label="{% translate 'Settings for Attendee emails' %}" title="{% translate 'Settings for Attendee emails' %}"><i class="fa fa-cog fa-fw"></i></a>
@@ -294,15 +278,7 @@
                                 </div>
                             </td>
                             <td class="text-center">
-                                <ul class="list-unstyled products-list">
-                                    {% for product in system_field_products.company %}
-                                        <li>
-                                            <a href="{% url 'control:event.product' organizer=request.event.organizer.slug event=request.event.slug product=product.id %}">{{ product }}</a>
-                                        </li>
-                                    {% empty %}
-                                        <li class="text-muted">{% translate "No products" %}</li>
-                                    {% endfor %}
-                                </ul>
+                                {% include "pretixcontrol/items/_orderform_products_cell.html" with products=system_field_products.company %}
                             </td>
                             <td class="dnd-container text-center text-nowrap">
                                 <a href="{% url 'control:event.products.orderforms.defaultfield' organizer=request.event.organizer.slug event=request.event.slug field='company' %}" class="btn btn-default btn-sm" aria-label="{% translate 'Settings for Company' %}" title="{% translate 'Settings for Company' %}"><i class="fa fa-cog fa-fw"></i></a>
@@ -340,15 +316,7 @@
                                 </div>
                             </td>
                             <td class="text-center">
-                                <ul class="list-unstyled products-list">
-                                    {% for product in system_field_products.job_title %}
-                                        <li>
-                                            <a href="{% url 'control:event.product' organizer=request.event.organizer.slug event=request.event.slug product=product.id %}">{{ product }}</a>
-                                        </li>
-                                    {% empty %}
-                                        <li class="text-muted">{% translate "No products" %}</li>
-                                    {% endfor %}
-                                </ul>
+                                {% include "pretixcontrol/items/_orderform_products_cell.html" with products=system_field_products.job_title %}
                             </td>
                             <td class="dnd-container text-center text-nowrap">
                                 <a href="{% url 'control:event.products.orderforms.defaultfield' organizer=request.event.organizer.slug event=request.event.slug field='job_title' %}" class="btn btn-default btn-sm" aria-label="{% translate 'Settings for Job title' %}" title="{% translate 'Settings for Job title' %}"><i class="fa fa-cog fa-fw" aria-hidden="true"></i></a>
@@ -386,15 +354,7 @@
                                 </div>
                             </td>
                             <td class="text-center">
-                                <ul class="list-unstyled products-list">
-                                    {% for product in system_field_products.street %}
-                                        <li>
-                                            <a href="{% url 'control:event.product' organizer=request.event.organizer.slug event=request.event.slug product=product.id %}">{{ product }}</a>
-                                        </li>
-                                    {% empty %}
-                                        <li class="text-muted">{% translate "No products" %}</li>
-                                    {% endfor %}
-                                </ul>
+                                {% include "pretixcontrol/items/_orderform_products_cell.html" with products=system_field_products.street %}
                             </td>
                             <td class="dnd-container text-center text-nowrap">
                                 <a href="{% url 'control:event.products.orderforms.defaultfield' organizer=request.event.organizer.slug event=request.event.slug field='street' %}" class="btn btn-default btn-sm" aria-label="{% translate 'Settings for Postal addresses' %}"><i class="fa fa-cog fa-fw" aria-hidden="true"></i></a>
@@ -446,15 +406,7 @@
                                 {% endif %}
                             </td>
                             <td class="text-center">
-                                <ul class="list-unstyled products-list">
-                                    {% for product in q.products.all %}
-                                        <li>
-                                            <a href="{% url "control:event.product" organizer=request.event.organizer.slug event=request.event.slug product=product.id %}">{{ product }}</a>
-                                        </li>
-                                    {% empty %}
-                                        <li class="text-muted">{% translate "All products" %}</li>
-                                    {% endfor %}
-                                </ul>
+                                {% include "pretixcontrol/items/_orderform_products_cell.html" with products=q.products.all empty_means_all=1 %}
                             </td>
                             <td class="dnd-container text-center text-nowrap">
                                 {% if q.type == "DES" %}

--- a/app/eventyay/static/pretixcontrol/css/order-form-toggles.css
+++ b/app/eventyay/static/pretixcontrol/css/order-form-toggles.css
@@ -352,6 +352,24 @@ select.required-status-dropdown[data-current="optional"] {
     margin: 0;
 }
 
+/* "+N more" disclosure for fields with a large number of products */
+.order-form-option-table .products-list-more {
+    margin-top: 4px;
+}
+
+.order-form-option-table .products-list-more > summary {
+    cursor: pointer;
+    color: #2185d0;
+    font-size: 0.9em;
+    outline: none;
+}
+
+.order-form-option-table .products-list-extra {
+    margin: 4px 0 0;
+    max-height: 160px;
+    overflow-y: auto;
+}
+
 /* Create buttons container */
 .order-form-create-buttons {
     margin-top: 2em;

--- a/app/tests/tickets/control/test_items.py
+++ b/app/tests/tickets/control/test_items.py
@@ -102,6 +102,25 @@ class CategoriesTest(ItemFormTest):
 
 
 class QuestionsTest(ItemFormTest):
+    def test_order_forms_products_list_is_capped(self):
+        with scopes_disabled():
+            products = [
+                Item.objects.create(event=self.event1, name='Product %d' % i, default_price=0, position=i)
+                for i in range(20)
+            ]
+            question = Question.objects.create(
+                event=self.event1,
+                question=LazyI18nString({'en': 'Custom field'}),
+                type=Question.TYPE_TEXT,
+                position=0,
+            )
+            question.products.set(products)
+
+        doc = self.get_doc('/control/event/%s/%s/orderforms/' % (self.orga1.slug, self.event1.slug))
+        products_cell = doc.select_one('tr[data-dnd-id="%s"] td.text-center ul.products-list' % question.id).parent
+        assert len(products_cell.select('ul.products-list > li')) <= 5
+        assert '+15' in products_cell.get_text()
+
     def test_create(self):
         doc = self.get_doc('/control/event/%s/%s/questions/add' % (self.orga1.slug, self.event1.slug))
         form_data = extract_form_fields(doc.select('.container-fluid form')[0])


### PR DESCRIPTION
Fixes #4210

## Summary
Replaced the unbounded per-field products <ul> in orderforms.html with a shared partial that shows only the first 5 products plus a native <details> "+N more" disclosure (with its own scrollable container) for the rest, fixing the table-breaking infinite list for events with many products; added a regression test and CSS for the new disclosure widget.

## Changes
- `app/eventyay/control/templates/pretixcontrol/items/orderforms.html`
- `app/eventyay/control/templates/pretixcontrol/items/_orderform_products_cell.html`
- `app/eventyay/static/pretixcontrol/css/order-form-toggles.css`
- `app/tests/tickets/control/test_items.py`

## How this was tested
Ran `pytest tests/` locally.
