### PR TITLE
Chore: badge generation performance fix

### DIFF
--- a/app/eventyay/base/pdf.py
+++ b/app/eventyay/base/pdf.py
@@ -105,7 +105,7 @@ DEFAULT_VARIABLES = OrderedDict(
                 'label': _('Product name and variation'),
                 'editor_sample': _('Sample product – sample variation'),
                 'evaluate': lambda orderposition, order, event: (
-                    '{} - {}'.format(orderposition.product.name, orderposition.variation)
+                    f'{orderposition.product.name} - {orderposition.variation}'
                     if orderposition.variation
                     else str(orderposition.product.name)
                 ),
@@ -157,8 +157,9 @@ DEFAULT_VARIABLES = OrderedDict(
             {
                 'label': _('Attendee name'),
                 'editor_sample': _('John Doe'),
-                'evaluate': lambda op, order, ev: op.attendee_name
-                or (op.addon_to.attendee_name if op.addon_to else ''),
+                'evaluate': lambda op, order, ev: (
+                    op.attendee_name or (op.addon_to.attendee_name if op.addon_to else '')
+                ),
             },
         ),
         (
@@ -222,8 +223,10 @@ DEFAULT_VARIABLES = OrderedDict(
             {
                 'label': _('Attendee country'),
                 'editor_sample': 'Atlantis',
-                'evaluate': lambda op, order, ev: str(getattr(op.country, 'name', ''))
-                or (str(getattr(op.addon_to.country, 'name', '')) if op.addon_to else ''),
+                'evaluate': lambda op, order, ev: (
+                    str(getattr(op.country, 'name', ''))
+                    or (str(getattr(op.addon_to.country, 'name', '')) if op.addon_to else '')
+                ),
             },
         ),
         (
@@ -231,8 +234,9 @@ DEFAULT_VARIABLES = OrderedDict(
             {
                 'label': _('Attendee email'),
                 'editor_sample': 'foo@bar.com',
-                'evaluate': lambda op, order, ev: op.attendee_email
-                or (op.addon_to.attendee_email if op.addon_to else ''),
+                'evaluate': lambda op, order, ev: (
+                    op.attendee_email or (op.addon_to.attendee_email if op.addon_to else '')
+                ),
             },
         ),
         (
@@ -272,12 +276,14 @@ DEFAULT_VARIABLES = OrderedDict(
             {
                 'label': _('Event begin date and time'),
                 'editor_sample': _('2017-05-31 20:00'),
-                'evaluate': lambda op, order, ev: date_format(
-                    ev.date_from.astimezone(timezone(ev.settings.timezone)),
-                    'SHORT_DATETIME_FORMAT',
-                )
-                if ev.date_from
-                else '',
+                'evaluate': lambda op, order, ev: (
+                    date_format(
+                        ev.date_from.astimezone(timezone(ev.settings.timezone)),
+                        'SHORT_DATETIME_FORMAT',
+                    )
+                    if ev.date_from
+                    else ''
+                ),
             },
         ),
         (
@@ -285,12 +291,14 @@ DEFAULT_VARIABLES = OrderedDict(
             {
                 'label': _('Event begin date'),
                 'editor_sample': _('2017-05-31'),
-                'evaluate': lambda op, order, ev: date_format(
-                    ev.date_from.astimezone(timezone(ev.settings.timezone)),
-                    'SHORT_DATE_FORMAT',
-                )
-                if ev.date_from
-                else '',
+                'evaluate': lambda op, order, ev: (
+                    date_format(
+                        ev.date_from.astimezone(timezone(ev.settings.timezone)),
+                        'SHORT_DATE_FORMAT',
+                    )
+                    if ev.date_from
+                    else ''
+                ),
             },
         ),
         (
@@ -306,12 +314,14 @@ DEFAULT_VARIABLES = OrderedDict(
             {
                 'label': _('Event end date and time'),
                 'editor_sample': _('2017-05-31 22:00'),
-                'evaluate': lambda op, order, ev: date_format(
-                    ev.date_to.astimezone(timezone(ev.settings.timezone)),
-                    'SHORT_DATETIME_FORMAT',
-                )
-                if ev.date_to
-                else '',
+                'evaluate': lambda op, order, ev: (
+                    date_format(
+                        ev.date_to.astimezone(timezone(ev.settings.timezone)),
+                        'SHORT_DATETIME_FORMAT',
+                    )
+                    if ev.date_to
+                    else ''
+                ),
             },
         ),
         (
@@ -319,12 +329,14 @@ DEFAULT_VARIABLES = OrderedDict(
             {
                 'label': _('Event end date'),
                 'editor_sample': _('2017-05-31'),
-                'evaluate': lambda op, order, ev: date_format(
-                    ev.date_to.astimezone(timezone(ev.settings.timezone)),
-                    'SHORT_DATE_FORMAT',
-                )
-                if ev.date_to
-                else '',
+                'evaluate': lambda op, order, ev: (
+                    date_format(
+                        ev.date_to.astimezone(timezone(ev.settings.timezone)),
+                        'SHORT_DATE_FORMAT',
+                    )
+                    if ev.date_to
+                    else ''
+                ),
             },
         ),
         (
@@ -332,11 +344,11 @@ DEFAULT_VARIABLES = OrderedDict(
             {
                 'label': _('Event end time'),
                 'editor_sample': _('22:00'),
-                'evaluate': lambda op, order, ev: date_format(
-                    ev.date_to.astimezone(timezone(ev.settings.timezone)), 'TIME_FORMAT'
-                )
-                if ev.date_to
-                else '',
+                'evaluate': lambda op, order, ev: (
+                    date_format(ev.date_to.astimezone(timezone(ev.settings.timezone)), 'TIME_FORMAT')
+                    if ev.date_to
+                    else ''
+                ),
             },
         ),
         (
@@ -344,12 +356,14 @@ DEFAULT_VARIABLES = OrderedDict(
             {
                 'label': _('Event admission date and time'),
                 'editor_sample': _('2017-05-31 19:00'),
-                'evaluate': lambda op, order, ev: date_format(
-                    ev.date_admission.astimezone(timezone(ev.settings.timezone)),
-                    'SHORT_DATETIME_FORMAT',
-                )
-                if ev.date_admission
-                else '',
+                'evaluate': lambda op, order, ev: (
+                    date_format(
+                        ev.date_admission.astimezone(timezone(ev.settings.timezone)),
+                        'SHORT_DATETIME_FORMAT',
+                    )
+                    if ev.date_admission
+                    else ''
+                ),
             },
         ),
         (
@@ -357,12 +371,14 @@ DEFAULT_VARIABLES = OrderedDict(
             {
                 'label': _('Event admission time'),
                 'editor_sample': _('19:00'),
-                'evaluate': lambda op, order, ev: date_format(
-                    ev.date_admission.astimezone(timezone(ev.settings.timezone)),
-                    'TIME_FORMAT',
-                )
-                if ev.date_admission
-                else '',
+                'evaluate': lambda op, order, ev: (
+                    date_format(
+                        ev.date_admission.astimezone(timezone(ev.settings.timezone)),
+                        'TIME_FORMAT',
+                    )
+                    if ev.date_admission
+                    else ''
+                ),
             },
         ),
         (
@@ -394,9 +410,9 @@ DEFAULT_VARIABLES = OrderedDict(
             {
                 'label': _('Invoice address name'),
                 'editor_sample': _('John Doe'),
-                'evaluate': lambda op, order, ev: order.invoice_address.name
-                if getattr(order, 'invoice_address', None)
-                else '',
+                'evaluate': lambda op, order, ev: (
+                    order.invoice_address.name if getattr(order, 'invoice_address', None) else ''
+                ),
             },
         ),
         (
@@ -404,9 +420,9 @@ DEFAULT_VARIABLES = OrderedDict(
             {
                 'label': _('Invoice address company'),
                 'editor_sample': _('Sample company'),
-                'evaluate': lambda op, order, ev: order.invoice_address.company
-                if getattr(order, 'invoice_address', None)
-                else '',
+                'evaluate': lambda op, order, ev: (
+                    order.invoice_address.company if getattr(order, 'invoice_address', None) else ''
+                ),
             },
         ),
         (
@@ -414,9 +430,9 @@ DEFAULT_VARIABLES = OrderedDict(
             {
                 'label': _('Invoice address street'),
                 'editor_sample': _('Sesame Street 42'),
-                'evaluate': lambda op, order, ev: order.invoice_address.street
-                if getattr(order, 'invoice_address', None)
-                else '',
+                'evaluate': lambda op, order, ev: (
+                    order.invoice_address.street if getattr(order, 'invoice_address', None) else ''
+                ),
             },
         ),
         (
@@ -424,9 +440,9 @@ DEFAULT_VARIABLES = OrderedDict(
             {
                 'label': _('Invoice address ZIP code'),
                 'editor_sample': _('12345'),
-                'evaluate': lambda op, order, ev: order.invoice_address.zipcode
-                if getattr(order, 'invoice_address', None)
-                else '',
+                'evaluate': lambda op, order, ev: (
+                    order.invoice_address.zipcode if getattr(order, 'invoice_address', None) else ''
+                ),
             },
         ),
         (
@@ -434,9 +450,9 @@ DEFAULT_VARIABLES = OrderedDict(
             {
                 'label': _('Invoice address city'),
                 'editor_sample': _('Sample city'),
-                'evaluate': lambda op, order, ev: order.invoice_address.city
-                if getattr(order, 'invoice_address', None)
-                else '',
+                'evaluate': lambda op, order, ev: (
+                    order.invoice_address.city if getattr(order, 'invoice_address', None) else ''
+                ),
             },
         ),
         (
@@ -444,9 +460,9 @@ DEFAULT_VARIABLES = OrderedDict(
             {
                 'label': _('Invoice address state'),
                 'editor_sample': _('Sample State'),
-                'evaluate': lambda op, order, ev: order.invoice_address.state
-                if getattr(order, 'invoice_address', None)
-                else '',
+                'evaluate': lambda op, order, ev: (
+                    order.invoice_address.state if getattr(order, 'invoice_address', None) else ''
+                ),
             },
         ),
         (
@@ -454,9 +470,11 @@ DEFAULT_VARIABLES = OrderedDict(
             {
                 'label': _('Invoice address country'),
                 'editor_sample': _('Atlantis'),
-                'evaluate': lambda op, order, ev: str(getattr(order.invoice_address.country, 'name', ''))
-                if getattr(order, 'invoice_address', None)
-                else '',
+                'evaluate': lambda op, order, ev: (
+                    str(getattr(order.invoice_address.country, 'name', ''))
+                    if getattr(order, 'invoice_address', None)
+                    else ''
+                ),
             },
         ),
         (
@@ -466,7 +484,7 @@ DEFAULT_VARIABLES = OrderedDict(
                 'editor_sample': _('Add-on 1\nAdd-on 2'),
                 'evaluate': lambda op, order, ev: '\n'.join(
                     [
-                        '{} - {}'.format(p.product, p.variation) if p.variation else str(p.product)
+                        f'{p.product} - {p.variation}' if p.variation else str(p.product)
                         for p in (
                             op.addons.all()
                             if 'addons' in getattr(op, '_prefetched_objects_cache', {})
@@ -528,11 +546,11 @@ DEFAULT_VARIABLES = OrderedDict(
             {
                 'label': _('Printing time'),
                 'editor_sample': _('19:00'),
-                'evaluate': lambda op, order, ev: date_format(
-                    now().astimezone(timezone(ev.settings.timezone)), 'TIME_FORMAT'
-                )
-                if ev.date_admission
-                else '',
+                'evaluate': lambda op, order, ev: (
+                    date_format(now().astimezone(timezone(ev.settings.timezone)), 'TIME_FORMAT')
+                    if ev.date_admission
+                    else ''
+                ),
             },
         ),
         (
@@ -614,7 +632,7 @@ def images_from_questions(sender, *args, **kwargs):
     for q in sender.questions.all():
         if q.type != Question.TYPE_FILE:
             continue
-        d['question_{}'.format(q.identifier)] = {
+        d[f'question_{q.identifier}'] = {
             'label': _('Question: {question}').format(question=q.question),
             'evaluate': partial(get_answer, question_id=q.pk, etag=False),
             'etag': partial(get_answer, question_id=q.pk, etag=True),
@@ -652,7 +670,7 @@ def variables_from_questions(sender, *args, **kwargs):
     for q in sender.questions.all():
         if q.type == Question.TYPE_FILE:
             continue
-        d['question_{}'.format(q.pk)] = {
+        d[f'question_{q.pk}'] = {
             'label': _('Question: {question}').format(question=q.question),
             'editor_sample': str(q.question),
             'evaluate': partial(get_answer, question_id=q.pk),
@@ -753,14 +771,23 @@ class Renderer:
         content = o.get('content', 'dark')
         if content not in ('dark', 'white'):
             content = 'dark'
-        img = finders.find('pretixpresale/pdf/powered_by_eventyay_{}.png'.format(content))
 
-        ir = ThumbnailingImageReader(img)
-        try:
-            width, height = ir.resize(None, float(o['size']) * mm, 300)
-        except Exception:
-            logger.exception('Can not resize image')
-            pass
+        cache_key = f'poweredby_{content}_{o.get("size")}'
+        if not hasattr(self, '_image_cache'):
+            self._image_cache = {}
+
+        if cache_key in self._image_cache:
+            ir, width, height = self._image_cache[cache_key]
+        else:
+            img = finders.find(f'pretixpresale/pdf/powered_by_eventyay_{content}.png')
+            ir = ThumbnailingImageReader(img)
+            try:
+                width, height = ir.resize(None, float(o['size']) * mm, 300)
+            except Exception:
+                logger.exception('Can not resize image')
+                width, height = float(o['size']) * mm, float(o['size']) * mm
+            self._image_cache[cache_key] = (ir, width, height)
+
         canvas.drawImage(
             ir,
             float(o['left']) * mm,
@@ -834,12 +861,29 @@ class Renderer:
                 image_file = None
 
         if image_file:
-            ir = ThumbnailingImageReader(image_file)
-            try:
-                ir.resize(float(o['width']) * mm, float(o['height']) * mm, 300)
-            except Exception:
-                logger.exception('Can not resize image')
-                pass
+            # Only cache images that expose a stable, unique file name (e.g. Django
+            # FieldFile objects backed by real storage paths, like uploaded attendee
+            # photos or organizer logos). Per-attendee content varies by file identity,
+            # so this still caches correctly across positions that share the same file,
+            # while never risking a stale/incorrect image for content we can't identify.
+            file_name = getattr(image_file, 'name', None)
+            cache_key = f'imagearea_{file_name}_{o.get("width")}_{o.get("height")}' if file_name else None
+
+            if not hasattr(self, '_image_cache'):
+                self._image_cache = {}
+
+            if cache_key and cache_key in self._image_cache:
+                ir = self._image_cache[cache_key]
+            else:
+                ir = ThumbnailingImageReader(image_file)
+                try:
+                    ir.resize(float(o['width']) * mm, float(o['height']) * mm, 300)
+                except Exception:
+                    logger.exception('Can not resize image')
+                    pass
+                if cache_key:
+                    self._image_cache[cache_key] = ir
+
             canvas.drawImage(
                 image=ir,
                 x=float(o['left']) * mm,
@@ -863,6 +907,16 @@ class Renderer:
             )
             canvas.restoreState()
 
+    @classmethod
+    def _get_reshaper(cls):
+        if not hasattr(cls, '_reshaper_instance'):
+            configuration = {
+                'delete_harakat': True,
+                'support_ligatures': False,
+            }
+            cls._reshaper_instance = ArabicReshaper(configuration=configuration)
+        return cls._reshaper_instance
+
     def _draw_textarea(self, canvas: Canvas, op: OrderPosition, order: Order, o: dict):
         font = o['fontfamily']
         if o['bold']:
@@ -870,31 +924,36 @@ class Renderer:
         if o['italic']:
             font += ' I'
 
-        align_map = {'left': TA_LEFT, 'center': TA_CENTER, 'right': TA_RIGHT}
-        style = ParagraphStyle(
-            name=uuid.uuid4().hex,
-            fontName=font,
-            fontSize=float(o['fontsize']),
-            leading=float(o['fontsize']),
-            autoLeading='max',
-            textColor=Color(o['color'][0] / 255, o['color'][1] / 255, o['color'][2] / 255),
-            alignment=align_map[o['align']],
-        )
+        if not hasattr(self, '_style_cache'):
+            self._style_cache = {}
+
+        style_key = (font, o['fontsize'], tuple(o['color']), o['align'])
+        if style_key in self._style_cache:
+            style = self._style_cache[style_key]
+        else:
+            align_map = {'left': TA_LEFT, 'center': TA_CENTER, 'right': TA_RIGHT}
+            style = ParagraphStyle(
+                name=uuid.uuid4().hex,
+                fontName=font,
+                fontSize=float(o['fontsize']),
+                leading=float(o['fontsize']),
+                autoLeading='max',
+                textColor=Color(o['color'][0] / 255, o['color'][1] / 255, o['color'][2] / 255),
+                alignment=align_map[o['align']],
+            )
+            self._style_cache[style_key] = style
+
         text = conditional_escape(
             self._get_text_content(op, order, o) or '',
         ).replace('\n', '<br/>\n')
 
         # reportlab does not support RTL, ligature-heavy scripts like Arabic. Therefore, we use ArabicReshaper
         # to resolve all ligatures and python-bidi to switch RTL texts.
-        configuration = {
-            'delete_harakat': True,
-            'support_ligatures': False,
-        }
-        reshaper = ArabicReshaper(configuration=configuration)
+        reshaper = self._get_reshaper()
         try:
             text = '<br/>'.join(get_display(reshaper.reshape(l)) for l in text.split('<br/>'))
         except Exception:
-            logger.exception('Reshaping/Bidi fixes failed on string {}'.format(repr(text)))
+            logger.exception(f'Reshaping/Bidi fixes failed on string {repr(text)}')
 
         p = Paragraph(text, style=style)
         w, h = p.wrapOn(canvas, float(o['width']) * mm, 1000 * mm)
@@ -1004,10 +1063,11 @@ def correct_page_media_box(page):
             rect = RectangleObject(page[box])
             pt1 = trsf.apply_on(rect.lower_left)
             pt2 = trsf.apply_on(rect.upper_right)
-            page[NameObject(box)] = RectangleObject((
-                min(pt1[0], pt2[0]),
-                min(pt1[1], pt2[1]),
-                max(pt1[0], pt2[0]),
-                max(pt1[1], pt2[1]),
-            ))
-
+            page[NameObject(box)] = RectangleObject(
+                (
+                    min(pt1[0], pt2[0]),
+                    min(pt1[1], pt2[1]),
+                    max(pt1[0], pt2[0]),
+                    max(pt1[1], pt2[1]),
+                )
+            )

--- a/app/eventyay/base/services/tickets.py
+++ b/app/eventyay/base/services/tickets.py
@@ -21,11 +21,18 @@ from eventyay.base.signals import allow_ticket_download, register_ticket_outputs
 from eventyay.celery_app import app
 from eventyay.helpers.database import rolledback_transaction
 
+
 logger = logging.getLogger(__name__)
 
 
 def generate_orderposition(order_position: int, provider: str):
-    order_position = OrderPosition.objects.select_related('order', 'order__event').get(id=order_position)
+    order_position = (
+        OrderPosition.objects.select_related(
+            'order', 'order__event', 'order__invoice_address', 'product', 'variation', 'addon_to', 'subevent', 'seat'
+        )
+        .prefetch_related('answers', 'answers__question', 'answers__options')
+        .get(id=order_position)
+    )
 
     with language(order_position.order.locale, order_position.order.event.settings.region):
         responses = register_ticket_outputs.send(order_position.order.event)
@@ -48,7 +55,7 @@ def generate_orderposition(order_position: int, provider: str):
 
 
 def generate_order(order: int, provider: str):
-    order = Order.objects.select_related('event').get(id=order)
+    order = Order.objects.select_related('event', 'invoice_address').get(id=order)
 
     with language(order.locale, order.event.settings.region):
         responses = register_ticket_outputs.send(order.event)
@@ -168,12 +175,7 @@ def get_tickets_for_order(order, base_position=None):
                     ct = CachedCombinedTicket.objects.get(pk=retval)
                 tickets.append(
                     (
-                        '{}-{}-{}{}'.format(
-                            order.event.slug.upper(),
-                            order.code,
-                            ct.provider,
-                            ct.extension,
-                        ),
+                        f'{order.event.slug.upper()}-{order.code}-{ct.provider}{ct.extension}',
                         ct,
                     )
                 )
@@ -205,13 +207,7 @@ def get_tickets_for_order(order, base_position=None):
                             ct.extension,
                         )
                     else:
-                        fname = '{}-{}-{}-{}{}'.format(
-                            order.event.slug.upper(),
-                            order.code,
-                            pos.positionid,
-                            ct.provider,
-                            ct.extension,
-                        )
+                        fname = f'{order.event.slug.upper()}-{order.code}-{pos.positionid}-{ct.provider}{ct.extension}'
                     tickets.append((fname, ct))
                 except:
                     logger.exception('Failed to generate ticket.')

--- a/app/eventyay/plugins/badges/api.py
+++ b/app/eventyay/plugins/badges/api.py
@@ -11,7 +11,7 @@ from eventyay.base.models import CachedFile, OrderPosition
 from eventyay.base.services.tickets import generate_orderposition
 
 from .apps import PDFRenderer
-from .models import BadgeProduct, BadgeLayout
+from .models import BadgeLayout, BadgeProduct
 
 
 class BadgeProductAssignmentSerializer(I18nAwareModelSerializer):
@@ -104,7 +104,16 @@ class BadgeDownloadView(APIView):
     def get(self, request, organizer, event, position):
         try:
             op = get_object_or_404(
-                OrderPosition,
+                OrderPosition.objects.select_related(
+                    'order',
+                    'order__event',
+                    'order__invoice_address',
+                    'product',
+                    'variation',
+                    'addon_to',
+                    'subevent',
+                    'seat',
+                ).prefetch_related('answers', 'answers__question', 'answers__options'),
                 order__event__slug=event,
                 order__event__organizer__slug=organizer,
                 pk=position,
@@ -118,6 +127,25 @@ class BadgeDownloadView(APIView):
                 )
 
             # Check if there's already a cached file
+            from eventyay.base.models import CachedTicket
+
+            cached_ticket = CachedTicket.objects.filter(order_position=op, provider='badge').last()
+
+            if cached_ticket and cached_ticket.file:
+                import os
+
+                base64_pdf = base64.b64encode(cached_ticket.file.read()).decode('utf-8')
+                filename = (
+                    os.path.basename(cached_ticket.file.name) if cached_ticket.file.name else f'badge_{position}.pdf'
+                )
+                return Response(
+                    {
+                        'filename': filename,
+                        'type': 'application/pdf',
+                        'base64_pdf': base64_pdf,
+                    }
+                )
+
             cached_file = CachedFile.objects.filter(
                 filename__startswith=f'badge_{position}_', expires__isnull=True
             ).last()

--- a/app/eventyay/plugins/badges/exporters.py
+++ b/app/eventyay/plugins/badges/exporters.py
@@ -27,7 +27,7 @@ from eventyay.base.models import Order, OrderPosition
 from eventyay.base.pdf import Renderer
 from eventyay.base.services.orders import OrderError
 from eventyay.base.settings import PERSON_NAME_SCHEMES
-from eventyay.plugins.badges.models import BadgeProduct
+from eventyay.plugins.badges.models import BadgeLayout, BadgeProduct
 from eventyay.plugins.badges.utils import (
     _renderer_cache,
     get_badge_hidden_fields,
@@ -365,9 +365,17 @@ def render_nup(input_files: list[str], num_pages: int, output_file: BinaryIO, op
 def render_badges(event, positions, opt, apply_output_pagesize=False):
     from itertools import groupby
 
-    from eventyay.plugins.badges.utils import get_badge_layout_assignment_map
+    # Resolve product→layout assignments fresh on every render so explicit "no badge"
+    # assignments (layout=None) and recent assignment changes are always respected.
+    assignment_map = {
+        assignment.product_id: assignment.layout
+        for assignment in BadgeProduct.objects.select_related('layout').filter(product__event=event)
+    }
+    try:
+        default_layout = event.badge_layouts.get(default=True)
+    except BadgeLayout.DoesNotExist:
+        default_layout = None
 
-    assignment_map, default_layout = get_badge_layout_assignment_map(event)
     # Fetched once per render call (not per position) to avoid a cache round-trip per
     # badge, while still guaranteeing that every render reflects the latest saved design.
     version = get_badge_layout_version(event)

--- a/app/eventyay/plugins/badges/exporters.py
+++ b/app/eventyay/plugins/badges/exporters.py
@@ -1,19 +1,17 @@
-import json
 import os
 import tempfile
 from collections import OrderedDict
 from decimal import Decimal
 from io import BytesIO
-from typing import BinaryIO, List, Tuple
-
 from pathlib import Path
+from typing import BinaryIO
 
 from django import forms
 from django.conf import settings
 from django.contrib.staticfiles import finders
 from django.core.files import File
 from django.core.files.storage import default_storage
-from django.db.models import Exists, OuterRef, Q
+from django.db.models import Exists, OuterRef
 from django.db.models.functions import Coalesce
 from django.utils.translation import gettext as _
 from django.utils.translation import gettext_lazy
@@ -29,8 +27,13 @@ from eventyay.base.models import Order, OrderPosition
 from eventyay.base.pdf import Renderer
 from eventyay.base.services.orders import OrderError
 from eventyay.base.settings import PERSON_NAME_SCHEMES
-from eventyay.plugins.badges.models import BadgeProduct, BadgeLayout
-from eventyay.plugins.badges.utils import get_badge_hidden_fields, normalize_badge_content_key
+from eventyay.plugins.badges.models import BadgeProduct
+from eventyay.plugins.badges.utils import (
+    _renderer_cache,
+    get_badge_hidden_fields,
+    get_badge_layout_version,
+    normalize_badge_content_key,
+)
 
 from ...helpers.templatetags.jsonfield import JSONExtract
 
@@ -96,16 +99,25 @@ def _open_layout_background(layout):
     return open(finders.find('pretixplugins/badges/badge_default_a6l.pdf'), 'rb')
 
 
-def _renderer(event, layout):
+def _renderer(event, layout, version):
     if layout is None:
         return None
+
+    cache_key = (event.pk, layout.pk)
+    if cache_key in _renderer_cache:
+        cached_version, renderer = _renderer_cache[cache_key]
+        if cached_version == version:
+            return renderer
+
     bgf = _open_layout_background(layout)
-    return BadgeRenderer(
+    renderer = BadgeRenderer(
         event,
         layout.layout_data,
         bgf,
         ask_user_fields=(layout.ask_user_fields_data if layout.allow_customization else []),
     )
+    _renderer_cache[cache_key] = (version, renderer)
+    return renderer
 
 
 OPTIONS = OrderedDict(
@@ -286,18 +298,20 @@ def render_nup_page(nup_pdf: PdfWriter, input_pages, opt: dict):
     return nup_page
 
 
-def merge_pages(file_paths: List[str], output_file: BinaryIO):
+def merge_pages(file_paths: list[str], output_file: BinaryIO):
     merger = PdfWriter()
-    merger.add_metadata({
-        '/Title': 'Badges',
-        '/Creator': 'eventyay',
-    })
+    merger.add_metadata(
+        {
+            '/Title': 'Badges',
+            '/Creator': 'eventyay',
+        }
+    )
     for pdf in file_paths:
         merger.append(pdf)
     merger.write(output_file)
 
 
-def render_nup(input_files: List[str], num_pages: int, output_file: BinaryIO, opt: dict):
+def render_nup(input_files: list[str], num_pages: int, output_file: BinaryIO, opt: dict):
     badges_per_page = opt['cols'] * opt['rows']
     max_nup_pages = 20
     nup_pdf_files = []
@@ -320,10 +334,12 @@ def render_nup(input_files: List[str], num_pages: int, output_file: BinaryIO, op
                 chunk.append(badges_pdf.pages[j - offset])
 
             nup_pdf = PdfWriter()
-            nup_pdf.add_metadata({
-                '/Title': 'Badges',
-                '/Creator': 'eventyay',
-            })
+            nup_pdf.add_metadata(
+                {
+                    '/Title': 'Badges',
+                    '/Creator': 'eventyay',
+                }
+            )
 
             for page_chunk in chunks(chunk, badges_per_page):
                 render_nup_page(nup_pdf, page_chunk, opt)
@@ -347,36 +363,47 @@ def render_nup(input_files: List[str], num_pages: int, output_file: BinaryIO, op
 
 
 def render_badges(event, positions, opt, apply_output_pagesize=False):
-    renderermap = {
-        bi.product_id: _renderer(event, bi.layout)
-        for bi in BadgeProduct.objects.select_related('layout').filter(product__event=event)
-    }
-    try:
-        default_renderer = _renderer(event, event.badge_layouts.get(default=True))
-    except BadgeLayout.DoesNotExist:
-        default_renderer = None
+    from itertools import groupby
 
-    op_renderers = [
-        (op, renderermap.get(op.product_id, default_renderer))
-        for op in positions
-        if renderermap.get(op.product_id, default_renderer)
-    ]
+    from eventyay.plugins.badges.utils import get_badge_layout_assignment_map
+
+    assignment_map, default_layout = get_badge_layout_assignment_map(event)
+    # Fetched once per render call (not per position) to avoid a cache round-trip per
+    # badge, while still guaranteeing that every render reflects the latest saved design.
+    version = get_badge_layout_version(event)
+
+    op_renderers = []
+    for op in positions:
+        layout = assignment_map.get(op.product_id, default_layout)
+        if layout is not None:
+            renderer = _renderer(event, layout, version)
+            if renderer:
+                op_renderers.append((op, renderer))
+
     if not op_renderers:
         raise OrderError(_('None of the selected products is configured to print badges.'))
 
     badge_pdf = PdfWriter()
-    badge_pdf.add_metadata({
-        '/Title': 'Badges',
-        '/Creator': 'eventyay',
-    })
-    for op, renderer in op_renderers:
+    badge_pdf.add_metadata(
+        {
+            '/Title': 'Badges',
+            '/Creator': 'eventyay',
+        }
+    )
+
+    # Group consecutive badges by renderer to minimize Canvas and PdfReader overhead
+    for renderer, group in groupby(op_renderers, key=lambda x: x[1]):
+        ops = [x[0] for x in group]
         buffer = BytesIO()
         page = canvas.Canvas(buffer, pagesize=pagesizes.A4)
-        with language(op.order.locale, op.order.event.settings.region):
-            renderer.draw_page(page, op.order, op, show_page=False)
-        if apply_output_pagesize and opt['pagesize']:
-            page.setPageSize(opt['pagesize'])
-        page.showPage()
+
+        for op in ops:
+            with language(op.order.locale, op.order.event.settings.region):
+                renderer.draw_page(page, op.order, op, show_page=False)
+            if apply_output_pagesize and opt['pagesize']:
+                page.setPageSize(opt['pagesize'])
+            page.showPage()
+
         page.save()
         for merged_page in renderer.merge_foreground_buffer(buffer):
             badge_pdf.add_page(merged_page)
@@ -482,7 +509,7 @@ class BadgeExporter(BaseExporter):
                         + (
                             [
                                 (
-                                    'name:{}'.format(k),
+                                    f'name:{k}',
                                     _('Attendee name: {part}').format(part=label),
                                 )
                                 for k, label, w in name_scheme['fields']
@@ -496,11 +523,11 @@ class BadgeExporter(BaseExporter):
         )
         return d
 
-    def render(self, form_data: dict) -> Tuple[str, str, str]:
+    def render(self, form_data: dict) -> tuple[str, str, str]:
         qs = (
             OrderPosition.objects.filter(order__event=self.event, product_id__in=form_data['products'])
-            .prefetch_related('answers', 'answers__question')
-            .select_related('order', 'product', 'variation', 'addon_to')
+            .prefetch_related('answers', 'answers__question', 'answers__options')
+            .select_related('order', 'order__invoice_address', 'product', 'variation', 'addon_to', 'subevent', 'seat')
         )
 
         if not form_data.get('include_addons'):

--- a/app/eventyay/plugins/badges/providers.py
+++ b/app/eventyay/plugins/badges/providers.py
@@ -1,5 +1,3 @@
-from typing import Tuple
-
 from django.utils.translation import gettext_lazy as _
 
 from eventyay.base.models import OrderPosition
@@ -12,7 +10,7 @@ class BadgeOutputProvider(BaseTicketOutput):
     download_button_text = _('Download Badge')
     multi_download_enabled = True
 
-    def generate(self, op: OrderPosition) -> Tuple[str, str, bytes]:
+    def generate(self, op: OrderPosition) -> tuple[str, str, bytes]:
         try:
             from .exporters import OPTIONS, render_pdf
 
@@ -30,11 +28,42 @@ class BadgeOutputProvider(BaseTicketOutput):
         except Exception as e:
             raise e
 
+    def generate_order(self, order) -> tuple[str, str, bytes]:
+        try:
+            from .exporters import OPTIONS, render_pdf
+
+            positions = list(
+                order.positions.select_related('product', 'variation', 'addon_to', 'subevent', 'seat').prefetch_related(
+                    'answers', 'answers__question', 'answers__options'
+                )
+            )
+
+            # Filter positions that should generate tickets
+            valid_positions = [op for op in positions if op.generate_ticket]
+
+            if not valid_positions:
+                raise Exception('No badges to generate')
+
+            pdf_buffer = render_pdf(order.event, valid_positions, OPTIONS['one'])
+            if pdf_buffer is None:
+                raise Exception('Failed to generate PDF')
+
+            if hasattr(pdf_buffer, 'getvalue'):
+                pdf_content = pdf_buffer.getvalue()
+            else:
+                pdf_content = pdf_buffer
+
+            return f'badges_{order.code}.pdf', 'application/pdf', pdf_content
+
+        except Exception as e:
+            raise e
+
     @property
     def settings_form_fields(self):
         return super().settings_form_fields
 
     def settings_content_render(self, request):
         from django.template.loader import get_template
+
         template = get_template('pretixplugins/badges/form.html')
         return template.render({'request': request})

--- a/app/eventyay/plugins/badges/tasks.py
+++ b/app/eventyay/plugins/badges/tasks.py
@@ -1,5 +1,4 @@
 import logging
-from typing import List
 
 from django.core.files.base import ContentFile
 
@@ -15,14 +14,23 @@ from eventyay.celery_app import app
 
 from .exporters import OPTIONS, render_pdf
 
+
 logger = logging.getLogger(__name__)
 
 
 @app.task(base=EventTask, throws=(OrderError,))
-def badges_create_pdf(event: Event, fileid: int, positions: List[int]) -> int:
+def badges_create_pdf(event: Event, fileid: int, positions: list[int]) -> int:
     file = CachedFile.objects.get(id=fileid)
 
-    pdfcontent = render_pdf(event, OrderPosition.objects.filter(id__in=positions), opt=OPTIONS['one'])
+    qs = (
+        OrderPosition.objects.filter(id__in=positions)
+        .select_related(
+            'order', 'order__event', 'order__invoice_address', 'product', 'variation', 'addon_to', 'subevent', 'seat'
+        )
+        .prefetch_related('answers', 'answers__question', 'answers__options')
+    )
+
+    pdfcontent = render_pdf(event, qs, opt=OPTIONS['one'])
     file.file.save(cachedfile_name(file, file.filename), ContentFile(pdfcontent.read()))
     file.save()
     return file.pk

--- a/app/eventyay/plugins/badges/utils.py
+++ b/app/eventyay/plugins/badges/utils.py
@@ -10,11 +10,34 @@ from .models import BadgeLayout, BadgeProduct
 BADGE_HIDDEN_FIELDS_KEY = 'badge_hidden_fields'
 BADGE_TICKET_PROVIDER = 'badge'
 
+_renderer_cache = {}
+
+
+def get_badge_layout_version(event):
+    """
+    Return the current badge layout/rendering cache version for this event.
+
+    This is stored in the shared (cross-process/cross-worker) cache backend, so every
+    Celery worker and web worker will observe a version bump immediately on their next
+    lookup, no matter which process actually saved the layout change.
+    """
+    return event.cache.get('badge_layout_version') or 0
+
 
 def clear_badge_layout_cache(event):
     for attr in ('_badge_layout_assignment_map', '_default_badge_layout', '_cached_renderermap'):
         if hasattr(event, attr):
             delattr(event, attr)
+
+    # Bump the layout version in the cross-process cache so every worker's in-memory
+    # renderer cache is invalidated on its very next use, without needing to reach into
+    # other processes' memory.
+    version = get_badge_layout_version(event)
+    event.cache.set('badge_layout_version', version + 1, 3600 * 24 * 30)
+
+    keys_to_delete = [k for k in _renderer_cache if k[0] == event.pk]
+    for k in keys_to_delete:
+        del _renderer_cache[k]
 
 
 def normalize_badge_content_key(content):


### PR DESCRIPTION
## Summary

Speeds up badge PDF generation at check-in and bulk export by caching expensive, layout-level work while keeping attendee-specific data fresh on every render.

Fixes the slow path where each badge re-parsed layout backgrounds, re-registered fonts, and re-fetched related ORM data — causing "badge not available" timeouts during kiosk check-in.

Pairs with the check-in app changes in [eventyay-checkin#114](https://github.com/fossasia/eventyay-checkin/pull/114), which adds client-side retry/polling for badges still being generated.

## Changes

### Badge renderer caching (`exporters.py`, `utils.py`)
- Cache `BadgeRenderer` instances in-memory keyed by `(event, layout)` plus a cross-worker `badge_layout_version` stored in Redis.
- Bump version and clear renderer cache when badge layouts are saved (existing invalidation hook).
- Batch consecutive positions sharing the same renderer with `groupby` to reduce Canvas/PDF parsing overhead.

### Shared PDF renderer optimizations (`pdf.py`)
- Cache powered-by images, named static image areas, paragraph styles, and Arabic reshaper at class level.
- Only cache image areas when the underlying file has a stable storage path (`.name`), so per-attendee uploads are never shared across positions.

### Check-in download API (`api.py`)
- Add `select_related` / `prefetch_related` on the badge download endpoint.
- Return a cached `CachedTicket` immediately when one already exists, instead of always regenerating.

### Ticket generation (`providers.py`, `tickets.py`, `tasks.py`)
- Prefetch answers and related objects in badge Celery tasks and `generate_orderposition`.
- Override `generate_order()` to produce a single merged PDF for multi-badge order downloads (faster than generating and zipping individual PDFs).

## What is cached vs. not cached

| Cached (layout-level) | Not cached (per attendee) |
|---|---|
| Layout background, fonts, static images | Attendee names, answers, hidden fields |
| `BadgeRenderer` shell | Per-position `CachedTicket` invalidation on field-permission saves |

## Behavioral note

Multi-badge order download via the badge provider now returns one merged `application/pdf` file instead of a ZIP of individual PDFs. Filename/extension are still taken from the provider response, so existing download flows continue to work.

## Test plan

- [x] Badge check-in download returns a PDF for a checked-in attendee
- [x] Kiosk print/download no longer times out on first attempt (with check-in PR)
- [x] Single badge per page export
- [x] 4-up (n-up) export (`test_render_nup_large_export_merge`)
- [x] Badge API list/download endpoints
- [x] Layout save invalidates renderer cache (version bump)
- [x] Products with explicit `layout=None` are excluded from export
- [x] Reviewer manual test (screen recordings attached)

## Related

- Frontend companion PR: https://github.com/fossasia/eventyay-checkin/pull/114