### PR TITLE
Revert "revert(badges): remove manual cache-bust on PDF editor.js"

### DIFF
--- a/app/eventyay/control/templates/pretixcontrol/pdf/index.html
+++ b/app/eventyay/control/templates/pretixcontrol/pdf/index.html
@@ -479,7 +479,7 @@
 
     <script type="text/javascript" src="{% static "pdfjs/pdf.js" %}"></script>
     <script type="text/javascript" src="{% static "fabric/fabric.min.js" %}"></script>
-    <script type="text/javascript" src="{% static "pretixcontrol/js/ui/editor.js" %}"></script>
+    <script type="text/javascript" src="{% static "pretixcontrol/js/ui/editor.js" %}?v=autofit2"></script>
     <img src="{% static 'pretixpresale/pdf/powered_by_eventyay_dark.png' %}" id="poweredby-dark" class="sr-only">
     <img src="{% static 'pretixpresale/pdf/powered_by_eventyay_white.png' %}" id="poweredby-white" class="sr-only">
     {% for family, styles in fonts.items %}


### PR DESCRIPTION
Reverts fossasia/eventyay#4457

## Summary by Sourcery

Bug Fixes:
- Ensure the PDF editor JavaScript file is reloaded by browsers after updates by re-adding a cache-busting query parameter to its script URL.