### PR TITLE
Fix : Buttons overlapping in mobile view

### DIFF
--- a/app/eventyay/static/common/css/_component_nav_mobile.css
+++ b/app/eventyay/static/common/css/_component_nav_mobile.css
@@ -47,7 +47,6 @@
   #event-nav .navigation .navigation-button,
   .header-nav .navigation .navigation-button {
     order: -1;
-    margin-top: 0;
     margin-bottom: 10px;
   }
 


### PR DESCRIPTION
## BEFORE

https://github.com/user-attachments/assets/0cf67a39-ebdd-4a18-921b-dc5d822823a7

## AFTER 

https://github.com/user-attachments/assets/a91b3576-5e1e-40a9-b2b8-6970188d872d

## Summary by Sourcery

Bug Fixes:
- Resolve overlapping buttons in the mobile navigation header by updating spacing rules.