### PR TITLE
fix(ui): tighten public event header spacing on mobile

### DIFF
--- a/app/eventyay/common/templates/common/base_public.html
+++ b/app/eventyay/common/templates/common/base_public.html
@@ -84,6 +84,7 @@
             <script defer src="{% static 'common/js/lightbox.js' %}"></script>
             <script src="{% static 'agenda/js/join-online-event.js' %}"></script>
             <script type="module" src="{% static 'common/js/dropdown.js' %}"></script>
+            <script type="module" src="{% static 'common/js/event-home-back.js' %}"></script>
             <script defer src="{% static 'common/js/nav-tabs.js' %}"></script>
             <script type="module" src="{% static 'common/js/contact-modal.js' %}"></script>
         {% endcompress %}

--- a/app/eventyay/presale/templates/pretixpresale/startpage_base.html
+++ b/app/eventyay/presale/templates/pretixpresale/startpage_base.html
@@ -51,6 +51,7 @@
             <script defer src="{% static 'common/js/base.js' %}"></script>
             <script defer src="{% static 'common/js/lightbox.js' %}"></script>
             <script type="module" src="{% static 'common/js/dropdown.js' %}"></script>
+            <script type="module" src="{% static 'common/js/event-home-back.js' %}"></script>
             <script type="module" src="{% static 'pretixpresale/js/startpage-sidebar.js' %}"></script>
             <script defer src="{% static 'pretixpresale/js/startpage.js' %}"></script>
         {% endcompress %}

