### PR TITLE
refactor: navbar refactor for tickets area

### DIFF
--- a/app/eventyay/common/templates/common/includes/header_nav.html
+++ b/app/eventyay/common/templates/common/includes/header_nav.html
@@ -4,6 +4,10 @@
         <div class="navigation-title">
             <h2>{{ header_title }}{% if header_title_extra %} {{ header_title_extra|safe }}{% endif %}</h2>
         </div>
-        {% include "orga/event/component_link.html" %}
+        {% if header_component_link %}
+            {% include header_component_link %}
+        {% else %}
+            {% include "orga/event/component_link.html" %}
+        {% endif %}
     </div>
 </nav>

--- a/app/eventyay/control/templates/pretixcontrol/checkin/index.html
+++ b/app/eventyay/control/templates/pretixcontrol/checkin/index.html
@@ -3,37 +3,32 @@
 {% load eventurl %}
 {% load urlreplace %}
 {% load bootstrap3 %}
+{% load captureas %}
 {% block title %}
     {% blocktrans with name=checkinlist.name %}Check-in list: {{ name }}{% endblocktrans %}
 {% endblock %}
 {% block content %}
-    <nav id="event-nav" class="header-nav">
-        <div class="navigation">
-            <div class="navigation-title">
-                    <h1>
-                        {% blocktrans with name=checkinlist.name %}Check-in list: {{ name }}{% endblocktrans %}
-                        {% if 'can_change_event_settings' in request.eventpermset %}
-                            <a href="{% url "control:event.orders.checkinlists.edit" event=request.event.slug organizer=request.event.organizer.slug list=checkinlist.pk %}"
-                                    class="btn btn-default">
-                                <span class="fa fa-wrench"></span>
-                                {% trans "Edit list configuration" %}
-                            </a>
-                        {% endif %}
-                        <a href="{% url "control:event.orders.export" event=request.event.slug organizer=request.event.organizer.slug %}?identifier=checkinlistpdf&checkinlistpdf-list={{ checkinlist.pk }}"
-                                class="btn btn-default" target="_blank">
-                            <span class="fa fa-download"></span>
-                            {% trans "PDF" %}
-                        </a>
-                        <a href="{% url "control:event.orders.export" event=request.event.slug organizer=request.event.organizer.slug %}?identifier=checkinlist&checkinlist-list={{ checkinlist.pk }}"
-                                class="btn btn-default" target="_blank">
-                            <span class="fa fa-download"></span>
-                            {% trans "CSV" %}
-                        </a>
-                    </h1>
-            </div>
-            {% include "pretixcontrol/event/component_link.html" %}
-        </div>
-    </nav>
+    {% blocktrans with name=checkinlist.name as header_title_var %}Check-in list: {{ name }}{% endblocktrans %}
+    {% captureas header_extra_var %}
+        {% if 'can_change_event_settings' in request.eventpermset %}
+            <a href="{% url "control:event.orders.checkinlists.edit" event=request.event.slug organizer=request.event.organizer.slug list=checkinlist.pk %}"
+                    class="btn btn-default">
+                <span class="fa fa-wrench"></span>
+                {% trans "Edit list configuration" %}
+            </a>
+        {% endif %}
+        <a href="{% url "control:event.orders.export" event=request.event.slug organizer=request.event.organizer.slug %}?identifier=checkinlistpdf&checkinlistpdf-list={{ checkinlist.pk }}"
+                class="btn btn-default" target="_blank">
+            <span class="fa fa-download"></span>
+            {% trans "PDF" %}
+        </a>
+        <a href="{% url "control:event.orders.export" event=request.event.slug organizer=request.event.organizer.slug %}?identifier=checkinlist&checkinlist-list={{ checkinlist.pk }}"
+                class="btn btn-default" target="_blank">
+            <span class="fa fa-download"></span>
+            {% trans "CSV" %}
+        </a>
+    {% endcaptureas %}
+    {% include "common/includes/header_nav.html" with header_title=header_title_var header_title_extra=header_extra_var header_component_link="pretixcontrol/event/component_link.html" %}
     <form class="row filter-form" action="" method="get">
         <div class="col-md-4 col-sm-6 col-xs-12">
             {% bootstrap_field filter_form.user layout='inline' %}

--- a/app/eventyay/control/templates/pretixcontrol/checkin/list_edit.html
+++ b/app/eventyay/control/templates/pretixcontrol/checkin/list_edit.html
@@ -11,18 +11,12 @@
     {% endif %}
 {% endblock %}
 {% block inside %}
-    <nav id="event-nav" class="header-nav">
-        <div class="navigation">
-            <div class="navigation-title">
-                {% if checkinlist %}
-                    <h1>{% blocktrans with name=checkinlist.name %}Check-in list: {{ name }}{% endblocktrans %}</h1>
-                {% else %}
-                    <h1>{% trans "Check-in list" %}</h1>
-                {% endif %}
-            </div>
-            {% include "pretixcontrol/event/component_link.html" %}
-        </div>
-    </nav>
+    {% if checkinlist %}
+        {% blocktrans with name=checkinlist.name as header_title_var %}Check-in list: {{ name }}{% endblocktrans %}
+    {% else %}
+        {% trans "Check-in list" as header_title_var %}
+    {% endif %}
+    {% include "common/includes/header_nav.html" with header_title=header_title_var header_component_link="pretixcontrol/event/component_link.html" %}
     <form action="" method="post" class="form-horizontal">
         <script type="text/plain"
                 id="product-select2">{% url "control:event.products.select2" event=request.event.slug organizer=request.organizer.slug %}</script>

