### PR TITLE
revert(badges): remove manual cache-bust on PDF editor.js

### DIFF
--- a/app/eventyay/control/templates/pretixcontrol/pdf/index.html
+++ b/app/eventyay/control/templates/pretixcontrol/pdf/index.html
@@ -477,7 +477,7 @@
 
     <script type="text/javascript" src="{% static "pdfjs/pdf.js" %}"></script>
     <script type="text/javascript" src="{% static "fabric/fabric.min.js" %}"></script>
-    <script type="text/javascript" src="{% static "pretixcontrol/js/ui/editor.js" %}?v=autofit2"></script>
+    <script type="text/javascript" src="{% static "pretixcontrol/js/ui/editor.js" %}"></script>
     <img src="{% static 'pretixpresale/pdf/powered_by_eventyay_dark.png' %}" id="poweredby-dark" class="sr-only">
     <img src="{% static 'pretixpresale/pdf/powered_by_eventyay_white.png' %}" id="poweredby-white" class="sr-only">
     {% for family, styles in fonts.items %}


### PR DESCRIPTION
## Summary
- Reverts the `?v=autofit2` cache-bust query param on `editor.js` from #4455
- Restores the standard static URL for the PDF/badge editor script

## Test plan
- [ ] Open badge layout editor and confirm it loads normally
- [ ] Verify `editor.js` is requested without a manual version query param