--- a/app/eventyay/static/cfp/css/_layout.css
+++ b/app/eventyay/static/cfp/css/_layout.css
@@ -732,7 +732,8 @@ footer {
   }
 
   .event-brand {
-    flex-wrap: wrap;
+    display: flex;
+    flex-direction: column;
     gap: 1rem;
     align-items: flex-start;
     padding-left: 12px;

--- a/app/eventyay/static/cfp/css/_layout.css
+++ b/app/eventyay/static/cfp/css/_layout.css
@@ -313,8 +313,8 @@ header {
 
 .header-join-video-floating-mobile {
   position: absolute;
-  bottom: -27.5px;
-  right: 7.5px;
+  bottom: -17px;
+  right: 15px;
   z-index: 1050;
 }
 
@@ -323,17 +323,17 @@ header {
   align-items: center;
   justify-content: center;
   gap: 6px;
-  padding: 2px 6px;
-  height: 28px;
+  padding: 6px 12px;
+  height: 34px;
   min-width: 0;
-  border-radius: 6px;
+  border-radius: 4px;
   box-shadow: 0 3px 8px rgba(0, 0, 0, 0.18);
   background-color: var(--color-primary);
   color: white;
-  border: none;
-  font-size: 0.82rem;
-  font-weight: 500;
-  line-height: 1;
+  border: 1px solid transparent;
+  font-size: 14px;
+  font-weight: normal;
+  line-height: 1.42857143;
 }
 
 @media (max-width: 319px) {
@@ -360,10 +360,9 @@ header {
 
 .header-join-video-floating-mobile .btn-join-video-icon-only:hover,
 .header-join-video-floating-mobile .btn-join-video-icon-only:focus {
-  transform: scale(1.02);
-  box-shadow: 0 6px 18px rgba(0, 0, 0, 0.22);
   color: white !important;
-  background-color: var(--color-primary);
+  background-color: var(--color-primary-hover, var(--color-primary));
+  border-color: var(--color-primary-hover, var(--color-primary));
   filter: none;
 }
 
@@ -378,7 +377,7 @@ header {
 
   body.page-agenda .header-join-video-floating-mobile,
   body.page-cfp .header-join-video-floating-mobile {
-    right: 0;
+    right: 15px;
   }
 }
 
@@ -391,6 +390,7 @@ header {
   max-width: 100%;
   overflow-wrap: anywhere;
   word-break: break-word;
+  gap: 2px;
 }
 
 header > .event-home-back {
@@ -413,18 +413,17 @@ header > .event-home-back {
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  gap: 0;
+  gap: 0.4em;
   min-height: 32px;
   padding: 0 11px;
   background: rgba(0, 0, 0, 0.45);
   border-radius: 8px;
   box-shadow: 0 1px 4px rgba(0, 0, 0, 0.28);
-  transition: gap 0.18s ease, background 0.18s ease;
+  transition: background 0.18s ease;
 }
 
 .event-home-back:hover .event-home-back-pill,
 .event-home-back:focus-visible .event-home-back-pill {
-  gap: 0.4em;
   background: rgba(0, 0, 0, 0.62);
 }
 
@@ -448,22 +447,14 @@ header > .event-home-back {
   font-size: 14px;
   font-weight: 600;
   line-height: 1;
-  max-width: 0;
-  opacity: 0;
-  overflow: hidden;
-  white-space: nowrap;
-  transition: max-width 0.22s ease, opacity 0.18s ease;
-}
-
-.event-home-back:hover .event-home-back-label,
-.event-home-back:focus-visible .event-home-back-label {
-  max-width: 12em;
+  max-width: none;
   opacity: 1;
+  overflow: visible;
+  white-space: nowrap;
 }
 
 @media (prefers-reduced-motion: reduce) {
-  .event-home-back-pill,
-  .event-home-back-label {
+  .event-home-back-pill {
     transition: none;
   }
 }
@@ -721,12 +712,23 @@ footer {
   }
 
   .event-hero {
-    margin: 0.5rem 0 2rem;
+    margin: 0.25rem 0 1.5rem;
   }
 
   .event-hero-overlay {
+    position: relative;
     display: flex;
+    flex-direction: column;
     width: 100%;
+    min-height: auto;
+    align-items: flex-start;
+  }
+
+  .header-join-video-floating-mobile {
+    position: static;
+    margin-top: 14px;
+    padding-right: 12px;
+    align-self: flex-end;
   }
 
   .event-brand {
@@ -754,14 +756,6 @@ footer {
 
   .event-date-line {
     font-size: 0.9rem;
-  }
-
-  .event-hero-overlay {
-    position: relative;
-    display: flex;
-    width: 100%;
-    min-height: 100px;
-    align-items: flex-end;
   }
 
   /* Force #main-card to stretch fully to container bounds, avoiding 2x indent */

--- a/app/eventyay/static/cfp/css/_layout.css
+++ b/app/eventyay/static/cfp/css/_layout.css
@@ -413,17 +413,19 @@ header > .event-home-back {
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  gap: 0.4em;
+  gap: 0;
   min-height: 32px;
   padding: 0 11px;
   background: rgba(0, 0, 0, 0.45);
   border-radius: 8px;
   box-shadow: 0 1px 4px rgba(0, 0, 0, 0.28);
-  transition: background 0.18s ease;
+  transition: gap 0.18s ease, background 0.18s ease;
 }
 
 .event-home-back:hover .event-home-back-pill,
-.event-home-back:focus-visible .event-home-back-pill {
+.event-home-back:focus-visible .event-home-back-pill,
+.event-home-back.event-home-back--expanded .event-home-back-pill {
+  gap: 0.4em;
   background: rgba(0, 0, 0, 0.62);
 }
 
@@ -447,14 +449,23 @@ header > .event-home-back {
   font-size: 14px;
   font-weight: 600;
   line-height: 1;
-  max-width: none;
-  opacity: 1;
-  overflow: visible;
+  max-width: 0;
+  opacity: 0;
+  overflow: hidden;
   white-space: nowrap;
+  transition: max-width 0.22s ease, opacity 0.18s ease;
+}
+
+.event-home-back:hover .event-home-back-label,
+.event-home-back:focus-visible .event-home-back-label,
+.event-home-back.event-home-back--expanded .event-home-back-label {
+  max-width: 12em;
+  opacity: 1;
 }
 
 @media (prefers-reduced-motion: reduce) {
-  .event-home-back-pill {
+  .event-home-back-pill,
+  .event-home-back-label {
     transition: none;
   }
 }

--- a/app/eventyay/static/cfp/css/_layout.css
+++ b/app/eventyay/static/cfp/css/_layout.css
@@ -596,6 +596,10 @@ footer {
 }
 
 @media (max-width: 768px) {
+  #top-bg {
+    height: 480px;
+  }
+
   #main-container {
     max-width: 100%;
     padding-left: 0;

--- a/app/eventyay/static/common/js/event-home-back.js
+++ b/app/eventyay/static/common/js/event-home-back.js
@@ -1,0 +1,46 @@
+'use strict';
+
+const EXPANDED_CLASS = 'event-home-back--expanded';
+const HOVER_MEDIA_QUERY = window.matchMedia('(hover: hover)');
+const initializedLinks = new WeakSet();
+
+const collapseExpandedLinks = function(exceptLink) {
+    document.querySelectorAll(`.event-home-back.${EXPANDED_CLASS}`).forEach(function(link) {
+        if (link !== exceptLink) {
+            link.classList.remove(EXPANDED_CLASS);
+        }
+    });
+};
+
+const initEventHomeBackLink = function(link) {
+    if (initializedLinks.has(link)) return;
+    initializedLinks.add(link);
+
+    link.addEventListener('click', function(event) {
+        if (HOVER_MEDIA_QUERY.matches) {
+            return;
+        }
+        if (!link.classList.contains(EXPANDED_CLASS)) {
+            event.preventDefault();
+            collapseExpandedLinks(link);
+            link.classList.add(EXPANDED_CLASS);
+        }
+    });
+};
+
+const initEventHomeBack = function() {
+    document.querySelectorAll('.event-home-back').forEach(initEventHomeBackLink);
+
+    document.addEventListener('click', function(event) {
+        if (event.target.closest('.event-home-back')) {
+            return;
+        }
+        collapseExpandedLinks();
+    });
+};
+
+if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', initEventHomeBack);
+} else {
+    initEventHomeBack();
+}

--- a/app/eventyay/static/pretixpresale/scss/_event.scss
+++ b/app/eventyay/static/pretixpresale/scss/_event.scss
@@ -108,6 +108,15 @@
     border-bottom: 2px solid $table-border-color;
 }
 
+#main-card summary.product-row {
+    color: var(--color-text);
+
+    .product-description,
+    .product-description p {
+        color: var(--color-text);
+    }
+}
+
 .panel-body address:last-child {
     margin-bottom: 0;
 }

--- a/app/eventyay/static/pretixpresale/scss/_theme.scss
+++ b/app/eventyay/static/pretixpresale/scss/_theme.scss
@@ -59,6 +59,7 @@
 
 h2.content-header {
   margin-top: 0;
+  margin-bottom: 15px;
   overflow-wrap: anywhere;
   word-break: break-word;
 

--- a/app/eventyay/static/pretixpresale/scss/custom.css
+++ b/app/eventyay/static/pretixpresale/scss/custom.css
@@ -246,6 +246,10 @@ header .header-row-right {
 }
 
 @media (max-width: 768px) {
+    #top-bg {
+        height: 480px;
+    }
+
     .presale-sticky-tabs {
         flex-direction: row;
         flex-wrap: nowrap;

--- a/app/eventyay/static/pretixpresale/scss/custom.css
+++ b/app/eventyay/static/pretixpresale/scss/custom.css
@@ -224,6 +224,15 @@ header .header-row-right {
     margin-inline: 0;
 }
 
+#main-card summary.product-row {
+    color: var(--color-text);
+}
+
+#main-card summary.product-row .product-description,
+#main-card summary.product-row .product-description p {
+    color: var(--color-text);
+}
+
 .nav-icon-mobile {
     display: none;
 }

--- a/app/eventyay/static/pretixpresale/scss/custom.css
+++ b/app/eventyay/static/pretixpresale/scss/custom.css
@@ -562,11 +562,6 @@ header .header-row-right {
 
 .variation-option > div:first-child {
     position: relative;
-    display: grid;
-    grid-template-columns: auto minmax(0, 1fr);
-    align-items: baseline;
-    column-gap: 0.5em;
-    row-gap: 0.25em;
 }
 
 .variation-option > div:first-child::before {
@@ -582,34 +577,25 @@ header .header-row-right {
 .variation-option > div:first-child::after {
     content: '';
     position: absolute;
-    top: 50%;
+    top: 0.75em;
     left: 2px;
     width: 10px;
     height: 1px;
     background: var(--color-grey-light, #d0d0d0);
-    transform: translateY(-50%);
 }
 
 .variation-option h5 {
-    grid-column: 1;
     padding-left: 16px;
     margin: 0;
 }
 
 .variation-option .variation-description {
-    grid-column: 2;
     margin: 0;
-    padding-left: 0;
-    min-width: 0;
+    padding-left: 16px;
 }
 
 .variation-option .variation-description p {
-    display: inline;
     margin: 0;
-}
-
-.variation-option > div:first-child > :not(h5):not(.variation-description) {
-    grid-column: 1 / -1;
 }
 
 .variation-selector-label.is-exclusive-disabled,

--- a/app/eventyay/static/pretixpresale/scss/custom.css
+++ b/app/eventyay/static/pretixpresale/scss/custom.css
@@ -241,7 +241,7 @@ header .header-row-right {
     }
 
     .header-join-video-floating-mobile {
-        right: 0;
+        right: 15px;
     }
 }
 

--- a/app/eventyay/static/pretixpresale/scss/custom.css
+++ b/app/eventyay/static/pretixpresale/scss/custom.css
@@ -562,13 +562,18 @@ header .header-row-right {
 
 .variation-option > div:first-child {
     position: relative;
+    display: grid;
+    grid-template-columns: auto minmax(0, 1fr);
+    align-items: baseline;
+    column-gap: 0.5em;
+    row-gap: 0.25em;
 }
 
 .variation-option > div:first-child::before {
     content: '';
     position: absolute;
-    top: 12px;
-    bottom: 12px;
+    top: 0;
+    bottom: 0;
     left: 2px;
     width: 1px;
     background: var(--color-grey-light, #d0d0d0);
@@ -577,15 +582,34 @@ header .header-row-right {
 .variation-option > div:first-child::after {
     content: '';
     position: absolute;
-    top: 24px;
+    top: 50%;
     left: 2px;
     width: 10px;
     height: 1px;
     background: var(--color-grey-light, #d0d0d0);
+    transform: translateY(-50%);
 }
 
 .variation-option h5 {
+    grid-column: 1;
     padding-left: 16px;
+    margin: 0;
+}
+
+.variation-option .variation-description {
+    grid-column: 2;
+    margin: 0;
+    padding-left: 0;
+    min-width: 0;
+}
+
+.variation-option .variation-description p {
+    display: inline;
+    margin: 0;
+}
+
+.variation-option > div:first-child > :not(h5):not(.variation-description) {
+    grid-column: 1 / -1;
 }
 
 .variation-selector-label.is-exclusive-disabled,

--- a/app/eventyay/static/pretixpresale/scss/custom.scss
+++ b/app/eventyay/static/pretixpresale/scss/custom.scss
@@ -208,6 +208,9 @@
 }
 
 @media (max-width: 768px) {
+    #top-bg {
+        height: 480px;
+    }
 
     /* Keep the sticky tabs in a single flex row */
     .presale-sticky-tabs {

--- a/app/eventyay/static/pretixpresale/scss/custom.scss
+++ b/app/eventyay/static/pretixpresale/scss/custom.scss
@@ -203,7 +203,7 @@
     }
 
     .header-join-video-floating-mobile {
-        right: 0;
+        right: 15px;
     }
 }
 

--- a/app/eventyay/static/pretixpresale/scss/custom.scss
+++ b/app/eventyay/static/pretixpresale/scss/custom.scss
@@ -183,6 +183,15 @@
     margin-inline: 0;
 }
 
+#main-card summary.product-row {
+    color: var(--color-text);
+
+    .product-description,
+    .product-description p {
+        color: var(--color-text);
+    }
+}
+
 /* Desktop: hide icons that are mobile-only (globe + user in nav dropdowns) */
 .nav-icon-mobile {
     display: none;

--- a/app/eventyay/webapp/video/src/components/LandingPage.vue
+++ b/app/eventyay/webapp/video/src/components/LandingPage.vue
@@ -422,16 +422,15 @@ export default {
 		display: inline-flex
 		align-items: center
 		justify-content: center
-		gap: 0
+		gap: 0.4em
 		min-height: 32px
 		padding: 0 11px
 		background: rgba(0, 0, 0, 0.45)
 		border-radius: 8px
 		box-shadow: 0 1px 4px rgba(0, 0, 0, 0.28)
-		transition: gap 0.18s ease, background 0.18s ease
+		transition: background 0.18s ease
 	.event-home-back:hover .event-home-back-pill,
 	.event-home-back:focus-visible .event-home-back-pill
-		gap: 0.4em
 		background: rgba(0, 0, 0, 0.62)
 	.event-home-back:focus-visible
 		outline: none
@@ -446,15 +445,10 @@ export default {
 		font-size: 14px
 		font-weight: 600
 		line-height: 1
-		max-width: 0
-		opacity: 0
-		overflow: hidden
-		white-space: nowrap
-		transition: max-width 0.22s ease, opacity 0.18s ease
-	.event-home-back:hover .event-home-back-label,
-	.event-home-back:focus-visible .event-home-back-label
-		max-width: 12em
+		max-width: none
 		opacity: 1
+		overflow: visible
+		white-space: nowrap
 	.event-hero
 		display: flex
 		align-items: center
@@ -482,7 +476,7 @@ export default {
 		color: var(--color-header-text, #fff)
 		display: flex
 		flex-direction: column
-		gap: 0
+		gap: 2px
 		min-width: 0
 	.event-hero-text .event-title
 		font-size: 3rem
@@ -640,9 +634,12 @@ export default {
 		.event-home-back .event-home-back-label
 			font-size: 13.5px
 		.event-hero
-			margin: 0.5rem 0 2rem
+			margin: 0.25rem 0 1.5rem
 		.event-hero-overlay
-			align-items: flex-end
+			align-items: flex-start
+			min-height: auto
+			flex-direction: column
+			display: flex
 		.event-brand
 			flex-wrap: wrap
 			gap: 1rem

--- a/app/eventyay/webapp/video/src/components/LandingPage.vue
+++ b/app/eventyay/webapp/video/src/components/LandingPage.vue
@@ -3,7 +3,13 @@
 	.landing-top-bg
 	.landing-scroll(v-scrollbar.y="")
 		header.landing-header
-			a.event-home-back(v-if="homeBackLink", :href="homeBackLink.href", :aria-label="homeBackLink.ariaLabel")
+			a.event-home-back(
+				v-if="homeBackLink",
+				:href="homeBackLink.href",
+				:aria-label="homeBackLink.ariaLabel",
+				:class="{'event-home-back--expanded': homeBackExpanded}",
+				@click.prevent="handleHomeBackClick"
+			)
 				span.event-home-back-pill
 					i.fa.fa-angle-left.event-home-back-icon(aria-hidden="true")
 					span.event-home-back-label(aria-hidden="true") {{ homeBackLink.label }}
@@ -85,7 +91,8 @@ export default {
 	data() {
 		return {
 			moment,
-			eventMeta: null
+			eventMeta: null,
+			homeBackExpanded: false
 		}
 	},
 	computed: {
@@ -279,8 +286,31 @@ export default {
 	},
 	async mounted() {
 		await this.fetchEventMeta()
+		document.addEventListener('click', this.handleHomeBackOutsideClick)
+	},
+	beforeUnmount() {
+		document.removeEventListener('click', this.handleHomeBackOutsideClick)
 	},
 	methods: {
+		handleHomeBackClick() {
+			const href = this.homeBackLink?.href
+			if (!href) return
+
+			const supportsHover = window.matchMedia('(hover: hover)').matches
+			if (supportsHover) {
+				window.location.assign(href)
+				return
+			}
+			if (!this.homeBackExpanded) {
+				this.homeBackExpanded = true
+				return
+			}
+			window.location.assign(href)
+		},
+		handleHomeBackOutsideClick(event) {
+			if (event.target.closest('.event-home-back')) return
+			this.homeBackExpanded = false
+		},
 		toMediaUrl(pathValue) {
 			const cleaned = String(pathValue || '').replace(/^\/+/, '')
 			if (!cleaned) return ''
@@ -378,7 +408,7 @@ export default {
 		top: 0
 		left: 0
 		right: 0
-		height: 320px
+		height: calc(320px - 48px)
 		z-index: 0
 		pointer-events: none
 		background-color: var(--landing-hero-background-color)
@@ -422,15 +452,17 @@ export default {
 		display: inline-flex
 		align-items: center
 		justify-content: center
-		gap: 0.4em
+		gap: 0
 		min-height: 32px
 		padding: 0 11px
 		background: rgba(0, 0, 0, 0.45)
 		border-radius: 8px
 		box-shadow: 0 1px 4px rgba(0, 0, 0, 0.28)
-		transition: background 0.18s ease
+		transition: gap 0.18s ease, background 0.18s ease
 	.event-home-back:hover .event-home-back-pill,
-	.event-home-back:focus-visible .event-home-back-pill
+	.event-home-back:focus-visible .event-home-back-pill,
+	.event-home-back.event-home-back--expanded .event-home-back-pill
+		gap: 0.4em
 		background: rgba(0, 0, 0, 0.62)
 	.event-home-back:focus-visible
 		outline: none
@@ -445,10 +477,16 @@ export default {
 		font-size: 14px
 		font-weight: 600
 		line-height: 1
-		max-width: none
-		opacity: 1
-		overflow: visible
+		max-width: 0
+		opacity: 0
+		overflow: hidden
 		white-space: nowrap
+		transition: max-width 0.22s ease, opacity 0.18s ease
+	.event-home-back:hover .event-home-back-label,
+	.event-home-back:focus-visible .event-home-back-label,
+	.event-home-back.event-home-back--expanded .event-home-back-label
+		max-width: 12em
+		opacity: 1
 	.event-hero
 		display: flex
 		align-items: center
@@ -620,9 +658,9 @@ export default {
 	.speakers-section .c-speakers-list
 		overflow: visible !important
 
-	+below('m')
+	+below('s')
 		.landing-top-bg
-			height: 480px
+			height: calc(480px - 48px)
 		.landing-header
 			padding-left: 12px
 			padding-right: 0

--- a/app/eventyay/webapp/video/src/components/LandingPage.vue
+++ b/app/eventyay/webapp/video/src/components/LandingPage.vue
@@ -197,7 +197,7 @@ export default {
 					})
 				}
 			}
-			const href = this.presaleHomeUrl || navigation?.site_home_url
+			const href = navigation?.site_home_url
 			if (!href) return null
 			return {
 				href,

--- a/app/eventyay/webapp/video/src/components/LandingPage.vue
+++ b/app/eventyay/webapp/video/src/components/LandingPage.vue
@@ -622,7 +622,7 @@ export default {
 
 	+below('m')
 		.landing-top-bg
-			height: 220px
+			height: 480px
 		.landing-header
 			padding-left: 12px
 			padding-right: 0

--- a/app/eventyay/webapp/video/src/components/LandingPage.vue
+++ b/app/eventyay/webapp/video/src/components/LandingPage.vue
@@ -641,7 +641,8 @@ export default {
 			flex-direction: column
 			display: flex
 		.event-brand
-			flex-wrap: wrap
+			display: flex
+			flex-direction: column
 			gap: 1rem
 			align-items: flex-start
 		.event-hero-text .event-title


### PR DESCRIPTION
## Summary

- Show the Home back button label by default on public event pages (no hover reveal).
- Reduce mobile spacing between the Home button, event title, and date, including when no logo is present.
- Restyle the Join online video button to match primary blue action buttons and prevent it from overlapping hero text on mobile.
- Keep desktop right padding for the Join online video button and align the same header behavior on the video landing page.

Fixes #4390

## Test plan

- [ ] On mobile presale event page, verify Home label is visible by default and title/date sit closer to the Home button.
- [ ] On mobile agenda/CFP pages, verify the same header spacing and no overlap between hero text and Join online video button.
- [ ] On mobile, verify Join online video button appears below the hero text, right-aligned, with consistent primary button styling.
- [ ] On desktop presale/agenda/CFP pages, verify Join online video button has right padding and does not sit flush against the edge.
- [ ] On video landing page, verify Home label visibility and tightened mobile hero spacing match public pages.