### PR TITLE
Fix unauthorized video event access by removing implicit attendee trait assignment

### DIFF
--- a/app/eventyay/base/models/event.py
+++ b/app/eventyay/base/models/event.py
@@ -1474,8 +1474,8 @@ class Event(
         event_trait_grants = self._get_trait_grants_with_defaults()
         event_roles = self.roles if self.roles is not None else default_roles()
 
-        if allow_empty_traits and not traits:
-            traits = ['attendee']
+        if traits is None:
+            traits = []
 
         admin_mode_active = 'admin' in traits
         if admin_mode_active:
@@ -1588,8 +1588,6 @@ class Event(
         event_roles = self.roles if self.roles is not None else default_roles()
 
         user_traits = user.traits or []
-        if allow_empty_traits and not user_traits:
-            user_traits = ['attendee']
 
         for role, required_traits in event_trait_grants.items():
             if traits_match_required(user_traits, required_traits) and (required_traits or allow_empty_traits):

--- a/app/tests/stable/test_video_jwt_required.py
+++ b/app/tests/stable/test_video_jwt_required.py
@@ -24,10 +24,11 @@ def test_attendee_jwt_trait_grants_access(event):
 
 
 @pytest.mark.django_db
-def test_public_video_link_allows_anonymous_access(event):
+def test_public_video_link_requires_jwt(event):
     event.settings.set('venueless_show_public_link', True)
-    result = login(event=event, client_id='public-anonymous-client')
-    assert result.user.client_id == 'public-anonymous-client'
+    with pytest.raises(AuthError) as exc:
+        login(event=event, client_id='public-anonymous-client')
+    assert exc.value.code == 'auth.missing_token'
 
 
 @pytest.mark.django_db


### PR DESCRIPTION
Fixes #4569 

## Summary by Sourcery

Bug Fixes:
- Stop granting attendee permissions to users or contexts with no traits to avoid unauthorized video event access.