### PR TITLE
Standardize filter form design across admin, tickets and common list pages

### DIFF
--- a/app/eventyay/control/templates/pretixcontrol/admin/attendees/index.html
+++ b/app/eventyay/control/templates/pretixcontrol/admin/attendees/index.html
@@ -15,30 +15,26 @@
         {% translate "This is a list of all paid attendees and their check-in status." %}
     </p>
 
-    <div class="panel panel-default">
-        <div class="panel-heading">
-            <h3 class="panel-title">{% translate "Filter" %}</h3>
-        </div>
-
-        <div class="panel-body">
-            <form method="get" class="row filter-form">
-                <div class="col-md-3 col-sm-6 col-xs-12 form-group">
+    <div class="list-filter-container">
+        <form method="get" class="filter-form list-filter-form">
+            <div class="list-filter-grid">
+                <div class="list-filter-field">
                     {% bootstrap_field filter_form.query layout='inline' %}
                 </div>
-                <div class="col-md-3 col-sm-6 col-xs-12 form-group">
+                <div class="list-filter-field">
                     {% bootstrap_field filter_form.event_query layout='inline' %}
                 </div>
-                <div class="col-md-2 col-sm-6 col-xs-12 form-group">
+                <div class="list-filter-field">
                     {% bootstrap_field filter_form.event_status layout='inline' %}
                 </div>
-                <div class="col-md-2 col-sm-6 col-xs-12 form-group">
+                <div class="list-filter-field">
                     {% bootstrap_field filter_form.checkin_status layout='inline' %}
                 </div>
-                <div class="col-md-2 col-sm-6 col-xs-12 form-group">
+                <div class="list-filter-field list-filter-field--actions">
                     {% include "eventyay_common/filter_actions.html" %}
                 </div>
-            </form>
-        </div>
+            </div>
+        </form>
     </div>
 
     <div data-ajax-results-region>

--- a/app/eventyay/control/templates/pretixcontrol/admin/events/index.html
+++ b/app/eventyay/control/templates/pretixcontrol/admin/events/index.html
@@ -21,33 +21,28 @@
             </p>
         </div>
     {% else %}
-        <div class="panel panel-default">
-            <div class="panel-heading">
-                <h3 class="panel-title">{% trans "Filter" %}</h3>
-            </div>
-            <div class="panel-body">
-                <form class="" action="" method="get">
-                    <div class="row filter-form">
-                        <div class="col-md-3 col-sm-6 col-xs-12">
-                            {% bootstrap_field filter_form.query layout='inline' %}
-                        </div>
-                        <div class="col-md-3 col-sm-6 col-xs-12">
-                            {% bootstrap_field filter_form.status layout='inline' %}
-                        </div>
-                        <div class="col-md-3 col-sm-6 col-xs-12">
-                            {% bootstrap_field filter_form.organizer layout='inline' %}
-                        </div>
-                        {% for mf in meta_fields %}
-                            <div class="col-md-3 col-sm-6 col-xs-12">
-                                {% bootstrap_field mf layout='inline' %}
-                            </div>
-                        {% endfor %}
-                        <div class="col-md-3 col-sm-6 col-xs-12">
-                            {% include "eventyay_common/filter_actions.html" %}
-                        </div>
+        <div class="list-filter-container">
+            <form action="" method="get" class="filter-form list-filter-form">
+                <div class="list-filter-grid">
+                    <div class="list-filter-field">
+                        {% bootstrap_field filter_form.query layout='inline' %}
                     </div>
-                </form>
-            </div>
+                    <div class="list-filter-field">
+                        {% bootstrap_field filter_form.status layout='inline' %}
+                    </div>
+                    <div class="list-filter-field">
+                        {% bootstrap_field filter_form.organizer layout='inline' %}
+                    </div>
+                    {% for mf in meta_fields %}
+                        <div class="list-filter-field">
+                            {% bootstrap_field mf layout='inline' %}
+                        </div>
+                    {% endfor %}
+                    <div class="list-filter-field list-filter-field--actions">
+                        {% include "eventyay_common/filter_actions.html" %}
+                    </div>
+                </div>
+            </form>
         </div>
         <div data-ajax-results-region>
             <table class="table table-condensed table-hover"

