### PR TITLE
fix(video): require JWT for video access unless public link is enabled

### DIFF
--- a/app/eventyay/base/models/event.py
+++ b/app/eventyay/base/models/event.py
@@ -62,7 +62,10 @@ from eventyay.core.permissions import (
     traits_match_required,
 )
 from eventyay.core.utils.json import CustomJSONEncoder
-from eventyay.eventyay_common.video.permissions import VIDEO_TRAIT_ROLE_MAP
+from eventyay.eventyay_common.video.permissions import (
+    VIDEO_TRAIT_ROLE_MAP,
+    resolve_attendee_trait_grant,
+)
 from eventyay.helpers.database import GroupConcat
 from eventyay.helpers.daterange import daterange
 from eventyay.helpers.http import smtp_reachable
@@ -1405,7 +1408,7 @@ class Event(
     def decode_token(self, token, allow_raise=False):
         exc = None
         tried_any = False
-        for jwt_config in self.config.get('JWT_secrets', []):
+        for jwt_config in (self.config or {}).get('JWT_secrets', []):
             tried_any = True
             secret = jwt_config['secret']
             audience = jwt_config['audience']
@@ -1442,8 +1445,10 @@ class Event(
                         raise
                 except jwt.exceptions.InvalidTokenError as e:
                     exc = e
-        if exc and allow_raise:
-            raise exc
+        if allow_raise:
+            if exc:
+                raise exc
+            raise jwt.exceptions.InvalidTokenError('No JWT secrets configured')
 
     def _get_trait_grants_with_defaults(self):
         base_trait_grants = self.trait_grants if self.trait_grants is not None else default_grants()
@@ -1451,6 +1456,9 @@ class Event(
         if not slug:
             return base_trait_grants
         augmented = dict(base_trait_grants)
+        augmented['attendee'] = resolve_attendee_trait_grant(
+            self, augmented.get('attendee', ['attendee'])
+        )
         for role, trait_name in VIDEO_TRAIT_ROLE_MAP.items():
             augmented.setdefault(role, [f'eventyay-video-event-{slug}-{trait_name.replace("_", "-")}'])
         return augmented

--- a/app/eventyay/eventyay_common/video/permissions.py
+++ b/app/eventyay/eventyay_common/video/permissions.py
@@ -1,7 +1,10 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Iterable
+from typing import TYPE_CHECKING, Iterable
+
+if TYPE_CHECKING:
+    from eventyay.base.models import Event
 
 
 @dataclass(frozen=True)
@@ -14,6 +17,28 @@ class VideoPermissionDefinition:
     def trait_value(self, event_slug: str) -> str:
         normalized_trait = self.trait_name.replace('_', '-')
         return f'eventyay-video-event-{event_slug}-{normalized_trait}'
+
+
+def video_attendee_trait(event_slug: str) -> str:
+    """Event-scoped trait embedded in ticket/organizer JWTs for basic video access."""
+    return f'eventyay-video-event-{event_slug}'
+
+
+def resolve_attendee_trait_grant(event: Event, attendee_grant):
+    """
+    Require a JWT/ticket trait for attendee access unless the public video link is on.
+
+    Anonymous client_id users get empty traits rewritten to ['attendee']; locking the
+    default open grant blocks that path while preserving custom grants.
+    """
+    settings_obj = getattr(event, 'settings', None)
+    if settings_obj is not None and settings_obj.get('venueless_show_public_link', False):
+        return attendee_grant
+    if attendee_grant in (None, ['attendee'], 'attendee'):
+        slug = getattr(event, 'slug', None) or getattr(event, 'id', None)
+        if slug:
+            return [video_attendee_trait(slug)]
+    return attendee_grant
 
 
 VIDEO_PERMISSION_DEFINITIONS: dict[str, VideoPermissionDefinition] = {
@@ -65,4 +90,3 @@ def collect_user_video_traits(event_slug: str, team_permission_set: Iterable[str
         if definition := VIDEO_PERMISSION_BY_FIELD.get(perm_name):
             traits.append(definition.trait_value(event_slug))
     return traits
-

--- a/app/eventyay/eventyay_common/views/event.py
+++ b/app/eventyay/eventyay_common/views/event.py
@@ -42,6 +42,7 @@ from eventyay.base.models.cfp import default_fields
 from eventyay.consts import DEFAULT_PLUGINS
 from eventyay.base.services import tickets
 from eventyay.base.settings import DEFAULTS, SETTINGS_AFFECTING_CSS, is_event_series_creation_enabled
+from eventyay.eventyay_common.video.permissions import video_attendee_trait
 from eventyay.presale.style import regenerate_css
 from eventyay.common.text.path import resolve_media_path
 from eventyay.base.services.quotas import QuotaAvailability
@@ -1247,7 +1248,7 @@ class VideoAccessAuthenticator(View):
         - Users get specific video permission traits based on their team permissions
         - Only staff users (superuser, is_staff, or active staff session) get 'admin' trait
         """
-        traits = ['attendee']
+        traits = ['attendee', video_attendee_trait(self.request.event.slug)]
         traits.extend(video_traits)
         # Only add 'admin' trait for staff users - this grants full admin access
         # Regular organizers should NOT get 'admin' trait, only specific video permission traits

--- a/app/eventyay/features/live/modules/auth.py
+++ b/app/eventyay/features/live/modules/auth.py
@@ -72,7 +72,8 @@ class AuthModule(BaseModule):
         kwargs = {
             "event": self.consumer.event,
         }
-        if not body or "token" not in body:
+        body = body or {}
+        if "token" not in body or not body.get("token"):
             client_id = body.get("client_id")
             if not client_id:
                 async with statsd() as s:
@@ -86,9 +87,10 @@ class AuthModule(BaseModule):
                 kwargs["invite_token"] = body.get("invite_token")
         else:
             try:
-                token = self.consumer.event.decode_token(
-                    body["token"], allow_raise=True
-                )
+                # decode_token may read event.settings (DB-backed) when JWT_secrets are unset
+                token = await database_sync_to_async(
+                    self.consumer.event.decode_token
+                )(body["token"], allow_raise=True)
             except jwt.exceptions.ExpiredSignatureError:
                 async with statsd() as s:
                     s.increment(

--- a/app/tests/stable/test_attendee_direct_message_permission.py
+++ b/app/tests/stable/test_attendee_direct_message_permission.py
@@ -2,11 +2,16 @@ import pytest
 
 from eventyay.base.models.auth import User
 from eventyay.core.permissions import Permission
+from eventyay.eventyay_common.video.permissions import video_attendee_trait
 
 
 @pytest.mark.django_db
 def test_attendee_gets_direct_message_permission(event):
-    user = User.objects.create(event=event, profile={}, traits=['attendee'])
+    user = User.objects.create(
+        event=event,
+        profile={},
+        traits=['attendee', video_attendee_trait(event.slug)],
+    )
     perms = event.get_all_permissions(user)[event]
     assert Permission.EVENT_CHAT_DIRECT in perms
 
@@ -16,7 +21,7 @@ def test_attendee_without_admin_trait_keeps_direct_message(event):
     user = User.objects.create(
         event=event,
         profile={},
-        traits=['attendee', f'eventyay-video-event-{event.slug}'],
+        traits=['attendee', video_attendee_trait(event.slug)],
     )
     perms = event.get_all_permissions(user)[event]
     assert Permission.EVENT_CHAT_DIRECT in perms

--- a/app/tests/stable/test_video_jwt_required.py
+++ b/app/tests/stable/test_video_jwt_required.py
@@ -1,0 +1,38 @@
+import pytest
+import jwt
+
+from eventyay.base.services.user import AuthError, login
+from eventyay.core.permissions import Permission
+from eventyay.eventyay_common.video.permissions import video_attendee_trait
+
+
+@pytest.mark.django_db
+def test_anonymous_client_id_denied_without_jwt(event):
+    assert event.settings.get('venueless_show_public_link', False) is False
+    with pytest.raises(AuthError) as exc:
+        login(event=event, client_id='anonymous-client')
+    assert exc.value.code == 'auth.missing_token'
+
+
+@pytest.mark.django_db
+def test_attendee_jwt_trait_grants_access(event):
+    assert event.has_permission_implicit(
+        traits=['attendee', video_attendee_trait(event.slug)],
+        permissions=[Permission.EVENT_VIEW],
+        allow_empty_traits=False,
+    )
+
+
+@pytest.mark.django_db
+def test_public_video_link_allows_anonymous_access(event):
+    event.settings.set('venueless_show_public_link', True)
+    result = login(event=event, client_id='public-anonymous-client')
+    assert result.user.client_id == 'public-anonymous-client'
+
+
+@pytest.mark.django_db
+def test_decode_token_without_config_raises_invalid_token(event):
+    event.config = None
+    event.save(update_fields=['config'])
+    with pytest.raises(jwt.exceptions.InvalidTokenError):
+        event.decode_token('not-a-jwt', allow_raise=True)


### PR DESCRIPTION
## Summary
- Require a ticket/organizer JWT for video access by default; anonymous `client_id` login is denied unless the public video link is enabled.
- Include the event attendee trait in organizer JWTs so signed-in organizers keep access.
- Harden token decoding for events with missing JWT config so clients get `auth.missing_token` / `auth.invalid_token` instead of `server.fatal`.

## Test plan
- [ ] Open `/{org}/{event}/video/` without a token (or with only a random `client_id`) and confirm access is denied with the existing token error UI
- [ ] Join via attendee ticket JWT and confirm attendee-level access works
- [ ] Join via organizer video access flow and confirm elevated organizer permissions work
- [ ] Enable “show public video link” and confirm anonymous access works again
- [ ] On an event with `config=None`, send a garbage token and confirm `auth.invalid_token` (not fatal server error)
- [ ] Run `pytest tests/stable/test_video_jwt_required.py tests/stable/test_attendee_direct_message_permission.py`