### PR TITLE
fix(orga): align Talks dashboard tiles and Speaker Information action buttons

### DIFF
--- a/app/eventyay/orga/templates/orga/speaker/information_list.html
+++ b/app/eventyay/orga/templates/orga/speaker/information_list.html
@@ -59,7 +59,7 @@
                             {% if info.resource %}<a href="{{ info.resource.url }}"><i class="fa fa-paperclip"></i></a>{% endif %}
                         </td>
                         <td>{{ info.target_group }}</td>
-                        <td class="text-right">
+                        <td class="action-column">
                             <a href="{{ info.orga_urls.edit }}" class="btn btn-sm btn-info"><i class="fa fa-edit"></i></a>
                             <a href="{{ info.orga_urls.delete }}" class="btn btn-sm btn-danger"><i class="fa fa-trash"></i></a>
                         </td>

--- a/app/eventyay/orga/templates/orga/speaker/speakerinformation/list.html
+++ b/app/eventyay/orga/templates/orga/speaker/speakerinformation/list.html
@@ -27,7 +27,7 @@
             <tbody>
                 {% for info in information_list %}
                     <tr>
-                        <td>
+                        <td class="speaker-info-title">
                             {% if has_update_permission %}
                                 <a href="{{ info.orga_urls.edit }}">{{ info.title }}</a>
                             {% else %}
@@ -70,7 +70,7 @@
                                 </a>
                             {% endif %}
                         </td>
-                        <td class="text-right">
+                        <td class="action-column">
                             {% if has_update_permission %}
                                 <a href="{{ info.orga_urls.edit }}" class="btn btn-sm btn-info">
                                     <i class="fa fa-edit"></i>

--- a/app/eventyay/static/orga/css/_layout.css
+++ b/app/eventyay/static/orga/css/_layout.css
@@ -122,11 +122,37 @@ table.table-sticky thead {
 table .action-column {
   display: flex;
   flex-wrap: nowrap;
+  align-items: center;
   justify-content: flex-end;
+  gap: 4px;
+  width: 1%;
+  white-space: nowrap;
+  vertical-align: middle;
 
-  >* {
-    margin-left: 4px;
+  > * {
+    margin-left: 0;
+    flex: 0 0 auto;
+    align-self: center;
+    height: auto;
   }
+}
+
+#page-content .table.table-flip td.action-column {
+  width: 1%;
+  white-space: nowrap;
+}
+
+#page-content .table.table-flip td.action-column .btn {
+  flex: 0 0 auto;
+  height: auto;
+  align-self: center;
+}
+
+#page-content .table.table-flip td.speaker-info-title {
+  max-width: 0;
+  width: 40%;
+  overflow-wrap: anywhere;
+  word-break: break-word;
 }
 
 .accordion .card {
@@ -2525,12 +2551,17 @@ h2 .user-name-display img {
 
   #page-content table .action-column {
     gap: 0.35rem;
-    flex-wrap: wrap;
+    flex-wrap: nowrap;
+    align-items: center;
     justify-content: flex-end;
+    width: auto;
   }
 
   #page-content table .action-column > * {
     margin-left: 0;
+    flex: 0 0 auto;
+    height: auto;
+    align-self: center;
   }
 
   #page-content .table-flip tbody td.submission_featured {

--- a/app/eventyay/static/orga/css/_layout.css
+++ b/app/eventyay/static/orga/css/_layout.css
@@ -125,7 +125,6 @@ table .action-column {
   align-items: center;
   justify-content: flex-end;
   gap: 4px;
-  width: 1%;
   white-space: nowrap;
   vertical-align: middle;
 
@@ -135,17 +134,6 @@ table .action-column {
     align-self: center;
     height: auto;
   }
-}
-
-#page-content .table.table-flip td.action-column {
-  width: 1%;
-  white-space: nowrap;
-}
-
-#page-content .table.table-flip td.action-column .btn {
-  flex: 0 0 auto;
-  height: auto;
-  align-self: center;
 }
 
 #page-content .table.table-flip td.speaker-info-title {

--- a/app/eventyay/static/orga/css/dashboard.css
+++ b/app/eventyay/static/orga/css/dashboard.css
@@ -1,103 +1,134 @@
 .dashboard-list,
 .dashboard-list-metrics {
   padding-bottom: 20px;
+}
 