--- a/app/eventyay/control/templates/pretixcontrol/checkin/lists.html
+++ b/app/eventyay/control/templates/pretixcontrol/checkin/lists.html
@@ -2,14 +2,8 @@
 {% load i18n %}
 {% block title %}{% trans "Check-in lists" %}{% endblock %}
 {% block inside %}
-    <nav id="event-nav" class="header-nav">
-        <div class="navigation">
-            <div class="navigation-title">
-                <h1>{% trans "Check-in lists" %}</h1>
-            </div>
-            {% include "pretixcontrol/event/component_link.html" %}
-        </div>
-    </nav>
+    {% trans "Check-in lists" as header_title %}
+    {% include "common/includes/header_nav.html" with header_title=header_title header_component_link="pretixcontrol/event/component_link.html" %}
     <div class="checkin-lists-intro">
     <p>
         {% blocktrans trimmed %}

--- a/app/eventyay/control/templates/pretixcontrol/event/cancel.html
+++ b/app/eventyay/control/templates/pretixcontrol/event/cancel.html
@@ -2,14 +2,8 @@
 {% load i18n %}
 {% load bootstrap3 %}
 {% block inside %}
-    <nav id="event-nav" class="header-nav">
-        <div class="navigation">
-            <div class="navigation-title">
-                <h1>{% trans "Cancellation settings" %}</h1>
-            </div>
-            {% include "pretixcontrol/event/component_link.html" %}
-        </div>
-    </nav>
+    {% trans "Cancellation settings" as header_title %}
+    {% include "common/includes/header_nav.html" with header_title=header_title header_component_link="pretixcontrol/event/component_link.html" %}
     <form action="" method="post" class="form-horizontal" enctype="multipart/form-data">
         {% csrf_token %}
         {% bootstrap_form_errors form %}

--- a/app/eventyay/control/templates/pretixcontrol/event/index.html
+++ b/app/eventyay/control/templates/pretixcontrol/event/index.html
@@ -10,23 +10,18 @@
 
 {% block title %}{{ request.event.name }}{% endblock %}
 {% block content %}
-    <nav id="event-nav" class="header-nav">
-        <div class="navigation">
-            <div class="navigation-title">
-                <h2>
-                    {{ request.event.name }}
-                    <small class="event-date text-muted">
-                        {% if request.event.has_subevents %}
-                            {% trans "Event series" %}
-                        {% else %}
-                            {{ request.event.get_date_range_display }}
-                        {% endif %}
-                    </small>
-                </h2>
-            </div>
-            {% include "pretixcontrol/event/component_link.html" %}
-        </div>
-    </nav>
+    {% if request.event.has_subevents %}
+        {% trans "Event series" as date_text %}
+        {% with header_extra="<small class='event-date text-muted'>"|add:date_text|add:"</small>" %}
+            {% include "common/includes/header_nav.html" with header_title=request.event.name header_title_extra=header_extra header_component_link="pretixcontrol/event/component_link.html" %}
+        {% endwith %}
+    {% else %}
+        {% with date_text=request.event.get_date_range_display %}
+        {% with header_extra="<small class='event-date text-muted'>"|add:date_text|add:"</small>" %}
+            {% include "common/includes/header_nav.html" with header_title=request.event.name header_title_extra=header_extra header_component_link="pretixcontrol/event/component_link.html" %}
+        {% endwith %}
+        {% endwith %}
+    {% endif %}
     {% if has_overpaid_orders %}
         <div class="alert alert-warning">
             {% blocktrans trimmed %}

--- a/app/eventyay/control/templates/pretixcontrol/event/invoicing.html
+++ b/app/eventyay/control/templates/pretixcontrol/event/invoicing.html
@@ -2,14 +2,8 @@
 {% load i18n %}
 {% load bootstrap3 %}
 {% block inside %}
-    <nav id="event-nav" class="header-nav">
-        <div class="navigation">
-            <div class="navigation-title">
-                <h1>{% trans "Invoice settings" %}</h1>
-            </div>
-            {% include "pretixcontrol/event/component_link.html" %}
-        </div>
-    </nav>
+    {% trans "Invoice settings" as header_title %}
+    {% include "common/includes/header_nav.html" with header_title=header_title header_component_link="pretixcontrol/event/component_link.html" %}
     <form action="" method="post" class="form-horizontal" enctype="multipart/form-data">
         <div class="tabbed-form">
             {% csrf_token %}

--- a/app/eventyay/control/templates/pretixcontrol/event/mail.html
+++ b/app/eventyay/control/templates/pretixcontrol/event/mail.html
@@ -4,14 +4,8 @@
 {% load hierarkey_form %}
 {% load static %}
 {% block inside %}
-    <nav id="event-nav" class="header-nav">
-        <div class="navigation">
-            <div class="navigation-title">
-                <h1>{% trans "Ticket E-mail Settings" %}</h1>
-            </div>
-            {% include "pretixcontrol/event/component_link.html" %}
-        </div>
-    </nav>
+    {% trans "Ticket E-mail Settings" as header_title %}
+    {% include "common/includes/header_nav.html" with header_title=header_title header_component_link="pretixcontrol/event/component_link.html" %}
 
     <div class="alert alert-info" role="alert">
         <strong>{% trans "SMTP is configured centrally" %}</strong> —

--- a/app/eventyay/control/templates/pretixcontrol/event/payment.html
+++ b/app/eventyay/control/templates/pretixcontrol/event/payment.html
@@ -7,14 +7,8 @@
     <link rel="stylesheet" type="text/css" href="{% static 'pretixcontrol/css/tickets-mobile.css' %}" />
 {% endblock %}
 {% block inside %}
