### PR TITLE
fix(badges): expose questions mixed into other badge text

### DIFF
--- a/app/eventyay/plugins/badges/utils.py
+++ b/app/eventyay/plugins/badges/utils.py
@@ -5,7 +5,7 @@ from django.core.cache import cache as default_cache
 from django.db.models import Exists, OuterRef
 from django.utils.translation import gettext_lazy as _
 
-from eventyay.base.pdf import get_variables
+from eventyay.base.pdf import extract_layout_text_placeholders, get_variables
 
 from .models import BadgeLayout, BadgeProduct, BadgeVoucher
 
@@ -202,6 +202,62 @@ def get_badge_bundle_positions(position):
     return [root, *list(root.addons.all())]
 
 
+def _badge_layout_object_texts(obj):
+    """Collect raw text values from a layout object, including i18n/other mixes."""
+    texts = []
+    text = obj.get('text')
+    if text:
+        texts.append(str(text))
+    placeholder_text = obj.get('placeholder_text')
+    if placeholder_text:
+        texts.append(str(placeholder_text))
+    text_i18n = obj.get('text_i18n')
+    if isinstance(text_i18n, dict):
+        texts.extend(str(value) for value in text_i18n.values() if value)
+    return texts
+
+
+def _resolve_badge_placeholder_key(placeholder, variables):
+    """
+    Resolve a free-text placeholder (e.g. ``question:Username``) to a canonical
+    badge field key such as ``question_<id>``.
+    """
+    key = (placeholder or '').strip()
+    if not key:
+        return None
+    if key.lower().startswith('question:'):
+        label = key.split(':', 1)[1].strip().lower()
+        if not label:
+            return None
+        for var_key, var in variables.items():
+            question_label = var.get('question_label')
+            if question_label and str(question_label).strip().lower() == label:
+                return var.get('canonical_key') or var_key
+        return None
+
+    key = normalize_badge_content_key(key)
+    variable = variables.get(key)
+    if not variable:
+        return None
+    return variable.get('canonical_key') or key
+
+
+def _append_badge_customizable_field(fields, seen_keys, variables, key, sample=''):
+    if not key or key in seen_keys or key in ('other', 'other_i18n'):
+        return
+
+    variable = variables.get(key, {})
+    label = variable.get('label') or _badge_field_fallback_label(key)
+    fields.append(
+        {
+            'key': key,
+            'label': str(label),
+            'sample': str(variable.get('editor_sample') or variable.get('question_label') or sample or ''),
+        }
+    )
+    seen_keys.add(key)
+
+
 def get_badge_customizable_fields(event, layout):
     if not layout:
         return []
@@ -230,19 +286,25 @@ def get_badge_customizable_fields(event, layout):
             continue
 
         content = normalize_badge_content_key(obj.get('content'))
-        if not content or content in ('other', 'other_i18n') or content in seen_keys:
+        if not content:
             continue
 
