### PR TITLE
fix : remove geo location from tickets general settings

### DIFF
--- a/app/eventyay/control/forms/event.py
+++ b/app/eventyay/control/forms/event.py
@@ -532,10 +532,6 @@ class EventUpdateForm(I18nModelForm):
         kwargs.setdefault('initial', {})
         self.instance = kwargs['instance']
         super().__init__(*args, **kwargs)
-        self.fields['location'].widget.attrs['rows'] = '3'
-        self.fields['location'].widget.attrs['placeholder'] = _('Sample Conference Center\nHeidelberg, Germany')
-        self.fields['geo_lat'].widget.attrs['placeholder'] = _('Latitude, e.g. 40.7128')
-        self.fields['geo_lon'].widget.attrs['placeholder'] = _('Longitude, e.g. -74.0060')
         self.fields['sales_channels'] = forms.MultipleChoiceField(
             label=self.fields['sales_channels'].label,
             help_text=self.fields['sales_channels'].help_text,
@@ -558,9 +554,6 @@ class EventUpdateForm(I18nModelForm):
         localized_fields = '__all__'
         fields = [
             'currency',
-            'location',
-            'geo_lat',
-            'geo_lon',
             'presale_start',
             'presale_end',
             'sales_channels',

--- a/app/eventyay/control/templates/pretixcontrol/event/settings.html
+++ b/app/eventyay/control/templates/pretixcontrol/event/settings.html
@@ -27,7 +27,6 @@
                 <legend>{% trans "Basics" %}</legend>
                 {% bootstrap_field form.currency layout="control" %}
                 {% bootstrap_field form.sales_channels layout="control" %}
-                {% include "pretixcontrol/event/fragment_geodata.html" %}
 
                 {% if meta_forms %}
                     <div class="form-group metadata-group">

--- a/app/eventyay/eventyay_common/forms/event.py
+++ b/app/eventyay/eventyay_common/forms/event.py
@@ -189,6 +189,8 @@ class EventUpdateForm(I18nModelForm):
             self.fields['slug'].widget.attrs['readonly'] = 'readonly'
         self.fields['location'].widget.attrs['rows'] = '3'
         self.fields['location'].widget.attrs['placeholder'] = _('Sample Conference Center\nHeidelberg, Germany')
+        self.fields['geo_lat'].widget.attrs['placeholder'] = _('Latitude, e.g. 40.7128')
+        self.fields['geo_lon'].widget.attrs['placeholder'] = _('Longitude, e.g. -74.0060')
 
         # Configure email field with canonical label and help text
         self.fields['email'].required = False


### PR DESCRIPTION
Close : #4635

### Acceptance criteria check

| Criterion | Status |
|---|---|
| Location fields removed from ticket component | ✅ Removed from `EventUpdateForm.Meta.fields` |
| Geo coordinate fields removed from ticket component | ✅ Removed `geo_lat`, `geo_lon` from form and template |
| No duplicate map/location settings in ticket settings | ✅ `fragment_geodata.html` no longer included in `settings.html` |
| Common event settings still has location/geo as single source of truth | ✅ `eventyay_common/event/settings.html` line 62 unchanged |
| Sub-event location settings untouched | ✅ `subevents/detail.html` and `bulk.html` untouched |
| Public ticket pages unaffected | ✅ `presale/templates/pretixpresale/event/index.html` untouched — still reads from `ev.location` which comes from the common settings |
| Existing saved location data won't cause errors | ✅ Data stays in the DB; only the form/UI is changed — no migration needed |

### What's intentionally left alone
- **`eventyay_common/event/settings.html`** — the single source of truth for location/geo, kept intact
- **`eventyay_common/forms/event.py`** (`EventUpdateForm`) — still has `location`, `geo_lat`, `geo_lon` for the common settings
- **Sub-event forms/templates** — sub-events legitimately have their own per-event location overrides, unrelated to this issue
- **`EventWizardBasicsForm`** — event creation wizard still collects location/geo (correct, since it feeds the common event model)
- **No migrations needed** — no model changes, only UI/form changes

<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/9694a2dd-cb93-45fd-9460-37f6a79a07bf" />

## Summary by Sourcery

Remove location and geo coordinate configuration from the event general ticket settings to keep common event settings as the single source of truth.

Enhancements:
- Simplify the EventUpdateForm Meta fields by excluding location and geo_lat/geo_lon from ticket-related general settings.
- Clean up the general settings template by no longer including the geodata fragment in the basics section.