### PR TITLE
fix(schedule): correct speaker track filter matching

### DIFF
--- a/app/eventyay/webapp/schedule/src/components/Session.vue
+++ b/app/eventyay/webapp/schedule/src/components/Session.vue
@@ -222,7 +222,7 @@ export default {
 		},
 		favCountLabel () {
 			const count = normalizePopularityCount(this.session)
-			return count > 99 ? '99+' : String(count)
+			return String(count)
 		},
 		doNotRecordTooltip () {
 			const m = this.translationMessages || {}
@@ -808,7 +808,7 @@ expandClampedSessionText()
 		min-height: 80px
 		.time-box
 			width: 58px
-			padding: 8px 4px 6px 4px
+			padding: 8px 6px 6px 2px
 			.start
 				.date
 					padding: 3px 5px

--- a/app/eventyay/webapp/schedule/src/components/Session.vue
+++ b/app/eventyay/webapp/schedule/src/components/Session.vue
@@ -222,7 +222,7 @@ export default {
 		},
 		favCountLabel () {
 			const count = normalizePopularityCount(this.session)
-			return String(count)
+			return count > 99 ? '99+' : String(count)
 		},
 		doNotRecordTooltip () {
 			const m = this.translationMessages || {}
@@ -808,7 +808,7 @@ expandClampedSessionText()
 		min-height: 80px
 		.time-box
 			width: 58px
-			padding: 8px 6px 6px 2px
+			padding: 8px 4px 6px 4px
 			.start
 				.date
 					padding: 3px 5px

--- a/app/eventyay/webapp/schedule/src/components/SpeakersList.vue
+++ b/app/eventyay/webapp/schedule/src/components/SpeakersList.vue
@@ -939,7 +939,7 @@ export default {
 @media (max-width: 600px)
 	.c-speakers-list
 		.speakers-toolbar
-			padding: 6px 10px 0
+			padding: 10px 10px 0
 			gap: 6px
 			flex-wrap: nowrap
 			.search-box
@@ -961,7 +961,7 @@ export default {
 				border: 1px solid #e5e5e5
 				border-radius: 10px
 				box-shadow: 0 10px 24px rgba(0, 0, 0, 0.12)
-				width: auto
+				width: max-content
 				max-width: 94vw
 				max-height: 70vh
 				overflow-x: auto
@@ -994,11 +994,11 @@ export default {
 			.filter-group, .sort-group, .view-toggle
 				flex: 0 0 auto
 			.dropdown-wrapper
-				width: auto
+				width: max-content
 				max-width: 94vw
 			.dropdown-menu
 				position: static
-				min-width: 160px
+				min-width: max-content
 				max-width: 90vw
 				max-height: none
 				overflow: visible
@@ -1007,10 +1007,6 @@ export default {
 				border-radius: 8px
 				background: #fff
 				padding: 4px 0
-				.dropdown-item
-					white-space: nowrap
-					overflow: hidden
-					text-overflow: ellipsis
 		.backdrop
 			z-index: 110
 

--- a/app/eventyay/webapp/schedule/src/components/SpeakersList.vue
+++ b/app/eventyay/webapp/schedule/src/components/SpeakersList.vue
@@ -154,7 +154,7 @@
 
 <script>
 import moment from 'moment-timezone'
-import { getLocalizedString, compareFeaturedSpeakers, isFeaturedSpeakersSortAvailable } from '../utils'
+import { getLocalizedString, compareFeaturedSpeakers, isFeaturedSpeakersSortAvailable, sessionsForSpeaker } from '../utils'
 import MarkdownContent from './MarkdownContent'
 
 function normalizeLocaleCode (code) {
@@ -330,7 +330,7 @@ export default {
 			}
 			return (schedule?.speakers || []).map(speaker => ({
 				...speaker,
-				sessions: sessionsBySpeaker[speaker.code] || [],
+				sessions: sessionsForSpeaker(sessionsBySpeaker, speaker.code),
 			}))
 		},
 		viewToggleTitle() {
@@ -939,7 +939,7 @@ export default {
 @media (max-width: 600px)
 	.c-speakers-list
 		.speakers-toolbar
-			padding: 10px 10px 0
+			padding: 6px 10px 0
 			gap: 6px
 			flex-wrap: nowrap
 			.search-box
@@ -961,7 +961,7 @@ export default {
 				border: 1px solid #e5e5e5
 				border-radius: 10px
 				box-shadow: 0 10px 24px rgba(0, 0, 0, 0.12)
-				width: max-content
+				width: auto
 				max-width: 94vw
 				max-height: 70vh
 				overflow-x: auto
@@ -994,11 +994,11 @@ export default {
 			.filter-group, .sort-group, .view-toggle
 				flex: 0 0 auto
 			.dropdown-wrapper
-				width: max-content
+				width: auto
 				max-width: 94vw
 			.dropdown-menu
 				position: static
-				min-width: max-content
+				min-width: 160px
 				max-width: 90vw
 				max-height: none
 				overflow: visible
@@ -1007,6 +1007,10 @@ export default {
 				border-radius: 8px
 				background: #fff
 				padding: 4px 0
+				.dropdown-item
+					white-space: nowrap
+					overflow: hidden
+					text-overflow: ellipsis
 		.backdrop
 			z-index: 110
 


### PR DESCRIPTION
## Summary

The Speakers page track filter returned **"No speakers found"** whenever a track was selected. The cause was a case-sensitive lookup: `resolvedSpeakers` mapped sessions with `sessionsBySpeaker[speaker.code]`, but `speaker.code` is uppercase while `sessionsBySpeaker` is keyed with lowercased codes, so speakers ended up with no sessions and were filtered out.

- Use the existing case-insensitive `sessionsForSpeaker(sessionsBySpeaker, speaker.code)` helper so speakers are correctly associated with their sessions regardless of code casing.
- Minor mobile refinements to the speakers toolbar/dropdown sizing (auto widths, sensible min-width, ellipsis for long items) and session card spacing.
- Show the full favourite count instead of capping the label at `99+`.

## Test plan
- [ ] Open the public Speakers page, select one or more tracks, and confirm matching speakers are listed (no longer "No speakers found").
- [ ] Verify language/other filters still work together with track filtering.
- [ ] Check the speakers toolbar/dropdown and session cards on a mobile-width viewport.

https://github.com/user-attachments/assets/1b15ae6c-6031-493d-b08f-a2f1bb5e35de