-        variable = variables.get(content, {})
-        label = variable.get('label') or _badge_field_fallback_label(content)
-        fields.append(
-            {
-                'key': content,
-                'label': str(label),
-                'sample': str(variable.get('editor_sample') or obj.get('text') or ''),
-            }
+        # Free-text "other" blocks can mix several placeholders; expose each one
+        # as its own Ask-user / badge-option field (especially custom questions).
+        if content in ('other', 'other_i18n'):
+            for text in _badge_layout_object_texts(obj):
+                for placeholder in extract_layout_text_placeholders(text):
+                    key = _resolve_badge_placeholder_key(placeholder, variables)
+                    _append_badge_customizable_field(fields, seen_keys, variables, key)
+            continue
+
+        _append_badge_customizable_field(
+            fields,
+            seen_keys,
+            variables,
+            content,
+            sample=obj.get('text') or '',
         )
-        seen_keys.add(content)
 
     if isinstance(layout, BadgeLayout):
         layout._badge_customizable_fields_cache = fields

--- a/app/tests/tickets/plugins/badges/test_utils.py
+++ b/app/tests/tickets/plugins/badges/test_utils.py
@@ -27,6 +27,7 @@ from eventyay.plugins.badges.utils import (
     clear_badge_layout_cache,
     delete_badge_cached_pdfs,
     get_badge_bundle_option_choices,
+    get_badge_customizable_fields,
     get_badge_layout_for_position,
     get_badge_layout_version,
     append_badge_options_additional_field,
@@ -312,7 +313,7 @@ def test_badge_renderer_other_text_hides_placeholder_fields(badge_event):
     QuestionAnswer.objects.create(orderposition=position, question=q1, answer='Jane')
     QuestionAnswer.objects.create(orderposition=position, question=q2, answer='Doe')
     position.meta_info_data = {'question_form_data': {'badge_hidden_fields': [f'question_{q1.pk}']}}
-    position.save(update_fields=['meta_info_data'])
+    position.save(update_fields=['meta_info'])
 
     renderer = BadgeRenderer(
         event,
@@ -327,6 +328,60 @@ def test_badge_renderer_other_text_hides_placeholder_fields(badge_event):
     )
 
     assert result == ' Doe'
+
+
+@pytest.mark.django_db
+def test_customizable_fields_include_questions_mixed_in_other_text(badge_event):
+    """Questions embedded in free-text "other" blocks must appear as Ask-user options."""
+    event, position, product, layout = badge_event
+    q1 = Question.objects.create(event=event, question='First name', type='S')
+    q2 = Question.objects.create(event=event, question='Last name', type='S')
+    layout.layout = json.dumps(
+        [
+            {
+                'type': 'textarea',
+                'left': '0',
+                'bottom': '80',
+                'fontsize': '12.0',
+                'content': 'other',
+                'text': '{question:First name} {question:Last name} / {attendee_company}',
+            }
+        ]
+    )
+    layout.allow_customization = True
+    layout.ask_user_fields_data = [f'question_{q1.pk}', f'question_{q2.pk}', 'attendee_company']
+    layout.save(update_fields=['layout', 'allow_customization', 'ask_user_fields'])
+    clear_badge_layout_cache(event)
+
+    keys = [field['key'] for field in get_badge_customizable_fields(event, layout)]
+    assert keys == [f'question_{q1.pk}', f'question_{q2.pk}', 'attendee_company']
+
+    choices = get_badge_bundle_option_choices(event, position)
+    assert [key for key, _label in choices] == [f'question_{q1.pk}', f'question_{q2.pk}', 'attendee_company']
+    assert dict(choices)[f'question_{q1.pk}'] == 'First name'
+
+
+@pytest.mark.django_db
+def test_customizable_fields_include_question_id_placeholders_in_other_text(badge_event):
+    event, position, product, layout = badge_event
+    q1 = Question.objects.create(event=event, question='Handle', type='S')
+    layout.layout = json.dumps(
+        [
+            {
+                'type': 'textarea',
+                'content': 'other',
+                'text': f'Hello {{question_{q1.pk}}}',
+            }
+        ]
+    )
+    layout.allow_customization = True
+    layout.ask_user_fields_data = [f'question_{q1.pk}']
+    layout.save(update_fields=['layout', 'allow_customization', 'ask_user_fields'])
+    clear_badge_layout_cache(event)
+
+    keys = [field['key'] for field in get_badge_customizable_fields(event, layout)]
+    assert keys == [f'question_{q1.pk}']
+    assert get_badge_bundle_option_choices(event, position) == [(f'question_{q1.pk}', 'Handle')]
 
 
 @pytest.mark.django_db


### PR DESCRIPTION
## Summary
- Questions (and other variables) embedded in free-text **other** / **other_i18n** badge layout blocks are now discovered as Ask-user / badge-option fields.
- Previously only dedicated content fields (e.g. `question_<id>` as the whole text object) appeared; mixed placeholders like `{question:Username}` inside Other text were skipped.
- PDF rendering already hid those placeholders when selected; this wires the organizer UI and checkout/modify checkboxes to match.

## Test plan
- [x] Unit tests for other-text placeholder discovery (`test_customizable_fields_include_*`)
- [x] Related badge options suite: **25 passed**
- [x] End-to-end smoke: discovery → form → save hidden fields → rendered other-text omits hidden question
- [ ] Manual: badge layout with Other text `{question:…}` → settings Ask-user lists those questions → checkout/modify shows them → uncheck hides from badge PDF
- [ ] Local sandbox: http://localhost:8000/bomb/badge-sandbox/

Rebased onto latest `dev` (follow-up to #4542, which merged without this commit).