### PR TITLE
Move cart redirect and timeline options to Ticket settings Basics tab

### DIFF
--- a/app/eventyay/control/templates/pretixcontrol/event/settings.html
+++ b/app/eventyay/control/templates/pretixcontrol/event/settings.html
@@ -47,6 +47,11 @@
                         </div>
                     </div>
                 {% endif %}
+                {% bootstrap_field sform.redirect_to_checkout_directly layout="control" %}
+                {% bootstrap_field form.presale_start layout="control" %}
+                {% bootstrap_field sform.presale_start_show_date layout="control" %}
+                {% bootstrap_field form.presale_end layout="control" %}
+                {% bootstrap_field sform.show_products_outside_presale_period layout="control" %}
             </fieldset>
             <fieldset>
                 <legend>{% trans "Order Modification" %}</legend>
@@ -138,15 +143,6 @@
                 {% bootstrap_field sform.banner_text_bottom layout="control" %}
                 {% bootstrap_field sform.event_info_text layout="control" %}
             </fieldset>
-
-
-            <fieldset>
-                <legend>{% trans "Timeline" %}</legend>
-                {% bootstrap_field form.presale_start layout="control" %}
-                {% bootstrap_field sform.presale_start_show_date layout="control" %}
-                {% bootstrap_field form.presale_end layout="control" %}
-                {% bootstrap_field sform.show_products_outside_presale_period layout="control" %}
-            </fieldset>
             <fieldset>
                 <legend>{% trans "Display" %}</legend>
                 {% bootstrap_field sform.show_dates_on_frontpage layout="control" %}
@@ -170,7 +166,6 @@
                 <legend>{% trans "Cart" %}</legend>
                 {% bootstrap_field sform.reservation_time layout="control" %}
                 {% bootstrap_field sform.max_products_per_order layout="control" %}
-                {% bootstrap_field sform.redirect_to_checkout_directly layout="control" %}
             </fieldset>
             <fieldset>
                 <legend>{% trans "Waiting list" %}</legend>


### PR DESCRIPTION
## Summary

Move the checkout redirect option from the `Cart` tab and all `Timeline` options into the `Basics` tab in Ticket settings General. Remove the now-empty `Timeline` tab.

Fixes #4691



<img width="5088" height="3364" alt="image" src="https://github.com/user-attachments/assets/848b424e-4157-41e6-a159-d420721e2f14" />


<img width="5088" height="3364" alt="image" src="https://github.com/user-attachments/assets/2ffed5d8-adea-46ed-8864-31c5be188590" />



## Summary by Sourcery

Move checkout redirect and presale timeline settings from their dedicated tabs into the Basics section of general ticket settings, simplifying the event settings layout.

Enhancements:
- Relocate the checkout redirect option from the Cart section to the Basics section in general ticket settings.
- Relocate presale timeline fields into the Basics section and remove the now-empty Timeline section to streamline settings organization.