### PR TITLE
Hide empty statistics boxes and sections on Talk dashboard when no data exists

### DIFF
--- a/app/eventyay/orga/templates/orga/submission/includes/statistics.html
+++ b/app/eventyay/orga/templates/orga/submission/includes/statistics.html
@@ -1,9 +1,11 @@
 {% load i18n %}
 {% load static %}
 
+{% if submission_timeline_data or submission_type_data or submission_track_data or submission_state_data or submission_language_data or talk_timeline_data or talk_type_data or talk_track_data or talk_state_data or talk_language_data %}
 <div id="stats" class="mt-4">
     <div id="global-data" class="d-none" data-url="{{ request.event.orga_urls.submissions }}?" data-mapping="{{ id_mapping }}" data-annotations="{{ timeline_annotations }}"></div>
 
+    {% if submission_timeline_data or submission_type_data or submission_track_data or submission_state_data or submission_language_data %}
     <section class="stats-section mb-5" id="proposal-statistics">
         <h2>{% translate "Proposal Statistics" %}</h2>
 
@@ -57,7 +59,9 @@
             {% endif %}
         </div>
     </section>
+    {% endif %}
 
+    {% if talk_timeline_data or talk_type_data or talk_track_data or talk_state_data or talk_language_data %}
     <section class="stats-section mb-4" id="session-statistics">
         <h2>{% translate "Session Statistics" %}</h2>
 
@@ -111,4 +115,6 @@
             {% endif %}
         </div>
     </section>
+    {% endif %}
 </div>
+{% endif %}

--- a/app/eventyay/orga/views/submission.py
+++ b/app/eventyay/orga/views/submission.py
@@ -879,7 +879,9 @@ class SubmissionStatsMixin:
             .annotate(count=DbCount('id'))
         )
         state_labels = dict(SubmissionStates.get_choices())
-        counter = {str(state_labels.get(row['state'], row['state'])): row['count'] for row in rows}
+        counter = {str(state_labels.get(row['state'], row['state'])): row['count'] for row in rows if row['count']}
+        if not counter:
+            return ''
         return json.dumps(
             sorted(
                 [{'label': label, 'value': value} for label, value in counter.items()],
@@ -903,8 +905,10 @@ class SubmissionStatsMixin:
         }
         counter = {
             types_dict[row['submission_type_id']]: row['count']
-            for row in rows if row['submission_type_id'] in types_dict
+            for row in rows if row['submission_type_id'] in types_dict and row['count']
         }
+        if not counter:
+            return ''
         return json.dumps(
             sorted(
                 [{'label': label, 'value': value} for label, value in counter.items()],
@@ -929,8 +933,10 @@ class SubmissionStatsMixin:
             }
             counter = {
                 tracks_dict[row['track_id']]: row['count']
-                for row in rows if row['track_id'] in tracks_dict
+                for row in rows if row['track_id'] in tracks_dict and row['count']
             }
+            if not counter:
+                return ''
             return json.dumps(
                 sorted(
                     [{'label': label, 'value': value} for label, value in counter.items()],
@@ -952,8 +958,10 @@ class SubmissionStatsMixin:
         )
         counter = {
             str(locales_dict.get(row['content_locale'], row['content_locale'])): row['count']
-            for row in rows if row['content_locale']
+            for row in rows if row['content_locale'] and row['count']
         }
+        if not counter:
+            return ''
         return json.dumps(
             sorted(
                 [{'label': label, 'value': value} for label, value in counter.items()],
@@ -996,7 +1004,9 @@ class SubmissionStatsMixin:
             .annotate(count=DbCount('id'))
         )
         state_labels = dict(SubmissionStates.get_choices())
-        counter = {str(state_labels.get(row['state'], row['state'])): row['count'] for row in rows}
+        counter = {str(state_labels.get(row['state'], row['state'])): row['count'] for row in rows if row['count']}
+        if not counter:
+            return ''
         return json.dumps(
             sorted(
                 [{'label': label, 'value': value} for label, value in counter.items()],
@@ -1020,8 +1030,10 @@ class SubmissionStatsMixin:
         }
         counter = {
             types_dict[row['submission_type_id']]: row['count']
-            for row in rows if row['submission_type_id'] in types_dict
+            for row in rows if row['submission_type_id'] in types_dict and row['count']
         }
+        if not counter:
+            return ''
         return json.dumps(
             sorted(
                 [{'label': label, 'value': value} for label, value in counter.items()],
@@ -1046,8 +1058,10 @@ class SubmissionStatsMixin:
             }
             counter = {
                 tracks_dict[row['track_id']]: row['count']
-                for row in rows if row['track_id'] in tracks_dict
+                for row in rows if row['track_id'] in tracks_dict and row['count']
             }
+            if not counter:
+                return ''
             return json.dumps(
                 sorted(
                     [{'label': label, 'value': value} for label, value in counter.items()],
@@ -1069,8 +1083,10 @@ class SubmissionStatsMixin:
         )
         counter = {
             str(locales_dict.get(row['content_locale'], row['content_locale'])): row['count']
-            for row in rows if row['content_locale']
+            for row in rows if row['content_locale'] and row['count']
         }
+        if not counter:
+            return ''
         return json.dumps(
             sorted(
                 [{'label': label, 'value': value} for label, value in counter.items()],


### PR DESCRIPTION
Fixes #4639

<img width="1500" height="763" alt="Screenshot 2026-07-30 191711" src="https://github.com/user-attachments/assets/d50869c2-dcb2-4b6b-8747-7bfb0592a22e" />

## Summary by Sourcery

Hide submission and talk statistics on the dashboard when no underlying data exists to display them.

Bug Fixes:
- Prevent empty statistics boxes from rendering for submission and talk metrics when all counts are zero.

Enhancements:
- Skip JSON data generation for submission and talk statistics when counters are empty so the UI reflects the absence of data.