-  .dashboard-block-wrapper {
-    padding: 0;
-    max-width: 100%;
+.dashboard-list .dashboard-block-wrapper,
+.dashboard-list-metrics .dashboard-block-wrapper {
+  padding: 0;
+  max-width: 100%;
+}
 
-    > .dashboard-block {
-      margin: 0;
-      padding: 0;
-      width: 100%;
-      max-width: 100%;
-    }
+.dashboard-list .dashboard-block-wrapper > .dashboard-block,
+.dashboard-list-metrics .dashboard-block-wrapper > .dashboard-block {
+  margin: 0;
+  padding: 0;
+  width: 100%;
+  max-width: 100%;
+}
 
-    .dashboard-block-extension {
-      position: absolute;
-      bottom: 0;
-      left: 0;
-      width: 100%;
-      display: flex;
-      .dashboard-block-addon {
-        flex: 1;
-        font-weight: 400;
-        &:first-child {
-          border-right: 2px solid var(--color-grey-light);
-        }
-        &:hover {
-          background: var(--color-grey-lightest);
-          color: var(--color-primary);
-          text-decoration: none;
-        }
-        &.dashboard-block-addon-success {
-          color: var(--color-grey-lightest);
-          background-color: var(--color-success);
-        }
-        &.dashboard-block-addon-info {
-          color: var(--color-grey-lightest);
-          background-color: var(--color-info);
-        }
-        &.dashboard-block-addon-error {
-          color: var(--color-grey-lightest);
-          background-color: var(--color-danger);
-        }
-        &.dashboard-block-addon-secondary {
-          color: var(--color-grey-lightest);
-          background-color: var(--color-secondary);
-        }
-      }
-    }
-  }
+.dashboard-list .dashboard-block-extension,
+.dashboard-list-metrics .dashboard-block-extension {
+  position: absolute;
+  bottom: 0;
+  left: 0;
+  width: 100%;
+  display: flex;
+}
 
-  .dashboard-block {
-    color: var(--color-primary);
-    background: var(--color-grey-ultralight);
-    overflow-wrap: break-word;
-    &.dashboard-block-extended {
-      min-height: 100px;
-    }
-    &:hover {
-      color: var(--color-primary-text-dark);
-      background-color: var(--color-grey-pale);
-      text-decoration: none;
-    }
+.dashboard-list .dashboard-block-addon,
+.dashboard-list-metrics .dashboard-block-addon {
+  flex: 1;
+  font-weight: 400;
+}
 
-    &.symbol {
-      display: flex;
-      padding: 0;
-      align-items: center;
-      justify-content: center;
-      i {
-        font-size: 56px;
-      }
-      .icon-calendar-series-svg {
-        display: block;
-        width: 56px;
-        height: 56px;
-        margin: 0 auto;
-        color: inherit;
-      }
-    }
+.dashboard-list .dashboard-block-addon:first-child,
+.dashboard-list-metrics .dashboard-block-addon:first-child {
+  border-right: 2px solid var(--color-grey-light);
+}
 
-    h1 {
-      font-size: 36px;
-      font-weight: normal;
+.dashboard-list .dashboard-block-addon:hover,
+.dashboard-list-metrics .dashboard-block-addon:hover {
+  background: var(--color-grey-lightest);
+  color: var(--color-primary);
+  text-decoration: none;
+}
 
-      .fa {
-        padding-right: 0.3em;
-      }
-    }
+.dashboard-list .dashboard-block-addon-success,
+.dashboard-list-metrics .dashboard-block-addon-success {
+  color: var(--color-grey-lightest);
+  background-color: var(--color-success);
+}
 
-    .dashboard-description {
-      padding: 0 8px;
-      font-size: 20px;
+.dashboard-list .dashboard-block-addon-info,
+.dashboard-list-metrics .dashboard-block-addon-info {
+  color: var(--color-grey-lightest);
+  background-color: var(--color-info);
+}
 
-      ul {
-        text-align: left;
-      }
-    }
-  }
+.dashboard-list .dashboard-block-addon-error,
+.dashboard-list-metrics .dashboard-block-addon-error {
+  color: var(--color-grey-lightest);
+  background-color: var(--color-danger);
+}
+
+.dashboard-list .dashboard-block-addon-secondary,
+.dashboard-list-metrics .dashboard-block-addon-secondary {
+  color: var(--color-grey-lightest);
+  background-color: var(--color-secondary);
+}
+
+.dashboard-list .dashboard-block,
+.dashboard-list-metrics .dashboard-block {
+  color: var(--color-primary);
+  background: var(--color-grey-ultralight);
+  overflow-wrap: break-word;
+}
+
+.dashboard-list .dashboard-block.dashboard-block-extended,
+.dashboard-list-metrics .dashboard-block.dashboard-block-extended {
+  min-height: 100px;
+}
+
+.dashboard-list .dashboard-block:hover,
+.dashboard-list-metrics .dashboard-block:hover {
+  color: var(--color-primary-text-dark);
+  background-color: var(--color-grey-pale);
+  text-decoration: none;
+}
+
+.dashboard-list .dashboard-block.symbol,
+.dashboard-list-metrics .dashboard-block.symbol {
+  display: flex;
+  padding: 0;
+  align-items: center;
+  justify-content: center;
+}
+
+.dashboard-list .dashboard-block.symbol i,
+.dashboard-list-metrics .dashboard-block.symbol i {
+  font-size: 56px;
+}
+
+.dashboard-list .dashboard-block.symbol .icon-calendar-series-svg,
+.dashboard-list-metrics .dashboard-block.symbol .icon-calendar-series-svg {
+  display: block;
+  width: 56px;
+  height: 56px;
+  margin: 0 auto;
+  color: inherit;
+}
+
+.dashboard-list .dashboard-block h1,
+.dashboard-list-metrics .dashboard-block h1 {
+  font-size: 36px;
+  font-weight: normal;
+}
+
+.dashboard-list .dashboard-block h1 .fa,
+.dashboard-list-metrics .dashboard-block h1 .fa {
+  padding-right: 0.3em;
+}
+
+.dashboard-list .dashboard-description,
+.dashboard-list-metrics .dashboard-description {
+  padding: 0 8px;
+  font-size: 20px;
+}
+
+.dashboard-list .dashboard-description ul,
+.dashboard-list-metrics .dashboard-description ul {
+  text-align: left;
 }
 
 .dashboard-list {
@@ -106,32 +137,73 @@
   align-items: stretch;
 }
 