-    <nav id="event-nav" class="header-nav">
-        <div class="navigation">
-            <div class="navigation-title">
-                <h1>{% trans "Payment settings" %}</h1>
-            </div>
-            {% include "pretixcontrol/event/component_link.html" %}
-        </div>
-    </nav>
+    {% trans "Payment settings" as header_title %}
+    {% include "common/includes/header_nav.html" with header_title=header_title header_component_link="pretixcontrol/event/component_link.html" %}
     <form action="" method="post" class="form-horizontal form-plugins">
         {% csrf_token %}
         <div class="tabbed-form">

--- a/app/eventyay/control/templates/pretixcontrol/event/plugins.html
+++ b/app/eventyay/control/templates/pretixcontrol/event/plugins.html
@@ -3,14 +3,8 @@
 {% load static %}
 {% load bootstrap3 %}
 {% block inside %}
-    <nav id="event-nav" class="header-nav">
-        <div class="navigation">
-            <div class="navigation-title">
-                <h1>{% trans "Installed plugins" %}</h1>
-            </div>
-            {% include "pretixcontrol/event/component_link.html" %}
-        </div>
-    </nav>
+    {% trans "Installed plugins" as header_title %}
+    {% include "common/includes/header_nav.html" with header_title=header_title header_component_link="pretixcontrol/event/component_link.html" %}
     <form action="" method="post" class="form-horizontal form-plugins">
         {% csrf_token %}
         {% if "success" in request.GET %}

--- a/app/eventyay/control/templates/pretixcontrol/event/settings.html
+++ b/app/eventyay/control/templates/pretixcontrol/event/settings.html
@@ -10,14 +10,8 @@
     <link type="text/css" rel="stylesheet" href="{% url "control:pdf.css" %}">
 {% endblock %}
 {% block inside %}
-    <nav id="event-nav" class="header-nav">
-        <div class="navigation">
-            <div class="navigation-title">
-                <h1>{% trans "General settings" %}</h1>
-            </div>
-            {% include "pretixcontrol/event/component_link.html" %}
-        </div>
-    </nav>
+    {% trans "General settings" as header_title %}
+    {% include "common/includes/header_nav.html" with header_title=header_title header_component_link="pretixcontrol/event/component_link.html" %}
     <form action="" method="post" class="form-horizontal" enctype="multipart/form-data">
         {% csrf_token %}
         {% bootstrap_form_errors form %}

--- a/app/eventyay/control/templates/pretixcontrol/event/tax_edit.html
+++ b/app/eventyay/control/templates/pretixcontrol/event/tax_edit.html
@@ -10,18 +10,12 @@
     {% endif %}
 {% endblock %}
 {% block inside %}
-    <nav id="event-nav" class="header-nav">
-        <div class="navigation">
-            <div class="navigation-title">
-                {% if rule %}
-                    <h1>{% blocktrans with name=rule.name %}Tax rule: {{ name }}{% endblocktrans %}</h1>
-                {% else %}
-                    <h1>{% trans "Tax rule" %}</h1>
-                {% endif %}
-            </div>
-            {% include "pretixcontrol/event/component_link.html" %}
-        </div>
-    </nav>
+    {% if rule %}
+        {% blocktrans with name=rule.name as header_title_var %}Tax rule: {{ name }}{% endblocktrans %}
+    {% else %}
+        {% trans "Tax rule" as header_title_var %}
+    {% endif %}
+    {% include "common/includes/header_nav.html" with header_title=header_title_var header_component_link="pretixcontrol/event/component_link.html" %}
     <form action="" method="post" class="form-horizontal">
         {% csrf_token %}
         {% bootstrap_form_errors form %}

--- a/app/eventyay/control/templates/pretixcontrol/event/tax_index.html
+++ b/app/eventyay/control/templates/pretixcontrol/event/tax_index.html
@@ -2,14 +2,8 @@
 {% load i18n %}
 {% block title %}{% trans "Tax rules" %}{% endblock %}
 {% block inside %}
-    <nav id="event-nav" class="header-nav">
-        <div class="navigation">
-            <div class="navigation-title">
-                <h1>{% trans "Tax rules" %}</h1>
-            </div>
-            {% include "pretixcontrol/event/component_link.html" %}
-        </div>
-    </nav>
+    {% trans "Tax rules" as header_title %}
+    {% include "common/includes/header_nav.html" with header_title=header_title header_component_link="pretixcontrol/event/component_link.html" %}
     {% if taxrules|length == 0 %}
         <div class="empty-collection">
             <p>

--- a/app/eventyay/control/templates/pretixcontrol/event/tickets.html
+++ b/app/eventyay/control/templates/pretixcontrol/event/tickets.html
@@ -5,14 +5,8 @@
 {% block inside %}
     <form action="" method="post" class="form-horizontal" enctype="multipart/form-data">
         {% csrf_token %}
-        <nav id="event-nav" class="header-nav">
-            <div class="navigation">
-                <div class="navigation-title">
-                    <h1>{% trans "Ticket download" %}</h1>
-                </div>
-                {% include "pretixcontrol/event/component_link.html" %}
-            </div>
-        </nav>
+    {% trans "Ticket download" as header_title %}
+    {% include "common/includes/header_nav.html" with header_title=header_title header_component_link="pretixcontrol/event/component_link.html" %}
         <div class="">
             <fieldset>
                 <legend>{% trans "Download settings" %}</legend>

