### PR TITLE
fix(badges): stop serving stale badge layouts and PDFs

### DIFF
--- a/app/eventyay/base/pdf.py
+++ b/app/eventyay/base/pdf.py
@@ -1017,10 +1017,7 @@ class Renderer:
         while size > min_size:
             fits = True
             for line in lines:
-                parts = line.split()
-                if not parts:
-                    continue
-                if max(pdfmetrics.stringWidth(part, font_name, size) for part in parts) > width_pt:
+                if pdfmetrics.stringWidth(line, font_name, size) > width_pt:
                     fits = False
                     break
             if fits:

--- a/app/eventyay/base/services/tickets.py
+++ b/app/eventyay/base/services/tickets.py
@@ -24,6 +24,9 @@ from eventyay.helpers.database import rolledback_transaction
 
 logger = logging.getLogger(__name__)
 
+# Providers whose PDFs must always be regenerated from current layout data.
+_PROVIDERS_WITHOUT_TICKET_CACHE = frozenset({'badge'})
+
 
 def generate_orderposition(order_position: int, provider: str):
     order_position = (
@@ -167,7 +170,11 @@ def get_tickets_for_order(order, base_position=None):
             try:
                 if len(positions) == 0:
                     continue
-                ct = CachedCombinedTicket.objects.filter(order=order, provider=p.identifier, file__isnull=False).last()
+                ct = None
+                if p.identifier not in _PROVIDERS_WITHOUT_TICKET_CACHE:
+                    ct = CachedCombinedTicket.objects.filter(
+                        order=order, provider=p.identifier, file__isnull=False
+                    ).last()
                 if not ct or not ct.file:
                     retval = generate_order(order.pk, p.identifier)
                     if not retval:
@@ -184,9 +191,11 @@ def get_tickets_for_order(order, base_position=None):
         else:
             for pos in positions:
                 try:
-                    ct = CachedTicket.objects.filter(
-                        order_position=pos, provider=p.identifier, file__isnull=False
-                    ).last()
+                    ct = None
+                    if p.identifier not in _PROVIDERS_WITHOUT_TICKET_CACHE:
+                        ct = CachedTicket.objects.filter(
+                            order_position=pos, provider=p.identifier, file__isnull=False
+                        ).last()
                     if not ct or not ct.file:
                         retval = generate_orderposition(pos.pk, p.identifier)
                         if not retval:

--- a/app/eventyay/control/templates/pretixcontrol/pdf/index.html
+++ b/app/eventyay/control/templates/pretixcontrol/pdf/index.html
@@ -279,7 +279,7 @@
                         <div class="col-sm-12">
                             <div class="checkbox">
                                 <label for="toolbox-autofit-width"
-                                       title="{% trans 'Shrink font size for long text so it fits within the text box width' %}">
+                                       title="{% trans 'Shrink font size so each line fits within the text box width without expanding the box' %}">
                                     <input type="checkbox" id="toolbox-autofit-width">
                                     {% trans "Adapt content to container width" %}
                                 </label>
@@ -386,7 +386,9 @@
                             <label>{% trans "Text content" %}</label><br>
                             <select class="input-block-level form-control" id="toolbox-content">
                                 {% for varname, var in variables.items %}
+                                    {% if var.canonical_key|default:varname == varname %}
                                     <option data-sample="{{ var.editor_sample }}" value="{{ varname }}">{{ var.label }}</option>
+                                    {% endif %}
                                 {% endfor %}
                                 {% for p in request.organizer.meta_properties.all %}
                                     <option value="meta:{{ p.name }}">
@@ -477,7 +479,7 @@
 
     <script type="text/javascript" src="{% static "pdfjs/pdf.js" %}"></script>
     <script type="text/javascript" src="{% static "fabric/fabric.min.js" %}"></script>
-    <script type="text/javascript" src="{% static "pretixcontrol/js/ui/editor.js" %}"></script>
+    <script type="text/javascript" src="{% static "pretixcontrol/js/ui/editor.js" %}?v=autofit4"></script>
     <img src="{% static 'pretixpresale/pdf/powered_by_eventyay_dark.png' %}" id="poweredby-dark" class="sr-only">
     <img src="{% static 'pretixpresale/pdf/powered_by_eventyay_white.png' %}" id="poweredby-white" class="sr-only">
     {% for family, styles in fonts.items %}

--- a/app/eventyay/plugins/badges/api.py
+++ b/app/eventyay/plugins/badges/api.py
@@ -7,7 +7,7 @@ from rest_framework.views import APIView
 
 from eventyay.api.serializers.i18n import I18nAwareModelSerializer
 from eventyay.api.serializers.order import CompatibleJSONField
-from eventyay.base.models import CachedFile, OrderPosition
+from eventyay.base.models import OrderPosition
 from eventyay.base.services.tickets import generate_orderposition
 
 from .apps import PDFRenderer
@@ -126,50 +126,13 @@ class BadgeDownloadView(APIView):
                     status=status.HTTP_400_BAD_REQUEST,
                 )
 
