### PR TITLE
feat: include attendee badge options in order export

### DIFF
--- a/app/eventyay/base/exporters/orderlist.py
+++ b/app/eventyay/base/exporters/orderlist.py
@@ -847,6 +847,13 @@ class OrderListExporter(MultiSheetListExporter):
             _('Payment providers'),
         ]
 
+        try:
+            from eventyay.plugins.badges.utils import get_badge_visible_field_labels
+            badge_support = True
+            headers.append(_('Badge options'))
+        except ImportError:
+            badge_support = False
+
         yield headers
 
         all_ids = list(base_qs.order_by('order__datetime', 'positionid').values_list('pk', flat=True))
@@ -1004,13 +1011,18 @@ class OrderListExporter(MultiSheetListExporter):
                         ]
                     )
                 )
+
+                if badge_support:
+                    badge_labels = get_badge_visible_field_labels(self.event_object_cache[order.event_id], op)
+                    row.append(', '.join(badge_labels) if badge_labels else '')
+
                 yield row
 
     def get_filename(self):
         if self.is_multievent:
-            return '{}_orders'.format(self.events.first().organizer.slug)
+            return f'{self.events.first().organizer.slug}_orders'
         else:
-            return '{}_orders'.format(self.event.slug)
+            return f'{self.event.slug}_orders'
 
 
 class OrderPositionListExporter(OrderListExporter):
@@ -1043,9 +1055,9 @@ class OrderPositionListExporter(OrderListExporter):
 
     def get_filename(self):
         if self.is_multievent:
-            return '{}_orderpositions'.format(self.events.first().organizer.slug)
+            return f'{self.events.first().organizer.slug}_orderpositions'
         else:
-            return '{}_orderpositions'.format(self.event.slug)
+            return f'{self.event.slug}_orderpositions'
 
     def render(self, form_data: dict, output_file=None):
         return super(MultiSheetListExporter, self).render(form_data, output_file=output_file)
@@ -1140,9 +1152,9 @@ class PaymentListExporter(ListExporter):
 
     def get_filename(self):
         if self.is_multievent:
-            return '{}_payments'.format(self.events.first().organizer.slug)
+            return f'{self.events.first().organizer.slug}_payments'
         else:
-            return '{}_payments'.format(self.event.slug)
+            return f'{self.event.slug}_payments'
 
 
 class QuotaListExporter(ListExporter):
@@ -1205,7 +1217,7 @@ class QuotaListExporter(ListExporter):
             yield row
 
     def get_filename(self):
-        return '{}_quotas'.format(self.event.slug)
+        return f'{self.event.slug}_quotas'
 
 
 class GiftcardRedemptionListExporter(ListExporter):
@@ -1256,9 +1268,9 @@ class GiftcardRedemptionListExporter(ListExporter):
 
     def get_filename(self):
         if self.is_multievent:
-            return '{}_giftcardredemptions'.format(self.events.first().organizer.slug)
+            return f'{self.events.first().organizer.slug}_giftcardredemptions'
         else:
-            return '{}_giftcardredemptions'.format(self.event.slug)
+            return f'{self.event.slug}_giftcardredemptions'
 
 
 def generate_GiftCardListExporter(organizer):  # hackhack
@@ -1384,7 +1396,7 @@ def generate_GiftCardListExporter(organizer):  # hackhack
                 yield row
 
         def get_filename(self):
-            return '{}_giftcards'.format(organizer.slug)
+            return f'{organizer.slug}_giftcards'
 
     return GiftcardListExporter
 

--- a/app/eventyay/base/exporters/orderlist.py
+++ b/app/eventyay/base/exporters/orderlist.py
@@ -848,7 +848,7 @@ class OrderListExporter(MultiSheetListExporter):
         ]
 
         try:
-            from eventyay.plugins.badges.utils import get_badge_visible_field_labels
+            from eventyay.plugins.badges.utils import get_badge_visible_field_values
             badge_support = True
             headers.append(_('Badge options'))
         except ImportError:
@@ -1013,8 +1013,8 @@ class OrderListExporter(MultiSheetListExporter):
                 )
 
                 if badge_support:
-                    badge_labels = get_badge_visible_field_labels(self.event_object_cache[order.event_id], op)
-                    row.append(', '.join(badge_labels) if badge_labels else '')
+                    badge_values = get_badge_visible_field_values(self.event_object_cache[order.event_id], op)
+                    row.append(', '.join(badge_values) if badge_values else '')
 
                 yield row
 

--- a/app/eventyay/plugins/badges/utils.py
+++ b/app/eventyay/plugins/badges/utils.py
@@ -1,4 +1,7 @@
 import json
+import logging
+
+logger = logging.getLogger(__name__)
 
 from django.utils.translation import gettext_lazy as _
 
@@ -237,8 +240,8 @@ def get_badge_visible_field_values(event, position, hidden_fields=None):
                     val = variables[field['key']]['evaluate'](position, position.order, event)
                     if val:
                         values.append(str(val))
-                except Exception:
-                    pass
+                except (KeyError, ValueError, AttributeError, TypeError):
+                    logger.exception('Failed to evaluate badge field')
     return values
 
 

--- a/app/eventyay/plugins/badges/utils.py
+++ b/app/eventyay/plugins/badges/utils.py
@@ -217,6 +217,31 @@ def get_badge_visible_field_labels(event, position, hidden_fields=None):
     ]
 
 
+def get_badge_visible_field_values(event, position, hidden_fields=None):
+    layout = get_badge_layout_for_position(event, position)
+    if not layout or not layout.allow_customization:
+        return []
+
+    ask_user_keys = set(layout.ask_user_fields_data)
+    hidden_fields = {
+        str(value) for value in (hidden_fields if hidden_fields is not None else get_badge_hidden_fields(position))
+    }
+    
+    variables = get_variables(event)
+    
+    values = []
+    for field in get_badge_customizable_fields(event, layout):
+        if field['key'] in ask_user_keys and field['key'] not in hidden_fields:
+            if field['key'] in variables:
+                try:
+                    val = variables[field['key']]['evaluate'](position, position.order, event)
+                    if val:
+                        values.append(str(val))
+                except Exception:
+                    pass
+    return values
+
+
 def _badge_field_fallback_label(content):
     if content.startswith('question_'):
         return _('Question')


### PR DESCRIPTION
## Summary

This PR ensures that the badge options selected by attendees (i.e. what they would like printed on their badge) are included in the order data export.

## Why

The badge plugin dynamically injects a checkout question asking attendees what they would like on their badge. Because this data is stored in the position's `meta_info_data` rather than as a standard database `Question` object, it was completely absent from the exported order data. This made it difficult for organizers to review or cross-check badge content preferences from the export.

## Changes

* Safely imported `get_badge_visible_field_labels` from the badges plugin in the `OrderListExporter`.
* Dynamically appended a new `Badge options` header column if the plugin is available.
* Populated the column for each `OrderPosition` row with a comma-separated list of the badge fields that will be printed on the attendee's badge (after applying their hidden preferences).
* Gracefully handled instances where the badges plugin is disabled or unavailable.

## Testing

* Verified the export generates successfully when the badges plugin is disabled.
* Verified that when the badges plugin is active, the `Badge options` column lists the correct checked options.
* Ensured the multi-event and single-event exporters process this field smoothly.

## Issue

Fixes #4421


https://github.com/user-attachments/assets/79a83b13-61ee-4bf8-b7e5-eecbc15e5ee3


https://github.com/user-attachments/assets/ab68dfbe-4c6a-4f6b-9636-2cdbb2020b01



