### PR TITLE
fix(orga): align component link buttons and prevent overlap

### DIFF
--- a/app/eventyay/orga/templates/orga/mails/compose_choice.html
+++ b/app/eventyay/orga/templates/orga/mails/compose_choice.html
@@ -5,7 +5,7 @@
 {% block extra_title %}{% translate "Compose" %} :: {% endblock extra_title %}
 
 {% block content %}
-  <div class="d-md-flex justify-content-between">
+  <div class="d-md-flex justify-content-between align-items-center mb-2">
       <h2>{% translate "Compose emails" %}</h2>
       {% include "orga/event/component_link.html" %}
   </div>

--- a/app/eventyay/orga/templates/orga/mails/outbox_form.html
+++ b/app/eventyay/orga/templates/orga/mails/outbox_form.html
@@ -14,7 +14,7 @@
     {% endif %}
     <form method="post">
         {% csrf_token %}
-        <div class="d-md-flex justify-content-between">
+        <div class="d-md-flex justify-content-between align-items-center mb-2">
             <h2>{% translate "Mail Editor" %}</h2>
             {% include "orga/event/component_link.html" %}
         </div>

--- a/app/eventyay/orga/templates/orga/mails/outbox_list.html
+++ b/app/eventyay/orga/templates/orga/mails/outbox_list.html
@@ -10,7 +10,7 @@
 {% endblock scripts %}
 
 {% block mail_content %}
-    <div class="d-md-flex justify-content-between">
+    <div class="d-md-flex justify-content-between align-items-center mb-2">
         <h2 id="orga-mail-outbox-count" data-outbox-refresh>
             <span>
                 {{ page_obj.paginator.count }}

--- a/app/eventyay/orga/templates/orga/mails/sent_list.html
+++ b/app/eventyay/orga/templates/orga/mails/sent_list.html
@@ -3,7 +3,7 @@
 {% load i18n %}
 
 {% block mail_content %}
-    <div class="d-md-flex justify-content-between">
+    <div class="d-md-flex justify-content-between align-items-center mb-2">
         <h2>
             {{ page_obj.paginator.count }}
             {% translate "Sent emails" %}

--- a/app/eventyay/orga/templates/orga/review/assignment-import.html
+++ b/app/eventyay/orga/templates/orga/review/assignment-import.html
@@ -8,7 +8,7 @@
 {% block extra_title %}{% translate "Assign reviewers" %} :: {% endblock extra_title %}
 
 {% block content %}
-    <div class="d-md-flex justify-content-between">
+    <div class="d-md-flex justify-content-between align-items-center mb-2">
         <h2>{% translate "Assign reviewers" %}</h2>
         {% include "orga/event/component_link.html" %}
     </div>

--- a/app/eventyay/orga/templates/orga/review/assignment.html
+++ b/app/eventyay/orga/templates/orga/review/assignment.html
@@ -11,7 +11,7 @@
     {% compress js %}
         <script defer src="{% static "orga/js/reviewAssignment.js" %}"></script>
     {% endcompress %}
-    <div class="d-md-flex justify-content-between">
+    <div class="d-md-flex justify-content-between align-items-center mb-2">
         <h2>{% translate "Assign reviewers" %}</h2>
         {% include "orga/event/component_link.html" %}
     </div>

--- a/app/eventyay/orga/templates/orga/speaker/information_form.html
+++ b/app/eventyay/orga/templates/orga/speaker/information_form.html
@@ -5,7 +5,7 @@
 {% block extra_title %}{% blocktranslate trimmed count count=1 %}Speaker Information Note{% plural %}Speaker Information Notes{% endblocktranslate %} :: {% endblock extra_title %}
 
 {% block content %}
-    <div class="d-md-flex justify-content-between">
+    <div class="d-md-flex justify-content-between align-items-center mb-2">
         <h2>
             {% blocktranslate trimmed count count=1 %}
                 Speaker Information Note

--- a/app/eventyay/orga/templates/orga/speaker/information_list.html
+++ b/app/eventyay/orga/templates/orga/speaker/information_list.html
@@ -13,7 +13,7 @@
 {% block extra_title %}{{ information.count }} {% blocktranslate trimmed count count=information.count %}Speaker Information Note{% plural %}Speaker Information Notes{% endblocktranslate %} :: {% endblock extra_title %}
 
 {% block content %}
-    <div class="d-md-flex justify-content-between">
+    <div class="d-md-flex justify-content-between align-items-center mb-2">
     <h2>
         {{ information.count }}
         {% blocktranslate trimmed count count=information.count %}

--- a/app/eventyay/orga/templates/orga/speaker/list.html
+++ b/app/eventyay/orga/templates/orga/speaker/list.html
@@ -21,7 +21,7 @@
 {% endblock scripts %}
 
 {% block content %}
-    <div class="d-md-flex justify-content-between">
+    <div class="d-md-flex justify-content-between align-items-center mb-2">
         <h2>
             {{ page_obj.paginator.count }}
             {% blocktranslate trimmed count count=page_obj.paginator.count %}


### PR DESCRIPTION
This PR fixes a UI issue where the 'Talks' and 'Videos' component link buttons overlap with the grey background on the Message Center, Speakers, and Review assignment pages.

**What was happening:**
The header row (div class=d-md-flex justify-content-between) on those pages was missing the align-items-center and mb-2 classes that are present on other pages like the Sessions page. Without align-items-center, the flex container would stretch vertically to match the height of the h2 tag (which has a 0.5rem bottom margin). 

Because the 'Talks' and 'Videos' buttons use FontAwesome icons (fa-group, fa-video-camera) that render slightly taller than the icons for 'Home' and 'Tickets', their overall bounding box was slightly taller. With no bottom margin (mb-2) on the flex container, these buttons would stretch all the way down and directly touch or overlap the grey search bar (.submit-group) below them, giving the appearance that they were 'too big.'

**What I changed:**
Updated the container wrappers across all 9 affected templates to include the align-items-center mb-2 classes. This vertically centers the buttons alongside the title and adds a proper 8px bottom gap so that the buttons no longer touch or overlap the grey background.