### PR TITLE
fix(badges): show badge options on checkout and modify answers

### DIFF
--- a/app/eventyay/base/models/orders.py
+++ b/app/eventyay/base/models/orders.py
@@ -925,6 +925,18 @@ class Order(LockModel, LoggedModel):
             if product_has_system_questions(self.event, cp.product) or cp.product.questions.all():
                 return True
 
+        if 'eventyay.plugins.badges' in self.event.get_plugins():
+            from eventyay.plugins.badges.utils import (
+                get_badge_bundle_option_choices,
+                get_badge_config_position,
+            )
+
+            for cp in positions:
+                if get_badge_config_position(cp) != cp:
+                    continue
+                if get_badge_bundle_option_choices(self.event, cp):
+                    return True
+
         return False  # nothing there to modify
 
     def is_modification_allowed_by(self, email: str) -> bool:

--- a/app/eventyay/plugins/badges/utils.py
+++ b/app/eventyay/plugins/badges/utils.py
@@ -153,15 +153,6 @@ def position_has_printable_badge(event, position):
     return get_badge_layout_for_position(event, position) is not None
 
 
-def position_has_explicit_badge_assignment(event, position):
-    product_map, voucher_map, _default_layout = get_badge_layout_assignment_maps(event)
-    if position.voucher_id and position.voucher_id in voucher_map:
-        return voucher_map[position.voucher_id] is not None
-    if position.product_id in product_map:
-        return product_map[position.product_id] is not None
-    return False
-
-
 def exclude_explicit_no_badge(qs, assignment_model, fk_lookup):
     return qs.annotate(
         no_badging=Exists(
@@ -264,13 +255,14 @@ def get_badge_bundle_option_choices(event, position):
 
     The bundle is defined as a base position plus all attached add-ons.
     Choices are deduplicated by key while preserving discovery order.
+
+    Includes products that only use the event default layout when that layout
+    allows customization with ask-user fields. Explicit no-badge assignments
+    (layout=None) are skipped because no layout resolves for them.
     """
     seen_keys = set()
     choices = []
     for bundle_position in get_badge_bundle_positions(position):
-        if not position_has_explicit_badge_assignment(event, bundle_position):
-            continue
-
         layout = get_badge_layout_for_position(event, bundle_position)
         if not layout or not layout.allow_customization:
             continue
@@ -318,8 +310,8 @@ def get_badge_options_display(event, position):
     """
     Return a human-readable badge-options summary for order views.
 
-    Unlike checkout form injection, this includes products that only use the
-    event default layout so organizers can confirm what will be printed.
+    Uses the same layout resolution as checkout/modify form injection, including
+    the event default layout when no product/voucher assignment exists.
     """
     layout = get_badge_layout_for_position(event, position)
     if not layout or not layout.allow_customization or not layout.ask_user_fields_data:

--- a/app/tests/tickets/plugins/badges/test_badge_options_forms.py
+++ b/app/tests/tickets/plugins/badges/test_badge_options_forms.py
@@ -1,0 +1,283 @@
+"""End-to-end coverage for badge options on checkout and modify-answers forms."""
+
+import datetime
+
+import pytest
+from django.http import QueryDict
+from django_scopes import scopes_disabled
+
+from eventyay.base.forms.questions import BaseQuestionsForm
+from eventyay.base.models import (
+    CartPosition,
+    Event,
+    Order,
+    OrderPosition,
+    Organizer,
+    Product,
+)
+from eventyay.base.views.mixins import BaseQuestionsViewMixin
+from eventyay.plugins.badges.models import BadgeProduct
+from eventyay.plugins.badges.signals import badge_question_form_fields
+from eventyay.plugins.badges.utils import (
+    BADGE_HIDDEN_FIELDS_KEY,
+    get_badge_bundle_option_choices,
+    get_badge_hidden_fields,
+)
+
+
+@pytest.fixture
+def badge_checkout_env():
+    with scopes_disabled():
+        organizer = Organizer.objects.create(name='Badge Org', slug='badge-org')
+        event = Event.objects.create(
+            organizer=organizer,
+            name='Badge Event',
+            slug='badge-event',
+            plugins='eventyay.plugins.badges',
+            date_from=datetime.datetime(2030, 12, 26, tzinfo=datetime.timezone.utc),
+        )
+        event.settings.set('invoice_address_asked', False)
+        event.settings.set('attendee_names_asked', False)
+        event.settings.set('attendee_emails_asked', False)
+        event.settings.set('allow_modifications', 'order')
+
+        product = Product.objects.create(event=event, name='Standard', default_price=0, admission=True)
+        product.questions_to_ask = []
+
+        layout = event.badge_layouts.create(
+            name='Default',
+            default=True,
+            allow_customization=True,
+            ask_user_fields_data=['attendee_name', 'attendee_company'],
+        )
+
+        cart = CartPosition.objects.create(
+            event=event,
+            cart_id='badge-cart',
+            product=product,
+            price=0,
+            expires=datetime.datetime.now(datetime.timezone.utc) + datetime.timedelta(minutes=30),
+        )
+
+        order = Order.objects.create(
+            event=event,
+            email='buyer@example.com',
+            status=Order.STATUS_PAID,
+            datetime=datetime.datetime(2030, 1, 1, tzinfo=datetime.timezone.utc),
+            expires=datetime.datetime(2030, 2, 1, tzinfo=datetime.timezone.utc),
+            total=0,
+        )
+        position = OrderPosition.objects.create(
+            order=order,
+            product=product,
+            price=0,
+            secret='badge-secret',
+        )
+
+        yield {
+            'event': event,
+            'product': product,
+            'layout': layout,
+            'cart': cart,
+            'order': order,
+            'position': position,
+        }
+
+
+def _split_badge_fields(form):
+    """Mirror BaseQuestionsViewMixin form field splitting used by templates."""
+    form.badge_option_fields = []
+    form.regular_fields = []
+    for field_name in form.fields:
+        bound = form[field_name]
+        if getattr(bound.field, 'badge_option', False):
+            form.badge_option_fields.append(bound)
+        else:
+            form.regular_fields.append(bound)
+    return form
+
+
+def _prefixed_form_data(prefix, data):
+    query = QueryDict(mutable=True)
+    for key, value in data.items():
+        field_name = f'{prefix}-{key}'
+        if isinstance(value, (list, tuple)):
+            for item in value:
+                query.appendlist(field_name, item)
+        else:
+            query[field_name] = value
+    return query
+
+
+def _build_cart_form(env, data=None):
+    prefix = str(env['cart'].pk)
+    kwargs = {
+        'event': env['event'],
+        'cartpos': env['cart'],
+        'all_optional': False,
+        'prefix': prefix,
+    }
+    if data is not None:
+        kwargs['data'] = _prefixed_form_data(prefix, data)
+    return BaseQuestionsForm(**kwargs)
+
+
+def _build_order_form(env, data=None):
+    prefix = str(env['position'].pk)
+    kwargs = {
+        'event': env['event'],
+        'orderpos': env['position'],
+        'all_optional': False,
+        'prefix': prefix,
+    }
+    if data is not None:
+        kwargs['data'] = _prefixed_form_data(prefix, data)
+    return BaseQuestionsForm(**kwargs)
+
+
+@pytest.mark.django_db
+def test_signal_injects_badge_options_for_default_layout(badge_checkout_env):
+    env = badge_checkout_env
+    fields = badge_question_form_fields(env['event'], env['cart'])
+    assert BADGE_HIDDEN_FIELDS_KEY in fields
+    assert [c[0] for c in fields[BADGE_HIDDEN_FIELDS_KEY].choices] == [
+        'attendee_name',
+        'attendee_company',
+    ]
+
+
+@pytest.mark.django_db
+def test_checkout_form_shows_badge_options_with_default_layout(badge_checkout_env):
+    env = badge_checkout_env
+    form = _split_badge_fields(_build_cart_form(env))
+
+    assert BADGE_HIDDEN_FIELDS_KEY in form.fields
+    assert len(form.badge_option_fields) == 1
+    assert form.badge_option_fields[0].name == BADGE_HIDDEN_FIELDS_KEY
+    assert set(form.fields[BADGE_HIDDEN_FIELDS_KEY].initial) == {
+        'attendee_name',
+        'attendee_company',
+    }
+
+
+@pytest.mark.django_db
+def test_modify_answers_form_shows_badge_options_with_default_layout(badge_checkout_env):
+    env = badge_checkout_env
+    form = _split_badge_fields(_build_order_form(env))
+
+    assert BADGE_HIDDEN_FIELDS_KEY in form.fields
+    assert len(form.badge_option_fields) == 1
+    assert form.orderpos == env['position']
+
+
+@pytest.mark.django_db
+def test_checkout_and_modify_save_hidden_fields_semantics(badge_checkout_env):
+    """Checked boxes = visible; cleaned value stores unchecked (hidden) keys."""
+    env = badge_checkout_env
+
+    cart_form = _build_cart_form(env, {BADGE_HIDDEN_FIELDS_KEY: ['attendee_name']})
+    assert cart_form.is_valid()
+    assert cart_form.cleaned_data[BADGE_HIDDEN_FIELDS_KEY] == ['attendee_company']
+
+    order_form = _build_order_form(env, {BADGE_HIDDEN_FIELDS_KEY: ['attendee_company']})
+    assert order_form.is_valid()
+    assert order_form.cleaned_data[BADGE_HIDDEN_FIELDS_KEY] == ['attendee_name']
+
+
+@pytest.mark.django_db
+def test_mixin_save_persists_badge_options_on_order_and_cart(badge_checkout_env):
+    env = badge_checkout_env
+
+    class _Saver(BaseQuestionsViewMixin):
+        def __init__(self, forms):
+            self._forms = forms
+
+        @property
+        def forms(self):
+            return self._forms
+
+        def get_question_override_sets(self, *args, **kwargs):
+            return []
+
+    cart_form = _build_cart_form(env, {BADGE_HIDDEN_FIELDS_KEY: ['attendee_name']})
+    cart_form.pos = env['cart']
+    order_form = _build_order_form(env, {BADGE_HIDDEN_FIELDS_KEY: ['attendee_name']})
+    order_form.pos = env['position']
+
+    assert _Saver([cart_form, order_form]).save() is True
+
+    env['cart'].refresh_from_db()
+    env['position'].refresh_from_db()
+    assert get_badge_hidden_fields(env['cart']) == ['attendee_company']
+    assert get_badge_hidden_fields(env['position']) == ['attendee_company']
+
+
+@pytest.mark.django_db
+def test_forms_hidden_when_product_has_explicit_no_badge(badge_checkout_env):
+    from eventyay.plugins.badges.utils import clear_badge_layout_cache
+
+    env = badge_checkout_env
+    BadgeProduct.objects.create(product=env['product'], layout=None)
+    clear_badge_layout_cache(env['event'])
+
+    assert get_badge_bundle_option_choices(env['event'], env['cart']) == []
+    assert badge_question_form_fields(env['event'], env['cart']) == {}
+    assert BADGE_HIDDEN_FIELDS_KEY not in _build_cart_form(env).fields
+    assert BADGE_HIDDEN_FIELDS_KEY not in _build_order_form(env).fields
+    assert not env['order'].can_modify_answers
+
+
+@pytest.mark.django_db
+def test_forms_shown_with_explicit_product_assignment(badge_checkout_env):
+    from eventyay.plugins.badges.utils import clear_badge_layout_cache
+
+    env = badge_checkout_env
+    BadgeProduct.objects.create(product=env['product'], layout=env['layout'])
+    clear_badge_layout_cache(env['event'])
+
+    assert BADGE_HIDDEN_FIELDS_KEY in _build_cart_form(env).fields
+    assert BADGE_HIDDEN_FIELDS_KEY in _build_order_form(env).fields
+    assert env['order'].can_modify_answers
+
+
+@pytest.mark.django_db
+def test_addon_position_does_not_get_own_badge_options(badge_checkout_env):
+    env = badge_checkout_env
+    with scopes_disabled():
+        addon_product = Product.objects.create(event=env['event'], name='Addon', default_price=0)
+        addon_product.questions_to_ask = []
+        addon = OrderPosition.objects.create(
+            order=env['order'],
+            product=addon_product,
+            price=0,
+            secret='addon-secret',
+            addon_to=env['position'],
+        )
+
+    assert badge_question_form_fields(env['event'], addon) == {}
+    assert BADGE_HIDDEN_FIELDS_KEY in badge_question_form_fields(env['event'], env['position'])
+
+
+@pytest.mark.django_db
+def test_modify_answers_initial_reflects_saved_hidden_fields(badge_checkout_env):
+    env = badge_checkout_env
+    env['position'].meta_info_data = {
+        'question_form_data': {BADGE_HIDDEN_FIELDS_KEY: ['attendee_company']}
+    }
+    env['position'].save(update_fields=['meta_info'])
+
+    form = _build_order_form(env)
+    assert set(form.fields[BADGE_HIDDEN_FIELDS_KEY].initial) == {'attendee_name'}
+
+
+@pytest.mark.django_db
+def test_can_modify_answers_requires_active_ask_user_fields(badge_checkout_env):
+    from eventyay.plugins.badges.utils import clear_badge_layout_cache
+
+    env = badge_checkout_env
+    assert env['order'].can_modify_answers
+
+    env['layout'].ask_user_fields_data = []
+    env['layout'].save(update_fields=['ask_user_fields'])
+    clear_badge_layout_cache(env['event'])
+    assert not env['order'].can_modify_answers

--- a/app/tests/tickets/plugins/badges/test_utils.py
+++ b/app/tests/tickets/plugins/badges/test_utils.py
@@ -73,22 +73,37 @@ def badge_event():
 
 
 @pytest.mark.django_db
-def test_badge_options_hidden_without_product_layout_assignment(badge_event):
+def test_badge_options_shown_with_default_layout(badge_event):
+    """Checkout/modify should offer badge options when only the default layout applies."""
     event, position, product, layout = badge_event
 
-    assert get_badge_bundle_option_choices(event, position) == []
+    choices = get_badge_bundle_option_choices(event, position)
+
+    assert len(choices) == 1
+    assert choices[0][0] == 'attendee_name'
 
 
 @pytest.mark.django_db
 def test_badge_options_display_uses_default_layout_on_order_page(badge_event):
-    """Order detail should still show badge options when only the default layout applies."""
+    """Order detail should show badge options when only the default layout applies."""
     event, position, product, layout = badge_event
 
-    assert get_badge_bundle_option_choices(event, position) == []
+    assert get_badge_bundle_option_choices(event, position)
     display = get_badge_options_display(event, position)
     # Default layout includes attendee_name as an ask-user field.
     assert display
     assert 'name' in display.lower()
+
+
+@pytest.mark.django_db
+def test_badge_options_hidden_without_customization(badge_event):
+    event, position, product, layout = badge_event
+    layout.allow_customization = False
+    layout.ask_user_fields_data = []
+    layout.save(update_fields=['allow_customization', 'ask_user_fields'])
+
+    assert get_badge_bundle_option_choices(event, position) == []
+    assert get_badge_options_display(event, position) is None
 
 
 @pytest.mark.django_db
@@ -97,6 +112,7 @@ def test_badge_options_display_hidden_when_product_has_no_badge(badge_event):
     BadgeProduct.objects.create(product=product, layout=None)
 
     assert get_badge_options_display(event, position) is None
+    assert get_badge_bundle_option_choices(event, position) == []
 
 
 def test_format_badge_option_labels_empty():
@@ -139,6 +155,32 @@ def test_badge_options_shown_with_product_layout_assignment(badge_event):
 
     assert len(choices) == 1
     assert choices[0][0] == 'attendee_name'
+
+
+@pytest.mark.django_db
+def test_can_modify_answers_when_only_badge_options_exist(badge_event):
+    event, position, product, layout = badge_event
+    event.settings.set('invoice_address_asked', False)
+    event.settings.set('attendee_names_asked', False)
+    event.settings.set('attendee_emails_asked', False)
+    event.settings.set('allow_modifications', 'order')
+
+    assert not product.questions.exists()
+    assert position.order.can_modify_answers
+
+
+@pytest.mark.django_db
+def test_can_modify_answers_false_when_badge_customization_disabled(badge_event):
+    event, position, product, layout = badge_event
+    layout.allow_customization = False
+    layout.ask_user_fields_data = []
+    layout.save(update_fields=['allow_customization', 'ask_user_fields'])
+    event.settings.set('invoice_address_asked', False)
+    event.settings.set('attendee_names_asked', False)
+    event.settings.set('attendee_emails_asked', False)
+    event.settings.set('allow_modifications', 'order')
+
+    assert not position.order.can_modify_answers
 
 
 @pytest.mark.django_db


### PR DESCRIPTION
## Summary
- Show Ask-user **Badge options** during ticket purchase and modify answers when a printable layout applies, including the event **default** layout (not only explicit product/voucher assignments).
- Explicit no-badge assignments (`layout=None`) still hide options.
- Enable **Change details** when badge options are the only editable answers (`Order.can_modify_answers`).

## Test plan
- [x] Unit/integration: `test_badge_options_forms.py` + related `test_utils.py` cases (21 passed)
- [ ] Shop: buy product using **default** badge layout → checkout shows Badge options
- [ ] Shop: buy product with explicit **no badge** → no Badge options
- [ ] After order: **Change details** appears and can update badge options
- [ ] Control: badge layout settings / Ask-user fields still save correctly
- [ ] Local sandbox event `bomb/badge-sandbox` can be used for manual QA