### PR TITLE
chore: bump teamshifts plugin

### DIFF
--- a/app/uv.lock
+++ b/app/uv.lock
@@ -1196,7 +1196,7 @@ dependencies = [
 [[package]]
 name = "eventyay-teamshifts"
 version = "0.1.0"
-source = { git = "https://github.com/fossasia/eventyay-teamshifts.git?rev=main#96b77d6e43e5d3884c126c91a09744cfa02668fb" }
+source = { git = "https://github.com/fossasia/eventyay-teamshifts.git?rev=main#488b219869411bf6754c6d8809d063d6eef6e5f1" }
 
 [[package]]
 name = "eventyay-unified"


### PR DESCRIPTION
This PR bumps the `eventyay-teamshifts` dependency in `uv.lock` to the latest commit on the plugin's main branch.

## Summary by Sourcery

Chores:
- Update uv.lock to reference the latest eventyay-teamshifts plugin version.