### PR TITLE
fix : improve ticketing quickstart intro text and icon

### DIFF
--- a/app/eventyay/control/templates/pretixcontrol/event/quick_setup.html
+++ b/app/eventyay/control/templates/pretixcontrol/event/quick_setup.html
@@ -7,18 +7,17 @@
     {% if request.method == "GET" %}
         <div class="quick-setup-step">
             <div class="quick-icon">
-                <span class="fa fa-fw fa-check-circle text-success"></span>
+                <span class="fa fa-fw fa-ticket text-muted"></span>
             </div>
             <div class="quick-content">
 
-                <h2>{% trans "Congratulations!" %}</h2>
+                <h2>{% trans "Ticketing Quickstart" %}</h2>
                 <p>
-                    <strong>{% trans "You just created an event!" %}</strong>
+                    {% trans "Create your first ticket products here." %}
                 </p>
                 <p>
                     {% blocktrans trimmed %}
-                        You can scroll down and create your first ticket products quickly, or you can use the navigation
-                        on the left to modify the settings of your event in much more detail.
+                        You can configure more ticket, product, payment, tax, order form, and check-in options from the menu on the left.
                     {% endblocktrans %}
                 </p>
                 <div class="clearfix"></div>

--- a/app/eventyay/control/templates/pretixcontrol/event/quick_setup.html
+++ b/app/eventyay/control/templates/pretixcontrol/event/quick_setup.html
@@ -44,7 +44,7 @@
         </fieldset>
         <fieldset class="quick-setup-step">
             <div class="quick-icon">
-                <span class="fa fa-fw fa-ticket text-muted"></span>
+                <span class="fa fa-fw fa-magic text-muted"></span>
             </div>
             <div class="quick-content">
                 <legend>{% trans "Create ticket types" %}</legend>

--- a/app/eventyay/control/templates/pretixcontrol/event/quick_setup.html
+++ b/app/eventyay/control/templates/pretixcontrol/event/quick_setup.html
@@ -7,7 +7,7 @@
     {% if request.method == "GET" %}
         <div class="quick-setup-step">
             <div class="quick-icon">
-                <span class="fa fa-fw fa-ticket text-muted"></span>
+                <span class="fa fa-fw fa-magic text-muted"></span>
             </div>
             <div class="quick-content">
 

--- a/app/eventyay/control/templates/pretixcontrol/event/quick_setup.html
+++ b/app/eventyay/control/templates/pretixcontrol/event/quick_setup.html
@@ -44,7 +44,7 @@
         </fieldset>
         <fieldset class="quick-setup-step">
             <div class="quick-icon">
-                <span class="fa fa-fw fa-magic text-muted"></span>
+                <span class="fa fa-fw fa-ticket text-muted"></span>
             </div>
             <div class="quick-content">
                 <legend>{% trans "Create ticket types" %}</legend>


### PR DESCRIPTION
Close  #4714

1. Replaced the green success checkmark icon (`fa-check-circle text-success`) with a ticket-related icon (`fa-ticket text-muted`).
2. Changed the main heading from "Congratulations!" to **"Ticketing Quickstart"**.
3. Replaced the introductory text regarding event creation with the new text guiding the organizer to create their first ticket products and directing them to the left menu for additional configuration. 
4. Ensured that the newly added text is still appropriately marked for translations (i18n).

https://github.com/user-attachments/assets/788c0cd4-465e-41f7-9735-db7a2523ba86

## Summary by Sourcery

Update the ticketing quickstart panel to better guide organizers in configuring ticket products and related options.

Enhancements:
- Replace the success checkmark icon with a ticket-themed icon in the quickstart view.
- Revise the ticketing quickstart heading and introductory copy to focus on creating ticket products and using the left menu for further configuration.