-            # Check if there's already a cached file
-            from eventyay.base.models import CachedTicket
-
-            cached_ticket = CachedTicket.objects.filter(order_position=op, provider='badge').last()
-
-            if cached_ticket and cached_ticket.file:
-                import os
-
-                base64_pdf = base64.b64encode(cached_ticket.file.read()).decode('utf-8')
-                filename = (
-                    os.path.basename(cached_ticket.file.name) if cached_ticket.file.name else f'badge_{position}.pdf'
-                )
-                return Response(
-                    {
-                        'filename': filename,
-                        'type': 'application/pdf',
-                        'base64_pdf': base64_pdf,
-                    }
-                )
-
-            cached_file = CachedFile.objects.filter(
-                filename__startswith=f'badge_{position}_', expires__isnull=True
-            ).last()
-
-            if cached_file and cached_file.file:
-                base64_pdf = base64.b64encode(cached_file.file.read()).decode('utf-8')
-                return Response(
-                    {
-                        'filename': cached_file.filename,
-                        'type': 'application/pdf',
-                        'base64_pdf': base64_pdf,
-                    }
-                )
-
-            # If no cached file exists, generate one
+            # Always regenerate so downloads never return a stale layout PDF.
             from .providers import BadgeOutputProvider
 
             provider = BadgeOutputProvider(op.order.event)
 
             try:
-                # Try to generate immediately
                 filename, mimetype, pdf_content = provider.generate(op)
