### PR TITLE
fix(badges): keep autofit text inside container width

### DIFF
--- a/app/eventyay/base/pdf.py
+++ b/app/eventyay/base/pdf.py
@@ -1017,10 +1017,7 @@ class Renderer:
         while size > min_size:
             fits = True
             for line in lines:
-                parts = line.split()
-                if not parts:
-                    continue
-                if max(pdfmetrics.stringWidth(part, font_name, size) for part in parts) > width_pt:
+                if pdfmetrics.stringWidth(line, font_name, size) > width_pt:
                     fits = False
                     break
             if fits:

--- a/app/eventyay/control/templates/pretixcontrol/pdf/index.html
+++ b/app/eventyay/control/templates/pretixcontrol/pdf/index.html
@@ -279,7 +279,7 @@
                         <div class="col-sm-12">
                             <div class="checkbox">
                                 <label for="toolbox-autofit-width"
-                                       title="{% trans 'Shrink font size for long text so it fits within the text box width' %}">
+                                       title="{% trans 'Shrink font size so each line fits within the text box width without expanding the box' %}">
                                     <input type="checkbox" id="toolbox-autofit-width">
                                     {% trans "Adapt content to container width" %}
                                 </label>

--- a/app/eventyay/static/pretixcontrol/js/ui/editor.js
+++ b/app/eventyay/static/pretixcontrol/js/ui/editor.js
@@ -90,6 +90,22 @@ fabric.Textarea = fabric.util.createClass(fabric.Textbox, {
         }
     },
 
+    initDimensions: function () {
+        if (this.__skipDimension) {
+            return;
+        }
+        this.isEditing && this.initDelayedCursor();
+        this.clearContextTop();
+        this._clearCache();
+        this.dynamicMinWidth = 0;
+        this._styleMap = this._generateStyleMap(this._splitText());
+        if (this.textAlign.indexOf('justify') !== -1) {
+            this.enlargeSpaces();
+        }
+        this.height = this.calcTextHeight();
+        this.saveState({propertySet: '_dimensionAffectingProps'});
+    },
+
     toObject: function(propertiesToInclude) {
         return this.callSuper('toObject', ['content', 'autofit_width', 'maxFontPt'].concat(propertiesToInclude));
     }
@@ -186,14 +202,8 @@ var editor = {
             ctx.font = fontStyle + fontWeight + editor._pt2px(pt) + 'px ' + fontFamily;
             var fits = true;
             for (var i = 0; i < lines.length; i++) {
-                var parts = lines[i].trim() ? lines[i].trim().split(/\s+/) : [];
-                for (var j = 0; j < parts.length; j++) {
-                    if (ctx.measureText(parts[j]).width > widthPx) {
-                        fits = false;
-                        break;
-                    }
-                }
-                if (!fits) {
+                if (ctx.measureText(lines[i]).width > widthPx) {
+                    fits = false;
                     break;
                 }
             }
@@ -210,6 +220,9 @@ var editor = {
         o.set('fontSize', editor._pt2px(
             o.autofit_width ? editor._compute_autofit_pt(o, maxPt, widthMm) : maxPt
         ));
+        if (o.initDimensions) {
+            o.initDimensions();
+        }
     },
 
     _csrf_token: function () {

--- a/app/tests/tickets/plugins/badges/test_utils.py
+++ b/app/tests/tickets/plugins/badges/test_utils.py
@@ -130,7 +130,7 @@ def test_fit_fontsize_to_width_shrinks_unbreakable_text():
     assert fitted >= 4.0
 
 
-def test_fit_fontsize_to_width_keeps_wrappable_text_at_max():
+def test_fit_fontsize_to_width_shrinks_wrappable_text_to_single_line():
     Renderer._register_fonts()
     fitted = Renderer._fit_fontsize_to_width(
         'Very Long Attendee Name Example',
@@ -139,7 +139,8 @@ def test_fit_fontsize_to_width_keeps_wrappable_text_at_max():
         width_mm=30,
     )
 
-    assert fitted == 12.0
+    assert fitted < 12.0
+    assert fitted >= 4.0
 
 
 def test_fit_fontsize_to_width_keeps_short_text_at_max():


### PR DESCRIPTION
## Summary
- Fix badge/PDF editor "Adapt content to container width" so text stays within the defined box width instead of expanding the container or wrapping outside it
- Measure full line width when computing autofit font size in both the editor preview and PDF renderer
- Prevent Fabric.js text areas from auto-expanding width beyond the user-set container

## Test plan
- [x] `pytest tests/tickets/plugins/badges/test_utils.py -q -k fit_fontsize`
- [ ] Open badge layout editor, add a text field with a narrow width, enable **Adapt content to container width**, and verify long sample text shrinks inside the box
- [ ] Use **Preview** with long attendee names and confirm PDF output matches the editor bounds