### PR TITLE
fix(video): allow organizers to delete chat without admin mode

### DIFF
--- a/app/eventyay/base/models/organizer.py
+++ b/app/eventyay/base/models/organizer.py
@@ -569,8 +569,7 @@ class Team(LoggedModel, TimestampedModel, RulesModelMixin, models.Model, metacla
         default=False,
         verbose_name=_('Video: Can message, ban, and silence users'),
         help_text=_(
-            'Allows moderating users (ban, silence, reactivate) and deleting chat messages '
-            'in Eventyay Video without requiring staff admin mode.'
+            'Allows moderating users (ban, silence, reactivate) and deleting chat messages.'
         ),
     )
     can_video_manage_rooms = models.BooleanField(

--- a/app/eventyay/base/models/organizer.py
+++ b/app/eventyay/base/models/organizer.py
@@ -568,7 +568,10 @@ class Team(LoggedModel, TimestampedModel, RulesModelMixin, models.Model, metacla
     can_video_manage_users = models.BooleanField(
         default=False,
         verbose_name=_('Video: Can message, ban, and silence users'),
-        help_text=_('Allows moderating users (ban, silence, reactivate) in Eventyay Video.'),
+        help_text=_(
+            'Allows moderating users (ban, silence, reactivate) and deleting chat messages '
+            'in Eventyay Video without requiring staff admin mode.'
+        ),
     )
     can_video_manage_rooms = models.BooleanField(
         default=False,

--- a/app/eventyay/base/models/world.py
+++ b/app/eventyay/base/models/world.py
@@ -93,7 +93,10 @@ def default_roles():
     video_channel_manager = [Permission.EVENT_ROOMS_CREATE_CHAT, Permission.EVENT_ROOMS_CREATE_BBB]
     video_announcement_manager = [Permission.EVENT_ANNOUNCE]
     video_user_viewer = [Permission.EVENT_USERS_LIST]
-    video_user_moderator = [Permission.EVENT_USERS_MANAGE]
+    video_user_moderator = [
+        Permission.EVENT_USERS_MANAGE,
+        Permission.ROOM_CHAT_MODERATE,
+    ]
     video_room_manager = [Permission.ROOM_UPDATE, Permission.ROOM_DELETE]
     video_kiosk_manager = [Permission.EVENT_KIOSKS_MANAGE]
     video_config_manager = [Permission.EVENT_UPDATE, Permission.EVENT_GRAPHS]

--- a/app/eventyay/core/permissions.py
+++ b/app/eventyay/core/permissions.py
@@ -92,6 +92,9 @@ SYSTEM_ROLES = {
     ],
     "video_user_moderator": [
         Permission.EVENT_USERS_MANAGE.value,
+        # Organizers with user-moderation rights can delete chat messages without
+        # entering staff admin mode (admin trait).
+        Permission.ROOM_CHAT_MODERATE.value,
     ],
     "video_room_manager": [
         Permission.ROOM_UPDATE.value,

--- a/app/eventyay/core/permissions.py
+++ b/app/eventyay/core/permissions.py
@@ -92,8 +92,6 @@ SYSTEM_ROLES = {
     ],
     "video_user_moderator": [
         Permission.EVENT_USERS_MANAGE.value,
-        # Organizers with user-moderation rights can delete chat messages without
-        # entering staff admin mode (admin trait).
         Permission.ROOM_CHAT_MODERATE.value,
     ],
     "video_room_manager": [

--- a/app/tests/stable/test_room_unscheduled.py
+++ b/app/tests/stable/test_room_unscheduled.py
@@ -18,6 +18,31 @@ def test_video_poll_question_manager_grants_read_and_moderate_permissions():
     assert Permission.ROOM_POLL_MANAGE.value in perms
 
 
+def test_video_user_moderator_grants_chat_moderate_without_admin_role():
+    """Organizers with manage-users video permission can delete chat messages
+    without needing the staff admin trait/session."""
+    perms = set(SYSTEM_ROLES['video_user_moderator'])
+    assert Permission.EVENT_USERS_MANAGE.value in perms
+    assert Permission.ROOM_CHAT_MODERATE.value in perms
+    # Must remain a scoped organizer role — not the full admin role set
+    assert Permission.EVENT_UPDATE.value not in perms
+    assert Permission.ROOM_UPDATE.value not in perms
+
+
+@pytest.mark.django_db
+def test_event_grants_chat_moderate_via_organizer_video_trait(event):
+    """Organizer JWT traits (without admin) must unlock room:chat.moderate."""
+    trait = f'eventyay-video-event-{event.slug}-video-user-moderator'
+    assert event.has_permission_implicit(
+        traits=['attendee', trait],
+        permissions=[Permission.ROOM_CHAT_MODERATE],
+    )
+    assert not event.has_permission_implicit(
+        traits=['attendee'],
+        permissions=[Permission.ROOM_CHAT_MODERATE],
+    )
+
+
 @pytest.mark.django_db
 def test_room_has_linked_submissions(event):
     with scope(event=event):


### PR DESCRIPTION
## Summary
- Grant `room:chat.moderate` to the `video_user_moderator` role so organizers with **Video: Can message, ban, and silence users** can delete chat messages without entering staff admin mode.
- Keep world default roles and organizer permission help text aligned with this behavior.
- Add unit coverage for the role permission and Event trait grant path.

## Why
Delete message previously required the full `admin` trait (Admin mode). Regular organizers only receive granular video traits, so the UI action was missing unless they started an admin session.

## Test plan
- [ ] As an organizer with `can_video_manage_users`, turn **Admin mode OFF**, hard-refresh video, and confirm **delete message** works on another user's chat message.
- [ ] Confirm the same organizer can still delete with Admin mode ON.
- [ ] Confirm an attendee / organizer without `can_video_manage_users` cannot delete others' messages.
- [ ] Run: `pytest tests/stable/test_room_unscheduled.py -k 'video_user_moderator or grants_chat_moderate' -q`

## Issue

Fixes #4538


https://github.com/user-attachments/assets/664376b4-b75c-4633-8786-d54b1bbbc313

