### PR TITLE
Fix mobile navigation bar sorting order

### DIFF
--- a/app/eventyay/static/cfp/css/_layout.css
+++ b/app/eventyay/static/cfp/css/_layout.css
@@ -657,10 +657,6 @@ footer {
     font-size: 0.8rem;
   }
 
-  .presale-sticky-tabs a.header-tab.active {
-    order: -1;
-  }
-
   .presale-sticky-tabs .header-row-right {
     margin-left: 0;
     margin-right: 2px;

--- a/app/eventyay/static/pretixpresale/scss/custom.css
+++ b/app/eventyay/static/pretixpresale/scss/custom.css
@@ -335,10 +335,6 @@ header .header-row-right {
         padding: 2px 4px;
     }
 
-    .presale-sticky-tabs a.header-tab.active {
-        order: -1;
-    }
-
     .cfs-full {
         display: none;
     }


### PR DESCRIPTION
Removes active tab 'order: -1' overrides on mobile devices so that the menu sorting remains identical to the desktop layout.

## Summary by Sourcery

Enhancements:
- Remove mobile-specific CSS that forced active presale sticky tabs to appear first, preserving consistent tab order across viewports.