### PR TITLE
fix(video): hide chat webhook fields behind a separate toggle

### DIFF
--- a/app/eventyay/webapp/video/src/views/admin/rooms/types-edit/SidebarAddons.vue
+++ b/app/eventyay/webapp/video/src/views/admin/rooms/types-edit/SidebarAddons.vue
@@ -3,8 +3,14 @@
 	h2 Sidebar addons
 	bunt-switch(name="enable-chat", v-model="hasChat", label="Enable Chat")
 	template(v-if="hasChat")
-		bunt-switch(name="configure-webhook", v-model="configureWebhook", label="Configure Webhook")
-		.webhook-config(v-if="configureWebhook")
+		button.webhook-toggle(
+			type="button"
+			:aria-expanded="String(showWebhookConfig)"
+			@click="showWebhookConfig = !showWebhookConfig"
+		)
+			span.webhook-toggle-icon {{ showWebhookConfig ? '▼' : '►' }}
+			span Webhook
+		.webhook-config(v-if="showWebhookConfig")
 			h4 Chat Webhook
 			p.hint Send chat messages to an external endpoint in real-time
 			bunt-input-outline-container(label="Webhook URL")
@@ -49,6 +55,17 @@ import mixin from './mixin'
 
 export default {
 	mixins: [mixin],
+	data() {
+		return {
+			showWebhookConfig: false
+		}
+	},
+	created() {
+		const config = this.modules['chat.native']?.config
+		if (config?.webhook_url || config?.webhook_hmac_secret) {
+			this.showWebhookConfig = true
+		}
+	},
 	computed: {
 		hasChat: {
 			get() {
@@ -60,26 +77,7 @@ export default {
 				} else {
 					this.clearChatWebhookConfig()
 					this.removeModule('chat.native')
-				}
-			}
-		},
-		configureWebhook: {
-			get() {
-				const config = this.modules['chat.native']?.config
-				if (!config) return false
-				// Read reactive properties so Vue tracks changes correctly.
-				if (config.webhook_enabled !== undefined) {
-					return !!config.webhook_enabled
-				}
-				return !!(config.webhook_url || config.webhook_hmac_secret)
-			},
-			set(value) {
-				const config = this.modules['chat.native']?.config
-				if (!config) return
-				if (value) {
-					config.webhook_enabled = true
-				} else {
-					this.clearChatWebhookConfig()
+					this.showWebhookConfig = false
 				}
 			}
 		},
@@ -117,7 +115,6 @@ export default {
 		clearChatWebhookConfig() {
 			const config = this.modules['chat.native']?.config
 			if (!config) return
-			config.webhook_enabled = false
 			config.webhook_url = ''
 			config.webhook_hmac_secret = ''
 		}
@@ -128,8 +125,25 @@ export default {
 .c-sidebar-addons
 	.bunt-checkbox
 		margin-bottom: 8px
+	.webhook-toggle
+		display: flex
+		align-items: center
+		gap: 6px
+		margin: 4px 0 8px 0
+		padding: 0
+		border: 0
+		background: transparent
+		color: #333
+		font: inherit
+		font-size: 14px
+		cursor: pointer
+		.webhook-toggle-icon
+			display: inline-block
+			width: 1em
+			font-size: 12px
+			line-height: 1
 	.webhook-config
-		margin: 8px 0 16px 0
+		margin: 0 0 16px 0
 		padding: 12px 16px
 		background: rgba(0, 0, 0, 0.03)
 		border-radius: 6px

--- a/app/eventyay/webapp/video/src/views/admin/rooms/types-edit/SidebarAddons.vue
+++ b/app/eventyay/webapp/video/src/views/admin/rooms/types-edit/SidebarAddons.vue
@@ -3,8 +3,9 @@
 	h2 Sidebar addons
 	bunt-switch(name="enable-chat", v-model="hasChat", label="Enable Chat")
 	template(v-if="hasChat")
-		.webhook-config
-			h4 Chat Webhook (optional)
+		bunt-switch(name="configure-webhook", v-model="configureWebhook", label="Configure Webhook")
+		.webhook-config(v-if="configureWebhook")
+			h4 Chat Webhook
 			p.hint Send chat messages to an external endpoint in real-time
 			bunt-input-outline-container(label="Webhook URL")
 				template(#default="{focus, blur}")
@@ -50,6 +51,13 @@ export default {
 	mixins: [mixin],
 	data() {
 		return {
+			showWebhookConfig: false
+		}
+	},
+	created() {
+		const chatConfig = this.modules['chat.native']?.config
+		if (chatConfig?.webhook_url || chatConfig?.webhook_hmac_secret) {
+			this.showWebhookConfig = true
 		}
 	},
 	computed: {
@@ -62,6 +70,19 @@ export default {
 					this.addModule('chat.native', {volatile: true})
 				} else {
 					this.removeModule('chat.native')
+					this.showWebhookConfig = false
+				}
+			}
+		},
+		configureWebhook: {
+			get() {
+				return this.showWebhookConfig
+			},
+			set(value) {
+				this.showWebhookConfig = value
+				if (!value && this.modules['chat.native']) {
+					this.modules['chat.native'].config.webhook_url = ''
+					this.modules['chat.native'].config.webhook_hmac_secret = ''
 				}
 			}
 		},

--- a/app/eventyay/webapp/video/src/views/admin/rooms/types-edit/SidebarAddons.vue
+++ b/app/eventyay/webapp/video/src/views/admin/rooms/types-edit/SidebarAddons.vue
@@ -47,19 +47,13 @@
 <script>
 import mixin from './mixin'
 
+function hasWebhookConfigKeys(config) {
+	return Object.prototype.hasOwnProperty.call(config, 'webhook_url')
+		|| Object.prototype.hasOwnProperty.call(config, 'webhook_hmac_secret')
+}
+
 export default {
 	mixins: [mixin],
-	data() {
-		return {
-			showWebhookConfig: false
-		}
-	},
-	created() {
-		const chatConfig = this.modules['chat.native']?.config
-		if (chatConfig?.webhook_url || chatConfig?.webhook_hmac_secret) {
-			this.showWebhookConfig = true
-		}
-	},
 	computed: {
 		hasChat: {
 			get() {
@@ -69,20 +63,28 @@ export default {
 				if (value) {
 					this.addModule('chat.native', {volatile: true})
 				} else {
+					this.clearChatWebhookConfig()
 					this.removeModule('chat.native')
-					this.showWebhookConfig = false
 				}
 			}
 		},
 		configureWebhook: {
 			get() {
-				return this.showWebhookConfig
+				const config = this.modules['chat.native']?.config
+				return !!config && hasWebhookConfigKeys(config)
 			},
 			set(value) {
-				this.showWebhookConfig = value
-				if (!value && this.modules['chat.native']) {
-					this.modules['chat.native'].config.webhook_url = ''
-					this.modules['chat.native'].config.webhook_hmac_secret = ''
+				const config = this.modules['chat.native']?.config
+				if (!config) return
+				if (value) {
+					if (!Object.prototype.hasOwnProperty.call(config, 'webhook_url')) {
+						config.webhook_url = ''
+					}
+					if (!Object.prototype.hasOwnProperty.call(config, 'webhook_hmac_secret')) {
+						config.webhook_hmac_secret = ''
+					}
+				} else {
+					this.clearChatWebhookConfig()
 				}
 			}
 		},
@@ -114,6 +116,14 @@ export default {
 					this.removeModule('poll')
 				}
 			}
+		}
+	},
+	methods: {
+		clearChatWebhookConfig() {
+			const config = this.modules['chat.native']?.config
+			if (!config) return
+			delete config.webhook_url
+			delete config.webhook_hmac_secret
 		}
 	}
 }

--- a/app/eventyay/webapp/video/src/views/admin/rooms/types-edit/SidebarAddons.vue
+++ b/app/eventyay/webapp/video/src/views/admin/rooms/types-edit/SidebarAddons.vue
@@ -47,11 +47,6 @@
 <script>
 import mixin from './mixin'
 
-function hasWebhookConfigKeys(config) {
-	return Object.prototype.hasOwnProperty.call(config, 'webhook_url')
-		|| Object.prototype.hasOwnProperty.call(config, 'webhook_hmac_secret')
-}
-
 export default {
 	mixins: [mixin],
 	computed: {
@@ -71,18 +66,18 @@ export default {
 		configureWebhook: {
 			get() {
 				const config = this.modules['chat.native']?.config
-				return !!config && hasWebhookConfigKeys(config)
+				if (!config) return false
+				// Read reactive properties so Vue tracks changes correctly.
+				if (config.webhook_enabled !== undefined) {
+					return !!config.webhook_enabled
+				}
+				return !!(config.webhook_url || config.webhook_hmac_secret)
 			},
 			set(value) {
 				const config = this.modules['chat.native']?.config
 				if (!config) return
 				if (value) {
-					if (!Object.prototype.hasOwnProperty.call(config, 'webhook_url')) {
-						config.webhook_url = ''
-					}
-					if (!Object.prototype.hasOwnProperty.call(config, 'webhook_hmac_secret')) {
-						config.webhook_hmac_secret = ''
-					}
+					config.webhook_enabled = true
 				} else {
 					this.clearChatWebhookConfig()
 				}
@@ -122,8 +117,9 @@ export default {
 		clearChatWebhookConfig() {
 			const config = this.modules['chat.native']?.config
 			if (!config) return
-			delete config.webhook_url
-			delete config.webhook_hmac_secret
+			config.webhook_enabled = false
+			config.webhook_url = ''
+			config.webhook_hmac_secret = ''
 		}
 	}
 }


### PR DESCRIPTION
## Summary
- Adds a **Configure Webhook** toggle in room sidebar addons so webhook URL/HMAC fields stay hidden when chat is enabled
- Auto-expands the webhook section when editing a room that already has webhook settings
- Clears webhook values when the configure toggle is turned off

Closes #4693

## Test plan
- [ ] Open Video admin → create/edit a room → enable Chat; webhook fields should stay hidden
- [ ] Toggle **Configure Webhook** on; URL and HMAC fields should appear
- [ ] Toggle **Configure Webhook** off; fields hide and values are cleared on save
- [ ] Edit a room that already has webhook URL/secret configured; Configure Webhook should be on and fields visible
- [ ] Disable Chat entirely; webhook toggle/fields disappear

## Summary by Sourcery

Gate chat webhook configuration behind a dedicated toggle in the video room sidebar addons and ensure existing webhook setups remain visible.

New Features:
- Add a separate Configure Webhook toggle under the Chat addon to control visibility of webhook URL and HMAC fields.

Bug Fixes:
- Ensure rooms with existing chat webhook settings automatically show the webhook configuration section when edited.
- Clear stored webhook URL and HMAC secret when webhook configuration is disabled while chat remains enabled.