--- a/app/eventyay/control/templates/pretixcontrol/event/widget.html
+++ b/app/eventyay/control/templates/pretixcontrol/event/widget.html
@@ -5,14 +5,8 @@
 {% load eventurl %}
 {% load eventsignal %}
 {% block inside %}
-    <nav id="event-nav" class="header-nav">
-        <div class="navigation">
-            <div class="navigation-title">
-                <h1>{% trans "Widget" %}</h1>
-            </div>
-            {% include "pretixcontrol/event/component_link.html" %}
-        </div>
-    </nav>
+    {% trans "Widget" as header_title %}
+    {% include "common/includes/header_nav.html" with header_title=header_title header_component_link="pretixcontrol/event/component_link.html" %}
     <p>
         {% blocktrans trimmed %}
         A widget allows you to embed your ticket shop directly into your event website. This enables your visitors to purchase tickets instantly without leaving your site.

--- a/app/eventyay/control/templates/pretixcontrol/item/base.html
+++ b/app/eventyay/control/templates/pretixcontrol/item/base.html
@@ -2,7 +2,7 @@
 {% load i18n %}
 {% block title %}{{ object.name }} :: {% trans "Product" %}{% endblock %}
 {% block content %}
-    {% trans "Modify product:" as header_title %} {{ object.name }}
+    {% blocktrans trimmed with name=object.name as header_title %}Modify product: {{ name }}{% endblocktrans %}
     {% include "common/includes/header_nav.html" with header_title=header_title header_component_link="pretixcontrol/event/component_link.html" %}
     {% if object.id and not object.quotas.exists %}
         <div class="alert alert-warning">

--- a/app/eventyay/control/templates/pretixcontrol/item/base.html
+++ b/app/eventyay/control/templates/pretixcontrol/item/base.html
@@ -1,9 +1,20 @@
 {% extends "pretixcontrol/event/base.html" %}
 {% load i18n %}
+{% load captureas %}
 {% block title %}{{ object.name }} :: {% trans "Product" %}{% endblock %}
 {% block content %}
-    {% blocktrans trimmed with name=object.name as header_title %}Modify product: {{ name }}{% endblocktrans %}
-    {% include "common/includes/header_nav.html" with header_title=header_title header_component_link="pretixcontrol/event/component_link.html" %}
+    {% if object.id %}
+        {% blocktrans trimmed with name=object.name as header_title_var %}Modify product: {{ name }}{% endblocktrans %}
+        {% include "common/includes/header_nav.html" with header_title=header_title_var header_component_link="pretixcontrol/event/component_link.html" %}
+    {% else %}
+        {% trans "Create product" as header_title_var %}
+        {% captureas header_extra_var %}
+            <p>{% blocktrans trimmed %}
+                You will be able to adjust further settings in the next step.
+            {% endblocktrans %}</p>
+        {% endcaptureas %}
+        {% include "common/includes/header_nav.html" with header_title=header_title_var header_title_extra=header_extra_var header_component_link="pretixcontrol/event/component_link.html" %}
+    {% endif %}
     {% if object.id and not object.quotas.exists %}
         <div class="alert alert-warning">
             {% blocktrans trimmed %}

--- a/app/eventyay/control/templates/pretixcontrol/item/base.html
+++ b/app/eventyay/control/templates/pretixcontrol/item/base.html
@@ -2,21 +2,8 @@
 {% load i18n %}
 {% block title %}{{ object.name }} :: {% trans "Product" %}{% endblock %}
 {% block content %}
-    <nav id="event-nav" class="header-nav">
-        <div class="navigation">
-            <div class="navigation-title">
-                {% if object.id %}
-                    <h1>{% trans "Modify product:" %} {{ object.name }}</h1>
-                {% else %}
-                    <h1>{% trans "Create product" %}</h1>
-                    <p>{% blocktrans trimmed %}
-                        You will be able to adjust further settings in the next step.
-                    {% endblocktrans %}</p>
-                {% endif %}
-            </div>
-            {% include "pretixcontrol/event/component_link.html" %}
-        </div>
-    </nav>
+    {% trans "Modify product:" as header_title %} {{ object.name }}
+    {% include "common/includes/header_nav.html" with header_title=header_title header_component_link="pretixcontrol/event/component_link.html" %}
     {% if object.id and not object.quotas.exists %}
         <div class="alert alert-warning">
             {% blocktrans trimmed %}

--- a/app/eventyay/control/templates/pretixcontrol/items/categories.html
+++ b/app/eventyay/control/templates/pretixcontrol/items/categories.html
@@ -2,14 +2,8 @@
 {% load i18n %}
 {% block title %}{% trans "Product categories" %}{% endblock %}
 {% block inside %}
-    <nav id="event-nav" class="header-nav">
-        <div class="navigation">
-            <div class="navigation-title">
-                <h1>{% trans "Product categories" %}</h1>
-            </div>
-            {% include "pretixcontrol/event/component_link.html" %}
-        </div>
-    </nav>
+    {% trans "Product categories" as header_title %}
+    {% include "common/includes/header_nav.html" with header_title=header_title header_component_link="pretixcontrol/event/component_link.html" %}
     <p>
         {% blocktrans trimmed %}
             You can use categories to group multiple products together in an organized way.

--- a/app/eventyay/control/templates/pretixcontrol/items/category.html
+++ b/app/eventyay/control/templates/pretixcontrol/items/category.html
@@ -3,14 +3,8 @@
 {% load bootstrap3 %}
 {% block title %}{% trans "Product category" %}{% endblock %}
 {% block inside %}
