### PR TITLE
Prevent duplicate proposals after speaker validation errors

### DIFF
--- a/app/eventyay/orga/forms/submission.py
+++ b/app/eventyay/orga/forms/submission.py
@@ -323,11 +323,15 @@ class AddSpeakerForm(forms.Form):
     def __init__(self, *args, event=None, form_renderer=None, require_name=False, **kwargs):
         super().__init__(*args, **kwargs)
         self.require_name = require_name
+        email_key = self.add_prefix('email')
+        name_key = self.add_prefix('name')
+        if self.is_bound and (email := self.data.get(email_key)):
+            name = self.data.get(name_key)
+            label = f'{name} ({email})' if name else email
+            self.fields['email'].widget.choices = [(email, label)]
         if require_name:
             self.fields['email'].required = True
             self.fields['name'].required = True
-            email_key = self.add_prefix('email')
-            name_key = self.add_prefix('name')
             if self.is_bound and self.data.get(email_key) and not self.data.get(name_key):
                 existing_user = User.objects.filter(email__iexact=self.data[email_key]).only('fullname').first()
                 if existing_user and existing_user.fullname:
@@ -342,7 +346,7 @@ class AddSpeakerForm(forms.Form):
     def clean(self):
         data = super().clean()
         if data.get('name') and not data.get('email'):
-            raise forms.ValidationError(_('Please provide an email address.'))
+            self.add_error('email', _('Please provide an email address.'))
         return data
 
 

--- a/app/eventyay/orga/forms/submission.py
+++ b/app/eventyay/orga/forms/submission.py
@@ -300,6 +300,10 @@ class SubmissionStateChangeForm(forms.Form):
     )
 
 