--- a/app/eventyay/control/templates/pretixcontrol/admin/orders/index.html
+++ b/app/eventyay/control/templates/pretixcontrol/admin/orders/index.html
@@ -10,23 +10,20 @@
 <h1>{% translate "All Orders" %}</h1>
 <p>{% translate "This is a list of all orders across all events." %}</p>
 
-<div class="panel panel-default">
-    <div class="panel-heading">
-        <h3 class="panel-title">{% translate "Filter" %}</h3>
-    </div>
-    <div class="panel-body">
-        <form method="get" class="row filter-form">
-            <div class="col-md-5 col-sm-6 col-xs-12 form-group">
+<div class="list-filter-container">
+    <form method="get" class="filter-form list-filter-form">
+        <div class="list-filter-grid">
+            <div class="list-filter-field">
                 {% bootstrap_field filter_form.query layout='inline' %}
             </div>
-            <div class="col-md-3 col-sm-6 col-xs-12 form-group">
+            <div class="list-filter-field">
                 {% bootstrap_field filter_form.status layout='inline' %}
             </div>
-            <div class="col-md-4 col-sm-6 col-xs-12 form-group">
+            <div class="list-filter-field list-filter-field--actions">
                 {% include "eventyay_common/filter_actions.html" %}
             </div>
-        </form>
-    </div>
+        </div>
+    </form>
 </div>
 
 <div data-ajax-results-region>

--- a/app/eventyay/control/templates/pretixcontrol/admin/organizers.html
+++ b/app/eventyay/control/templates/pretixcontrol/admin/organizers.html
@@ -7,14 +7,7 @@
 {% block content %}
 	<h1>{% trans "Organizers" %}</h1>
 	<p>{% trans "The list below shows all organizer accounts you have administrative access to." %}</p>
-    <form class="row filter-form" action="" method="get">
-        <div class="col-md-10 col-sm-6 col-xs-12">
-            {% bootstrap_field filter_form.query layout='inline' %}
-        </div>
-        <div class="col-md-2 col-sm-6 col-xs-12">
-            {% include "eventyay_common/filter_actions.html" %}
-        </div>
-    </form>
+    {% include "eventyay_common/includes/list_filter_search.html" %}
     {% if staff_session %}
         <p>
             <a href="{% url "control:organizers.add" %}" class="btn btn-default">

--- a/app/eventyay/control/templates/pretixcontrol/admin/submissions/index.html
+++ b/app/eventyay/control/templates/pretixcontrol/admin/submissions/index.html
@@ -15,36 +15,32 @@
         {% translate "This is a list of all talk submissions across events." %}
     </p>
 
-    <div class="panel panel-default">
-        <div class="panel-heading">
-            <h3 class="panel-title">{% translate "Filter" %}</h3>
-        </div>
-
-        <div class="panel-body">
-            <form method="get" class="row filter-form">
-                <div class="col-md-3 col-sm-6 col-xs-12 form-group">
+    <div class="list-filter-container">
+        <form method="get" class="filter-form list-filter-form">
+            <div class="list-filter-grid">
+                <div class="list-filter-field">
                     {% bootstrap_field filter_form.query layout='inline' %}
                 </div>
-                <div class="col-md-3 col-sm-6 col-xs-12 form-group">
+                <div class="list-filter-field">
                     {% bootstrap_field filter_form.event_query layout='inline' %}
                 </div>
-                <div class="col-md-3 col-sm-6 col-xs-12 form-group">
+                <div class="list-filter-field">
                     {% bootstrap_field filter_form.submission_type layout='inline' %}
                 </div>
-                <div class="col-md-3 col-sm-6 col-xs-12 form-group">
+                <div class="list-filter-field">
                     {% bootstrap_field filter_form.track layout='inline' %}
                 </div>
-                <div class="col-md-4 col-sm-6 col-xs-12 form-group">
+                <div class="list-filter-field">
                     {% bootstrap_field filter_form.tags layout='inline' %}
                 </div>
-                <div class="col-md-4 col-sm-6 col-xs-12 form-group">
+                <div class="list-filter-field">
                     {% bootstrap_field filter_form.proposal_state layout='inline' %}
                 </div>
