### PR TITLE
fix(video): contain mobile landing overflow and timezone slash

### DIFF
--- a/app/eventyay/webapp/video/src/components/LandingPage.vue
+++ b/app/eventyay/webapp/video/src/components/LandingPage.vue
@@ -403,9 +403,11 @@ export default {
 	display: flex
 	flex-direction: column
 	min-height: 0
+	min-width: 0
 	width: 100%
 	position: relative
 	background-color: $clr-grey-50
+	overflow-x: hidden
 	.landing-top-bg
 		position: absolute
 		top: 0
@@ -427,8 +429,10 @@ export default {
 	.landing-scroll
 		flex: auto
 		min-height: 0
+		min-width: 0
 		position: relative
 		z-index: 1
+		overflow-x: hidden
 	.landing-header
 		display: flex
 		flex-direction: column
@@ -559,10 +563,13 @@ export default {
 		box-shadow: 0 5px 10px rgba(0, 0, 0, 0.2)
 		border-radius: 4px 4px 0 0
 		box-sizing: border-box
+		min-width: 0
+		overflow-x: hidden
 	.content
 		display: flex
 		flex-direction: column
 		width: 100%
+		min-width: 0
 		padding: 24px
 		box-sizing: border-box
 	.rich-text-content, .c-markdown-content
@@ -592,21 +599,26 @@ export default {
 			letter-spacing: normal
 			themed-button-primary()
 
+	.sessions
+		min-width: 0
+		> *
+			width: 100%
+			max-width: 100%
+			min-width: 0
+			margin-right: 0
+			box-sizing: border-box
 	.split-layout
 		display: grid
-		grid-template-columns: 1fr
+		grid-template-columns: minmax(0, 1fr)
 		gap: 32px
 		margin-top: 24px
 		@media (min-width: 900px)
-			grid-template-columns: 1fr 1fr
-		.split-left
+			grid-template-columns: minmax(0, 1fr) minmax(0, 1fr)
+		.split-left, .split-right
 			display: flex
 			flex-direction: column
 			gap: 24px
-		.split-right
-			display: flex
-			flex-direction: column
-			gap: 24px
+			min-width: 0
 
 	.active-rooms-list
 		display: flex
@@ -658,8 +670,6 @@ export default {
 				color: $clr-secondary-text-light
 				margin-left: 12px
 				flex-shrink: 0
-	.speakers-section .c-speakers-list
-		overflow: visible !important
 
 	+below('s')
 		.landing-top-bg

--- a/app/eventyay/webapp/video/src/locales/en.json
+++ b/app/eventyay/webapp/video/src/locales/en.json
@@ -169,7 +169,7 @@
 	"LandingPage:speakers:header": "Featured speakers",
 	"LandingPage:speakers:link": "All speakers",
 	"LandingPage:speakers:more": "and {{additional_speakers}} more",
-	"LandingPage:dateRange:to": "To {{date}}",
+	"LandingPage:dateRange:to": "To {{- date}}",
 	"LandingPage:home-back:label": "Home",
 	"LandingPage:home-back:organizer": "Back to {{name}}",
 	"Livestream:automuted-unmute:text": "Tap to unmute",

--- a/app/eventyay/webapp/video/src/views/rooms/item.vue
+++ b/app/eventyay/webapp/video/src/views/rooms/item.vue
@@ -203,6 +203,7 @@ export default {
 	flex: auto
 	display: flex
 	min-height: 0
+	min-width: 0
 	.stage
 		display: flex
 		flex-direction: column


### PR DESCRIPTION
## Summary
- Contain horizontal overflow on the video landing page so mobile viewports no longer clip the hero and “Upcoming sessions” section.
- Use unescaped i18next interpolation for the end-date timezone so `Europe/Paris` no longer renders as `Europe&#x2F;Paris`.
- Allow the room flex shell to shrink with `min-width: 0`.

## Test plan
- [ ] Open a video event landing page (e.g. Wikimania) on a ~390px-wide phone viewport
- [ ] Confirm “Upcoming sessions” and the hero title/dates are fully visible (not clipped on the left)
- [ ] Confirm session cards and “Complete schedule” stay within the screen width
- [ ] Confirm the end date shows `(Europe/Paris)` without HTML entities
- [ ] Spot-check desktop (≥900px) two-column landing layout still looks correct

## Summary by Sourcery

Improve video event landing and room layouts on small viewports and correct timezone rendering.

Bug Fixes:
- Prevent horizontal overflow and clipping of hero, sessions, and schedule sections on mobile video landing pages.
- Ensure room flex containers can shrink properly without causing layout overflow.
- Fix timezone display so values like Europe/Paris render without HTML entity escaping.

Enhancements:
- Update grid and flex layout constraints to allow split columns and session cards to fully fit within available width on all viewports.