### PR TITLE
Fix BootstrapError on event settings due to obsolete max_products_per_order field

### DIFF
--- a/app/eventyay/control/templates/pretixcontrol/event/settings.html
+++ b/app/eventyay/control/templates/pretixcontrol/event/settings.html
@@ -90,10 +90,7 @@
                     {% bootstrap_field sform.event_list_available_only layout="control" %}
                 {% endif %}
             </fieldset>
-            <fieldset>
-                <legend>{% trans "Cart" %}</legend>
-                {% bootstrap_field sform.max_products_per_order layout="control" %}
-            </fieldset>
+
             <fieldset>
                 <legend>{% trans "Waiting list" %}</legend>
                 {% bootstrap_field sform.waiting_list_enabled layout="control" %}


### PR DESCRIPTION
Close : #4749

## Before 


https://github.com/user-attachments/assets/675ef2a2-f01c-4f1e-a586-3ee2b3285370



## After 

https://github.com/user-attachments/assets/b1d0ce21-aa37-4fc2-8e8b-ff523d6faada


## Summary by Sourcery

Bug Fixes:
- Eliminate use of the migrated max_products_per_order setting from the event settings page to resolve the BootstrapError when rendering event settings.