### PR TITLE
perf(base): optimize 404 handler, session creation, Sentry filtering, and Nginx scanner blocking (#4603)

### DIFF
--- a/app/eventyay/base/views/errors.py
+++ b/app/eventyay/base/views/errors.py
@@ -46,23 +46,10 @@ def csrf_failure(request, reason=''):
 
 @requires_csrf_token
 def page_not_found(request, exception):
-    exception_repr = exception.__class__.__name__
-    # Try to get an "interesting" exception message, if any (and not the ugly
-    # Resolver404 dictionary)
-    try:
-        message = exception.args[0]
-    except (AttributeError, IndexError):
-        pass
-    else:
-        if isinstance(message, (str, Promise)):
-            exception_repr = str(message)
-    context = {
-        'request_path': request.path,
-        'exception': exception_repr,
-    }
-    template = get_template('404.html')
-    body = template.render(context, request)
-    r = HttpResponseNotFound(body)
+    r = HttpResponseNotFound(
+        b'<html><body><h1>404 Not Found</h1></body></html>',
+        content_type='text/html',
+    )
     r.xframe_options_exempt = True
     return r
 

--- a/app/eventyay/common/middleware/domains.py
+++ b/app/eventyay/common/middleware/domains.py
@@ -197,8 +197,8 @@ class SessionMiddleware(BaseSessionMiddleware):
                     expires_time = time.time() + max_age
                     expires = http_date(expires_time)
                 # Save the session data and refresh the client cookie.
-                # Skip session save for 500 responses, refs #3881.
-                if response.status_code != 500:
+                # Skip session save for 404/500 responses (unless modified), refs #3881.
+                if response.status_code not in (404, 500) or modified:
                     try:
                         request.session.save()
                     except UpdateError:  # pragma: no cover

--- a/app/eventyay/config/settings.py
+++ b/app/eventyay/config/settings.py
@@ -1454,12 +1454,15 @@ EVENTYAY_ENVIRONMENT = os.getenv('EVENTYAY_ENVIRONMENT', 'unknown')
 SENTRY_DSN = conf.sentry_dsn
 if SENTRY_DSN:
     import sentry_sdk
+    from django.core.exceptions import PermissionDenied
+    from django.http import Http404
     from sentry_sdk.integrations.celery import CeleryIntegration
     from sentry_sdk.integrations.django import DjangoIntegration
 
     sentry_sdk.init(
         dsn=SENTRY_DSN,
         integrations=[CeleryIntegration(), DjangoIntegration()],
+        ignore_errors=[Http404, PermissionDenied],
         send_default_pii=False,
         debug=DEBUG,
         release=EVENTYAY_COMMIT if EVENTYAY_COMMIT != 'unknown' else None,

--- a/app/eventyay/multidomain/middlewares.py
+++ b/app/eventyay/multidomain/middlewares.py
@@ -133,8 +133,8 @@ class SessionMiddleware(BaseSessionMiddleware):
                         expires_time = time.time() + max_age
                         expires = http_date(expires_time)
                     # Save the session data and refresh the client cookie.
-                    # Skip session save for 500 responses, refs #3881.
-                    if response.status_code != 500:
+                    # Skip session save for 404/500 responses (unless modified), refs #3881.
+                    if response.status_code not in (404, 500) or modified:
                         request.session.save()
                         set_cookie_without_samesite(
                             request,

--- a/app/tests/tickets/base/test_errors.py
+++ b/app/tests/tickets/base/test_errors.py
@@ -1,0 +1,73 @@
+from django.http import Http404, HttpResponse
+from django.test import RequestFactory
+
+from eventyay.base.views.errors import page_not_found
+from eventyay.common.middleware.domains import SessionMiddleware as CommonSessionMiddleware
+from eventyay.multidomain.middlewares import SessionMiddleware as MultidomainSessionMiddleware
+
+
+def test_page_not_found_returns_static_response():
+    rf = RequestFactory()
+    request = rf.get('/some-invalid-path-12345')
+    response = page_not_found(request, Http404('Not found'))
+
+    assert response.status_code == 404
+    assert response.content == b'<html><body><h1>404 Not Found</h1></body></html>'
+    assert response.headers['content-type'] == 'text/html'
+    assert getattr(response, 'xframe_options_exempt', False) is True
+
+
+def test_session_middleware_skips_save_on_404_when_unmodified():
+    rf = RequestFactory()
+    request = rf.get('/some-invalid-path-12345')
+
+    class DummySession(dict):
+        accessed = True
+        modified = False
+        saved = False
+        session_key = 'testkey'
+
+        def is_empty(self):
+            return True
+
+        def save(self):
+            self.saved = True
+
+    request.session = DummySession()
+    response = HttpResponse(status=404)
+
+    middleware = MultidomainSessionMiddleware(lambda req: response)
+    middleware.process_response(request, response)
+    assert request.session.saved is False
+
+    common_middleware = CommonSessionMiddleware(lambda req: response)
+    common_middleware.process_response(request, response)
+    assert request.session.saved is False
+
+
+def test_session_middleware_saves_on_404_when_modified():
+    rf = RequestFactory()
+    request = rf.get('/some-invalid-path-12345')
+    request.host = 'example.com'
+
+    class DummySession(dict):
+        accessed = True
+        modified = True
+        saved = False
+        session_key = 'testkey'
+
+        def is_empty(self):
+            return False
+
+        def get_expire_at_browser_close(self):
+            return True
+
+        def save(self):
+            self.saved = True
+
+    request.session = DummySession()
+    response = HttpResponse(status=404)
+
+    middleware = MultidomainSessionMiddleware(lambda req: response)
+    middleware.process_response(request, response)
+    assert request.session.saved is True

--- a/deployment/nginx/enext-direct
+++ b/deployment/nginx/enext-direct
@@ -42,6 +42,16 @@ server {
 		set $cors_reject_preflight 0;
 	}
 
+	# Reject common automated scanner targets before reaching the application.
+	location ~* ^/(wp-admin|wp-login|phpmyadmin|xmlrpc\.php|\.env|\.git|\.well-known/security\.txt|admin\.php|shell\.php|config\.php) {
+		return 444;
+	}
+
+	# Reject paths with obvious attack signatures
+	location ~* \.(php|asp|aspx|jsp|cgi)$ {
+		return 444;
+	}
+
 	# WebSocket connections - route to daphne
 	location /ws/ {
 		proxy_pass http://127.0.0.1:8001;
@@ -72,6 +82,9 @@ server {
 
 	# Regular HTTP requests - route to gunicorn
 	location / {
+		limit_req zone=scanner_limit burst=20 nodelay;
+		limit_req_status 429;
+
 		add_header Referrer-Policy same-origin always;
 
 		if ($cors_reject_preflight = 1) {


### PR DESCRIPTION
## Summary of Changes

Close: #4603

### Problem
- 404 error responses rendered full Django templates (`404.html`) along with middleware execution and context database processing.
- Requests to invalid or scanner URLs triggered database session creation (`django_session`).
- Unhandled 404/403 exceptions flooded Sentry error logs.
- Reverse proxy (Nginx) passed scanner targets (e.g. `/wp-admin/`, `.env`) upstream to Python Gunicorn workers.

### Solution
1. **Static 404 Handler (`errors.py`)**: Changed `page_not_found` view handler to return a lightweight, static `HttpResponseNotFound(b'<html><body><h1>404 Not Found</h1></body></html>', content_type='text/html')` without rendering Django templates or running DB queries.
2. **Skip 404 Session Creation (`SessionMiddleware`)**: Updated session middleware in `eventyay/multidomain/middlewares.py` and `eventyay/common/middleware/domains.py` to bypass `request.session.save()` on 404 responses when `request.session.modified` is `False`.
3. **Nginx Scanner Rejection & Rate Limiting (`enext-direct`)**: Added Nginx location rules to drop scanner targets (`/wp-admin`, `/.env`, `.php`, etc.) with HTTP `444` (No Response) and added `limit_req` rate-limiting directives.
4. **Sentry Exception Exclusion (`settings.py`)**: Added `ignore_errors=[Http404, PermissionDenied]` to `sentry_sdk.init`.
5. **Automated Unit Testing (`test_errors.py`)**: Added test cases covering static 404 response output and session middleware 404 bypass logic.

### Testing Evidence
- Executed unit test suite via `pytest tests/tickets/base/test_errors.py`:
  `3 passed in 0.10s`

## Summary by Sourcery

Optimize 404 handling, session persistence, Sentry error reporting, and add coverage for the new behavior.

Bug Fixes:
- Prevent unnecessary session saves for unmodified 404 responses in both common and multidomain session middleware.
- Reduce noisy Sentry reporting by ignoring Http404 and PermissionDenied exceptions.

Enhancements:
- Serve a lightweight static HTML 404 response instead of rendering the full Django template for page_not_found.

Deployment:
- Update Nginx configuration to aggressively reject common scanner paths and apply rate limiting to suspicious requests.

Tests:
- Add unit tests for the static 404 response and session middleware behavior on 404 responses.