-                <div class="col-md-4 col-sm-6 col-xs-12 form-group">
+                <div class="list-filter-field list-filter-field--actions">
                     {% include "eventyay_common/filter_actions.html" %}
                 </div>
-            </form>
-        </div>
+            </div>
+        </form>
     </div>
 
     <div data-ajax-results-region>

--- a/app/eventyay/control/templates/pretixcontrol/admin/task_management/task_management.html
+++ b/app/eventyay/control/templates/pretixcontrol/admin/task_management/task_management.html
@@ -8,30 +8,25 @@
 
 {% block content %}
     <h1>{% trans "Task management" %}</h1>
-    <div class="panel panel-default">
-        <div class="panel-heading">
-            <h3 class="panel-title">{% trans "Filter" %}</h3>
-        </div>
-        <div class="panel-body">
-            <form class="" action="" method="get">
-                <div class="row filter-form">
-                    <div class="col-md-3 col-sm-6 col-xs-12">
-                         {% bootstrap_field filter_form.name layout='inline' %}
-                    </div>
-                    <div class="col-md-3 col-sm-6 col-xs-12">
-                         {% bootstrap_field filter_form.status layout='inline' %}
-                    </div>
-                    {% for mf in meta_fields %}
-                        <div class="col-md-3 col-sm-6 col-xs-12">
-                            {% bootstrap_field mf layout='inline' %}
-                        </div>
-                    {% endfor %}
-                    <div class="col-md-3 col-sm-6 col-xs-12">
-                        {% include "eventyay_common/filter_actions.html" %}
-                    </div>
+    <div class="list-filter-container">
+        <form action="" method="get" class="filter-form list-filter-form">
+            <div class="list-filter-grid">
+                <div class="list-filter-field">
+                     {% bootstrap_field filter_form.name layout='inline' %}
                 </div>
-            </form>
-        </div>
+                <div class="list-filter-field">
+                     {% bootstrap_field filter_form.status layout='inline' %}
+                </div>
+                {% for mf in meta_fields %}
+                    <div class="list-filter-field">
+                        {% bootstrap_field mf layout='inline' %}
+                    </div>
+                {% endfor %}
+                <div class="list-filter-field list-filter-field--actions">
+                    {% include "eventyay_common/filter_actions.html" %}
+                </div>
+            </div>
+        </form>
     </div>
     <div data-ajax-results-region>
         <div class="table-responsive">

--- a/app/eventyay/control/templates/pretixcontrol/base.html
+++ b/app/eventyay/control/templates/pretixcontrol/base.html
@@ -21,6 +21,7 @@
             <link rel="stylesheet" type="text/css" href="{% static 'leaflet/leaflet.css' %}" />
             <link rel="stylesheet" type="text/css" href="{% static 'eventyay-common/css/language-grid.css' %}" />
             <link rel="stylesheet" type="text/css" href="{% static 'eventyay-common/css/loading_modal.css' %}" />
+            <link rel="stylesheet" type="text/css" href="{% static 'common/css/list-filters.css' %}" />
 		{% endcompress %}
         {% if DEBUG %}
             <script type="text/javascript" src="{% url 'javascript-catalog' lang=request.LANGUAGE_CODE %}"

--- a/app/eventyay/control/templates/pretixcontrol/organizers/detail.html
+++ b/app/eventyay/control/templates/pretixcontrol/organizers/detail.html
@@ -24,30 +24,25 @@
             <em>{% trans "You currently do not have access to any events." %}</em>
         </p>
     {% else %}
-        <div class="panel panel-default">
-            <div class="panel-heading">
-                <h3 class="panel-title">{% trans "Filter" %}</h3>
-            </div>
-            <div class="panel-body">
-                <form class="" action="" method="get">
-                    <div class="row filter-form">
-                        <div class="col-md-3 col-sm-6 col-xs-12">
-                            {% bootstrap_field filter_form.query layout='inline' %}
-                        </div>
-                        <div class="col-md-3 col-sm-6 col-xs-12">
-                            {% bootstrap_field filter_form.status layout='inline' %}
-                        </div>
-                        {% for mf in meta_fields %}
-                            <div class="col-md-3 col-sm-6 col-xs-12">
-                                {% bootstrap_field mf layout='inline' %}
-                            </div>
-                        {% endfor %}
-                        <div class="col-md-3 col-sm-6 col-xs-12">
-                            {% include "eventyay_common/filter_actions.html" %}
-                        </div>
+        <div class="list-filter-container">
+            <form action="" method="get" class="filter-form list-filter-form">
+                <div class="list-filter-grid">
+                    <div class="list-filter-field">
+                        {% bootstrap_field filter_form.query layout='inline' %}
                     </div>
