### PR TITLE
fix: remove unnecessary email settings info box

### DIFF
--- a/app/eventyay/eventyay_common/templates/eventyay_common/event/settings.html
+++ b/app/eventyay/eventyay_common/templates/eventyay_common/event/settings.html
@@ -208,14 +208,6 @@
         </fieldset>
         <fieldset id="email-settings-tab">
             <legend>{% trans "Email" %}</legend>
-            <div class="alert alert-info">
-                {% blocktrans trimmed %}
-                    All outgoing event emails — both <strong>Tickets</strong> and <strong>Talks</strong> —
-                    share the settings on this page. Component-specific email templates can still be
-                    customised on each component's own email settings page.
-                {% endblocktrans %}
-            </div>
-
             <h4 class="settings-sub-heading">{% trans "General" %}</h4>
             {% bootstrap_field email_form.mail_from layout="control" %}
             {% bootstrap_field email_form.mail_from_name layout="control" %}


### PR DESCRIPTION
Fixes #4624 

<img width="1506" height="350" alt="Screenshot 2026-07-30 121356" src="https://github.com/user-attachments/assets/f46868b5-dd8e-4780-9174-6834425bac04" />

## Summary by Sourcery

Enhancements:
- Streamline the event email settings page by removing the redundant info message about shared email configuration.