### PR TITLE
fix: color contrast for tags in "Review Proposals"

### DIFF
--- a/app/eventyay/base/models/tag.py
+++ b/app/eventyay/base/models/tag.py
@@ -62,3 +62,20 @@ class Tag(PretalxModel):
     @property
     def log_parent(self):
         return self.event
+
+    @property
+    def contrast_color(self) -> str:
+        if not self.color:
+            return 'white'
+        try:
+            color = self.color.lstrip('#')
+            if len(color) == 3:
+                color = ''.join([c * 2 for c in color])
+            r = int(color[0:2], 16)
+            g = int(color[2:4], 16)
+            b = int(color[4:6], 16)
+            brightness = (r * 299 + g * 587 + b * 114) / 1000
+            return 'black' if brightness > 128 else 'white'
+        except Exception:
+            return 'white'
+

--- a/app/eventyay/base/models/tag.py
+++ b/app/eventyay/base/models/tag.py
@@ -67,15 +67,26 @@ class Tag(PretalxModel):
     def contrast_color(self) -> str:
         if not self.color:
             return 'white'
-        try:
-            color = self.color.lstrip('#')
-            if len(color) == 3:
-                color = ''.join([c * 2 for c in color])
-            r = int(color[0:2], 16)
-            g = int(color[2:4], 16)
-            b = int(color[4:6], 16)
-            brightness = (r * 299 + g * 587 + b * 114) / 1000
-            return 'black' if brightness > 128 else 'white'
-        except Exception:
+
+        color = self.color.lstrip('#')
+        # Only allow 3- or 6-character hex strings
+        if len(color) not in (3, 6):
             return 'white'
+
+        # Ensure all characters are valid hex digits
+        if not all(c in '0123456789abcdefABCDEF' for c in color):
+            return 'white'
+
+        # Normalize 3-digit hex to 6-digit hex
+        if len(color) == 3:
+            color = ''.join(c * 2 for c in color)
+
+        # At this point, color is a valid 6-char hex string; parsing should not fail
+        r = int(color[0:2], 16)
+        g = int(color[2:4], 16)
+        b = int(color[4:6], 16)
+
+        brightness = (r * 299 + g * 587 + b * 114) / 1000
+        return 'black' if brightness > 128 else 'white'
+
 

--- a/app/eventyay/orga/templates/orga/review/dashboard.html
+++ b/app/eventyay/orga/templates/orga/review/dashboard.html
@@ -268,7 +268,7 @@
                             {% if filter_form.tags %}<td class="col-tags">
                                 <div class="d-flex flex-wrap">
                                     {% for tag in submission.tags.all %}
-                                        <span class="badge" {% if tag.color %}style="background-color: {{ tag.color }}"{% endif %}>{{ tag.tag }}</span>
+                                        <span class="badge" {% if tag.color %}style="background-color: {{ tag.color }}; color: {{ tag.contrast_color }};"{% endif %}>{{ tag.tag }}</span>
                                     {% endfor %}
                                 </div>
                             </td>{% endif %}

--- a/app/eventyay/orga/templates/orga/submission/content.html
+++ b/app/eventyay/orga/templates/orga/submission/content.html
@@ -62,7 +62,7 @@
                 <label class="col-md-3 col-form-label">{% translate "Tags" %}</label>
                 <div class="col-md-9">
                     {% for tag in submission.tags.all %}
-                        <span class="badge" {% if tag.color %}style="background-color: {{ tag.color }}"{% endif %}>{{ tag.tag }}</span>
+                        <span class="badge" {% if tag.color %}style="background-color: {{ tag.color }}; color: {{ tag.contrast_color }};"{% endif %}>{{ tag.tag }}</span>
                     {% endfor %}
                 </div>
             </div>


### PR DESCRIPTION
## Closes #4349                         

Fixes an issue where proposal tags with light background colors had poor readability because the tag text defaulted to white. This made the text completely invisible on light grey or white backgrounds.

This PR introduces dynamic text color calculation based on background color brightness using the YIQ formula.

## Screenshot/Video

https://github.com/user-attachments/assets/2cee3d2b-6db1-488e-ae5e-a913dda0041e

---

https://github.com/user-attachments/assets/d6c32693-367d-4857-80f4-c67c667b50c3

## Summary by Sourcery

Bug Fixes:
- Ensure tag text remains visible on light-colored backgrounds in review and submission views by computing a contrast-appropriate text color.