### PR TITLE
fix(email): resolve event_name placeholder in ticket emails

### DIFF
--- a/app/eventyay/base/email.py
+++ b/app/eventyay/base/email.py
@@ -521,9 +521,20 @@ def base_placeholders(sender: Event, **kwargs):
         # TODO: Make the label translatable.
         return f'<a href="{url}" class="button">Join online event</a>'
     ph = [
+        # `{event}` is the historical tickets placeholder; `{event_name}` is the
+        # talk/Tiptap alias so both resolve to the event title in order emails.
         SimpleFunctionalMailTextPlaceholder('event', ['event'], lambda event: event.name, lambda event: event.name),
         SimpleFunctionalMailTextPlaceholder(
+            'event_name', ['event'], lambda event: event.name, lambda event: event.name
+        ),
+        SimpleFunctionalMailTextPlaceholder(
             'event',
+            ['event_or_subevent'],
+            lambda event_or_subevent: event_or_subevent.name,
+            lambda event_or_subevent: event_or_subevent.name,
+        ),
+        SimpleFunctionalMailTextPlaceholder(
+            'event_name',
             ['event_or_subevent'],
             lambda event_or_subevent: event_or_subevent.name,
             lambda event_or_subevent: event_or_subevent.name,

--- a/app/tests/tickets/base/test_rich_text.py
+++ b/app/tests/tickets/base/test_rich_text.py
@@ -2,6 +2,7 @@ import datetime
 
 import pytest
 
+from eventyay.base.email import get_available_placeholders, get_email_context
 from eventyay.base.models import Event, Organizer
 from eventyay.base.templatetags.rich_text import (
     compile_email_body,
@@ -31,6 +32,27 @@ def test_expand_email_preview_placeholders_replaces_sample_values(event):
     assert '{event_slug}' not in result
     assert event.slug in result
     assert 'class="placeholder"' in result
+
+
+@pytest.mark.django_db
+def test_event_name_alias_registered_and_renders(event):
+    placeholders = get_available_placeholders(event, ['event'])
+    assert 'event' in placeholders
+    assert 'event_name' in placeholders
+    assert str(placeholders['event_name'].render_sample(event)) == str(event.name)
+
+    ctx = get_email_context(event=event)
+    assert str(ctx['event_name']) == str(event.name)
+    assert str(ctx['event']) == str(event.name)
+
+
+@pytest.mark.django_db
+def test_expand_email_preview_placeholders_resolves_event_name_alias(event):
+    html = '<p>Welcome to {event_name}</p>'
+    result = expand_email_preview_placeholders(html, event)
+    assert '{event_name}' not in result
+    assert 'event_name' not in result  # TolerantDict leftover
+    assert str(event.name) in result
 
 
 def test_compile_email_body_preserves_html():


### PR DESCRIPTION
## Summary
- Registers `{event_name}` as an alias of `{event}` for ticket/order email placeholders so Tiptap editor templates resolve the event title correctly.
- Adds tests for placeholder registration, render context, and email preview expansion.

## Test plan
- [x] `pytest tests/tickets/base/test_rich_text.py::test_event_name_alias_registered_and_renders tests/tickets/base/test_rich_text.py::test_expand_email_preview_placeholders_resolves_event_name_alias`
- [ ] Insert `{event_name}` in an order email template preview and confirm the event title appears
- [ ] Confirm `{event}` still works unchanged

## Summary by Sourcery

Register the `event_name` email placeholder as an alias for the existing event title placeholders and verify correct resolution in ticket email previews.

New Features:
- Support `{event_name}` as a ticket email placeholder that resolves to the event title alongside existing `{event}` placeholders.

Tests:
- Add tests ensuring `{event_name}` is registered, included in the email render context, and correctly expanded in email preview HTML.