### PR TITLE
Fix badge editor default text box alignment

### DIFF
--- a/app/eventyay/static/pretixcontrol/js/ui/editor.js
+++ b/app/eventyay/static/pretixcontrol/js/ui/editor.js
@@ -1015,9 +1015,9 @@ var editor = {
 
     _add_text: function () {
         var text = new fabric.Textarea(editor._get_text_sample('event_name'), {
-            left: 100,
+            left: 0,
             top: 100,
-            width: editor._mm2px(50),
+            width: editor.pdf_viewport.width,
             lockRotation: false,
             centeredRotation: true,
             fontFamily: 'Open Sans',


### PR DESCRIPTION
Fixes #4539

https://github.com/user-attachments/assets/cbd39f6f-00f4-48e8-86d7-fe2c9da0c053

## Summary by Sourcery

Bug Fixes:
- Fix misaligned default text box in the badge editor by aligning it to the left and spanning the full badge width.