### PR TITLE
fix(checkin): update check-in list counts immediately after revert

### DIFF
--- a/app/eventyay/control/views/checkin.py
+++ b/app/eventyay/control/views/checkin.py
@@ -157,6 +157,7 @@ class CheckInListShow(EventPermissionRequiredMixin, PaginationMixin, ListView):
                     )
                     op.order.touch()
 
+            self.list.touch()
             messages.success(request, _('The selected check-ins have been reverted.'))
         else:
             for op in positions:

--- a/app/tests/tickets/control/test_checkins.py
+++ b/app/tests/tickets/control/test_checkins.py
@@ -338,10 +338,12 @@ def test_manual_checkins_revert(client, checkin_list_env):
         '/control/event/dummy/dummy/checkinlists/{}/'.format(checkin_list_env[6].pk),
         {'checkin': [checkin_list_env[5][3].pk]},
     )
+    assert checkin_list_env[6].checkin_count == 3
     client.post(
         '/control/event/dummy/dummy/checkinlists/{}/'.format(checkin_list_env[6].pk),
         {'checkin': [checkin_list_env[5][3].pk], 'revert': 'true'},
     )
+    assert checkin_list_env[6].checkin_count == 2
     with scopes_disabled():
         assert not checkin_list_env[5][3].checkins.exists()
     assert LogEntry.objects.filter(


### PR DESCRIPTION
Close : #4416

## Summary
- Bulk reverting check-ins left stale `checkin_count` values on `/control/event/.../checkinlists/` because list totals are cached for 60s and `QuerySet.delete()` does not run model `delete()` / `touch()`.
- Call `self.list.touch()` after bulk revert so the progress numbers refresh immediately.
- Extend the existing revert test with count assertions that cover the cache invalidation path.

## Test plan
- [ ] Open a check-in list, check in some attendees, then open `/control/event/<org>/<event>/checkinlists/` and note the Checked in totals
- [ ] Select checked-in (and mixed) attendees and click **Revert selected check-ins**
- [ ] Return to the check-in lists page and confirm the Checked in number updates immediately (no wait for cache expiry)
- [ ] Re-run a check-in and confirm normal check-in still increments the count as before


## Before 

https://github.com/user-attachments/assets/7eb7b1f0-787a-4ef0-a7af-d88ba45d3a04

## After 

https://github.com/user-attachments/assets/d2d2533a-6c23-4553-ad9a-cd749554b121
