### PR TITLE
Add badge text autofit and voucher-based layout assignment

### DIFF
--- a/app/eventyay/base/models/orders.py
+++ b/app/eventyay/base/models/orders.py
@@ -14,6 +14,7 @@ import dateutil
 import pycountry
 import pytz
 from django.conf import settings
+from django.contrib.postgres.indexes import GinIndex
 from django.db import models, transaction
 from django.db.models import (
     Case,
@@ -214,6 +215,13 @@ class Order(LockModel, LoggedModel):
         verbose_name = _('Order')
         verbose_name_plural = _('Orders')
         ordering = ('-datetime',)
+        indexes = [
+            GinIndex(
+                fields=['code'],
+                name='order_code_trgm',
+                opclasses=['gin_trgm_ops'],
+            ),
+        ]
 
     def __str__(self):
         return self.full_code
@@ -2325,6 +2333,18 @@ class OrderPosition(AbstractPosition):
         verbose_name = _('Order position')
         verbose_name_plural = _('Order positions')
         ordering = ('positionid', 'id')
+        indexes = [
+            GinIndex(
+                fields=['attendee_name_cached'],
+                name='orderpos_name_trgm',
+                opclasses=['gin_trgm_ops'],
+            ),
+            GinIndex(
+                fields=['attendee_email'],
+                name='orderpos_email_trgm',
+                opclasses=['gin_trgm_ops'],
+            ),
+        ]
 
     @cached_property
     def sort_key(self):

--- a/app/eventyay/base/pdf.py
+++ b/app/eventyay/base/pdf.py
@@ -922,11 +922,15 @@ class Renderer:
         if not text:
             return float(max_fontsize)
 
+        lines = [line for line in text.splitlines() if line]
+        if not lines:
+            return float(max_fontsize)
+
         width_pt = float(width_mm) * mm
         size = float(max_fontsize)
         min_size = float(min_fontsize)
         while size > min_size:
-            if pdfmetrics.stringWidth(text, font_name, size) <= width_pt:
+            if all(pdfmetrics.stringWidth(line, font_name, size) <= width_pt for line in lines):
                 return size
             size -= 0.5
         return min_size

--- a/app/eventyay/base/pdf.py
+++ b/app/eventyay/base/pdf.py
@@ -930,7 +930,15 @@ class Renderer:
         size = float(max_fontsize)
         min_size = float(min_fontsize)
         while size > min_size:
-            if all(pdfmetrics.stringWidth(line, font_name, size) <= width_pt for line in lines):
+            fits = True
+            for line in lines:
+                parts = line.split()
+                if not parts:
+                    continue
+                if max(pdfmetrics.stringWidth(part, font_name, size) for part in parts) > width_pt:
+                    fits = False
+                    break
+            if fits:
                 return size
             size -= 0.5
         return min_size

--- a/app/eventyay/base/pdf.py
+++ b/app/eventyay/base/pdf.py
@@ -917,6 +917,20 @@ class Renderer:
             cls._reshaper_instance = ArabicReshaper(configuration=configuration)
         return cls._reshaper_instance
 
+    @staticmethod
+    def _fit_fontsize_to_width(text, font_name, max_fontsize, width_mm, min_fontsize=4.0):
+        if not text:
+            return float(max_fontsize)
+
+        width_pt = float(width_mm) * mm
+        size = float(max_fontsize)
+        min_size = float(min_fontsize)
+        while size > min_size:
+            if pdfmetrics.stringWidth(text, font_name, size) <= width_pt:
+                return size
+            size -= 0.5
+        return min_size
+
     def _draw_textarea(self, canvas: Canvas, op: OrderPosition, order: Order, o: dict):
         font = o['fontfamily']
         if o['bold']:
@@ -927,7 +941,12 @@ class Renderer:
         if not hasattr(self, '_style_cache'):
             self._style_cache = {}
 
-        style_key = (font, o['fontsize'], tuple(o['color']), o['align'])
+        text_content = self._get_text_content(op, order, o) or ''
+        fontsize = float(o['fontsize'])
+        if o.get('autofit_width'):
+            fontsize = self._fit_fontsize_to_width(text_content, font, fontsize, o['width'])
+
+        style_key = (font, fontsize, tuple(o['color']), o['align'])
         if style_key in self._style_cache:
             style = self._style_cache[style_key]
         else:
@@ -935,17 +954,15 @@ class Renderer:
             style = ParagraphStyle(
                 name=uuid.uuid4().hex,
                 fontName=font,
-                fontSize=float(o['fontsize']),
-                leading=float(o['fontsize']),
+                fontSize=fontsize,
+                leading=fontsize,
                 autoLeading='max',
                 textColor=Color(o['color'][0] / 255, o['color'][1] / 255, o['color'][2] / 255),
                 alignment=align_map[o['align']],
             )
             self._style_cache[style_key] = style
 
-        text = conditional_escape(
-            self._get_text_content(op, order, o) or '',
-        ).replace('\n', '<br/>\n')
+        text = conditional_escape(text_content).replace('\n', '<br/>\n')
 
         # reportlab does not support RTL, ligature-heavy scripts like Arabic. Therefore, we use ArabicReshaper
         # to resolve all ligatures and python-bidi to switch RTL texts.
@@ -958,7 +975,7 @@ class Renderer:
         p = Paragraph(text, style=style)
         w, h = p.wrapOn(canvas, float(o['width']) * mm, 1000 * mm)
         # p_size = p.wrap(float(o['width']) * mm, 1000 * mm)
-        ad = getAscentDescent(font, float(o['fontsize']))
+        ad = getAscentDescent(font, fontsize)
         canvas.saveState()
         # The ascent/descent offsets here are not really proven to be correct, they're just empirical values to get
         # reportlab render similarly to browser canvas.

--- a/app/eventyay/config/settings.py
+++ b/app/eventyay/config/settings.py
@@ -336,6 +336,7 @@ _OURS_APPS = (
     'eventyay.orga',
     'eventyay.api',
     'eventyay.base',
+    'eventyay.core',
     'eventyay.cfp',
     'eventyay.control.ControlConfig',
     'eventyay.event',

--- a/app/eventyay/config/settings.py
+++ b/app/eventyay/config/settings.py
@@ -336,7 +336,6 @@ _OURS_APPS = (
     'eventyay.orga',
     'eventyay.api',
     'eventyay.base',
-    'eventyay.core',
     'eventyay.cfp',
     'eventyay.control.ControlConfig',
     'eventyay.event',

--- a/app/eventyay/control/templates/pretixcontrol/pdf/index.html
+++ b/app/eventyay/control/templates/pretixcontrol/pdf/index.html
@@ -277,6 +277,14 @@
                     </div>
                     <div class="row control-group text">
                         <div class="col-sm-12">
+                            <button type="button" class="btn btn-default btn-block toggling" data-action="autofit_width"
+                                    title="{% trans 'Shrink font size for long text so it fits within the text box width' %}">
+                                {% trans "Adapt content to container width" %}
+                            </button>
+                        </div>
+                    </div>
+                    <div class="row control-group text">
+                        <div class="col-sm-12">
                             <label>{% trans "Font style" %}</label><br>
                             <div class="btn-group btn-group-justified" role="group">
                                 <div class="btn-group" role="group">

--- a/app/eventyay/control/templates/pretixcontrol/pdf/index.html
+++ b/app/eventyay/control/templates/pretixcontrol/pdf/index.html
@@ -277,10 +277,13 @@
                     </div>
                     <div class="row control-group text">
                         <div class="col-sm-12">
-                            <button type="button" class="btn btn-default btn-block toggling" data-action="autofit_width"
-                                    title="{% trans 'Shrink font size for long text so it fits within the text box width' %}">
-                                {% trans "Adapt content to container width" %}
-                            </button>
+                            <div class="checkbox">
+                                <label for="toolbox-autofit-width"
+                                       title="{% trans 'Shrink font size for long text so it fits within the text box width' %}">
+                                    <input type="checkbox" id="toolbox-autofit-width">
+                                    {% trans "Adapt content to container width" %}
+                                </label>
+                            </div>
                         </div>
                     </div>
                     <div class="row control-group text">

--- a/app/eventyay/plugins/badges/exporters.py
+++ b/app/eventyay/plugins/badges/exporters.py
@@ -11,7 +11,6 @@ from django.conf import settings
 from django.contrib.staticfiles import finders
 from django.core.files import File
 from django.core.files.storage import default_storage
-from django.db.models import Exists, OuterRef
 from django.db.models.functions import Coalesce
 from django.utils.translation import gettext as _
 from django.utils.translation import gettext_lazy
@@ -27,10 +26,12 @@ from eventyay.base.models import Order, OrderPosition
 from eventyay.base.pdf import Renderer
 from eventyay.base.services.orders import OrderError
 from eventyay.base.settings import PERSON_NAME_SCHEMES
-from eventyay.plugins.badges.models import BadgeLayout, BadgeProduct
+from eventyay.plugins.badges.models import BadgeProduct, BadgeVoucher
 from eventyay.plugins.badges.utils import (
     _renderer_cache,
+    exclude_explicit_no_badge,
     get_badge_hidden_fields,
+    get_badge_layout_for_position,
     get_badge_layout_version,
     normalize_badge_content_key,
 )
@@ -365,24 +366,13 @@ def render_nup(input_files: list[str], num_pages: int, output_file: BinaryIO, op
 def render_badges(event, positions, opt, apply_output_pagesize=False):
     from itertools import groupby
 
-    # Resolve product→layout assignments fresh on every render so explicit "no badge"
-    # assignments (layout=None) and recent assignment changes are always respected.
-    assignment_map = {
-        assignment.product_id: assignment.layout
-        for assignment in BadgeProduct.objects.select_related('layout').filter(product__event=event)
-    }
-    try:
-        default_layout = event.badge_layouts.get(default=True)
-    except BadgeLayout.DoesNotExist:
-        default_layout = None
-
     # Fetched once per render call (not per position) to avoid a cache round-trip per
     # badge, while still guaranteeing that every render reflects the latest saved design.
     version = get_badge_layout_version(event)
 
     op_renderers = []
     for op in positions:
-        layout = assignment_map.get(op.product_id, default_layout)
+        layout = get_badge_layout_for_position(event, op)
         if layout is not None:
             renderer = _renderer(event, layout, version)
             if renderer:
@@ -458,12 +448,23 @@ class BadgeExporter(BaseExporter):
                 (
                     'products',
                     forms.ModelMultipleChoiceField(
-                        queryset=self.event.products.annotate(
-                            no_badging=Exists(BadgeProduct.objects.filter(product=OuterRef('pk'), layout__isnull=True))
-                        ).exclude(no_badging=True),
+                        queryset=exclude_explicit_no_badge(self.event.products, BadgeProduct, 'product'),
                         label=_('Limit to products'),
                         widget=forms.CheckboxSelectMultiple(attrs={'class': 'scrolling-multiple-choice'}),
                         initial=self.event.products.filter(admission=True),
+                    ),
+                ),
+                (
+                    'vouchers',
+                    forms.ModelMultipleChoiceField(
+                        queryset=exclude_explicit_no_badge(
+                            self.event.vouchers.order_by('code'),
+                            BadgeVoucher,
+                            'voucher',
+                        ),
+                        label=_('Limit to vouchers'),
+                        required=False,
+                        widget=forms.CheckboxSelectMultiple(attrs={'class': 'scrolling-multiple-choice'}),
                     ),
                 ),
                 (
@@ -535,8 +536,11 @@ class BadgeExporter(BaseExporter):
         qs = (
             OrderPosition.objects.filter(order__event=self.event, product_id__in=form_data['products'])
             .prefetch_related('answers', 'answers__question', 'answers__options')
-            .select_related('order', 'order__invoice_address', 'product', 'variation', 'addon_to', 'subevent', 'seat')
+            .select_related('order', 'order__invoice_address', 'product', 'variation', 'addon_to', 'subevent', 'seat', 'voucher')
         )
+
+        if form_data.get('vouchers'):
+            qs = qs.filter(voucher_id__in=form_data['vouchers'])
 
         if not form_data.get('include_addons'):
             qs = qs.filter(addon_to__isnull=True)

--- a/app/eventyay/plugins/badges/forms.py
+++ b/app/eventyay/plugins/badges/forms.py
@@ -2,9 +2,16 @@ from django import forms
 from django.db import transaction
 from django.utils.translation import gettext_lazy as _
 
-from eventyay.base.models import Product
-from eventyay.plugins.badges.models import BadgeLayout, BadgeProduct
+from eventyay.base.models import Product, Voucher
+from eventyay.plugins.badges.models import BadgeLayout, BadgeProduct, BadgeVoucher
 from eventyay.plugins.badges.utils import get_badge_customizable_fields
+
+
+def _sync_badge_assignments(model, layout, related_name, selected):
+    selected_ids = set(selected.values_list('pk', flat=True))
+    model.objects.filter(layout=layout).exclude(**{f'{related_name}_id__in': selected_ids}).delete()
+    for item in selected:
+        model.objects.update_or_create(**{related_name: item}, defaults={'layout': layout})
 
 
 class BadgeLayoutForm(forms.ModelForm):
@@ -18,6 +25,12 @@ class BadgeLayoutSettingsForm(forms.Form):
         queryset=Product.objects.none(),
         required=False,
         label=_('Products assigned to this layout'),
+        widget=forms.CheckboxSelectMultiple(attrs={'class': 'scrolling-multiple-choice'}),
+    )
+    vouchers = forms.ModelMultipleChoiceField(
+        queryset=Voucher.objects.none(),
+        required=False,
+        label=_('Vouchers assigned to this layout'),
         widget=forms.CheckboxSelectMultiple(attrs={'class': 'scrolling-multiple-choice'}),
     )
     allow_customization = forms.BooleanField(
@@ -37,9 +50,14 @@ class BadgeLayoutSettingsForm(forms.Form):
 
         self.fields['products'].queryset = self.event.products.order_by('category__position', 'position')
         self.fields['products'].initial = list(self.layout.product_assignments.values_list('product_id', flat=True))
+        self.fields['vouchers'].queryset = self.event.vouchers.order_by('code')
+        self.fields['vouchers'].initial = list(self.layout.voucher_assignments.values_list('voucher_id', flat=True))
         if self.layout.default:
             self.fields['products'].help_text = _(
                 'Products not explicitly assigned to another layout will also use the default layout.'
+            )
+            self.fields['vouchers'].help_text = _(
+                'Vouchers not explicitly assigned to another layout will fall back to the product or default layout.'
             )
 
         self.customizable_fields = get_badge_customizable_fields(self.event, self.layout)
@@ -71,12 +89,8 @@ class BadgeLayoutSettingsForm(forms.Form):
 
     @transaction.atomic
     def save(self):
-        selected_products = self.cleaned_data['products']
-        selected_ids = set(selected_products.values_list('pk', flat=True))
-
-        BadgeProduct.objects.filter(layout=self.layout).exclude(product_id__in=selected_ids).delete()
-        for product in selected_products:
-            BadgeProduct.objects.update_or_create(product=product, defaults={'layout': self.layout})
+        _sync_badge_assignments(BadgeProduct, self.layout, 'product', self.cleaned_data['products'])
+        _sync_badge_assignments(BadgeVoucher, self.layout, 'voucher', self.cleaned_data['vouchers'])
 
         self.layout.allow_customization = self.cleaned_data['allow_customization']
         self.layout.ask_user_fields_data = self.cleaned_data['ask_user_fields']

--- a/app/eventyay/plugins/badges/migrations/0004_badgevoucher.py
+++ b/app/eventyay/plugins/badges/migrations/0004_badgevoucher.py
@@ -1,0 +1,41 @@
+import django.db.models.deletion
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ('badges', '0003_badgelayout_allow_customization_and_more'),
+        ('base', '0001_initial'),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name='BadgeVoucher',
+            fields=[
+                ('id', models.AutoField(auto_created=True, primary_key=True, serialize=False, verbose_name='ID')),
+                (
+                    'layout',
+                    models.ForeignKey(
+                        blank=True,
+                        null=True,
+                        on_delete=django.db.models.deletion.CASCADE,
+                        related_name='voucher_assignments',
+                        to='badges.badgelayout',
+                    ),
+                ),
+                (
+                    'voucher',
+                    models.OneToOneField(
+                        blank=True,
+                        null=True,
+                        on_delete=django.db.models.deletion.CASCADE,
+                        related_name='badge_assignment',
+                        to='base.voucher',
+                    ),
+                ),
+            ],
+            options={
+                'ordering': ('id',),
+            },
+        ),
+    ]

--- a/app/eventyay/plugins/badges/migrations/0004_badgevoucher.py
+++ b/app/eventyay/plugins/badges/migrations/0004_badgevoucher.py
@@ -12,7 +12,7 @@ class Migration(migrations.Migration):
         migrations.CreateModel(
             name='BadgeVoucher',
             fields=[
-                ('id', models.AutoField(auto_created=True, primary_key=True, serialize=False, verbose_name='ID')),
+                ('id', models.BigAutoField(auto_created=True, primary_key=True, serialize=False, verbose_name='ID')),
                 (
                     'layout',
                     models.ForeignKey(

--- a/app/eventyay/plugins/badges/models.py
+++ b/app/eventyay/plugins/badges/models.py
@@ -103,3 +103,25 @@ class BadgeProduct(models.Model):
 
     class Meta:
         ordering = ('id',)
+
+
+class BadgeVoucher(models.Model):
+    # If no BadgeVoucher exists => fall back to product/default layout
+    # If BadgeVoucher exists with layout=None => don't print
+    voucher = models.OneToOneField(
+        'base.Voucher',
+        null=True,
+        blank=True,
+        related_name='badge_assignment',
+        on_delete=models.CASCADE,
+    )
+    layout = models.ForeignKey(
+        'BadgeLayout',
+        on_delete=models.CASCADE,
+        related_name='voucher_assignments',
+        null=True,
+        blank=True,
+    )
+
+    class Meta:
+        ordering = ('id',)

--- a/app/eventyay/plugins/badges/providers.py
+++ b/app/eventyay/plugins/badges/providers.py
@@ -33,7 +33,7 @@ class BadgeOutputProvider(BaseTicketOutput):
             from .exporters import OPTIONS, render_pdf
 
             positions = list(
-                order.positions.select_related('product', 'variation', 'addon_to', 'subevent', 'seat').prefetch_related(
+                order.positions.select_related('product', 'variation', 'addon_to', 'subevent', 'seat', 'voucher').prefetch_related(
                     'answers', 'answers__question', 'answers__options'
                 )
             )

--- a/app/eventyay/plugins/badges/signals.py
+++ b/app/eventyay/plugins/badges/signals.py
@@ -1,6 +1,5 @@
 import copy
 import json
-from collections import defaultdict
 
 from django.dispatch import receiver
 from django.template.loader import get_template
@@ -11,6 +10,7 @@ from django.utils.translation import gettext_lazy as _
 from eventyay.base.models import Event, Order
 from eventyay.base.signals import (
     event_copy_data,
+    layout_text_variables,
     product_copy_data,
     logentry_display,
     logentry_object_link,
@@ -25,12 +25,13 @@ from eventyay.control.signals import (
 from eventyay.presale.signals import question_form_fields
 
 from eventyay.plugins.badges.forms import BadgeOptionsField
-from eventyay.plugins.badges.models import BadgeProduct, BadgeLayout
+from eventyay.plugins.badges.models import BadgeProduct, BadgeLayout, BadgeVoucher
 from eventyay.plugins.badges.utils import (
     BADGE_HIDDEN_FIELDS_KEY,
     get_badge_bundle_option_choices,
     get_badge_config_position,
     get_badge_hidden_fields,
+    position_has_printable_badge,
 )
 
 
@@ -65,6 +66,25 @@ def control_nav_import(sender, request=None, **kwargs):
     ]
 
 
+@receiver(layout_text_variables, dispatch_uid='badges_layout_text_variables_vouchers')
+def badges_layout_text_variables_vouchers(sender, **kwargs):
+    def voucher_value(field):
+        return lambda op, order, event: getattr(op.voucher, field, '') if op.voucher_id else ''
+
+    return {
+        'voucher_code': {
+            'label': _('Voucher code'),
+            'editor_sample': 'SAMPLE123',
+            'evaluate': voucher_value('code'),
+        },
+        'voucher_tag': {
+            'label': _('Voucher tag'),
+            'editor_sample': _('Sample tag'),
+            'evaluate': voucher_value('tag'),
+        },
+    }
+
+
 @receiver(product_copy_data, dispatch_uid='badges_product_copy')
 def copy_product(sender, source, target, **kwargs):
     try:
@@ -75,7 +95,7 @@ def copy_product(sender, source, target, **kwargs):
 
 
 @receiver(signal=event_copy_data, dispatch_uid='badges_copy_data')
-def event_copy_data_receiver(sender, other, question_map, product_map, **kwargs):
+def event_copy_data_receiver(sender, other, question_map, product_map, voucher_map=None, **kwargs):
     layout_map = {}
     for bl in other.badge_layouts.all():
         oldid = bl.pk
@@ -109,6 +129,12 @@ def event_copy_data_receiver(sender, other, question_map, product_map, **kwargs)
     for bi in BadgeProduct.objects.filter(product__event=other):
         BadgeProduct.objects.create(product=product_map.get(bi.product_id), layout=layout_map.get(bi.layout_id))
 
+    if voucher_map:
+        for bv in BadgeVoucher.objects.filter(voucher__event=other):
+            mapped_voucher = voucher_map.get(bv.voucher_id)
+            if mapped_voucher:
+                BadgeVoucher.objects.create(voucher=mapped_voucher, layout=layout_map.get(bv.layout_id))
+
 
 @receiver(question_form_fields, dispatch_uid='badges_question_form_fields')
 def badge_question_form_fields(sender, position, **kwargs):
@@ -135,24 +161,9 @@ def register_pdf(sender, **kwargs):
     return BadgeExporter
 
 
-def _cached_rendermap(event):
-    if hasattr(event, '_cached_renderermap'):
-        return event._cached_renderermap
-    renderermap = {
-        bi.product_id: bi.layout_id for bi in BadgeProduct.objects.select_related('layout').filter(product__event=event)
-    }
-    try:
-        default_renderer = event.badge_layouts.get(default=True).pk
-    except BadgeLayout.DoesNotExist:
-        default_renderer = None
-    event._cached_renderermap = defaultdict(lambda: default_renderer)
-    event._cached_renderermap.update(renderermap)
-    return event._cached_renderermap
-
-
 @receiver(order_position_buttons, dispatch_uid='badges_control_order_buttons')
 def control_order_position_info(sender: Event, position, request, order: Order, **kwargs):
-    if _cached_rendermap(sender)[position.product_id] is None:
+    if not position_has_printable_badge(sender, position):
         return ''
     template = get_template('pretixplugins/badges/control_order_position_buttons.html')
     ctx = {'order': order, 'request': request, 'event': sender, 'position': position}
@@ -161,8 +172,7 @@ def control_order_position_info(sender: Event, position, request, order: Order, 
 
 @receiver(order_info, dispatch_uid='badges_control_order_info')
 def control_order_info(sender: Event, request, order: Order, **kwargs):
-    cm = _cached_rendermap(sender)
-    if all(cm[p.product_id] is None for p in order.positions.all()):
+    if not any(position_has_printable_badge(sender, p) for p in order.positions.all()):
         return ''
 
     template = get_template('pretixplugins/badges/control_order_info.html')

--- a/app/eventyay/plugins/badges/tasks.py
+++ b/app/eventyay/plugins/badges/tasks.py
@@ -25,7 +25,7 @@ def badges_create_pdf(event: Event, fileid: int, positions: list[int]) -> int:
     qs = (
         OrderPosition.objects.filter(id__in=positions)
         .select_related(
-            'order', 'order__event', 'order__invoice_address', 'product', 'variation', 'addon_to', 'subevent', 'seat'
+            'order', 'order__event', 'order__invoice_address', 'product', 'variation', 'addon_to', 'subevent', 'seat', 'voucher'
         )
         .prefetch_related('answers', 'answers__question', 'answers__options')
     )

--- a/app/eventyay/plugins/badges/templates/pretixplugins/badges/settings.html
+++ b/app/eventyay/plugins/badges/templates/pretixplugins/badges/settings.html
@@ -28,7 +28,28 @@
     {% bootstrap_form_errors form %}
 
     <fieldset>
-      {% bootstrap_field form.products layout='control' %}
+      <ul class="nav nav-tabs" role="tablist">
+        <li role="presentation" class="active">
+          <a href="#badge-settings-products" aria-controls="badge-settings-products" role="tab" data-toggle="tab">
+            {% trans 'Products' %}
+          </a>
+        </li>
+        <li role="presentation">
+          <a href="#badge-settings-vouchers" aria-controls="badge-settings-vouchers" role="tab" data-toggle="tab">
+            {% trans 'Vouchers' %}
+          </a>
+        </li>
+      </ul>
+
+      <div class="tab-content" style="padding-top: 15px;">
+        <div role="tabpanel" class="tab-pane active" id="badge-settings-products">
+          {% bootstrap_field form.products layout='control' %}
+        </div>
+        <div role="tabpanel" class="tab-pane" id="badge-settings-vouchers">
+          {% bootstrap_field form.vouchers layout='control' %}
+        </div>
+      </div>
+
       {% bootstrap_field form.allow_customization layout='control' %}
 
       <div id="badge-customization-fields" class="form-group">

--- a/app/eventyay/plugins/badges/utils.py
+++ b/app/eventyay/plugins/badges/utils.py
@@ -1,13 +1,14 @@
 import json
 import logging
 
-logger = logging.getLogger(__name__)
-
+from django.db.models import Exists, OuterRef
 from django.utils.translation import gettext_lazy as _
 
 from eventyay.base.pdf import get_variables
 
-from .models import BadgeLayout, BadgeProduct
+from .models import BadgeLayout, BadgeProduct, BadgeVoucher
+
+logger = logging.getLogger(__name__)
 
 
 BADGE_HIDDEN_FIELDS_KEY = 'badge_hidden_fields'
@@ -28,7 +29,7 @@ def get_badge_layout_version(event):
 
 
 def clear_badge_layout_cache(event):
-    for attr in ('_badge_layout_assignment_map', '_default_badge_layout', '_cached_renderermap'):
+    for attr in ('_badge_layout_assignment_map', '_badge_voucher_assignment_map', '_default_badge_layout'):
         if hasattr(event, attr):
             delattr(event, attr)
 
@@ -47,42 +48,63 @@ def normalize_badge_content_key(content):
     return 'event_name' if content == 'item' else content
 
 
-def get_badge_layout_assignment_map(event):
+def get_badge_layout_assignment_maps(event):
     if hasattr(event, '_badge_layout_assignment_map'):
-        return event._badge_layout_assignment_map, event._default_badge_layout
+        return (
+            event._badge_layout_assignment_map,
+            event._badge_voucher_assignment_map,
+            event._default_badge_layout,
+        )
 
-    assignment_map = {
+    product_map = {
         assignment.product_id: assignment.layout
         for assignment in BadgeProduct.objects.select_related('layout').filter(product__event=event)
+    }
+    voucher_map = {
+        assignment.voucher_id: assignment.layout
+        for assignment in BadgeVoucher.objects.select_related('layout').filter(voucher__event=event)
     }
     try:
         default_layout = event.badge_layouts.get(default=True)
     except BadgeLayout.DoesNotExist:
         default_layout = None
 
-    event._badge_layout_assignment_map = assignment_map
+    event._badge_layout_assignment_map = product_map
+    event._badge_voucher_assignment_map = voucher_map
     event._default_badge_layout = default_layout
-    return assignment_map, default_layout
-
-
-def product_has_badge_layout_assigned(event, product):
-    assignment_map, _ = get_badge_layout_assignment_map(event)
-    product_id = getattr(product, 'pk', product)
-    if product_id not in assignment_map:
-        return False
-    return assignment_map[product_id] is not None
-
-
-def get_badge_layout_for_product(event, product):
-    assignment_map, default_layout = get_badge_layout_assignment_map(event)
-    product_id = getattr(product, 'pk', product)
-    if product_id in assignment_map:
-        return assignment_map[product_id]
-    return default_layout
+    return product_map, voucher_map, default_layout
 
 
 def get_badge_layout_for_position(event, position):
-    return get_badge_layout_for_product(event, position.product_id)
+    product_map, voucher_map, default_layout = get_badge_layout_assignment_maps(event)
+
+    if position.voucher_id and position.voucher_id in voucher_map:
+        return voucher_map[position.voucher_id]
+
+    if position.product_id in product_map:
+        return product_map[position.product_id]
+    return default_layout
+
+
+def position_has_printable_badge(event, position):
+    return get_badge_layout_for_position(event, position) is not None
+
+
+def position_has_explicit_badge_assignment(event, position):
+    product_map, voucher_map, _default_layout = get_badge_layout_assignment_maps(event)
+    if position.voucher_id and position.voucher_id in voucher_map:
+        return voucher_map[position.voucher_id] is not None
+    if position.product_id in product_map:
+        return product_map[position.product_id] is not None
+    return False
+
+
+def exclude_explicit_no_badge(qs, assignment_model, fk_lookup):
+    return qs.annotate(
+        no_badging=Exists(
+            assignment_model.objects.filter(**{fk_lookup: OuterRef('pk'), 'layout__isnull': True})
+        )
+    ).exclude(no_badging=True)
 
 
 def get_badge_hidden_fields(position):
@@ -183,7 +205,7 @@ def get_badge_bundle_option_choices(event, position):
     seen_keys = set()
     choices = []
     for bundle_position in get_badge_bundle_positions(position):
-        if not product_has_badge_layout_assigned(event, bundle_position.product_id):
+        if not position_has_explicit_badge_assignment(event, bundle_position):
             continue
 
         layout = get_badge_layout_for_position(event, bundle_position)

--- a/app/eventyay/plugins/badges/views.py
+++ b/app/eventyay/plugins/badges/views.py
@@ -118,6 +118,7 @@ class LayoutSettingsView(BadgePluginEnabledMixin, EventPermissionRequiredMixin, 
             user=self.request.user,
             data={
                 'products': list(form.cleaned_data['products'].values_list('pk', flat=True)),
+                'vouchers': list(form.cleaned_data['vouchers'].values_list('pk', flat=True)),
                 'allow_customization': form.cleaned_data['allow_customization'],
                 'ask_user_fields': form.cleaned_data['ask_user_fields'],
             },

--- a/app/eventyay/static/pretixcontrol/js/ui/editor.js
+++ b/app/eventyay/static/pretixcontrol/js/ui/editor.js
@@ -168,6 +168,13 @@ var editor = {
         maxPt = typeof maxPt === 'number' && !isNaN(maxPt) ? maxPt : editor._get_text_max_font_pt(o);
         widthMm = typeof widthMm === 'number' && !isNaN(widthMm) ? widthMm : editor._px2mm(o.width);
 
+        var lines = text.split(/\r\n|\r|\n/).filter(function (line) {
+            return line.length > 0;
+        });
+        if (!lines.length) {
+            return maxPt;
+        }
+
         var widthPx = editor._mm2px(widthMm);
         var canvas = document.createElement('canvas');
         var ctx = canvas.getContext('2d');
@@ -177,7 +184,14 @@ var editor = {
 
         for (var pt = maxPt; pt >= editor._AUTOFIT_MIN_PT; pt -= 0.5) {
             ctx.font = fontStyle + fontWeight + editor._pt2px(pt) + 'px ' + fontFamily;
-            if (ctx.measureText(text).width <= widthPx) {
+            var fits = true;
+            for (var i = 0; i < lines.length; i++) {
+                if (ctx.measureText(lines[i]).width > widthPx) {
+                    fits = false;
+                    break;
+                }
+            }
+            if (fits) {
                 return pt;
             }
         }

--- a/app/eventyay/static/pretixcontrol/js/ui/editor.js
+++ b/app/eventyay/static/pretixcontrol/js/ui/editor.js
@@ -186,8 +186,14 @@ var editor = {
             ctx.font = fontStyle + fontWeight + editor._pt2px(pt) + 'px ' + fontFamily;
             var fits = true;
             for (var i = 0; i < lines.length; i++) {
-                if (ctx.measureText(lines[i]).width > widthPx) {
-                    fits = false;
+                var parts = lines[i].trim() ? lines[i].trim().split(/\s+/) : [];
+                for (var j = 0; j < parts.length; j++) {
+                    if (ctx.measureText(parts[j]).width > widthPx) {
+                        fits = false;
+                        break;
+                    }
+                }
+                if (!fits) {
                     break;
                 }
             }

--- a/app/eventyay/static/pretixcontrol/js/ui/editor.js
+++ b/app/eventyay/static/pretixcontrol/js/ui/editor.js
@@ -84,7 +84,7 @@ fabric.Textarea = fabric.util.createClass(fabric.Textbox, {
 
         this.callSuper('initialize', text, options);
         this.set('content', options.content || '');
-        this.autofit_width = options.autofit_width || false;
+        this.autofit_width = editor._parse_autofit_width(options.autofit_width);
         if (typeof options.maxFontPt === 'number' && !isNaN(options.maxFontPt)) {
             this.maxFontPt = options.maxFontPt;
         }
@@ -684,6 +684,7 @@ var editor = {
     _update_toolbox_values: function () {
         var o = editor._get_toolbox_target_object(true);
         if (!o) {
+            $("#toolbox-autofit-width").prop('checked', false);
             return;
         }
         editor._toolbox_update_in_progress = true;

--- a/app/eventyay/static/pretixcontrol/js/ui/editor.js
+++ b/app/eventyay/static/pretixcontrol/js/ui/editor.js
@@ -84,6 +84,10 @@ fabric.Textarea = fabric.util.createClass(fabric.Textbox, {
 
         this.callSuper('initialize', text, options);
         this.set('content', options.content || '');
+        this.autofit_width = options.autofit_width || false;
+        if (typeof options.maxFontPt === 'number' && !isNaN(options.maxFontPt)) {
+            this.maxFontPt = options.maxFontPt;
+        }
     },
 
     toObject: function(propertiesToInclude) {
@@ -145,6 +149,10 @@ var editor = {
             return o.maxFontPt;
         }
         return editor._px2pt(o.fontSize);
+    },
+
+    _parse_autofit_width: function (value) {
+        return value === true || value === 'true' || value === 1 || value === '1';
     },
 
     _compute_autofit_pt: function (o, maxPt, widthMm) {
@@ -327,7 +335,7 @@ var editor = {
                     italic: o.fontStyle === 'italic',
                     width: editor._px2mm(o.width).toFixed(2),
                     downward: o.downward || false,
-                    autofit_width: o.autofit_width || false,
+                    autofit_width: editor._parse_autofit_width(o.autofit_width),
                     content: o.content,
                     text: o.text,
                     rotation: o.angle,
@@ -383,7 +391,7 @@ var editor = {
             o = editor._add_text();
             o.set('fill', 'rgb(' + d.color[0] + ',' + d.color[1] + ',' + d.color[2] + ')');
             o.maxFontPt = parseFloat(d.fontsize);
-            o.autofit_width = d.autofit_width || false;
+            o.autofit_width = editor._parse_autofit_width(d.autofit_width);
             o.set('fontSize', editor._pt2px(d.fontsize));
             o.set('lineHeight', d.lineheight || 1);
             o.set('fontFamily', d.fontfamily);
@@ -719,7 +727,7 @@ var editor = {
             $("#toolbox").find("button[data-action=bold]").toggleClass('active', o.fontWeight === 'bold');
             $("#toolbox").find("button[data-action=italic]").toggleClass('active', o.fontStyle === 'italic');
             $("#toolbox").find("button[data-action=downward]").toggleClass('active', o.downward || false);
-            $("#toolbox").find("button[data-action=autofit_width]").toggleClass('active', o.autofit_width || false);
+            $("#toolbox-autofit-width").prop('checked', editor._parse_autofit_width(o.autofit_width));
             $("#toolbox").find("button[data-action=left]").toggleClass('active', o.textAlign === 'left');
             $("#toolbox").find("button[data-action=center]").toggleClass('active', o.textAlign === 'center');
             $("#toolbox").find("button[data-action=right]").toggleClass('active', o.textAlign === 'right');
@@ -802,7 +810,7 @@ var editor = {
             o.set('fontFamily', $("#toolbox-fontfamily").val());
             o.set('fontWeight', $("#toolbox").find("button[data-action=bold]").is('.active') ? 'bold' : 'normal');
             o.set('fontStyle', $("#toolbox").find("button[data-action=italic]").is('.active') ? 'italic' : 'normal');
-            o.autofit_width = $("#toolbox").find("button[data-action=autofit_width]").is('.active');
+            o.autofit_width = $("#toolbox-autofit-width").prop('checked');
             var align = $("#toolbox-align").find(".active").attr("data-action");
             if (align) {
                 o.set('textAlign', align);
@@ -1340,7 +1348,8 @@ var editor = {
 
         $("#toolbox input[type=number], #toolbox textarea:not(#toolbox-content-other), #toolbox input[type=text]").bind('change keydown keyup' +
             ' input', editor._update_values_from_toolbox);
-        $("#toolbox input[type=number], #toolbox textarea:not(#toolbox-content-other), #toolbox input[type=text], #toolbox input[type=radio]").bind('change', editor._create_savepoint);
+        $("#toolbox input[type=number], #toolbox textarea:not(#toolbox-content-other), #toolbox input[type=text], #toolbox input[type=radio], #toolbox-autofit-width").bind('change', editor._create_savepoint);
+        $("#toolbox-autofit-width").bind('change', editor._update_values_from_toolbox);
         $("#toolbox label.btn").bind('click change', editor._update_values_from_toolbox);
         $("#toolbox select:not(#toolbox-content)").bind('change', editor._update_values_from_toolbox);
         $("#toolbox select:not(#toolbox-content)").bind('change', editor._create_savepoint);

--- a/app/eventyay/static/pretixcontrol/js/ui/editor.js
+++ b/app/eventyay/static/pretixcontrol/js/ui/editor.js
@@ -87,7 +87,7 @@ fabric.Textarea = fabric.util.createClass(fabric.Textbox, {
     },
 
     toObject: function(propertiesToInclude) {
-        return this.callSuper('toObject', ['content'].concat(propertiesToInclude));
+        return this.callSuper('toObject', ['content', 'autofit_width', 'maxFontPt'].concat(propertiesToInclude));
     }
 });
 fabric.Textarea.fromObject = function (object, callback, forceAsync) {
@@ -122,6 +122,7 @@ var editor = {
     _fabric_loaded: false,
     _last_active_object: null,
     _PAGE_SIZE_TOLERANCE: 0.05,
+    _AUTOFIT_MIN_PT: 4,
 
     _px2mm: function (v) {
         return v / editor.pdf_scale / 72 * editor.pdf_page.userUnit * 25.4;
@@ -137,6 +138,50 @@ var editor = {
 
     _pt2px: function (v) {
         return v * editor.pdf_scale / editor.pdf_page.userUnit;
+    },
+
+    _get_text_max_font_pt: function (o) {
+        if (typeof o.maxFontPt === 'number' && !isNaN(o.maxFontPt)) {
+            return o.maxFontPt;
+        }
+        return editor._px2pt(o.fontSize);
+    },
+
+    _compute_autofit_pt: function (o, maxPt, widthMm) {
+        if (!o.autofit_width) {
+            return maxPt;
+        }
+
+        var text = o.text || '';
+        if (!text) {
+            return maxPt;
+        }
+
+        maxPt = typeof maxPt === 'number' && !isNaN(maxPt) ? maxPt : editor._get_text_max_font_pt(o);
+        widthMm = typeof widthMm === 'number' && !isNaN(widthMm) ? widthMm : editor._px2mm(o.width);
+
+        var widthPx = editor._mm2px(widthMm);
+        var canvas = document.createElement('canvas');
+        var ctx = canvas.getContext('2d');
+        var fontFamily = o.fontFamily || 'Open Sans';
+        var fontWeight = o.fontWeight === 'bold' ? 'bold ' : '';
+        var fontStyle = o.fontStyle === 'italic' ? 'italic ' : '';
+
+        for (var pt = maxPt; pt >= editor._AUTOFIT_MIN_PT; pt -= 0.5) {
+            ctx.font = fontStyle + fontWeight + editor._pt2px(pt) + 'px ' + fontFamily;
+            if (ctx.measureText(text).width <= widthPx) {
+                return pt;
+            }
+        }
+        return editor._AUTOFIT_MIN_PT;
+    },
+
+    _apply_autofit_fontsize: function (o, maxPt, widthMm) {
+        maxPt = typeof maxPt === 'number' && !isNaN(maxPt) ? maxPt : editor._get_text_max_font_pt(o);
+        o.maxFontPt = maxPt;
+        o.set('fontSize', editor._pt2px(
+            o.autofit_width ? editor._compute_autofit_pt(o, maxPt, widthMm) : maxPt
+        ));
     },
 
     _csrf_token: function () {
@@ -274,7 +319,7 @@ var editor = {
                     locale: $("#pdf-info-locale").val(),
                     left: editor._px2mm(left).toFixed(2),
                     bottom: editor._px2mm(bottom).toFixed(2),
-                    fontsize: editor._px2pt(o.fontSize).toFixed(1),
+                    fontsize: editor._get_text_max_font_pt(o).toFixed(1),
                     color: col,
                     //lineheight: o.lineHeight,
                     fontfamily: o.fontFamily,
@@ -282,6 +327,7 @@ var editor = {
                     italic: o.fontStyle === 'italic',
                     width: editor._px2mm(o.width).toFixed(2),
                     downward: o.downward || false,
+                    autofit_width: o.autofit_width || false,
                     content: o.content,
                     text: o.text,
                     rotation: o.angle,
@@ -336,6 +382,8 @@ var editor = {
         } else if (d.type === "textarea" || d.type === "text") {
             o = editor._add_text();
             o.set('fill', 'rgb(' + d.color[0] + ',' + d.color[1] + ',' + d.color[2] + ')');
+            o.maxFontPt = parseFloat(d.fontsize);
+            o.autofit_width = d.autofit_width || false;
             o.set('fontSize', editor._pt2px(d.fontsize));
             o.set('lineHeight', d.lineheight || 1);
             o.set('fontFamily', d.fontfamily);
@@ -362,6 +410,7 @@ var editor = {
             }
             var widthVal = parseFloat(d.width);
             o.set('width', editor._mm2px(isNaN(widthVal) ? 50 : widthVal));
+            editor._apply_autofit_fontsize(o, o.maxFontPt, widthVal);
             if (d.locale) {
                 // The data format allows to set the locale per text field but we currently only expose a global field
                 $("#pdf-info-locale").val(d.locale);
@@ -498,6 +547,7 @@ var editor = {
         }
 
         editor._apply_text_content_to_object(o);
+        editor._apply_autofit_fontsize(o);
         o.setCoords();
         editor.fabric.renderAll();
         return true;
@@ -663,12 +713,13 @@ var editor = {
                 $colorInput.colorpicker('setValue', hexColor);
             }
             $colorInput.closest('.colorpicker-preview-group').find('.colorpicker-preview').css('background-color', hexColor);
-            setVal("#toolbox-fontsize", editor._px2pt(o.fontSize).toFixed(1));
+            setVal("#toolbox-fontsize", editor._get_text_max_font_pt(o).toFixed(1));
             //$("#toolbox-lineheight").val(o.lineHeight);
             setVal("#toolbox-fontfamily", o.fontFamily);
             $("#toolbox").find("button[data-action=bold]").toggleClass('active', o.fontWeight === 'bold');
             $("#toolbox").find("button[data-action=italic]").toggleClass('active', o.fontStyle === 'italic');
             $("#toolbox").find("button[data-action=downward]").toggleClass('active', o.downward || false);
+            $("#toolbox").find("button[data-action=autofit_width]").toggleClass('active', o.autofit_width || false);
             $("#toolbox").find("button[data-action=left]").toggleClass('active', o.textAlign === 'left');
             $("#toolbox").find("button[data-action=center]").toggleClass('active', o.textAlign === 'center');
             $("#toolbox").find("button[data-action=right]").toggleClass('active', o.textAlign === 'right');
@@ -743,11 +794,15 @@ var editor = {
             }
         } else if (o.type === "textarea" || o.type === "text") {
             o.set('fill', $("#toolbox-col").val());
-            o.set('fontSize', editor._pt2px($("#toolbox-fontsize").val()));
+            var maxFontPt = parseFloat($("#toolbox-fontsize").val());
+            if (!isNaN(maxFontPt)) {
+                o.maxFontPt = maxFontPt;
+            }
             o.set('lineHeight', $("#toolbox-lineheight").val() || 1);
             o.set('fontFamily', $("#toolbox-fontfamily").val());
             o.set('fontWeight', $("#toolbox").find("button[data-action=bold]").is('.active') ? 'bold' : 'normal');
             o.set('fontStyle', $("#toolbox").find("button[data-action=italic]").is('.active') ? 'italic' : 'normal');
+            o.autofit_width = $("#toolbox").find("button[data-action=autofit_width]").is('.active');
             var align = $("#toolbox-align").find(".active").attr("data-action");
             if (align) {
                 o.set('textAlign', align);
@@ -768,6 +823,7 @@ var editor = {
                 o.dirty = true;
             }
             editor._apply_text_content_to_object(o);
+            editor._apply_autofit_fontsize(o, o.maxFontPt, w);
         }
 
         o.setCoords();

--- a/app/tests/tickets/plugins/badges/test_utils.py
+++ b/app/tests/tickets/plugins/badges/test_utils.py
@@ -3,9 +3,14 @@ import datetime
 import pytest
 from django_scopes import scopes_disabled
 
-from eventyay.base.models import Event, Order, OrderPosition, Organizer, Product
-from eventyay.plugins.badges.models import BadgeProduct
-from eventyay.plugins.badges.utils import get_badge_bundle_option_choices
+from eventyay.base.models import Event, Order, OrderPosition, Organizer, Product, Voucher
+from eventyay.base.pdf import Renderer
+from eventyay.plugins.badges.models import BadgeProduct, BadgeVoucher
+from eventyay.plugins.badges.utils import (
+    get_badge_bundle_option_choices,
+    get_badge_layout_for_position,
+    position_has_printable_badge,
+)
 
 
 @pytest.fixture
@@ -68,3 +73,69 @@ def test_badge_options_hidden_when_product_explicitly_has_no_layout(badge_event)
     BadgeProduct.objects.create(product=product, layout=None)
 
     assert get_badge_bundle_option_choices(event, position) == []
+
+
+@pytest.mark.django_db
+def test_voucher_explicit_assignment_enables_checkout_options(badge_event):
+    event, position, product, layout = badge_event
+    voucher = Voucher.objects.create(event=event, code='VOUCHER3')
+    position.voucher = voucher
+    position.save(update_fields=['voucher'])
+    BadgeVoucher.objects.create(voucher=voucher, layout=layout)
+
+    choices = get_badge_bundle_option_choices(event, position)
+
+    assert len(choices) == 1
+    assert choices[0][0] == 'attendee_name'
+
+
+@pytest.mark.django_db
+def test_voucher_layout_overrides_product_default(badge_event):
+    event, position, product, layout = badge_event
+    voucher_layout = event.badge_layouts.create(name='Voucher layout')
+    voucher = Voucher.objects.create(event=event, code='VOUCHER1')
+    position.voucher = voucher
+    position.save(update_fields=['voucher'])
+
+    BadgeVoucher.objects.create(voucher=voucher, layout=voucher_layout)
+
+    assert get_badge_layout_for_position(event, position) == voucher_layout
+    assert position_has_printable_badge(event, position) is True
+
+
+@pytest.mark.django_db
+def test_voucher_layout_none_disables_badge_even_with_default_product(badge_event):
+    event, position, product, layout = badge_event
+    voucher = Voucher.objects.create(event=event, code='VOUCHER2')
+    position.voucher = voucher
+    position.save(update_fields=['voucher'])
+
+    BadgeVoucher.objects.create(voucher=voucher, layout=None)
+
+    assert get_badge_layout_for_position(event, position) is None
+    assert position_has_printable_badge(event, position) is False
+
+
+def test_fit_fontsize_to_width_shrinks_long_text():
+    Renderer._register_fonts()
+    fitted = Renderer._fit_fontsize_to_width(
+        'Very Long Attendee Name Example',
+        'Open Sans',
+        max_fontsize=12.0,
+        width_mm=30,
+    )
+
+    assert fitted < 12.0
+    assert fitted >= 4.0
+
+
+def test_fit_fontsize_to_width_keeps_short_text_at_max():
+    Renderer._register_fonts()
+    fitted = Renderer._fit_fontsize_to_width(
+        'Ann',
+        'Open Sans',
+        max_fontsize=12.0,
+        width_mm=30,
+    )
+
+    assert fitted == 12.0

--- a/app/tests/tickets/plugins/badges/test_utils.py
+++ b/app/tests/tickets/plugins/badges/test_utils.py
@@ -139,3 +139,15 @@ def test_fit_fontsize_to_width_keeps_short_text_at_max():
     )
 
     assert fitted == 12.0
+
+
+def test_fit_fontsize_to_width_multiline_uses_longest_line():
+    Renderer._register_fonts()
+    fitted = Renderer._fit_fontsize_to_width(
+        'John\nDoe',
+        'Open Sans',
+        max_fontsize=12.0,
+        width_mm=30,
+    )
+
+    assert fitted == 12.0

--- a/app/tests/tickets/plugins/badges/test_utils.py
+++ b/app/tests/tickets/plugins/badges/test_utils.py
@@ -116,7 +116,20 @@ def test_voucher_layout_none_disables_badge_even_with_default_product(badge_even
     assert position_has_printable_badge(event, position) is False
 
 
-def test_fit_fontsize_to_width_shrinks_long_text():
+def test_fit_fontsize_to_width_shrinks_unbreakable_text():
+    Renderer._register_fonts()
+    fitted = Renderer._fit_fontsize_to_width(
+        'VeryLongAttendeeNameExample',
+        'Open Sans',
+        max_fontsize=12.0,
+        width_mm=30,
+    )
+
+    assert fitted < 12.0
+    assert fitted >= 4.0
+
+
+def test_fit_fontsize_to_width_keeps_wrappable_text_at_max():
     Renderer._register_fonts()
     fitted = Renderer._fit_fontsize_to_width(
         'Very Long Attendee Name Example',
@@ -125,8 +138,7 @@ def test_fit_fontsize_to_width_shrinks_long_text():
         width_mm=30,
     )
 
-    assert fitted < 12.0
-    assert fitted >= 4.0
+    assert fitted == 12.0
 
 
 def test_fit_fontsize_to_width_keeps_short_text_at_max():


### PR DESCRIPTION
## Summary
- Add an **Adapt content to container width** toggle for PDF/badge text fields that shrinks font size at render time when long names exceed the box width (opt-in via `autofit_width`).
- Add **voucher badge layout assignment** mirroring product assignment, including a Vouchers tab in layout settings and an optional voucher filter in bulk badge export.
- Expose **Voucher code** and **Voucher tag** as badge editor text variables.

## Backward compatibility
- Existing layouts without `autofit_width` render unchanged.
- Events without voucher assignments keep the current product/default layout resolution.
- Checkout badge customization still requires explicit product/voucher assignment (default layout alone is not enough).

## Test plan
- [ ] Run `python manage.py migrate badges`
- [ ] In the badge editor, enable **Adapt content to container width** on a name field and verify long preview text shrinks; confirm printed/preview PDF matches
- [ ] Assign vouchers to a layout in badge settings and print badges for orders using those vouchers
- [ ] Use bulk badge export with the optional voucher filter
- [ ] Confirm ticket PDF editor and existing badge layouts without new options behave as before
- [ ] `pytest tests/tickets/plugins/badges/ -q`