-
-                # Cache the generated file
                 base64_pdf = base64.b64encode(pdf_content).decode('utf-8')
 
                 return Response(

--- a/app/eventyay/plugins/badges/exporters.py
+++ b/app/eventyay/plugins/badges/exporters.py
@@ -25,16 +25,18 @@ from eventyay.base.i18n import language
 from eventyay.base.models import Order, OrderPosition
 from eventyay.base.pdf import Renderer
 from eventyay.base.services.export import ExportError
-from eventyay.base.services.orders import OrderError
 from eventyay.base.settings import PERSON_NAME_SCHEMES
 from eventyay.plugins.badges.models import BadgeProduct, BadgeVoucher
 from eventyay.plugins.badges.utils import (
+    BADGE_LAYOUT_PERSISTED_FIELDS,
     _renderer_cache,
     exclude_explicit_no_badge,
     get_badge_hidden_fields,
     get_badge_layout_for_position,
+    get_badge_layout_renderer_token,
     get_badge_layout_version,
     normalize_badge_content_key,
+    reset_badge_layout_assignment_cache,
 )
 
 from ...helpers.templatetags.jsonfield import JSONExtract
@@ -121,11 +123,16 @@ def _renderer(event, layout, version):
     if layout is None:
         return None
 
-    cache_key = (event.pk, layout.pk)
+    token = get_badge_layout_renderer_token(layout)
+    cache_key = (event.pk, layout.pk, version, token)
     if cache_key in _renderer_cache:
-        cached_version, renderer = _renderer_cache[cache_key]
-        if cached_version == version:
-            return renderer
+        return _renderer_cache[cache_key]
+
+    # Drop older entries for this layout so the process-local cache cannot grow
+    # unbounded across repeated edits.
+    stale_keys = [key for key in _renderer_cache if key[0] == event.pk and key[1] == layout.pk]
+    for key in stale_keys:
+        del _renderer_cache[key]
 
     bgf = _open_layout_background(layout)
     renderer = BadgeRenderer(
@@ -134,7 +141,7 @@ def _renderer(event, layout, version):
         bgf,
         ask_user_fields=(layout.ask_user_fields_data if layout.allow_customization else []),
     )
-    _renderer_cache[cache_key] = (version, renderer)
+    _renderer_cache[cache_key] = renderer
     return renderer
 
 
@@ -383,17 +390,27 @@ def render_nup(input_files: list[str], num_pages: int, output_file: BinaryIO, op
 def render_badges(event, positions, opt, apply_output_pagesize=False):
     from itertools import groupby
 
+    # Always resolve assignments from the database for this render call.
+    reset_badge_layout_assignment_cache(event)
+
     # Fetched once per render call (not per position) to avoid a cache round-trip per
     # badge, while still guaranteeing that every render reflects the latest saved design.
     version = get_badge_layout_version(event)
+    refreshed_layouts = set()
 
     op_renderers = []
     for op in positions:
         layout = get_badge_layout_for_position(event, op)
-        if layout is not None:
-            renderer = _renderer(event, layout, version)
-            if renderer:
-                op_renderers.append((op, renderer))
+        if layout is None:
+            continue
+        if layout.pk not in refreshed_layouts:
+            # Assignment maps can retain older ORM instances; reload persisted fields
+            # once per layout so selected/default content always matches the database.
+            layout.refresh_from_db(fields=list(BADGE_LAYOUT_PERSISTED_FIELDS))
+            refreshed_layouts.add(layout.pk)
+        renderer = _renderer(event, layout, version)
+        if renderer:
+            op_renderers.append((op, renderer))
 
     if not op_renderers:
         raise ExportError(_('None of the selected products is configured to print badges.'))

--- a/app/eventyay/plugins/badges/utils.py
+++ b/app/eventyay/plugins/badges/utils.py
@@ -14,8 +14,16 @@ logger = logging.getLogger(__name__)
 
 BADGE_HIDDEN_FIELDS_KEY = 'badge_hidden_fields'
 BADGE_TICKET_PROVIDER = 'badge'
+BADGE_LAYOUT_PERSISTED_FIELDS = (
+    'layout',
+    'ask_user_fields',
+    'allow_customization',
+    'background',
+    'default',
+)
 
 _renderer_cache = {}
+_ASSIGNMENT_CACHE_ATTR = '_badge_layout_assignment_cache'
 
 
 def _badge_version_key(event):
@@ -45,10 +53,41 @@ def get_badge_layout_version(event):
     return default_cache.get(_badge_version_key(event)) or 0
 
 
+def get_badge_layout_renderer_token(layout):
+    """Return a content token used as part of the in-process renderer cache key."""
+    if layout is None:
+        return None
+    background = layout.background.name if layout.background else ''
+    return (
+        layout.layout or '',
+        layout.ask_user_fields or '',
+        bool(layout.allow_customization),
+        background,
+    )
+
+
+def reset_badge_layout_assignment_cache(event):
+    """Drop the per-Event assignment snapshot used within a process."""
+    if hasattr(event, _ASSIGNMENT_CACHE_ATTR):
+        delattr(event, _ASSIGNMENT_CACHE_ATTR)
+
+
+def delete_badge_cached_pdfs(event):
+    """Delete persisted badge PDF cache rows for one event."""
+    from eventyay.base.models import CachedCombinedTicket, CachedTicket
+
+    CachedTicket.objects.filter(
+        order_position__order__event=event,
+        provider=BADGE_TICKET_PROVIDER,
+    ).delete()
+    CachedCombinedTicket.objects.filter(
+        order__event=event,
+        provider=BADGE_TICKET_PROVIDER,
+    ).delete()
+
+
 def clear_badge_layout_cache(event):
-    for attr in ('_badge_layout_assignment_map', '_badge_voucher_assignment_map', '_default_badge_layout'):
-        if hasattr(event, attr):
-            delattr(event, attr)
+    reset_badge_layout_assignment_cache(event)
 
     # Bump the layout version in the cross-process cache so every worker's in-memory
     # renderer cache is invalidated on its very next use, without needing to reach into
@@ -60,9 +99,9 @@ def clear_badge_layout_cache(event):
     version = default_cache.get(key) or 0
     default_cache.set(key, version + 1, 3600 * 24 * 30)
 
-    keys_to_delete = [k for k in _renderer_cache if k[0] == event.pk]
-    for k in keys_to_delete:
-        del _renderer_cache[k]
+    stale_keys = [cache_key for cache_key in _renderer_cache if cache_key[0] == event.pk]
+    for cache_key in stale_keys:
+        del _renderer_cache[cache_key]
 
 
 def normalize_badge_content_key(content):
@@ -70,12 +109,16 @@ def normalize_badge_content_key(content):
 
 
 def get_badge_layout_assignment_maps(event):
-    if hasattr(event, '_badge_layout_assignment_map'):
-        return (
-            event._badge_layout_assignment_map,
-            event._badge_voucher_assignment_map,
-            event._default_badge_layout,
-        )
+    """
+    Resolve product/voucher/default layout assignments.
+
+    Cached on the Event instance only for the current layout version, so default
+    switches and assignment edits are picked up as soon as the version bumps.
+    """
+    version = get_badge_layout_version(event)
+    cached = getattr(event, _ASSIGNMENT_CACHE_ATTR, None)
+    if cached is not None and cached[0] == version:
+        return cached[1]
 
     product_map = {
         assignment.product_id: assignment.layout
@@ -90,10 +133,9 @@ def get_badge_layout_assignment_maps(event):
     except BadgeLayout.DoesNotExist:
         default_layout = None
 
-    event._badge_layout_assignment_map = product_map
-    event._badge_voucher_assignment_map = voucher_map
-    event._default_badge_layout = default_layout
-    return product_map, voucher_map, default_layout
+    maps = (product_map, voucher_map, default_layout)
+    setattr(event, _ASSIGNMENT_CACHE_ATTR, (version, maps))
+    return maps
 
 
 def get_badge_layout_for_position(event, position):

--- a/app/eventyay/plugins/badges/utils.py
+++ b/app/eventyay/plugins/badges/utils.py
@@ -1,6 +1,7 @@
 import json
 import logging
 
+from django.core.cache import cache as default_cache
 from django.db.models import Exists, OuterRef
 from django.utils.translation import gettext_lazy as _
 
@@ -17,6 +18,22 @@ BADGE_TICKET_PROVIDER = 'badge'
 _renderer_cache = {}
 
 
+def _badge_version_key(event):
+    """Return a cache key outside the NamespacedCache namespace.
+
+    ``event.cache`` is a ``NamespacedCache`` whose ``clear()`` rotates a
+    namespace prefix — making every previously stored key unreachable.
+    Because dozens of unrelated model saves (products, settings, …) call
+    ``event.cache.clear()``, storing the badge layout version *inside*
+    that namespace caused it to silently reset to 0.
+
+    By using Django's default cache directly with a simple key, we avoid
+    the namespace entirely while still sharing state across all processes
+    via the same Redis backend.
+    """
+    return f'badge_layout_version:{event.pk}'
+
+
 def get_badge_layout_version(event):
     """
     Return the current badge layout/rendering cache version for this event.
@@ -25,7 +42,7 @@ def get_badge_layout_version(event):
     Celery worker and web worker will observe a version bump immediately on their next
     lookup, no matter which process actually saved the layout change.
     """
-    return event.cache.get('badge_layout_version') or 0
+    return default_cache.get(_badge_version_key(event)) or 0
 
 
 def clear_badge_layout_cache(event):
@@ -36,8 +53,12 @@ def clear_badge_layout_cache(event):
     # Bump the layout version in the cross-process cache so every worker's in-memory
     # renderer cache is invalidated on its very next use, without needing to reach into
     # other processes' memory.
-    version = get_badge_layout_version(event)
-    event.cache.set('badge_layout_version', version + 1, 3600 * 24 * 30)
+    #
+    # We use Django's default cache directly (not event.cache) so the version survives
+    # event.cache.clear() calls triggered by unrelated model saves.
+    key = _badge_version_key(event)
+    version = default_cache.get(key) or 0
+    default_cache.set(key, version + 1, 3600 * 24 * 30)
 
     keys_to_delete = [k for k in _renderer_cache if k[0] == event.pk]
     for k in keys_to_delete:

--- a/app/eventyay/plugins/badges/views.py
+++ b/app/eventyay/plugins/badges/views.py
@@ -26,7 +26,11 @@ from eventyay.control.views.pdf import BaseEditorView, open_stored_pdf_file
 from eventyay.helpers.models import modelcopy
 from eventyay.plugins.badges.forms import BadgeLayoutForm, BadgeLayoutSettingsForm
 from eventyay.plugins.badges.tasks import badges_create_pdf
-from eventyay.plugins.badges.utils import clear_badge_layout_cache
+from eventyay.plugins.badges.utils import (
+    BADGE_TICKET_PROVIDER,
+    clear_badge_layout_cache,
+    delete_badge_cached_pdfs,
+)
 
 from .exporters import BadgeRenderer, _open_layout_background
 from .models import BadgeLayout
@@ -67,8 +71,11 @@ class BadgePluginEnabledMixin:
 def _schedule_badge_cache_invalidation(event):
     event_pk = event.pk
     clear_badge_layout_cache(event)
+    delete_badge_cached_pdfs(event)
     transaction.on_commit(
-        lambda event_pk=event_pk: invalidate_cache.apply_async(kwargs={'event': event_pk, 'provider': 'badge'})
+        lambda event_pk=event_pk: invalidate_cache.apply_async(
+            kwargs={'event': event_pk, 'provider': BADGE_TICKET_PROVIDER}
+        )
     )
 
 

--- a/app/eventyay/static/pretixcontrol/js/ui/editor.js
+++ b/app/eventyay/static/pretixcontrol/js/ui/editor.js
@@ -90,6 +90,22 @@ fabric.Textarea = fabric.util.createClass(fabric.Textbox, {
         }
     },
 
+    initDimensions: function () {
+        if (this.__skipDimension) {
+            return;
+        }
+        this.isEditing && this.initDelayedCursor();
+        this.clearContextTop();
+        this._clearCache();
+        this.dynamicMinWidth = 0;
+        this._styleMap = this._generateStyleMap(this._splitText());
+        if (this.textAlign.indexOf('justify') !== -1) {
+            this.enlargeSpaces();
+        }
+        this.height = this.calcTextHeight();
+        this.saveState({propertySet: '_dimensionAffectingProps'});
+    },
+
     toObject: function(propertiesToInclude) {
         return this.callSuper('toObject', ['content', 'autofit_width', 'maxFontPt'].concat(propertiesToInclude));
     }
@@ -186,14 +202,8 @@ var editor = {
             ctx.font = fontStyle + fontWeight + editor._pt2px(pt) + 'px ' + fontFamily;
             var fits = true;
             for (var i = 0; i < lines.length; i++) {
-                var parts = lines[i].trim() ? lines[i].trim().split(/\s+/) : [];
-                for (var j = 0; j < parts.length; j++) {
-                    if (ctx.measureText(parts[j]).width > widthPx) {
-                        fits = false;
-                        break;
-                    }
-                }
-                if (!fits) {
+                if (ctx.measureText(lines[i]).width > widthPx) {
+                    fits = false;
                     break;
                 }
             }
@@ -210,6 +220,9 @@ var editor = {
         o.set('fontSize', editor._pt2px(
             o.autofit_width ? editor._compute_autofit_pt(o, maxPt, widthMm) : maxPt
         ));
+        if (o.initDimensions) {
+            o.initDimensions();
+        }
     },
 
     _csrf_token: function () {

--- a/app/tests/tickets/plugins/badges/test_utils.py
+++ b/app/tests/tickets/plugins/badges/test_utils.py
@@ -1,15 +1,34 @@
 import datetime
+import json
 
 import pytest
+from django.core.cache import cache as default_cache
+from django.test import override_settings
 from django_scopes import scopes_disabled
 
-from eventyay.base.models import Event, Order, OrderPosition, Organizer, Product, Question, QuestionAnswer, Voucher
+from eventyay.base.models import (
+    CachedTicket,
+    Event,
+    Order,
+    OrderPosition,
+    Organizer,
+    Product,
+    Question,
+    QuestionAnswer,
+    Voucher,
+)
 from eventyay.base.pdf import Renderer, extract_layout_text_placeholders
-from eventyay.plugins.badges.exporters import BadgeRenderer
+from eventyay.plugins.badges.exporters import BadgeRenderer, OPTIONS, _renderer, render_badges, render_pdf
 from eventyay.plugins.badges.models import BadgeProduct, BadgeVoucher
 from eventyay.plugins.badges.utils import (
+    BADGE_TICKET_PROVIDER,
+    _badge_version_key,
+    _renderer_cache,
+    clear_badge_layout_cache,
+    delete_badge_cached_pdfs,
     get_badge_bundle_option_choices,
     get_badge_layout_for_position,
+    get_badge_layout_version,
     position_has_printable_badge,
 )
 
@@ -228,3 +247,219 @@ def test_renderer_other_text_still_supports_question_id_placeholders(badge_event
     )
 
     assert result == 'Jane'
+
+
+def _textarea_field(content, *, bottom='85', bold=False, text=None):
+    return {
+        'type': 'textarea',
+        'left': '0',
+        'bottom': bottom,
+        'fontsize': '12.0',
+        'color': [0, 0, 0, 1],
+        'fontfamily': 'Open Sans',
+        'bold': bold,
+        'italic': False,
+        'width': '80',
+        'content': content,
+        'text': text or content,
+        'align': 'center',
+    }
+
+
+def _set_default_layout(event, layout):
+    event.badge_layouts.exclude(pk=layout.pk).update(default=False)
+    layout.default = True
+    layout.save(update_fields=['default'])
+
+
+@pytest.mark.django_db
+@override_settings(
+    CACHES={
+        'default': {
+            'BACKEND': 'django.core.cache.backends.locmem.LocMemCache',
+            'LOCATION': 'badge-layout-version-tests',
+        }
+    }
+)
+def test_badge_layout_version_survives_event_cache_clear(badge_event):
+    event, position, product, layout = badge_event
+
+    # Store the version outside NamespacedCache so event.cache.clear() cannot
+    # rotate it away (the production bug that left workers on version 0).
+    default_cache.set(_badge_version_key(event), 42, 3600)
+    assert get_badge_layout_version(event) == 42
+
+    event.cache.clear()
+    assert get_badge_layout_version(event) == 42
+    assert default_cache.get(_badge_version_key(event)) == 42
+
+    clear_badge_layout_cache(event)
+    assert get_badge_layout_version(event) == 43
+
+
+@pytest.mark.django_db
+def test_default_layout_switch_is_reflected_immediately(badge_event):
+    event, position, product, layout = badge_event
+    other = event.badge_layouts.create(name='Layout 2', default=False)
+
+    assert get_badge_layout_for_position(event, position).pk == layout.pk
+
+    _set_default_layout(event, other)
+    clear_badge_layout_cache(event)
+
+    assert get_badge_layout_for_position(event, position).pk == other.pk
+
+
+@pytest.mark.django_db
+def test_render_badges_uses_latest_default_even_without_prior_cache_clear(badge_event):
+    event, position, product, layout = badge_event
+    other = event.badge_layouts.create(
+        name='Layout 2',
+        default=False,
+        layout=json.dumps([_textarea_field('attendee_company', text='Company')]),
+    )
+
+    # Prime an in-process assignment snapshot pointing at the old default.
+    assert get_badge_layout_for_position(event, position).pk == layout.pk
+
+    _set_default_layout(event, other)
+    # Intentionally skip clear_badge_layout_cache: render must still see DB truth.
+
+    Renderer._register_fonts()
+    _renderer_cache.clear()
+    badge_pdf, num_pages = render_badges(event, [position], OPTIONS['one'])
+    assert num_pages == 1
+    assert len(badge_pdf.pages) == 1
+
+    selected = get_badge_layout_for_position(event, position)
+    assert selected.pk == other.pk
+    renderer = _renderer(event, selected, get_badge_layout_version(event))
+    assert [field['content'] for field in renderer.layout] == ['attendee_company']
+
+
+@pytest.mark.django_db
+def test_product_assignment_overrides_default_layout(badge_event):
+    event, position, product, layout = badge_event
+    assigned = event.badge_layouts.create(name='Assigned', default=False)
+    BadgeProduct.objects.create(product=product, layout=assigned)
+    clear_badge_layout_cache(event)
+
+    assert get_badge_layout_for_position(event, position).pk == assigned.pk
+
+
+@pytest.mark.django_db
+def test_renderer_cache_uses_updated_layout_content(badge_event):
+    event, position, product, layout = badge_event
+    BadgeProduct.objects.create(product=product, layout=layout)
+
+    _renderer_cache.clear()
+    version = get_badge_layout_version(event)
+    renderer1 = _renderer(event, layout, version)
+    initial_count = len(renderer1.layout)
+
+    layout.layout = json.dumps(
+        renderer1.layout + [_textarea_field('attendee_company', bottom='70', text='Sample company')]
+    )
+    layout.save(update_fields=['layout'])
+    clear_badge_layout_cache(event)
+
+    layout.refresh_from_db()
+    renderer2 = _renderer(event, layout, get_badge_layout_version(event))
+    assert renderer2 is not renderer1
+    assert len(renderer2.layout) == initial_count + 1
+
+
+@pytest.mark.django_db
+def test_render_badges_uses_selected_default_layout_fields(badge_event):
+    event, position, product, layout = badge_event
+    layout.layout = json.dumps(
+        [
+            _textarea_field('attendee_name', bold=True, text='John Doe'),
+            _textarea_field('attendee_company', bottom='70', text='Company'),
+        ]
+    )
+    layout.save(update_fields=['layout'])
+    clear_badge_layout_cache(event)
+    _renderer_cache.clear()
+
+    selected = get_badge_layout_for_position(event, position)
+    assert selected.pk == layout.pk
+    assert len(selected.layout_data) == 2
+
+    Renderer._register_fonts()
+    renderer = _renderer(event, selected, get_badge_layout_version(event))
+    assert renderer is not None
+    assert len(renderer.layout) == 2
+    assert {field['content'] for field in renderer.layout} == {'attendee_name', 'attendee_company'}
+
+
+@pytest.mark.django_db
+def test_end_to_end_layout_selection_content_and_pdf_cache(badge_event):
+    """Full path: voucher wins, content edits apply, PDF cache clears, export renders."""
+    event, position, product, default_layout = badge_event
+    product_layout = event.badge_layouts.create(
+        name='Product layout',
+        default=False,
+        layout=json.dumps([_textarea_field('attendee_name', text='Name')]),
+    )
+    voucher_layout = event.badge_layouts.create(
+        name='Voucher layout',
+        default=False,
+        layout=json.dumps(
+            [
+                _textarea_field('attendee_name', text='Name'),
+                _textarea_field('attendee_company', bottom='70', text='Company'),
+            ]
+        ),
+    )
+    BadgeProduct.objects.create(product=product, layout=product_layout)
+    voucher = Voucher.objects.create(event=event, code='ENDTOEND')
+    position.voucher = voucher
+    position.save(update_fields=['voucher'])
+    BadgeVoucher.objects.create(voucher=voucher, layout=voucher_layout)
+
+    # Stale assignment snapshot must not win over DB truth on render.
+    assert get_badge_layout_for_position(event, position).pk == voucher_layout.pk
+
+    voucher_layout.layout = json.dumps(
+        [
+            _textarea_field('attendee_name', text='Name'),
+            _textarea_field('attendee_company', bottom='70', text='Company'),
+            _textarea_field('attendee_job_title', bottom='55', text='Job'),
+        ]
+    )
+    voucher_layout.save(update_fields=['layout'])
+    # No clear_badge_layout_cache: render_badges must still use updated fields.
+
+    CachedTicket.objects.create(
+        order_position=position,
+        provider=BADGE_TICKET_PROVIDER,
+        type='application/pdf',
+        extension='.pdf',
+    )
+    assert CachedTicket.objects.filter(order_position=position, provider=BADGE_TICKET_PROVIDER).exists()
+    delete_badge_cached_pdfs(event)
+    assert not CachedTicket.objects.filter(order_position=position, provider=BADGE_TICKET_PROVIDER).exists()
+
+    Renderer._register_fonts()
+    _renderer_cache.clear()
+    pdf = render_pdf(event, [position], OPTIONS['one'])
+    assert pdf.read(5) == b'%PDF-'
+
+    selected = get_badge_layout_for_position(event, position)
+    assert selected.pk == voucher_layout.pk
+    renderer = _renderer(event, selected, get_badge_layout_version(event))
+    assert {field['content'] for field in renderer.layout} == {
+        'attendee_name',
+        'attendee_company',
+        'attendee_job_title',
+    }
+    assert get_badge_layout_for_position(event, position).pk != default_layout.pk
+    assert get_badge_layout_for_position(event, position).pk != product_layout.pk
+
+
+def test_badge_provider_skips_persisted_ticket_cache():
+    """Single-order/control downloads must not reuse stale CachedTicket rows."""
+    from eventyay.base.services.tickets import _PROVIDERS_WITHOUT_TICKET_CACHE
+
+    assert BADGE_TICKET_PROVIDER in _PROVIDERS_WITHOUT_TICKET_CACHE


### PR DESCRIPTION
## Summary
- Store badge layout cache versions outside `event.cache` so unrelated `event.cache.clear()` calls cannot silently reset workers to stale renderers.
- Always regenerate badge downloads (skip stale `CachedTicket` / API cache short-circuits) and delete persisted badge PDFs when layouts change.
- Reload assignment maps and layout fields on each render so default / product / voucher selection and content edits apply without a manual Redis flush.
- Restore autofit / editor dropdown fixes that were dropped with the badge revert.

## Test plan
- [x] `pytest tests/tickets/plugins/badges/test_utils.py` cache/layout/e2e cases (13 passed)
- [x] `pytest tests/tickets/plugins/badges/test_export_form.py` + `test_api.py`
- [x] Smoke check: API download/preview always call `provider.generate`; layout save clears version + deletes badge PDFs
- [ ] After deploy: change default badge layout and confirm bulk export, single-order download, and editor preview all show the new layout/fields without manual cache flush
- [ ] Confirm web + Celery workers restarted as part of normal deploy