-                </form>
-            </div>
+                    <div class="list-filter-field">
+                        {% bootstrap_field filter_form.status layout='inline' %}
+                    </div>
+                    {% for mf in meta_fields %}
+                        <div class="list-filter-field">
+                            {% bootstrap_field mf layout='inline' %}
+                        </div>
+                    {% endfor %}
+                    <div class="list-filter-field list-filter-field--actions">
+                        {% include "eventyay_common/filter_actions.html" %}
+                    </div>
+                </div>
+            </form>
         </div>
         <div data-ajax-results-region>
             <table class="table table-condensed table-hover">

--- a/app/eventyay/control/templates/pretixcontrol/organizers/index.html
+++ b/app/eventyay/control/templates/pretixcontrol/organizers/index.html
@@ -7,14 +7,7 @@
 {% block content %}
 	<h1>{% trans "Organizers" %}</h1>
 	<p>{% trans "The list below shows all organizer accounts you have administrative access to." %}</p>
-    <form class="row filter-form" action="" method="get">
-        <div class="col-md-10 col-sm-6 col-xs-12">
-            {% bootstrap_field filter_form.query layout='inline' %}
-        </div>
-        <div class="col-md-2 col-sm-6 col-xs-12">
-            {% include "eventyay_common/filter_actions.html" %}
-        </div>
-    </form>
+    {% include "eventyay_common/includes/list_filter_search.html" %}
     {% if can_create_organizer %}
     <p>
         <a href='{% url "eventyay_common:organizers.add" %}' class="btn btn-default">

--- a/app/eventyay/eventyay_common/templates/eventyay_common/base.html
+++ b/app/eventyay/eventyay_common/templates/eventyay_common/base.html
@@ -18,6 +18,7 @@
             <link rel="stylesheet" type="text/css" href="{% static 'common/css/_component_nav_mobile.css' %}" />
             <link rel="stylesheet" href="{% static 'eventyay-common/css/dashboard.css' %}">
             <link rel="stylesheet" href="{% static 'eventyay-common/css/settings.css' %}" />
+            <link rel="stylesheet" type="text/css" href="{% static 'common/css/list-filters.css' %}" />
             <link rel="stylesheet" type="text/css" href="{% static 'eventyay-common/css/language-grid.css' %}" />
             <link rel="stylesheet" type="text/css" href="{% static 'common/css/_markdown_editor.css' %}" />
             <link rel="stylesheet" type="text/css" href="{% static 'leaflet/leaflet.css' %}" />

--- a/app/eventyay/eventyay_common/templates/eventyay_common/events/index.html
+++ b/app/eventyay/eventyay_common/templates/eventyay_common/events/index.html
@@ -25,28 +25,23 @@
             {% endif %}
         </div>
     {% else %}
-        <div class="panel panel-default">
-            <div class="panel-heading">
-                <h3 class="panel-title">{% trans "Filter" %}</h3>
-            </div>
-            <div class="panel-body">
-                <form class="" action="" method="get">
-                    <div class="row filter-form">
-                        <div class="col-md-3 col-sm-6 col-xs-12">
-                            {% bootstrap_field filter_form.query layout='inline' %}
-                        </div>
-                        <div class="col-md-3 col-sm-6 col-xs-12">
-                            {% bootstrap_field filter_form.status layout='inline' %}
-                        </div>
-                        <div class="col-md-3 col-sm-6 col-xs-12">
-                            {% bootstrap_field filter_form.organizer layout='inline' %}
-                        </div>
-                        <div class="col-md-3 col-sm-6 col-xs-12">
-                            {% include "eventyay_common/filter_actions.html" %}
-                        </div>
+        <div class="list-filter-container">
+            <form action="" method="get" class="filter-form list-filter-form">
+                <div class="list-filter-grid">
+                    <div class="list-filter-field">
+                        {% bootstrap_field filter_form.query layout='inline' %}
                     </div>