-    <nav id="event-nav" class="header-nav">
-        <div class="navigation">
-            <div class="navigation-title">
-                <h1>{% trans "Product category" %}</h1>
-            </div>
-            {% include "pretixcontrol/event/component_link.html" %}
-        </div>
-    </nav>
+    {% trans "Product category" as header_title %}
+    {% include "common/includes/header_nav.html" with header_title=header_title header_component_link="pretixcontrol/event/component_link.html" %}
 	<form action="" method="post" class="form-horizontal">
 		{% csrf_token %}
         {% bootstrap_form_errors form %}

--- a/app/eventyay/control/templates/pretixcontrol/items/description_edit.html
+++ b/app/eventyay/control/templates/pretixcontrol/items/description_edit.html
@@ -11,18 +11,12 @@
     {% endif %}
 {% endblock %}
 {% block inside %}
-    <nav id="event-nav" class="header-nav">
-        <div class="navigation">
-            <div class="navigation-title">
-                {% if question %}
-                    <h1>{% blocktrans with name=question.question %}Description: {{ name }}{% endblocktrans %}</h1>
-                {% else %}
-                    <h1>{% trans "Description" %}</h1>
-                {% endif %}
-            </div>
-            {% include "pretixcontrol/event/component_link.html" %}
-        </div>
-    </nav>
+    {% if question %}
+        {% blocktrans with name=question.question as header_title_var %}Description: {{ name }}{% endblocktrans %}
+    {% else %}
+        {% trans "Description" as header_title_var %}
+    {% endif %}
+    {% include "common/includes/header_nav.html" with header_title=header_title_var header_component_link="pretixcontrol/event/component_link.html" %}
     <form action="" method="post" class="form-horizontal">
         {% csrf_token %}
         {% bootstrap_form_errors form %}

--- a/app/eventyay/control/templates/pretixcontrol/items/index.html
+++ b/app/eventyay/control/templates/pretixcontrol/items/index.html
@@ -2,14 +2,8 @@
 {% load i18n %}
 {% block title %}{% trans "Products" %}{% endblock %}
 {% block inside %}
-    <nav id="event-nav" class="header-nav">
-        <div class="navigation">
-            <div class="navigation-title">
-                <h1>{% trans "Products" %}</h1>
-            </div>
-            {% include "pretixcontrol/event/component_link.html" %}
-        </div>
-    </nav>
+    {% trans "Products" as header_title %}
+    {% include "common/includes/header_nav.html" with header_title=header_title header_component_link="pretixcontrol/event/component_link.html" %}
     <p>
         {% blocktrans trimmed %}
             Below, you find a list of all available products. You can click on a product name to inspect and change

--- a/app/eventyay/control/templates/pretixcontrol/items/orderform_default_field_settings.html
+++ b/app/eventyay/control/templates/pretixcontrol/items/orderform_default_field_settings.html
@@ -5,14 +5,8 @@
 {% block title %}{% blocktrans with field=field_label %}Field settings: {{ field }}{% endblocktrans %}{% endblock %}
 
 {% block inside %}
-  <nav id="event-nav" class="header-nav">
-    <div class="navigation">
-      <div class="navigation-title">
-        <h1>{% blocktrans with field=field_label %}Field settings: {{ field }}{% endblocktrans %}</h1>
-      </div>
-      {% include 'pretixcontrol/event/component_link.html' %}
-    </div>
-  </nav>
+  {% blocktrans with field=field_label as header_title_var %}Field settings: {{ field }}{% endblocktrans %}
+  {% include 'common/includes/header_nav.html' with header_title=header_title_var header_component_link='pretixcontrol/event/component_link.html' %}
 
   <form action="" method="post" class="form-horizontal">
     {% csrf_token %}

--- a/app/eventyay/control/templates/pretixcontrol/items/orderforms.html
+++ b/app/eventyay/control/templates/pretixcontrol/items/orderforms.html
@@ -14,14 +14,8 @@
     {% endcompress %}
 {% endblock %}
 {% block inside %}
-    <nav id="event-nav" class="header-nav">
-        <div class="navigation">
-            <div class="navigation-title">
-                <h1>{% translate "Order forms" %}</h1>
-            </div>
-            {% include "pretixcontrol/event/component_link.html" %}
-        </div>
-    </nav>
+    {% translate "Order forms" as header_title %}
+    {% include "common/includes/header_nav.html" with header_title=header_title header_component_link="pretixcontrol/event/component_link.html" %}
     
     <form action="" method="post" class="form-horizontal order-forms-page" enctype="multipart/form-data">
         {% csrf_token %}

--- a/app/eventyay/control/templates/pretixcontrol/items/question_edit.html
+++ b/app/eventyay/control/templates/pretixcontrol/items/question_edit.html
@@ -11,18 +11,12 @@
     {% endif %}
 {% endblock %}
 {% block inside %}
-    <nav id="event-nav" class="header-nav">
-        <div class="navigation">
-            <div class="navigation-title">
-                {% if question %}
-                    <h1>{% blocktrans with name=question.question %}Custom Field: {{ name }}{% endblocktrans %}</h1>
-                {% else %}
-                    <h1>{% trans "Custom Field" %}</h1>
-                {% endif %}
-            </div>
-            {% include "pretixcontrol/event/component_link.html" %}
-        </div>
-    </nav>
+    {% if question %}
+        {% blocktrans with name=question.question as header_title_var %}Custom Field: {{ name }}{% endblocktrans %}
+    {% else %}
+        {% trans "Custom Field" as header_title_var %}
+    {% endif %}
+    {% include "common/includes/header_nav.html" with header_title=header_title_var header_component_link="pretixcontrol/event/component_link.html" %}
     <form action="" method="post" class="form-horizontal">
         {% csrf_token %}
         {% bootstrap_form_errors form %}

