### PR TITLE
fix(badges): deduplicate custom question fields in editor

### DIFF
--- a/app/eventyay/control/templates/pretixcontrol/pdf/index.html
+++ b/app/eventyay/control/templates/pretixcontrol/pdf/index.html
@@ -386,7 +386,9 @@
                             <label>{% trans "Text content" %}</label><br>
                             <select class="input-block-level form-control" id="toolbox-content">
                                 {% for varname, var in variables.items %}
+                                    {% if var.canonical_key|default:varname == varname %}
                                     <option data-sample="{{ var.editor_sample }}" value="{{ varname }}">{{ var.label }}</option>
+                                    {% endif %}
                                 {% endfor %}
                                 {% for p in request.organizer.meta_properties.all %}
                                     <option value="meta:{{ p.name }}">


### PR DESCRIPTION
## Summary
- Hide duplicate question alias entries in the badge/PDF editor **Text content** dropdown
- Each custom question now appears once (by canonical `question_{id}` key)
- No changes to PDF rendering, variable resolution, or saved layouts

## Approach
Question variables already carry a `canonical_key`. Alias entries (e.g. `question_{identifier}`) are kept for rendering/backward compatibility but filtered out of the dropdown only.

## Test plan
- [ ] Open badge layout editor → **Text content** dropdown shows each custom question once
- [ ] Existing layouts using identifier-based keys still render correctly in Preview