-                </form>
-            </div>
+                    <div class="list-filter-field">
+                        {% bootstrap_field filter_form.status layout='inline' %}
+                    </div>
+                    <div class="list-filter-field">
+                        {% bootstrap_field filter_form.organizer layout='inline' %}
+                    </div>
+                    <div class="list-filter-field list-filter-field--actions">
+                        {% include "eventyay_common/filter_actions.html" %}
+                    </div>
+                </div>
+            </form>
         </div>
         <div data-ajax-results-region>
             <p>

--- a/app/eventyay/eventyay_common/templates/eventyay_common/filter_actions.html
+++ b/app/eventyay/eventyay_common/templates/eventyay_common/filter_actions.html
@@ -1,12 +1,12 @@
 {% load i18n %}
 
 <div class="filter-actions">
-    <button class="btn btn-primary" type="submit" aria-label="{% translate 'Filter' %}">
-        <span class="fa fa-filter"></span>
-        <span class="sr-only">{% translate 'Filter' %}</span>
+    <button class="btn btn-primary" type="submit">
+        <span class="fa fa-search" aria-hidden="true"></span>
+        {% translate "Search" %}
     </button>
     <a href="{{ clear_url|default:request.path }}" class="btn btn-default btn-clear-filter" aria-label="{% translate 'Clear filters' %}" title="{% translate 'Clear filters' %}">
-        <span class="fa fa-eraser"></span>
+        <span class="fa fa-eraser" aria-hidden="true"></span>
         <span class="sr-only">{% translate 'Clear filters' %}</span>
     </a>
 </div>

--- a/app/eventyay/eventyay_common/templates/eventyay_common/includes/list_filter_search.html
+++ b/app/eventyay/eventyay_common/templates/eventyay_common/includes/list_filter_search.html
@@ -1,0 +1,33 @@
+{% load i18n %}
+
+<div class="list-filter-container">
+    <form action="" method="get" class="filter-form list-filter-form">
+        <div class="list-filter-search-bar">
+            <div class="input-group list-filter-query-group">
+                <input type="text"
+                       name="{{ filter_form.query.html_name }}"
+                       id="{{ filter_form.query.id_for_label }}"
+                       class="form-control"
+                       placeholder="{{ filter_form.query.field.widget.attrs.placeholder|default:_('Search…') }}"
+                       value="{{ filter_form.query.value|default_if_none:'' }}"
+                       {% if filter_form.query.field.widget.attrs.autofocus %}autofocus{% endif %}
+                       aria-label="{% trans 'Search' %}">
+                <span class="input-group-btn">
+                    <button class="btn btn-primary" type="submit">
+                        <span class="fa fa-search" aria-hidden="true"></span>
+                        {% trans "Search" %}
+                    </button>
+                </span>
+            </div>
+            <div class="list-filter-actions">
+                <a href="{{ clear_url|default:request.path }}"
+                   class="btn btn-default btn-clear-filter"
+                   aria-label="{% trans 'Clear filters' %}"
+                   title="{% trans 'Clear filters' %}">
+                    <span class="fa fa-eraser" aria-hidden="true"></span>
+                    <span class="sr-only">{% trans "Clear filters" %}</span>
+                </a>
+            </div>
+        </div>
+    </form>
+</div>

--- a/app/eventyay/eventyay_common/templates/eventyay_common/organizers/index.html
+++ b/app/eventyay/eventyay_common/templates/eventyay_common/organizers/index.html
@@ -5,19 +5,7 @@
 {% block title %}{% translate "Organizers" %}{% endblock %}
 {% block content %}
 	<h1>{% translate "Organizers" %}</h1>
-    <form class="row filter-form" action="" method="get">
-        <div class="col-md-10 col-sm-6 col-xs-12">
-            {% bootstrap_field filter_form.query layout='inline' %}
-        </div>
-        <div class="col-md-2 col-sm-6 col-xs-12">
-            <button class="btn btn-primary btn-block" type="submit">
-                <span class="fa fa-search"></span>
-                <span class="hidden-md">
-                    {% translate "Search" %}
-                </span>
-            </button>
-        </div>
-    </form>
+    {% include "eventyay_common/includes/list_filter_search.html" %}
     {% if can_create_organizer %}
         <p>
             <a href='{% url "eventyay_common:organizers.add" %}' class="btn btn-default">