--- a/app/eventyay/control/templates/pretixcontrol/items/questions.html
+++ b/app/eventyay/control/templates/pretixcontrol/items/questions.html
@@ -3,14 +3,8 @@
 {% load rich_text %}
 {% block title %}{% trans "Custom Fields" %}{% endblock %}
 {% block inside %}
-    <nav id="event-nav" class="header-nav">
-        <div class="navigation">
-            <div class="navigation-title">
-                <h1>{% trans "Custom Fields" %}</h1>
-            </div>
-            {% include "pretixcontrol/event/component_link.html" %}
-        </div>
-    </nav>
+    {% trans "Custom Fields" as header_title %}
+    {% include "common/includes/header_nav.html" with header_title=header_title header_component_link="pretixcontrol/event/component_link.html" %}
     <p>
         {% blocktrans trimmed %}
             Custom Fields allow your attendees to fill in additional data about their ticket. If you provide food, one

--- a/app/eventyay/control/templates/pretixcontrol/items/quota.html
+++ b/app/eventyay/control/templates/pretixcontrol/items/quota.html
@@ -3,25 +3,20 @@
 {% load bootstrap3 %}
 {% load escapejson %}
 {% load eventsignal %}
+{% load captureas %}
 {% block title %}{% blocktrans with name=quota.name %}Quota: {{ name }}{% endblocktrans %}{% endblock %}
 {% block inside %}
-    <nav id="event-nav" class="header-nav">
-        <div class="navigation">
-            <div class="navigation-title">
-                <h1>
-                    {% blocktrans with name=quota.name %}Quota: {{ name }}{% endblocktrans %}
-                    {% if 'can_change_items' in request.eventpermset %}
-                        <a href="{% url "control:event.products.quotas.edit" event=request.event.slug organizer=request.event.organizer.slug quota=quota.pk %}"
-                           class="btn btn-default">
-                            <span class="fa fa-edit"></span>
-                            {% trans "Edit quota" %}
-                        </a>
-                    {% endif %}
-                </h1>
-            </div>
-            {% include "pretixcontrol/event/component_link.html" %}
-        </div>
-    </nav>
+    {% blocktrans with name=quota.name as header_title_var %}Quota: {{ name }}{% endblocktrans %}
+    {% captureas header_extra_var %}
+        {% if 'can_change_items' in request.eventpermset %}
+            <a href="{% url "control:event.products.quotas.edit" event=request.event.slug organizer=request.event.organizer.slug quota=quota.pk %}"
+               class="btn btn-default">
+                <span class="fa fa-edit"></span>
+                {% trans "Edit quota" %}
+            </a>
+        {% endif %}
+    {% endcaptureas %}
+    {% include "common/includes/header_nav.html" with header_title=header_title_var header_title_extra=header_extra_var header_component_link="pretixcontrol/event/component_link.html" %}
     {% if quota.subevent %}
         <p>
             <span class="fa fa-calendar"></span> {{ quota.subevent.name }} – {{ quota.subevent.get_date_range_display }}

--- a/app/eventyay/control/templates/pretixcontrol/items/quota_edit.html
+++ b/app/eventyay/control/templates/pretixcontrol/items/quota_edit.html
@@ -9,18 +9,12 @@
     {% endif %}
 {% endblock %}
 {% block inside %}
-    <nav id="event-nav" class="header-nav">
-        <div class="navigation">
-            <div class="navigation-title">
-                {% if question %}
-                    <h1>{% blocktrans with name=quota.name %}Quota: {{ name }}{% endblocktrans %}</h1>
-                {% else %}
-                    <h1>{% trans "Quota" %}</h1>
-                {% endif %}
-            </div>
-            {% include "pretixcontrol/event/component_link.html" %}
-        </div>
-    </nav>
+    {% if question %}
+        {% blocktrans with name=quota.name as header_title_var %}Quota: {{ name }}{% endblocktrans %}
+    {% else %}
+        {% trans "Quota" as header_title_var %}
+    {% endif %}
+    {% include "common/includes/header_nav.html" with header_title=header_title_var header_component_link="pretixcontrol/event/component_link.html" %}
     <form action="" method="post" class="form-horizontal">
         {% csrf_token %}
         {% bootstrap_form_errors form %}

--- a/app/eventyay/control/templates/pretixcontrol/items/quotas.html
+++ b/app/eventyay/control/templates/pretixcontrol/items/quotas.html
@@ -3,14 +3,8 @@
 {% load urlreplace %}
 {% block title %}{% trans "Quotas" %}{% endblock %}
 {% block inside %}
-    <nav id="event-nav" class="header-nav">
-        <div class="navigation">
-            <div class="navigation-title">
-                <h1>{% trans "Quotas" %}</h1>
-            </div>
-            {% include "pretixcontrol/event/component_link.html" %}
-        </div>
-    </nav>
+    {% trans "Quotas" as header_title %}
+    {% include "common/includes/header_nav.html" with header_title=header_title header_component_link="pretixcontrol/event/component_link.html" %}
     <p>
         {% blocktrans trimmed %}
         To ensure your products are available as intended, you need to set quotas. Quotas determine how many instances of your product can be sold on the platform. This allows you to configure whether your event can accommodate an unlimited number of attendees or if the number of attendees is capped. You can assign a product to multiple quotas to meet more complex requirements, such as limiting the total number of tickets sold while also restricting the number of specific ticket types simultaneously.

