### PR TITLE
fix(ui): always show stage and channel icons for rooms with emojis in name

### DIFF
--- a/app/eventyay/webapp/video/src/components/RoomsSidebar.vue
+++ b/app/eventyay/webapp/video/src/components/RoomsSidebar.vue
@@ -12,7 +12,7 @@ transition(name="sidebar")
 				span {{ $t('RoomsSidebar:stages-headline:text') }}
 				bunt-icon-button(v-if="hasPermission('world:rooms.create.stage')", tooltip="Create Stage", :tooltip-fixed="true", @click="showStageCreationPrompt = true") plus
 			.stages(role="group", aria-describedby="stages-title")
-				router-link.stage(v-for="stage of roomsByType.stage", :to="homeRoom && stage.room === homeRoom ? {name: 'about'} : {name: 'room', params: {roomId: stage.room.id}}", :class="{active: stage.room.id === $route.params.roomId, session: stage.session, live: stage.session && stage.room.schedule_data, 'has-image': stage.image, 'starts-with-emoji': startsWithEmoji(stage.room.name)}")
+				router-link.stage(v-for="stage of roomsByType.stage", :to="homeRoom && stage.room === homeRoom ? {name: 'about'} : {name: 'room', params: {roomId: stage.room.id}}", :class="{active: stage.room.id === $route.params.roomId, session: stage.session, live: stage.session && stage.room.schedule_data, 'has-image': stage.image}")
 					template(v-if="stage.session")
 						img.preview(v-if="stage.image", :src="stage.image")
 						.info
@@ -37,11 +37,11 @@ transition(name="sidebar")
 				bunt-icon-button(v-if="hasPermission('world:rooms.create.chat') || hasPermission('world:rooms.create.bbb')", tooltip="Create Channel", :tooltip-fixed="true", @click="showChatCreationPrompt = true") plus
 				bunt-icon-button(v-if="worldHasTextChannels", tooltip="Browse all channels", :tooltip-fixed="true", @click="showChannelBrowser = true") compass-outline
 			.chats(v-if="roomsByType.videoChat.length || roomsByType.textChat.length || hasPermission('world:rooms.create.chat') || hasPermission('world:rooms.create.bbb')", role="group", aria-describedby="chats-title")
-				router-link.video-chat(v-for="chat of roomsByType.videoChat", :to="homeRoom && chat === homeRoom ? {name: 'about'} : {name: 'room', params: {roomId: chat.id}}", :class="{active: chat.id === $route.params.roomId, 'starts-with-emoji': startsWithEmoji(chat.name)}")
+				router-link.video-chat(v-for="chat of roomsByType.videoChat", :to="homeRoom && chat === homeRoom ? {name: 'about'} : {name: 'room', params: {roomId: chat.id}}", :class="{active: chat.id === $route.params.roomId}")
 					.room-icon(aria-hidden="true")
 					.name(v-html="$emojify(chat.name)")
 					i.bunt-icon.activity-icon.mdi(v-if="chat.users === 'many' || chat.users === 'few'", :class="{'mdi-account-group': (chat.users === 'many'), 'mdi-account-multiple': (chat.users === 'few')}", v-tooltip.bottom.fixed="{text: $t('RoomsSidebar:users-tooltip:' + chat.users)}", :aria-label="$t('RoomsSidebar:users-tooltip:' + chat.users)")
-				router-link.text-chat(v-for="chat of roomsByType.textChat", :to="homeRoom && chat.room === homeRoom ? {name: 'about'} : {name: 'room', params: {roomId: chat.room.id}}", :class="{unread: hasUnreadMessages(chat.room.modules[0].channel_id), 'starts-with-emoji': startsWithEmoji(chat.room.name)}")
+				router-link.text-chat(v-for="chat of roomsByType.textChat", :to="homeRoom && chat.room === homeRoom ? {name: 'about'} : {name: 'room', params: {roomId: chat.room.id}}", :class="{unread: hasUnreadMessages(chat.room.modules[0].channel_id)}")
 					.room-icon(aria-hidden="true")
 					.name(v-html="$emojify(chat.room.name)")
 					.notifications(v-if="chat.notifications") {{ chat.notifications }}
@@ -84,7 +84,6 @@ transition(name="sidebar")
 <script>
 import { mapState, mapGetters } from 'vuex'
 import theme from 'theme'
-import { startsWithEmoji } from 'lib/emoji'
 import { inferRoomType, inferType } from 'lib/room-types'
 import Avatar from 'components/Avatar'
 import ChannelBrowser from 'components/ChannelBrowser'
@@ -212,9 +211,6 @@ export default {
 	methods: {
 		getDMChannelName(channel) {
 			return channel.users.map(user => user.deleted ? this.$t('User:label:deleted') : user.profile.display_name).join(', ')
-		},
-		startsWithEmoji(string) {
-			return startsWithEmoji(string)
 		},
 		onPointerdown(event) {
 			// Begin tracking pointer for potential swipe-to-close gesture universally
@@ -345,30 +341,6 @@ export default {
 				&::before
 					line-height: 32px
 
-			&.starts-with-emoji
-				padding: 0 18px
-				// .room-icon
-				// 	position: absolute
-				// 	width: 18px
-				// 	height: @width
-				// 	left: 18px
-				// 	background-color: var(--clr-sidebar)
-				// 	border-radius: 50%
-				// 	&::before
-				// 		display: block
-				// 		height: 18px
-				// 		width: 18px
-				// 		line-height: @height
-				// 		font-size: 14px
-				// 		margin: 0 auto
-				// .room-icon
-				// 	width: 10px
-				// .name
-				// 	background-color: var(--clr-sidebar)
-				// 	padding-left: 3px
-				// 	border-radius: 18px
-				.room-icon
-					display: none
 			&.unread
 				color: var(--clr-sidebar-text-primary)
 				font-weight: 500


### PR DESCRIPTION
Close : #4406

Fixes an issue where rooms with emojis in their name did not show the stage or channel icons in the sidebar. This was caused by a CSS class that hid the icon for these rooms.

<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/2407478f-32b9-474c-8e71-255002b8448f" />