--- a/app/eventyay/static/common/css/list-filters.css
+++ b/app/eventyay/static/common/css/list-filters.css
@@ -1,0 +1,103 @@
+.list-filter-container {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  margin-bottom: 15px;
+}
+
+.list-filter-form {
+  width: 100%;
+}
+
+.list-filter-grid {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px 12px;
+  align-items: flex-end;
+}
+
+.list-filter-field {
+  flex: 1 1 180px;
+  min-width: 0;
+  margin-bottom: 0;
+}
+
+.list-filter-field .form-group {
+  margin-bottom: 0;
+}
+
+.list-filter-field .form-control,
+.list-filter-field select {
+  width: 100%;
+}
+
+.list-filter-field--actions {
+  flex: 0 0 auto;
+}
+
+.list-filter-search-bar {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  align-items: stretch;
+  width: 100%;
+}
+
+.list-filter-query-group {
+  flex: 1 1 300px;
+  min-width: 0;
+}
+
+.list-filter-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  align-items: center;
+  flex: 0 0 auto;
+}
+
+.list-filter-form .form-control,
+.list-filter-form .btn {
+  height: 38px;
+}
+
+.list-filter-form .filter-actions {
+  display: flex;
+  gap: 8px;
+  align-items: center;
+  margin-bottom: 0;
+}
+
+@media (max-width: 767px) {
+  .list-filter-search-bar {
+    flex-direction: column;
+  }
+
+  .list-filter-query-group,
+  .list-filter-actions {
+    width: 100%;
+  }
+
+  .list-filter-actions .btn {
+    flex: 1 1 auto;
+  }
+
+  .list-filter-grid {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .list-filter-field,
+  .list-filter-field--actions {
+    flex: 1 1 auto;
+    width: 100%;
+  }
+
+  .list-filter-form .filter-actions {
+    width: 100%;
+  }
+
+  .list-filter-form .filter-actions .btn {
+    flex: 1 1 50%;
+  }
+}

--- a/app/eventyay/static/pretixcontrol/scss/_forms.scss
+++ b/app/eventyay/static/pretixcontrol/scss/_forms.scss
@@ -733,7 +733,7 @@ table td > .checkbox input[type="checkbox"] {
 // Filter actions container - works for both panel and non-panel layouts
 .filter-form .filter-actions {
   display: flex;
-  gap: 20px;
+  gap: 8px;
   align-items: center;
   margin-bottom: 0;
 }


### PR DESCRIPTION
## Summary
- Removes gray Bootstrap "Filter" panels from common, admin, and control list pages.
- Adds shared `list-filters.css` and a reusable search-bar partial aligned with Tickets → All orders spacing (38px inputs, 8px gaps, flex layout).
- Updates filter actions to use Search + Clear buttons consistently; organizer lists now use an attached search input group.

## Pages updated
- `/common/events/`, `/common/organizers/`
- `/admin/attendees/`, `/admin/organizers/`, `/admin/events/`, `/admin/submissions/`, `/admin/orders/`
- Control organizers list and organizer detail event list
- Admin task management filter

## Test plan
- [ ] Open each listed page and confirm the gray Filter box is gone.
- [ ] Verify search/filter still returns expected results on events, organizers, attendees, and submissions lists.
- [ ] On `/common/organizers/` and `/admin/organizers/`, confirm search input and button are adjacent with no large gap.
- [ ] Confirm Clear resets filters and Search submits the form.
- [ ] Check laptop and mobile widths for wrapping/spacing.

Fixes #4674

## Summary by Sourcery

Standardize list filter UI across admin, control, and common pages using shared layout and styling.

New Features:
- Introduce a reusable search-bar partial for organizer lists with attached search and clear controls.

Enhancements:
- Replace legacy Bootstrap filter panels with a unified flex-based list filter layout on events, organizers, attendees, submissions, orders, and task management pages.
- Add a shared list-filters stylesheet to align spacing, sizing, and responsive behavior of filter forms across admin and common interfaces.
- Update filter action controls to consistently use Search and Clear buttons with improved icon semantics and accessibility labels.
- Reduce spacing between filter action buttons to match the All Orders filter bar design.