--- a/app/eventyay/control/templates/pretixcontrol/orders/export.html
+++ b/app/eventyay/control/templates/pretixcontrol/orders/export.html
@@ -3,6 +3,7 @@
 {% load bootstrap3 %}
 {% load order_overview %}
 {% load static %}
+{% load captureas %}
 {% block title %}{% trans "Data export" %}{% endblock %}
 {% block custom_header %}
     {{ block.super }}
@@ -38,19 +39,13 @@
     </script>
 {% endblock %}
 {% block content %}
-    <nav id="event-nav" class="header-nav">
-        <div class="navigation">
-            <div class="navigation-title">
-                <h1>
-                    {% trans "Data export" %}
-                    {% if "identifier" in request.GET %}
-                        <a href="?" class="btn btn-default">{% trans "Show all" %}</a>
-                    {% endif %}
-                </h1>
-            </div>
-            {% include "pretixcontrol/event/component_link.html" %}
-        </div>
-    </nav>
+    {% trans "Data export" as header_title_var %}
+    {% captureas header_extra_var %}
+        {% if "identifier" in request.GET %}
+            <a href="?" class="btn btn-default">{% trans "Show all" %}</a>
+        {% endif %}
+    {% endcaptureas %}
+    {% include "common/includes/header_nav.html" with header_title=header_title_var header_title_extra=header_extra_var header_component_link="pretixcontrol/event/component_link.html" %}
     {% for e in exporters %}
         <details class="panel panel-default" {% if "identifier" in request.GET or "exporter" in request.POST %}open{% endif %}>
             <summary class="panel-heading">

--- a/app/eventyay/control/templates/pretixcontrol/orders/import_start.html
+++ b/app/eventyay/control/templates/pretixcontrol/orders/import_start.html
@@ -7,14 +7,8 @@
     <link rel="stylesheet" type="text/css" href="{% static 'pretixcontrol/css/orders-mobile.css' %}" />
 {% endblock %}
 {% block content %}
-    <nav id="event-nav" class="header-nav">
-        <div class="navigation">
-            <div class="navigation-title">
-                <h1>{% trans "Import attendees" %}</h1>
-            </div>
-            {% include "pretixcontrol/event/component_link.html" %}
-        </div>
-    </nav>
+    {% trans "Import attendees" as header_title %}
+    {% include "common/includes/header_nav.html" with header_title=header_title header_component_link="pretixcontrol/event/component_link.html" %}
 
     <div class="panel panel-default orders-import-panel">
         <div class="panel-heading">

--- a/app/eventyay/control/templates/pretixcontrol/orders/index.html
+++ b/app/eventyay/control/templates/pretixcontrol/orders/index.html
@@ -7,14 +7,8 @@
 {% load static %}
 {% block title %}{% trans "Orders" %}{% endblock %}
 {% block content %}
-    <nav id="event-nav" class="header-nav">
-        <div class="navigation">
-            <div class="navigation-title">
-                <h1>{% trans "Orders" %}</h1>
-            </div>
-            {% include "pretixcontrol/event/component_link.html" %}
-        </div>
-    </nav>
+    {% trans "Orders" as header_title %}
+    {% include "common/includes/header_nav.html" with header_title=header_title header_component_link="pretixcontrol/event/component_link.html" %}
     {% if not filter_form.filtered and orders|length == 0 and not filter_strings %}
         <div class="empty-collection">
             <p>

--- a/app/eventyay/control/templates/pretixcontrol/orders/overview.html
+++ b/app/eventyay/control/templates/pretixcontrol/orders/overview.html
@@ -3,6 +3,7 @@
 {% load bootstrap3 %}
 {% load order_overview %}
 {% load static %}
+{% load captureas %}
 {% block title %}{% trans "Order overview" %}{% endblock %}
 {% block custom_header %}
     {{ block.super }}
@@ -13,21 +14,15 @@
 {% endblock %}
 {% block content %}
     {% url "control:event.orders" organizer=request.event.organizer.slug event=request.event.slug as listurl %}
-    <nav id="event-nav" class="header-nav">
-        <div class="navigation">
-            <div class="navigation-title">
-                <h1>
-                    {% trans "Order overview" %}
-                    <a href="{% url "control:event.orders.export" event=request.event.slug organizer=request.event.organizer.slug %}?identifier=pdfreport"
-                       class="btn btn-default" target="_blank">
-                        <span class="fa fa-download"></span>
-                        {% trans "PDF" %}
-                    </a>
-                </h1>
-            </div>
-            {% include "pretixcontrol/event/component_link.html" %}
-        </div>
-    </nav>
+    {% trans "Order overview" as header_title_var %}
+    {% captureas header_extra_var %}
+        <a href="{% url "control:event.orders.export" event=request.event.slug organizer=request.event.organizer.slug %}?identifier=pdfreport"
+           class="btn btn-default" target="_blank">
+            <span class="fa fa-download"></span>
+            {% trans "PDF" %}
+        </a>
+    {% endcaptureas %}
+    {% include "common/includes/header_nav.html" with header_title=header_title_var header_title_extra=header_extra_var header_component_link="pretixcontrol/event/component_link.html" %}
     <div class="orders-filter-container">
         <form class="orders-filter-form" action="" method="get">
             {% if request.event.has_subevents %}

