### PR TITLE
fix(badges): bump PDF editor.js cache-bust version to autofit3

### DIFF
--- a/app/eventyay/control/templates/pretixcontrol/pdf/index.html
+++ b/app/eventyay/control/templates/pretixcontrol/pdf/index.html
@@ -479,7 +479,7 @@
 
     <script type="text/javascript" src="{% static "pdfjs/pdf.js" %}"></script>
     <script type="text/javascript" src="{% static "fabric/fabric.min.js" %}"></script>
-    <script type="text/javascript" src="{% static "pretixcontrol/js/ui/editor.js" %}?v=autofit2"></script>
+    <script type="text/javascript" src="{% static "pretixcontrol/js/ui/editor.js" %}?v=autofit3"></script>
     <img src="{% static 'pretixpresale/pdf/powered_by_eventyay_dark.png' %}" id="poweredby-dark" class="sr-only">
     <img src="{% static 'pretixpresale/pdf/powered_by_eventyay_white.png' %}" id="poweredby-white" class="sr-only">
     {% for family, styles in fonts.items %}


### PR DESCRIPTION
Reapplies the cache-busting parameter to ?v=autofit3 to ensure clients receive the latest editor layout code. This overrides any previous cached version (e.g. autofit2 or older) and resolves the issue where the old design was still showing.

## Summary by Sourcery

Bug Fixes:
- Ensure clients receive the updated badge editor layout by bumping the editor.js cache-busting query parameter from autofit2 to autofit3.