+def get_speaker_choice_label(*, name: str | None, email: str) -> str:
+    return f'{name} ({email})' if name else email
+
+
 class AddSpeakerForm(forms.Form):
     email = forms.EmailField(
         label=phrases.cfp.speaker_email,
@@ -325,10 +329,10 @@ class AddSpeakerForm(forms.Form):
         self.require_name = require_name
         email_key = self.add_prefix('email')
         name_key = self.add_prefix('name')
-        if self.is_bound and (email := self.data.get(email_key)):
+        email_widget = self.fields['email'].widget
+        if isinstance(email_widget, forms.Select) and self.is_bound and (email := self.data.get(email_key)):
             name = self.data.get(name_key)
-            label = f'{name} ({email})' if name else email
-            self.fields['email'].widget.choices = [(email, label)]
+            email_widget.choices = [(email, get_speaker_choice_label(name=name, email=email))]
         if require_name:
             self.fields['email'].required = True
             self.fields['name'].required = True

--- a/app/eventyay/orga/views/organizer.py
+++ b/app/eventyay/orga/views/organizer.py
@@ -27,6 +27,7 @@ from eventyay.common.views.mixins import (
 from eventyay.event.forms import OrganizerForm
 from eventyay.base.models import Event, User
 from eventyay.base.models.organizer import Organizer
+from eventyay.orga.forms.submission import get_speaker_choice_label
 from eventyay.person.forms import UserSpeakerFilterForm
 
 logger = logging.getLogger(__name__)
@@ -180,7 +181,14 @@ def speaker_search(request, *args, **kwargs):
     return JsonResponse(
         {
             "count": len(users),
-            "results": [{"email": user.email, "name": user.fullname} for user in users],
+            "results": [
+                {
+                    "email": user.email,
+                    "name": user.fullname,
+                    "label": get_speaker_choice_label(name=user.fullname, email=user.email),
+                }
+                for user in users
+            ],
         }
     )
 

--- a/app/eventyay/orga/views/submission.py
+++ b/app/eventyay/orga/views/submission.py
@@ -499,24 +499,20 @@ class SubmissionContent(ActionFromUrl, ReviewerSubmissionFilter, SubmissionViewM
     @transaction.atomic()
     def form_valid(self, form):
         created = not self.object
-        self.object = form.instance
-        self._questions_form.submission = self.object
+        self._questions_form.submission = form.instance
         if not self._questions_form.is_valid():
             messages.error(self.request, phrases.base.error_saving_changes)
             return self.get(self.request, *self.args, **self.kwargs)
+        if created and not self.new_speaker_form.is_valid():
+            return self.form_invalid(form)
+
+        self.object = form.instance
         form.instance.event = self.request.event
         form.save()
         self._questions_form.save()
 
         if created:
-            if not self.new_speaker_form.is_valid():
-                if self.new_speaker_form.errors:
-                    for field, errors in self.new_speaker_form.errors.items():
-                        for error in errors:
-                            messages.error(self.request, f'{field}: {error}')
-                        break  # Only show errors for the first field
-                return self.form_invalid(form)
-            elif email := self.new_speaker_form.cleaned_data['email']:
+            if email := self.new_speaker_form.cleaned_data['email']:
                 form.instance.add_speaker(
                     email=email,
                     name=self.new_speaker_form.cleaned_data['name'],

--- a/app/eventyay/static/orga/js/speakers.js
+++ b/app/eventyay/static/orga/js/speakers.js
@@ -8,7 +8,7 @@ const initUserSearch = () => {
     const usersByEmail = new Map()
     const toChoice = (user) => ({
         value: user.email,
-        label: `${user.name} <${user.email}>`,
+        label: `${user.name} (${user.email})`,
         customProperties: {
             name: user.name,
         },

--- a/app/eventyay/static/orga/js/speakers.js
+++ b/app/eventyay/static/orga/js/speakers.js
@@ -8,7 +8,7 @@ const initUserSearch = () => {
     const usersByEmail = new Map()
     const toChoice = (user) => ({
         value: user.email,
-        label: `${user.name} (${user.email})`,
+        label: user.label,
         customProperties: {
             name: user.name,
         },

--- a/app/tests/talk/orga/views/test_orga_views_submission.py
+++ b/app/tests/talk/orga/views/test_orga_views_submission.py
@@ -440,6 +440,7 @@ def test_orga_create_submission_preserves_speaker_after_form_error(orga_client, 
     )
 
     speaker_form = response.context["new_speaker_form"]
+    assert not speaker_form.errors
     assert response.status_code == 200
     assert speaker_form["email"].value() == "foo@bar.com"
     assert list(speaker_form.fields["email"].widget.choices) == [
@@ -468,8 +469,11 @@ def test_orga_create_submission_does_not_save_before_speaker_validation(orga_cli
         },
     )
 
+    speaker_form = response.context["new_speaker_form"]
     assert response.status_code == 200
-    assert "email" in response.context["new_speaker_form"].errors
+    assert "__all__" not in speaker_form.errors
+    assert "email" in speaker_form.errors
+    assert len(speaker_form.errors["email"]) == 1
     with scope(event=event):
         assert event.submissions.count() == 0
 

--- a/app/tests/talk/orga/views/test_orga_views_submission.py
+++ b/app/tests/talk/orga/views/test_orga_views_submission.py
@@ -424,6 +424,57 @@ def test_orga_can_create_submission(orga_client, event, known_speaker, orga_user
 
 
 @pytest.mark.django_db
+def test_orga_create_submission_preserves_speaker_after_form_error(orga_client, event):
+    response = orga_client.post(
+        event.orga_urls.new_submission,
+        data={
+            "abstract": "abstract",
+            "content_locale": "en",
+            "description": "description",
+            "speaker-email": "foo@bar.com",
+            "speaker-name": "Foo Speaker",
+            "speaker-locale": "en",
+            "state": "submitted",
+            "title": "title",
+        },
+    )
+
+    speaker_form = response.context["new_speaker_form"]
+    assert response.status_code == 200
+    assert speaker_form["email"].value() == "foo@bar.com"
+    assert list(speaker_form.fields["email"].widget.choices) == [
+        ("foo@bar.com", "Foo Speaker (foo@bar.com)")
+    ]
+    with scope(event=event):
+        assert event.submissions.count() == 0
+
+
+@pytest.mark.django_db
+def test_orga_create_submission_does_not_save_before_speaker_validation(orga_client, event):
+    with scope(event=event):
+        type_pk = event.submission_types.first().pk
+
+    response = orga_client.post(
+        event.orga_urls.new_submission,
+        data={
+            "abstract": "abstract",
+            "content_locale": "en",
+            "description": "description",
+            "speaker-name": "Foo Speaker",
+            "speaker-locale": "en",
+            "state": "submitted",
+            "submission_type": type_pk,
+            "title": "title",
+        },
+    )
+
+    assert response.status_code == 200
+    assert "email" in response.context["new_speaker_form"].errors
+    with scope(event=event):
+        assert event.submissions.count() == 0
+
+
+@pytest.mark.django_db
 def test_orga_can_edit_submission(orga_client, event, accepted_submission):
     event.feature_flags["present_multiple_times"] = True
     event.save()


### PR DESCRIPTION
## Summary
- preserve the selected speaker email when the proposal form is re-rendered after validation fails
- validate the speaker form before saving a new proposal so invalid retries cannot leave duplicate database records
- attach missing-email validation to the email field and avoid duplicate or `__all__` error banners
- use an escape-safe speaker label and add regression coverage for preserved input and save ordering

## Why
The remote speaker field uses a select widget whose submitted value was not included in its server-rendered choices. After another proposal field failed validation, the autocomplete therefore lost the selected email on the next submission. The proposal was also saved before the nested speaker form was validated, leaving a database row behind when speaker validation failed and causing the next retry to create a duplicate.

## Test plan
- [x] Reproduced the missing session-type validation flow locally and confirmed the selected speaker remains bound
- [x] Confirmed an invalid speaker form does not change the event submission count
- [x] Run Python compilation checks for the modified Python files
- [x] Run `node --check` for `speakers.js`

## BEFORE

https://github.com/user-attachments/assets/1c37f677-771c-4875-af7b-6adc117c0d7c

## AFTER 

https://github.com/user-attachments/assets/55487a61-bffa-47ba-ad23-809cb6b3f678

## Summary by Sourcery

Ensure new proposal submissions validate speaker data before saving and preserve the selected remote speaker across validation errors.

Bug Fixes:
- Prevent duplicate submissions from being created when speaker validation fails during new proposal creation.
- Preserve the selected speaker email and label in the proposal form after a validation error so the speaker choice is not lost.
- Attach missing-email validation errors directly to the email field to avoid confusing or duplicate error banners.

Enhancements:
- Align the speaker autocomplete label format with a safer, consistent name-and-email representation.

Tests:
- Add regression tests covering speaker preservation after form errors and ensuring submissions are not saved before speaker validation.