--- a/app/eventyay/control/templates/pretixcontrol/orders/refunds.html
+++ b/app/eventyay/control/templates/pretixcontrol/orders/refunds.html
@@ -13,14 +13,8 @@
     <link rel="stylesheet" type="text/css" href="{% static 'pretixcontrol/css/orders-mobile.css' %}" />
 {% endblock %}
 {% block content %}
-    <nav id="event-nav" class="header-nav">
-        <div class="navigation">
-            <div class="navigation-title">
-                <h1>{% trans "Refunds" %}</h1>
-            </div>
-            {% include "pretixcontrol/event/component_link.html" %}
-        </div>
-    </nav>
+    {% trans "Refunds" as header_title %}
+    {% include "common/includes/header_nav.html" with header_title=header_title header_component_link="pretixcontrol/event/component_link.html" %}
     <div class="orders-filter-container">
         <form class="orders-filter-form" action="" method="get">
             <div class="orders-filter-form-group">

--- a/app/eventyay/control/templates/pretixcontrol/vouchers/bulk.html
+++ b/app/eventyay/control/templates/pretixcontrol/vouchers/bulk.html
@@ -4,14 +4,8 @@
 {% load bootstrap3 %}
 {% block title %}{% trans "Voucher" %}{% endblock %}
 {% block inside %}
-    <nav id="event-nav" class="header-nav">
-        <div class="navigation">
-            <div class="navigation-title">
-                <h1>{% trans "Create multiple vouchers" %}</h1>
-            </div>
-            {% include "pretixcontrol/event/component_link.html" %}
-        </div>
-    </nav>
+    {% trans "Create multiple vouchers" as header_title %}
+    {% include "common/includes/header_nav.html" with header_title=header_title header_component_link="pretixcontrol/event/component_link.html" %}
     <form action="" method="post" class="form-horizontal" data-asynctask>
         {% csrf_token %}
         {% bootstrap_form_errors form %}

--- a/app/eventyay/control/templates/pretixcontrol/vouchers/detail.html
+++ b/app/eventyay/control/templates/pretixcontrol/vouchers/detail.html
@@ -5,14 +5,8 @@
 {% load eventurl %}
 {% block title %}{% trans "Voucher" %}{% endblock %}
 {% block inside %}
-    <nav id="event-nav" class="header-nav">
-        <div class="navigation">
-            <div class="navigation-title">
-                <h1>{% trans "Voucher" %}</h1>
-            </div>
-            {% include "pretixcontrol/event/component_link.html" %}
-        </div>
-    </nav>
+    {% trans "Voucher" as header_title %}
+    {% include "common/includes/header_nav.html" with header_title=header_title header_component_link="pretixcontrol/event/component_link.html" %}
     {% if voucher.redeemed %}
         <div class="alert alert-warning">
             {% trans "This voucher already has been used. It is not recommended to modify it." %}

--- a/app/eventyay/control/templates/pretixcontrol/vouchers/index.html
+++ b/app/eventyay/control/templates/pretixcontrol/vouchers/index.html
@@ -10,14 +10,8 @@
     <link rel="stylesheet" type="text/css" href="{% static 'pretixcontrol/css/tickets-mobile.css' %}" />
 {% endblock %}
 {% block content %}
-    <nav id="event-nav" class="header-nav">
-        <div class="navigation">
-            <div class="navigation-title">
-                <h1>{% trans "Vouchers" %}</h1>
-            </div>
-            {% include "pretixcontrol/event/component_link.html" %}
-        </div>
-    </nav>
+    {% trans "Vouchers" as header_title %}
+    {% include "common/includes/header_nav.html" with header_title=header_title header_component_link="pretixcontrol/event/component_link.html" %}
     <ul class="nav nav-tabs">
         <li {% if tab == "vouchers" %}class="active"{% endif %}>
             <a href="?{% url_replace request 'tab' 'vouchers' %}">

--- a/app/eventyay/control/templates/pretixcontrol/waitinglist/index.html
+++ b/app/eventyay/control/templates/pretixcontrol/waitinglist/index.html
@@ -12,14 +12,8 @@
     <link rel="stylesheet" type="text/css" href="{% static 'pretixcontrol/css/orders-mobile.css' %}" />
 {% endblock %}
 {% block content %}
-    <nav id="event-nav" class="header-nav">
-        <div class="navigation">
-            <div class="navigation-title">
-                <h1>{% trans "Waiting list" %}</h1>
-            </div>
-            {% include "pretixcontrol/event/component_link.html" %}
-        </div>
-    </nav>
+    {% trans "Waiting list" as header_title %}
+    {% include "common/includes/header_nav.html" with header_title=header_title header_component_link="pretixcontrol/event/component_link.html" %}
     {% if not request.event.settings.waiting_list_enabled %}
         <div class="alert alert-danger">
             {% trans "The waiting list is disabled, so if the event is sold out, people cannot add themselves to this list. If you want to enable it, go to the event settings." %}


### PR DESCRIPTION
## Closes #4761 

This PR standardizes the header navigation across the Ticket area. Previously, the Talk area was updated to use a unified header_nav.html component. This PR brings the Ticket area up to parity by refactoring its templates to use the same common navigation component, removing redundant inline blocks.

## Videos

https://github.com/user-attachments/assets/a84a6c27-f8d4-4e89-94cb-4d9a0be0a893

---

https://github.com/user-attachments/assets/9a482753-281c-4a6c-a9a1-3d3327307990

---

https://github.com/user-attachments/assets/b0071953-32b2-413a-8856-807d35ae5ea5

---

https://github.com/user-attachments/assets/05994bef-0df9-44c6-81c1-7dd174677f75




