### PR TITLE
fix(badges): cache-bust PDF editor.js after autofit fix

### DIFF
--- a/app/eventyay/control/templates/pretixcontrol/pdf/index.html
+++ b/app/eventyay/control/templates/pretixcontrol/pdf/index.html
@@ -477,7 +477,7 @@
 
     <script type="text/javascript" src="{% static "pdfjs/pdf.js" %}"></script>
     <script type="text/javascript" src="{% static "fabric/fabric.min.js" %}"></script>
-    <script type="text/javascript" src="{% static "pretixcontrol/js/ui/editor.js" %}"></script>
+    <script type="text/javascript" src="{% static "pretixcontrol/js/ui/editor.js" %}?v=autofit2"></script>
     <img src="{% static 'pretixpresale/pdf/powered_by_eventyay_dark.png' %}" id="poweredby-dark" class="sr-only">
     <img src="{% static 'pretixpresale/pdf/powered_by_eventyay_white.png' %}" id="poweredby-white" class="sr-only">
     {% for family, styles in fonts.items %}


### PR DESCRIPTION
## Summary
- Static `editor.js` is served without content hashing, so production browsers/CDN can keep the old autofit logic after deploy
- Add an explicit cache-bust query param so clients load the fixed badge/PDF editor script

## Context
#4454 fixed autofit locally, but production can still show the old behavior until `editor.js` is re-fetched.

## Test plan
- [ ] Deploy, open badge layout editor, hard-refresh once
- [ ] In DevTools → Network, confirm `editor.js?v=autofit2` loads (not a stale cached copy)
- [ ] Confirm the response contains `initDimensions` on `fabric.Textarea`
- [ ] Enable **Adapt content to container width** and verify long text stays inside the box