### PR TITLE
Fix BBB rooms being treated as schedule-driven stages

### DIFF
--- a/app/eventyay/webapp/video/src/lib/stage-streams.js
+++ b/app/eventyay/webapp/video/src/lib/stage-streams.js
@@ -22,6 +22,11 @@ export const PLAYBACK_MODE_OPTIONS = [
 ]
 
 const PLAYBACK_MODES = new Set([PLAYBACK_MODE_ALWAYS_ON, PLAYBACK_MODE_SCHEDULE_DRIVEN])
+const STAGE_MODULE_TYPES = new Set([
+	'livestream.native',
+	'livestream.youtube',
+	'livestream.iframe',
+])
 
 export const STREAM_SOURCE_OPTIONS = [
 	{ id: STREAM_TYPE_HLS, label: 'HLS', module: 'livestream.native' },
@@ -38,6 +43,7 @@ export function getStreamSourceOptions() {
 
 export function getStagePlaybackMode(module) {
 	if (!module) return PLAYBACK_MODE_ALWAYS_ON
+	if (!STAGE_MODULE_TYPES.has(module.type)) return PLAYBACK_MODE_ALWAYS_ON
 
 	const config = module.config || {}
 	if (PLAYBACK_MODES.has(config.playback_mode)) return config.playback_mode


### PR DESCRIPTION
 ## Summary
  - prevent BigBlueButton rooms from being classified as schedule-driven stages
  - keep playback-mode inference limited to actual livestream modules
  - restore the frontend `bbb.room_url` request for BBB rooms without stream schedule data

  ## Problem
  BBB room joins could fail before reaching the backend because the frontend treated `call.bigbluebutton` modules as schedule-driven stages.

  When there was no active stream schedule, the media source never entered the BBB branch, so no `bbb.room_url` socket call was sent. That made the issue look like a BBB/server problem even though the frontend never actually requested a BBB join URL.

  ## Root Cause
  `getStagePlaybackMode()` defaulted unknown module types to `schedule_driven`. That logic is correct for stage/livestream modules, but not for BBB rooms.

  As a result, `MediaSource.vue` could skip the `call.bigbluebutton` path entirely for BBB rooms with no active scheduled stream.

  ## Fix
  Limit stage playback-mode inference to actual stage modules only:
  - `livestream.native`
  - `livestream.youtube`
  - `livestream.iframe`

  Non-stage modules such as `call.bigbluebutton` now default to `always_on`, allowing the frontend to correctly emit `bbb.room_url`.

  ## Testing
  - reproduced from browser console traces where `room.enter` succeeded but no `bbb.room_url` socket call was emitted
  - verified the fix logically restores the BBB join path
  - automated tests not run


https://github.com/user-attachments/assets/40d52418-85ba-4661-b349-a11fda562516

