### PR TITLE
Update teamshifts lock revision

### DIFF
--- a/app/uv.lock
+++ b/app/uv.lock
@@ -1195,7 +1195,7 @@ dependencies = [
 [[package]]
 name = "eventyay-teamshifts"
 version = "0.1.0"
-source = { git = "https://github.com/fossasia/eventyay-teamshifts.git?rev=main#7f709ae9bf60b9c458bebb59b8e962f7ecadf289" }
+source = { git = "https://github.com/fossasia/eventyay-teamshifts.git?rev=main#d1d76d3a33c52469357cd49bf2a1d1486fb1edc3" }
 
 [[package]]
 name = "eventyay-unified"


### PR DESCRIPTION
## Summary
- update the locked `eventyay-teamshifts` revision to `d1d76d3a33c52469357cd49bf2a1d1486fb1edc3`

## Test plan
- [x] Run `uv lock --check`
- [x] Confirm the PR changes only `app/uv.lock`

## Summary by Sourcery

Build:
- Refresh uv.lock to point to the latest eventyay-teamshifts revision.