### PR TITLE
fix(schedule): sync mobile list view with day tabs

### DIFF
--- a/app/eventyay/webapp/schedule/src/components/LinearSchedule.vue
+++ b/app/eventyay/webapp/schedule/src/components/LinearSchedule.vue
@@ -45,6 +45,7 @@ export default {
 			}
 		},
 		currentDay: String,
+		forceScrollDay: { type: Number, default: 0 },
 		now: Object,
 		scrollParent: Element,
 		onHomeServer: Boolean,
@@ -78,7 +79,8 @@ export default {
 	data () {
 		return {
 			getLocalizedString,
-			scrolledDay: null
+			scrolledDay: null,
+			_scrollDayUpdate: false
 		}
 	},
 	computed: {
@@ -177,6 +179,9 @@ export default {
 		}
 	},
 	watch: {
+		forceScrollDay () {
+			this.scrollToDay(this.currentDay, { force: true })
+		},
 		async sortObserverKey () {
 			await this.$nextTick()
 			if (this.observer) {
@@ -197,7 +202,13 @@ export default {
 				this.observer.observe(el[0])
 			}
 		},
-		currentDay: 'changeDay'
+		currentDay (day) {
+			if (this._scrollDayUpdate) {
+				this._scrollDayUpdate = false
+				return
+			}
+			this.scrollToDay(day)
+		}
 	},
 	async mounted () {
 		await this.$nextTick()
@@ -296,19 +307,21 @@ export default {
 			const rect = this.$parent.$el.getBoundingClientRect()
 			return rect.top + window.scrollY
 		},
-		changeDay (day) {
-			if (!this.showDayHeaders) return
-			if (this.scrolledDay?.format('YYYY-MM-DD') === day) return
-			const dayBucket = this.bucketFirstByDay[day]
+		scrollToDay (day, { force = false } = {}) {
+			if (!this.showDayHeaders || !day) return
+			const dayStr = day.format ? day.format('YYYY-MM-DD') : day
+			if (!force && this.scrolledDay?.format('YYYY-MM-DD') === dayStr) return
+			const dayBucket = this.bucketFirstByDay[dayStr]
 			if (!dayBucket) return
 			const el = this.$refs[this.getBucketName(dayBucket.date)]?.[0]
 			if (!el) return
-			const scrollTop = el.offsetTop + this.getOffsetTop() - 8
 			if (this.scrollParent) {
-				this.scrollParent.scrollTop = scrollTop
+				const top = el.getBoundingClientRect().top - this.scrollParent.getBoundingClientRect().top + this.scrollParent.scrollTop - 8
+				this.scrollParent.scrollTop = top
 			} else {
-				window.scroll({top: scrollTop})
+				window.scroll({ top: el.offsetTop + this.getOffsetTop() - 8 })
 			}
+			this.scrolledDay = moment.tz(dayStr, 'YYYY-MM-DD', this.timezone).startOf('day')
 		},
 		onIntersect (results) {
 			if (!this.showDayHeaders) return
@@ -316,9 +329,11 @@ export default {
 			const day = moment(intersection.target.dataset.date).tz(this.timezone).startOf('day')
 			if (intersection.isIntersecting) {
 				this.scrolledDay = day
+				this._scrollDayUpdate = true
 				this.$emit('changeDay', this.scrolledDay)
 			} else if (intersection.rootBounds && (intersection.boundingClientRect.y - intersection.rootBounds.y) > 0) {
 				this.scrolledDay = day.clone().subtract(1, 'day')
+				this._scrollDayUpdate = true
 				this.$emit('changeDay', this.scrolledDay)
 			}
 		}

--- a/app/eventyay/webapp/schedule/src/components/ScheduleView.vue
+++ b/app/eventyay/webapp/schedule/src/components/ScheduleView.vue
@@ -60,6 +60,7 @@
 				@unfav="onUnfav")
 			linear-schedule(v-else,
 				:sessions="filteredSessions",
+				:forceScrollDay="forceScrollDay",
 				:rooms="computedRooms",
 				:currentDay="currentDay",
 				:now="resolvedNow",
@@ -71,7 +72,7 @@
 				:showFavCount="showFavCountOnSchedule",
 				:sortBy="effectiveSortBy",
 				:includeRoomSortKey="sortIncludeRoom",
-				:includeDateSortKey="sortIncludeDate",
+				:includeDateSortKey="sortIncludeDate || linearScheduleGroupByDay",
 				:includePopularitySortKey="sortIncludePopularity",
 				:showBreaks="!linearOnly && !sessionsMode",
 				:density="'default'",
@@ -174,6 +175,7 @@ export default {
 				}
 			})(),
 			sortIncludePopularity: false,
+			forceScrollDay: 0,
 			filterState: {
 				tracks: [],
 				rooms: [],
@@ -393,6 +395,9 @@ export default {
 		showGrid() {
 			return !this.linearOnly && this.scrollParentWidth > 710
 		},
+		linearScheduleGroupByDay() {
+			return !this.showGrid && this.computedDays.length > 1
+		},
 		popularityFeatureEnabled() {
 			const flags = this.resolvedSchedule?.feature_flags || {}
 			return isPopularityFeatureEnabled(flags)
@@ -559,8 +564,10 @@ export default {
 		},
 		changeDay(day) {
 			const dayStr = day.format ? day.format('YYYY-MM-DD') : day
-			if (dayStr === this.currentDay) return
 			this.currentDay = dayStr
+			if (this.linearScheduleGroupByDay) {
+				this.forceScrollDay++
+			}
 		},
 		setCurrentDay(day) {
 			this.changeDay(day)


### PR DESCRIPTION
## Summary

Fixes mobile schedule list view so day tabs and session ordering match desktop grid behavior on narrow screens.

## Why

On viewports below the grid breakpoint, the list schedule showed sessions from all days mixed together (often by title), and day tabs did not scroll-sync or jump to the correct day.

## Changes

- Enable day grouping on mobile multi-day schedules via `includeDateSortKey` in `ScheduleView`.
- Fix scroll-to-day positioning inside the schedule scroll container in `LinearSchedule`.
- Prevent scroll/tab feedback loops and support re-tapping the same day tab to jump again.

## Testing

- [x] Verified mobile list view shows all days in one scroll with day headers
- [x] Verified sessions sort by start time within each day
- [x] Verified day tabs update while scrolling
- [x] Verified tapping a day tab scrolls to that day
- [x] Verified desktop grid schedule behavior is unchanged

## Issue

Fixes #4531



https://github.com/user-attachments/assets/01f661ea-c8c0-4277-be2d-4b8322e83807