+/* Equal 4-column cards matching Tickets dashboard */
 .dashboard-list-metrics {
   display: grid;
   grid-template-columns: repeat(4, minmax(0, 1fr));
+  align-items: stretch;
   margin-left: -5px;
   margin-right: -5px;
+}
 
-  > .dashboard-block,
-  > .dashboard-block-wrapper {
-    margin: 0;
-    padding: 15px 5px;
-    min-height: 160px;
-    border: 5px solid var(--color-bg, #fff);
-    border-radius: 0;
-    box-sizing: border-box;
-    user-select: none;
-  }
+.dashboard-list-metrics > .dashboard-block,
+.dashboard-list-metrics > .dashboard-block-wrapper {
+  flex: none;
+  width: auto;
+  max-width: none;
+  min-width: 0;
+  margin: 0;
+  min-height: 160px;
+  border: 5px solid var(--color-bg, #fff);
+  border-radius: 0;
+  box-sizing: border-box;
+  user-select: none;
+  position: relative;
+  overflow: hidden;
+}
 
-  .dashboard-block-wrapper > .dashboard-block {
-    border: none;
-    min-height: 100px;
-  }
+/* Direct tiles (e.g. live status): keep internal padding */
+.dashboard-list-metrics > .dashboard-block {
+  padding: 15px 5px;
+}
 
-  .dashboard-block h1 {
-    font-size: 40px;
-    padding: 10px 0;
-  }
+/*
+ * Wrappers with status bars: no padding on wrapper so the absolute
+ * blue/red extension lines share the exact left/right edges of the card.
+ */
+.dashboard-list-metrics > .dashboard-block-wrapper {
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+}
+
+.dashboard-list-metrics > .dashboard-block-wrapper > .dashboard-block {
+  flex: 1 1 auto;
+  width: 100%;
+  max-width: 100%;
+  margin: 0;
+  padding: 15px 5px;
+  border: none;
+  border-radius: 0;
+  box-sizing: border-box;
+  min-height: 160px;
+}
+
+.dashboard-list-metrics > .dashboard-block-wrapper > .dashboard-block.dashboard-block-extended {
+  min-height: 160px;
+  padding-bottom: 44px;
+}
+
+.dashboard-list-metrics .dashboard-block-extension {
+  left: 0;
+  right: 0;
+  bottom: 0;
+  width: 100%;
+}
+
+.dashboard-list-metrics .dashboard-block h1 {
+  font-size: 40px;
+  padding: 10px 0;
 }
 
 .dashboard-list:not(.dashboard-list-metrics) > .dashboard-block,
@@ -165,6 +237,11 @@
   flex: 1 0 auto;
   position: relative;
   text-align: center;
+}
+
+.dashboard-list-metrics > .dashboard-block,
+.dashboard-list-metrics > .dashboard-block-wrapper {
+  flex: none;
 }
 
 .dashboard-live {


### PR DESCRIPTION
close : #4400

## Summary
- Make Talks dashboard metric tiles equal-width in a four-column grid and align blue/red status bars with each card’s edges.
- Keep Speaker Information edit/delete buttons side-by-side and normal height when the sidebar expands.
- Prevent long titles from crushing the actions column.

https://github.com/user-attachments/assets/fc4d333a-b165-4aef-af0a-86a50f9f8577

## Test plan
- [ ] Open Talks dashboard: all metric tiles share the same width; bottom-row tiles stay one column wide.
- [ ] Confirm sessions/speakers status bars start and end with the card edges.
- [ ] Open Speaker Information: expand sidebar and verify edit/delete buttons stay compact and horizontal.
- [ ] Check with a very long title that actions still remain usable.