### PR TITLE
Remove Imprint URL field from organiser event settings

### DIFF
--- a/app/eventyay/eventyay_common/forms/event.py
+++ b/app/eventyay/eventyay_common/forms/event.py
@@ -33,7 +33,6 @@ class EventCommonSettingsForm(SettingsForm):
         'locales',
         'locale',
         'region',
-        'imprint_url',
         'contact_form_enabled',
         'contact_mail',
         'logo_image',

--- a/app/eventyay/eventyay_common/templates/eventyay_common/event/settings.html
+++ b/app/eventyay/eventyay_common/templates/eventyay_common/event/settings.html
@@ -60,7 +60,6 @@
             {% include "eventyay_common/includes/event_schedule_row.html" with date_from_form=form.date_from date_to_form=form.date_to timezone_form=sform.timezone %}
             {% bootstrap_field form.date_admission layout="control" %}
             {% include "pretixcontrol/event/fragment_geodata.html" %}
-            {% bootstrap_field sform.imprint_url layout="control" %}
             <div class="form-group">
                 <label class="col-md-3 control-label">
                     {% translate "Header links" %}

--- a/app/eventyay/orga/forms/event.py
+++ b/app/eventyay/orga/forms/event.py
@@ -56,13 +56,6 @@ class EventForm(ReadOnlyFlag, I18nHelpText, JsonSubfieldMixin, I18nModelForm):
         label='',
         help_text=_('You can type in your CSS instead of uploading it, too.'),
     )
-    imprint_url = forms.URLField(
-        label=_('Imprint URL'),
-        help_text=_(
-            'This should point e.g. to a part of your website that has your contact details and legal information.'
-        ),
-        required=False,
-    )
     show_featured = forms.ChoiceField(
         label=_('Show featured sessions'),
         choices=SHOW_FEATURED_VISIBILITY_CHOICES,
@@ -202,7 +195,6 @@ class EventForm(ReadOnlyFlag, I18nHelpText, JsonSubfieldMixin, I18nModelForm):
             'custom_css',
         ]
         json_fields = {
-            'imprint_url': 'display_settings',
             'show_featured': 'feature_flags',
             'show_featured_speakers': 'feature_flags',
             'use_feedback': 'feature_flags',


### PR DESCRIPTION
Fixes #4625

This PR removes the dedicated Imprint URL field from the "Basics" tab in organiser event settings, as organisers can already add imprint, legal, or custom links using the header/footer link options.

<img width="1340" height="489" alt="Screenshot 2026-08-01 102320" src="https://github.com/user-attachments/assets/b084c09c-26a0-459f-ba13-747a7cbfad02" />

