### PR TITLE
fix(badges): fix misleading badge export error when there is no data

### DIFF
--- a/app/eventyay/base/services/export.py
+++ b/app/eventyay/base/services/export.py
@@ -57,6 +57,8 @@ def export(self, event: Event, fileid: str, provider: str, form_data: Dict[str, 
                         'Your data table is too big for a PDF page. Please reduce the amount of data you are exporting.'
                     )
                     raise ExportError(msg) from e
+                except ExportError:
+                    raise
                 except Exception as e:
                     logger.exception(f'Error during export with provider {provider}.')
                     # Provide specific error message based on exception type
@@ -129,6 +131,8 @@ def multiexport(
                         'Your data table is too big for a PDF page. Please reduce the amount of data you are exporting.'
                     )
                     raise ExportError(msg) from e
+                except ExportError:
+                    raise
                 except Exception as e:
                     logger.exception(f'Error during multi-event export with provider {provider}.')
                     error_msg = str(e) if str(e) else type(e).__name__

--- a/app/eventyay/plugins/badges/exporters.py
+++ b/app/eventyay/plugins/badges/exporters.py
@@ -24,6 +24,7 @@ from eventyay.base.exporters.date import build_date_filter, parse_date_input
 from eventyay.base.i18n import language
 from eventyay.base.models import Order, OrderPosition
 from eventyay.base.pdf import Renderer
+from eventyay.base.services.export import ExportError
 from eventyay.base.services.orders import OrderError
 from eventyay.base.settings import PERSON_NAME_SCHEMES
 from eventyay.plugins.badges.models import BadgeProduct, BadgeVoucher
@@ -395,7 +396,7 @@ def render_badges(event, positions, opt, apply_output_pagesize=False):
                 op_renderers.append((op, renderer))
 
     if not op_renderers:
-        raise OrderError(_('None of the selected products is configured to print badges.'))
+        raise ExportError(_('None of the selected products is configured to print badges.'))
 
     badge_pdf = PdfWriter()
     badge_pdf.add_metadata(
@@ -595,6 +596,9 @@ class BadgeExporter(BaseExporter):
                 .annotate(resolved_name_part=JSONExtract('resolved_name', part))
                 .order_by('resolved_name_part')
             )
+
+        if not qs.exists():
+            return None
 
         outbuffer = render_pdf(self.event, qs, OPTIONS[form_data.get('rendering', 'one')])
         return 'badges.pdf', 'application/pdf', outbuffer.read()


### PR DESCRIPTION
This fixes an issue where a misleading error message 'None of the selected products is configured to print badges' is shown when exporting badges with no data matching the filters. This changes the behavior to correctly display 'Your export did not contain any data.' by returning None on empty QuerySets. It also prevents the export framework from wrapping custom ExportErrors.


https://github.com/user-attachments/assets/462a55d5-ba2d-4119-ab32-c1ce27f18dd3

