### PR TITLE
fix(video): allow organizers to delete chat without admin mode

### DIFF
--- a/app/eventyay/base/models/organizer.py
+++ b/app/eventyay/base/models/organizer.py
@@ -568,7 +568,10 @@ class Team(LoggedModel, TimestampedModel, RulesModelMixin, models.Model, metacla
     can_video_manage_users = models.BooleanField(
         default=False,
         verbose_name=_('Video: Can message, ban, and silence users'),
-        help_text=_('Allows moderating users (ban, silence, reactivate) in Eventyay Video.'),
+        help_text=_(
+            'Allows moderating users (ban, silence, reactivate) and deleting chat messages '
+            'in Eventyay Video without requiring staff admin mode.'
+        ),
     )
     can_video_manage_rooms = models.BooleanField(
         default=False,

--- a/app/eventyay/base/models/world.py
+++ b/app/eventyay/base/models/world.py
@@ -93,7 +93,10 @@ def default_roles():
     video_channel_manager = [Permission.EVENT_ROOMS_CREATE_CHAT, Permission.EVENT_ROOMS_CREATE_BBB]
     video_announcement_manager = [Permission.EVENT_ANNOUNCE]
     video_user_viewer = [Permission.EVENT_USERS_LIST]
-    video_user_moderator = [Permission.EVENT_USERS_MANAGE]
+    video_user_moderator = [
+        Permission.EVENT_USERS_MANAGE,
+        Permission.ROOM_CHAT_MODERATE,
+    ]
     video_room_manager = [Permission.ROOM_UPDATE, Permission.ROOM_DELETE]
     video_kiosk_manager = [Permission.EVENT_KIOSKS_MANAGE]
     video_config_manager = [Permission.EVENT_UPDATE, Permission.EVENT_GRAPHS]

--- a/app/eventyay/core/permissions.py
+++ b/app/eventyay/core/permissions.py
@@ -92,6 +92,9 @@ SYSTEM_ROLES = {
     ],
     "video_user_moderator": [
         Permission.EVENT_USERS_MANAGE.value,
+        # Organizers with user-moderation rights can delete chat messages without
+        # entering staff admin mode (admin trait).
+        Permission.ROOM_CHAT_MODERATE.value,
     ],
     "video_room_manager": [
         Permission.ROOM_UPDATE.value,

--- a/app/tests/stable/test_room_unscheduled.py
+++ b/app/tests/stable/test_room_unscheduled.py
@@ -18,6 +18,31 @@ def test_video_poll_question_manager_grants_read_and_moderate_permissions():
     assert Permission.ROOM_POLL_MANAGE.value in perms
 
 
+def test_video_user_moderator_grants_chat_moderate_without_admin_role():
+    """Organizers with manage-users video permission can delete chat messages
+    without needing the staff admin trait/session."""
+    perms = set(SYSTEM_ROLES['video_user_moderator'])
+    assert Permission.EVENT_USERS_MANAGE.value in perms
+    assert Permission.ROOM_CHAT_MODERATE.value in perms
+    # Must remain a scoped organizer role — not the full admin role set
+    assert Permission.EVENT_UPDATE.value not in perms
+    assert Permission.ROOM_UPDATE.value not in perms
+
+
+@pytest.mark.django_db
+def test_event_grants_chat_moderate_via_organizer_video_trait(event):
+    """Organizer JWT traits (without admin) must unlock room:chat.moderate."""
+    trait = f'eventyay-video-event-{event.slug}-video-user-moderator'
+    assert event.has_permission_implicit(
+        traits=['attendee', trait],
+        permissions=[Permission.ROOM_CHAT_MODERATE],
+    )
+    assert not event.has_permission_implicit(
+        traits=['attendee'],
+        permissions=[Permission.ROOM_CHAT_MODERATE],
+    )
+
+
 @pytest.mark.django_db
 def test_room_has_linked_submissions(event):
     with scope(event=event):


### PR DESCRIPTION
## Summary

- Grant `room:chat.moderate` to the organizer `video_user_moderator` role
- Let teams with **Video: Can message, ban, and silence users** delete chat messages without staff Admin mode
- Keep attendees limited to deleting their own messages

## Why

Delete-message for other users previously required the full `admin` role (Admin mode). Organizers already receive granular `video_user_moderator` traits from `can_video_manage_users`, but that role did not include chat moderate.

## Changes

- `SYSTEM_ROLES['video_user_moderator']` includes `ROOM_CHAT_MODERATE`
- Mirror the same grant in World `default_roles`
- Clarify team permission help text
- Add unit coverage for the role and Event trait permission path

## Test plan

- [x] Unit: `video_user_moderator` includes `room:chat.moderate` and not full admin perms
- [ ] Manual: as organizer with `can_video_manage_users`, Admin mode **OFF**, delete another user's chat message
- [ ] Manual: attendee / team without manage-users cannot delete others' messages
- [ ] Manual: Admin mode ON still works

## Summary by Sourcery

Grant chat moderation permissions to video organizers without requiring full admin role while keeping admin-level capabilities unchanged.

New Features:
- Allow organizers with the video user moderator role to delete chat messages via the ROOM_CHAT_MODERATE permission.

Enhancements:
- Expand the organizer video manage-users flag description to mention chat deletion without staff admin mode.
- Ensure the world default_roles configuration assigns chat moderation to the video_user_moderator role.

Tests:
- Add unit tests verifying video_user_moderator includes chat moderation but not full admin permissions and that organizer video traits grant room:chat.moderate implicitly.