### PR TITLE
revert: remove all badge autofit and editor changes after 0a0e935d9

### DIFF
--- a/app/eventyay/api/views/order.py
+++ b/app/eventyay/api/views/order.py
@@ -293,7 +293,6 @@ class OrderViewSet(viewsets.ModelViewSet):
         else:
             if ct.type == 'text/uri-list':
                 resp = HttpResponse(ct.file.file.read(), content_type='text/uri-list')
-                resp['Cache-Control'] = 'no-cache, no-store, must-revalidate'
                 return resp
             else:
                 resp = FileResponse(ct.file.file, content_type=ct.type)
@@ -302,7 +301,6 @@ class OrderViewSet(viewsets.ModelViewSet):
                     order.code,
                     ct.extension,
                 )
-                resp['Cache-Control'] = 'no-cache, no-store, must-revalidate'
                 return resp
 
     @action(detail=True, methods=['POST'])
@@ -1092,7 +1090,6 @@ class OrderPositionViewSet(mixins.DestroyModelMixin, mixins.UpdateModelMixin, vi
         else:
             if ct.type == 'text/uri-list':
                 resp = HttpResponse(ct.file.file.read(), content_type='text/uri-list')
-                resp['Cache-Control'] = 'no-cache, no-store, must-revalidate'
                 return resp
             else:
                 resp = FileResponse(ct.file.file, content_type=ct.type)
@@ -1102,7 +1099,6 @@ class OrderPositionViewSet(mixins.DestroyModelMixin, mixins.UpdateModelMixin, vi
                     pos.positionid,
                     ct.extension,
                 )
-                resp['Cache-Control'] = 'no-cache, no-store, must-revalidate'
                 return resp
 
     def perform_destroy(self, instance):

--- a/app/eventyay/base/pdf.py
+++ b/app/eventyay/base/pdf.py
@@ -1017,7 +1017,10 @@ class Renderer:
         while size > min_size:
             fits = True
             for line in lines:
-                if pdfmetrics.stringWidth(line, font_name, size) > width_pt:
+                parts = line.split()
+                if not parts:
+                    continue
+                if max(pdfmetrics.stringWidth(part, font_name, size) for part in parts) > width_pt:
                     fits = False
                     break
             if fits:

--- a/app/eventyay/control/templates/pretixcontrol/pdf/index.html
+++ b/app/eventyay/control/templates/pretixcontrol/pdf/index.html
@@ -279,7 +279,7 @@
                         <div class="col-sm-12">
                             <div class="checkbox">
                                 <label for="toolbox-autofit-width"
-                                       title="{% trans 'Shrink font size so each line fits within the text box width without expanding the box' %}">
+                                       title="{% trans 'Shrink font size for long text so it fits within the text box width' %}">
                                     <input type="checkbox" id="toolbox-autofit-width">
                                     {% trans "Adapt content to container width" %}
                                 </label>
@@ -386,9 +386,7 @@
                             <label>{% trans "Text content" %}</label><br>
                             <select class="input-block-level form-control" id="toolbox-content">
                                 {% for varname, var in variables.items %}
-                                    {% if var.canonical_key|default:varname == varname %}
                                     <option data-sample="{{ var.editor_sample }}" value="{{ varname }}">{{ var.label }}</option>
-                                    {% endif %}
                                 {% endfor %}
                                 {% for p in request.organizer.meta_properties.all %}
                                     <option value="meta:{{ p.name }}">
@@ -479,7 +477,7 @@
 
     <script type="text/javascript" src="{% static "pdfjs/pdf.js" %}"></script>
     <script type="text/javascript" src="{% static "fabric/fabric.min.js" %}"></script>
-    <script type="text/javascript" src="{% static "pretixcontrol/js/ui/editor.js" %}?v=autofit3"></script>
+    <script type="text/javascript" src="{% static "pretixcontrol/js/ui/editor.js" %}"></script>
     <img src="{% static 'pretixpresale/pdf/powered_by_eventyay_dark.png' %}" id="poweredby-dark" class="sr-only">
     <img src="{% static 'pretixpresale/pdf/powered_by_eventyay_white.png' %}" id="poweredby-white" class="sr-only">
     {% for family, styles in fonts.items %}

--- a/app/eventyay/plugins/badges/utils.py
+++ b/app/eventyay/plugins/badges/utils.py
@@ -28,8 +28,6 @@ def get_badge_layout_version(event):
     return event.cache.get('badge_layout_version') or 0
 
 
-import time
-
 def clear_badge_layout_cache(event):
     for attr in ('_badge_layout_assignment_map', '_badge_voucher_assignment_map', '_default_badge_layout'):
         if hasattr(event, attr):
@@ -38,7 +36,8 @@ def clear_badge_layout_cache(event):
     # Bump the layout version in the cross-process cache so every worker's in-memory
     # renderer cache is invalidated on its very next use, without needing to reach into
     # other processes' memory.
-    event.cache.set('badge_layout_version', int(time.time()), 3600 * 24 * 30)
+    version = get_badge_layout_version(event)
+    event.cache.set('badge_layout_version', version + 1, 3600 * 24 * 30)
 
     keys_to_delete = [k for k in _renderer_cache if k[0] == event.pk]
     for k in keys_to_delete:

--- a/app/eventyay/static/pretixcontrol/js/ui/editor.js
+++ b/app/eventyay/static/pretixcontrol/js/ui/editor.js
@@ -90,22 +90,6 @@ fabric.Textarea = fabric.util.createClass(fabric.Textbox, {
         }
     },
 
-    initDimensions: function () {
-        if (this.__skipDimension) {
-            return;
-        }
-        this.isEditing && this.initDelayedCursor();
-        this.clearContextTop();
-        this._clearCache();
-        this.dynamicMinWidth = 0;
-        this._styleMap = this._generateStyleMap(this._splitText());
-        if (this.textAlign.indexOf('justify') !== -1) {
-            this.enlargeSpaces();
-        }
-        this.height = this.calcTextHeight();
-        this.saveState({propertySet: '_dimensionAffectingProps'});
-    },
-
     toObject: function(propertiesToInclude) {
         return this.callSuper('toObject', ['content', 'autofit_width', 'maxFontPt'].concat(propertiesToInclude));
     }
@@ -202,8 +186,14 @@ var editor = {
             ctx.font = fontStyle + fontWeight + editor._pt2px(pt) + 'px ' + fontFamily;
             var fits = true;
             for (var i = 0; i < lines.length; i++) {
-                if (ctx.measureText(lines[i]).width > widthPx) {
-                    fits = false;
+                var parts = lines[i].trim() ? lines[i].trim().split(/\s+/) : [];
+                for (var j = 0; j < parts.length; j++) {
+                    if (ctx.measureText(parts[j]).width > widthPx) {
+                        fits = false;
+                        break;
+                    }
+                }
+                if (!fits) {
                     break;
                 }
             }
@@ -220,9 +210,6 @@ var editor = {
         o.set('fontSize', editor._pt2px(
             o.autofit_width ? editor._compute_autofit_pt(o, maxPt, widthMm) : maxPt
         ));
-        if (o.initDimensions) {
-            o.initDimensions();
-        }
     },
 
     _csrf_token: function () {

--- a/app/tests/tickets/plugins/badges/test_utils.py
+++ b/app/tests/tickets/plugins/badges/test_utils.py
@@ -130,7 +130,7 @@ def test_fit_fontsize_to_width_shrinks_unbreakable_text():
     assert fitted >= 4.0
 
 
-def test_fit_fontsize_to_width_shrinks_wrappable_text_to_single_line():
+def test_fit_fontsize_to_width_keeps_wrappable_text_at_max():
     Renderer._register_fonts()
     fitted = Renderer._fit_fontsize_to_width(
         'Very Long Attendee Name Example',
@@ -139,8 +139,7 @@ def test_fit_fontsize_to_width_shrinks_wrappable_text_to_single_line():
         width_mm=30,
     )
 
-    assert fitted < 12.0
-    assert fitted >= 4.0
+    assert fitted == 12.0
 
 
 def test_fit_fontsize_to_width_keeps_short_text_at_max():


### PR DESCRIPTION
Reverts all layout autofit and cache-busting commits after 0a0e935d9 to restore layout stability.