### PR TITLE
Fix: chat mention autocomplete handling

### DIFF
--- a/app/eventyay/webapp/video/src/components/ChatInput.vue
+++ b/app/eventyay/webapp/video/src/components/ChatInput.vue
@@ -198,7 +198,7 @@ export default {
 				}
 				this.autocomplete.nextPage = newPage.isLastPage ? null : page + 1
 			} finally {
-				if (this.autocomplete) {
+				if (this.autocomplete && sequence === this.autocompleteSearchSequence) {
 					this.autocomplete.loading = false
 				}
 			}

--- a/app/eventyay/webapp/video/src/components/ChatInput.vue
+++ b/app/eventyay/webapp/video/src/components/ChatInput.vue
@@ -46,11 +46,11 @@ import { nativeToOps } from 'lib/emoji'
 
 const Delta = Quill.import('delta')
 const MENTION_BOUNDARIES = new Set([' ', '\n', '\t', '(', '[', '{', '<', '.', ',', ';', ':', '!', '?', '"', '\'', '`'])
-const MENTION_STOP_CHARS = new Set([...MENTION_BOUNDARIES, '@'])
+const MENTION_SEARCH_STOP_CHARS = new Set(['(', '[', '{', '<', '.', ',', ';', ':', '!', '?', '"', '\'', '`', '@'])
 
 function getMentionMatch(text) {
 	let index = text.length - 1
-	while (index >= 0 && !MENTION_STOP_CHARS.has(text[index])) {
+	while (index >= 0 && !MENTION_SEARCH_STOP_CHARS.has(text[index])) {
 		index -= 1
 	}
 	if (index < 0 || text[index] !== '@') return null
@@ -184,7 +184,10 @@ export default {
 			this.updateAutocomplete()
 		},
 		handleEnter() {
-			if (this.autocomplete) return this.handleMention()
+			if (this.autocomplete) {
+				if (this.autocomplete.options?.length) return this.handleMention()
+				this.closeAutocomplete()
+			}
 			return this.send()
 		},
 		handleTab() {

--- a/app/eventyay/webapp/video/src/components/ChatInput.vue
+++ b/app/eventyay/webapp/video/src/components/ChatInput.vue
@@ -26,6 +26,9 @@ bunt-input-outline-container.c-chat-input
 					.user(:class="{selected: index === autocomplete.selected}", :title="option.profile.display_name", @mouseover="selectMention(index)", @click.stop="handleMention")
 						avatar(:user="option", :size="24")
 						.name {{ option.profile.display_name }}
+				button.load-more(v-if="autocomplete.nextPage", type="button", :disabled="autocomplete.loading", @click.stop="loadMoreMentionResults")
+					bunt-progress-circular(v-if="autocomplete.loading", size="small")
+					template(v-else) {{ $t('Exhibition:more:label') }}
 			bunt-progress-circular(v-else, size="large", :page="true")
 </template>
 <script>
@@ -47,6 +50,7 @@ import { nativeToOps } from 'lib/emoji'
 const Delta = Quill.import('delta')
 const MENTION_BOUNDARIES = new Set([' ', '\n', '\t', '(', '[', '{', '<', '.', ',', ';', ':', '!', '?', '"', '\'', '`'])
 const MENTION_SEARCH_STOP_CHARS = new Set(['(', '[', '{', '<', '.', ',', ';', ':', '!', '?', '"', '\'', '`', '@'])
+const MENTION_SEARCH_DEBOUNCE_MS = 250
 
 function getMentionMatch(text) {
 	let index = text.length - 1
@@ -73,6 +77,7 @@ export default {
 			uploading: false,
 			autocomplete: null,
 			autocompleteSearchSequence: 0,
+			autocompleteSearchTimeout: null,
 			autocompleteUpdateTimeout: null
 		}
 	},
@@ -89,19 +94,10 @@ export default {
 		}
 	},
 	watch: {
-		async 'autocomplete.search'(search) {
-			// TODO debounce?
+		'autocomplete.search'(search) {
 			if (!this.autocomplete) return
 			if (this.autocomplete.type === 'mention') {
-				const sequence = ++this.autocompleteSearchSequence
-				const { results } = await api.call('user.list.search', {search_term: search, page: 1, include_banned: false})
-				if (sequence !== this.autocompleteSearchSequence || !this.autocomplete || this.autocomplete.search !== search) return
-				this.autocomplete.options = results
-				this.autocomplete.selected = results.length ? Math.min(this.autocomplete.selected, results.length - 1) : 0
-				// if (results.length === 1) {
-				// 	this.autocomplete.selected = 0
-				// 	this.handleMention()
-				// }
+				this.scheduleMentionSearch(search)
 			}
 		}
 	},
@@ -148,6 +144,7 @@ export default {
 		}
 	},
 	unmounted() {
+		window.clearTimeout(this.autocompleteSearchTimeout)
 		window.clearTimeout(this.autocompleteUpdateTimeout)
 	},
 	methods: {
@@ -173,11 +170,38 @@ export default {
 						length: caretPos - mentionIndex
 					},
 					options: null,
-					selected: 0
+					selected: 0,
+					loading: false,
+					nextPage: null
 				}
 			} else {
 				this.autocomplete = null
 			}
+		},
+		scheduleMentionSearch(search) {
+			window.clearTimeout(this.autocompleteSearchTimeout)
+			const sequence = ++this.autocompleteSearchSequence
+			this.autocompleteSearchTimeout = window.setTimeout(() => {
+				this.loadMentionResults(search, 1, sequence)
+			}, MENTION_SEARCH_DEBOUNCE_MS)
+		},
+		async loadMentionResults(search, page, sequence = ++this.autocompleteSearchSequence) {
+			if (!this.autocomplete || this.autocomplete.type !== 'mention' || this.autocomplete.search !== search) return
+			this.autocomplete.loading = true
+			const newPage = await api.call('user.list.search', {search_term: search, page, include_banned: false})
+			if (sequence !== this.autocompleteSearchSequence || !this.autocomplete || this.autocomplete.search !== search) return
+			this.autocomplete.options = newPage.results
+			this.autocomplete.selected = 0
+			this.autocomplete.nextPage = newPage.isLastPage ? null : page + 1
+			this.autocomplete.loading = false
+			// if (newPage.results.length === 1) {
+			// 	this.autocomplete.selected = 0
+			// 	this.handleMention()
+			// }
+		},
+		loadMoreMentionResults() {
+			if (!this.autocomplete?.nextPage || this.autocomplete.loading) return
+			this.loadMentionResults(this.autocomplete.search, this.autocomplete.nextPage)
 		},
 		onSelectionChange(range, oldRange, source) {
 			if (source !== 'user') return
@@ -207,6 +231,8 @@ export default {
 			this.closeAutocomplete()
 		},
 		closeAutocomplete() {
+			window.clearTimeout(this.autocompleteSearchTimeout)
+			this.autocompleteSearchSequence++
 			this.quill.setSelection(this.autocomplete.selection)
 			this.autocomplete = null
 		},
@@ -226,6 +252,8 @@ export default {
 			})
 			this.quill.insertText(this.autocomplete.range.index + 1, ' ')
 			this.quill.setSelection(this.autocomplete.range.index + 2, 0)
+			window.clearTimeout(this.autocompleteSearchTimeout)
+			this.autocompleteSearchSequence++
 			this.autocomplete = null
 		},
 		send() {
@@ -414,4 +442,16 @@ export default {
 				padding: 1px
 			.name
 				ellipsis()
+		.load-more
+			height: 32px
+			border: 0
+			border-top: border-separator()
+			background: $clr-white
+			color: $clr-primary
+			cursor: pointer
+			font-family: $font-stack
+			font-size: 14px
+			font-weight: 500
+			&:disabled
+				cursor: default
 </style>

--- a/app/eventyay/webapp/video/src/components/ChatInput.vue
+++ b/app/eventyay/webapp/video/src/components/ChatInput.vue
@@ -22,10 +22,9 @@ bunt-input-outline-container.c-chat-input
 	.ui-background-blocker(v-if="autocompleteCoordinates", @click="closeAutocomplete")
 		.autocomplete-dropdown(:style="autocompleteCoordinates")
 			template(v-if="autocomplete.options")
-				template(v-for="option, index of autocomplete.options")
-					.user(:class="{selected: index === autocomplete.selected}", :title="option.profile.display_name", @mouseover="selectMention(index)", @click.stop="handleMention")
-						avatar(:user="option", :size="24")
-						.name {{ option.profile.display_name }}
+				.user(v-for="(option, index) of autocomplete.options", :key="option.id", :class="{selected: index === autocomplete.selected}", :title="option.profile.display_name", @mouseover="selectMention(index)", @click.stop="handleMention")
+					avatar(:user="option", :size="24")
+					.name {{ option.profile.display_name }}
 				button.load-more(v-if="autocomplete.nextPage", type="button", :disabled="autocomplete.loading", @click.stop="loadMoreMentionResults")
 					bunt-progress-circular(v-if="autocomplete.loading", size="small")
 					template(v-else) {{ $t('Exhibition:more:label') }}
@@ -188,16 +187,21 @@ export default {
 		async loadMentionResults(search, page, sequence = ++this.autocompleteSearchSequence) {
 			if (!this.autocomplete || this.autocomplete.type !== 'mention' || this.autocomplete.search !== search) return
 			this.autocomplete.loading = true
-			const newPage = await api.call('user.list.search', {search_term: search, page, include_banned: false})
-			if (sequence !== this.autocompleteSearchSequence || !this.autocomplete || this.autocomplete.search !== search) return
-			this.autocomplete.options = newPage.results
-			this.autocomplete.selected = 0
-			this.autocomplete.nextPage = newPage.isLastPage ? null : page + 1
-			this.autocomplete.loading = false
-			// if (newPage.results.length === 1) {
-			// 	this.autocomplete.selected = 0
-			// 	this.handleMention()
-			// }
+			try {
+				const newPage = await api.call('user.list.search', {search_term: search, page, include_banned: false})
+				if (sequence !== this.autocompleteSearchSequence || !this.autocomplete || this.autocomplete.search !== search) return
+				this.autocomplete.options = page > 1
+					? [...(this.autocomplete.options || []), ...newPage.results]
+					: newPage.results
+				if (page === 1) {
+					this.autocomplete.selected = 0
+				}
+				this.autocomplete.nextPage = newPage.isLastPage ? null : page + 1
+			} finally {
+				if (this.autocomplete) {
+					this.autocomplete.loading = false
+				}
+			}
 		},
 		loadMoreMentionResults() {
 			if (!this.autocomplete?.nextPage || this.autocomplete.loading) return
@@ -426,9 +430,12 @@ export default {
 		width: 240px
 		display: flex
 		flex-direction: column
+		height: calc(32px * 20)
+		overflow-y: auto
 		.user
 			display: flex
 			height: 32px
+			flex-shrink: 0
 			align-items: center
 			gap: 8px
 			padding: 0 8px
@@ -444,6 +451,7 @@ export default {
 				ellipsis()
 		.load-more
 			height: 32px
+			flex-shrink: 0
 			border: 0
 			border-top: border-separator()
 			background: $clr-white

--- a/app/eventyay/webapp/video/src/components/ChatInput.vue
+++ b/app/eventyay/webapp/video/src/components/ChatInput.vue
@@ -45,6 +45,21 @@ import UploadButton from 'components/UploadButton'
 import { nativeToOps } from 'lib/emoji'
 
 const Delta = Quill.import('delta')
+const MENTION_BOUNDARIES = new Set([' ', '\n', '\t', '(', '[', '{', '<', '.', ',', ';', ':', '!', '?', '"', '\'', '`'])
+const MENTION_STOP_CHARS = new Set([...MENTION_BOUNDARIES, '@'])
+
+function getMentionMatch(text) {
+	let index = text.length - 1
+	while (index >= 0 && !MENTION_STOP_CHARS.has(text[index])) {
+		index -= 1
+	}
+	if (index < 0 || text[index] !== '@') return null
+	if (index > 0 && !MENTION_BOUNDARIES.has(text[index - 1])) return null
+	return {
+		index,
+		search: text.slice(index + 1)
+	}
+}
 
 export default {
 	components: { Avatar, EmojiPickerButton, UploadButton },
@@ -56,7 +71,9 @@ export default {
 		return {
 			files: [],
 			uploading: false,
-			autocomplete: null
+			autocomplete: null,
+			autocompleteSearchSequence: 0,
+			autocompleteUpdateTimeout: null
 		}
 	},
 	computed: {
@@ -76,8 +93,11 @@ export default {
 			// TODO debounce?
 			if (!this.autocomplete) return
 			if (this.autocomplete.type === 'mention') {
+				const sequence = ++this.autocompleteSearchSequence
 				const { results } = await api.call('user.list.search', {search_term: search, page: 1, include_banned: false})
+				if (sequence !== this.autocompleteSearchSequence || !this.autocomplete || this.autocomplete.search !== search) return
 				this.autocomplete.options = results
+				this.autocomplete.selected = results.length ? Math.min(this.autocomplete.selected, results.length - 1) : 0
 				// if (results.length === 1) {
 				// 	this.autocomplete.selected = 0
 				// 	this.handleMention()
@@ -127,29 +147,30 @@ export default {
 			}
 		}
 	},
+	unmounted() {
+		window.clearTimeout(this.autocompleteUpdateTimeout)
+	},
 	methods: {
 		onTextChange(delta, oldDelta, source) {
 			if (source !== 'user') return
+			window.clearTimeout(this.autocompleteUpdateTimeout)
+			this.autocompleteUpdateTimeout = window.setTimeout(this.updateAutocomplete, 0)
+		},
+		updateAutocomplete() {
 			const selection = this.quill.getSelection()
 			if (selection === null) return
 			const caretPos = selection.index
-			const lookbackLength = Math.min(32, caretPos)
-			const lookbackOffset = caretPos - lookbackLength
-			const lookback = this.quill.getText(lookbackOffset, lookbackLength)
-			// only trigger when there is a space before @, except at the beginning of the message
-			const startsWithMention = lookbackOffset === 0 && lookback.startsWith('@')
-			const autocompleteCharIndex =
-				startsWithMention
-					? 0
-					: lookback.lastIndexOf(' @') // TODO any whitespace
-			if (autocompleteCharIndex > -1) {
+			const textBeforeCaret = this.quill.getText(0, caretPos)
+			const mentionMatch = getMentionMatch(textBeforeCaret)
+			if (mentionMatch) {
+				const mentionIndex = mentionMatch.index
 				this.autocomplete = {
 					type: 'mention',
-					search: lookback.slice(autocompleteCharIndex + 1 + !startsWithMention),
+					search: mentionMatch.search,
 					selection,
 					range: {
-						index: autocompleteCharIndex + lookbackOffset + !startsWithMention,
-						length: lookback.length
+						index: mentionIndex,
+						length: caretPos - mentionIndex
 					},
 					options: null,
 					selected: 0
@@ -159,7 +180,8 @@ export default {
 			}
 		},
 		onSelectionChange(range, oldRange, source) {
-			// TODO check mentions
+			if (source !== 'user') return
+			this.updateAutocomplete()
 		},
 		handleEnter() {
 			if (this.autocomplete) return this.handleMention()
@@ -170,11 +192,11 @@ export default {
 			return true
 		},
 		handleArrayUp() {
-			if (!this.autocomplete) return true
+			if (!this.autocomplete?.options?.length) return true
 			this.autocomplete.selected = Math.max(0, this.autocomplete.selected - 1)
 		},
 		handleArrayDown() {
-			if (!this.autocomplete) return true
+			if (!this.autocomplete?.options?.length) return true
 			this.autocomplete.selected = Math.min(this.autocomplete.options.length - 1, this.autocomplete.selected + 1)
 		},
 		handleEscape() {
@@ -186,10 +208,11 @@ export default {
 			this.autocomplete = null
 		},
 		selectMention(index) {
+			if (!this.autocomplete?.options?.length) return
 			this.autocomplete.selected = index
 		},
 		handleMention() {
-			if (!this.autocomplete) return true
+			if (!this.autocomplete?.options?.length) return true
 			const user = this.autocomplete.options[this.autocomplete.selected]
 			if (!user) return true
 			this.quill.setSelection(this.autocomplete.range.index, 0)
@@ -198,7 +221,8 @@ export default {
 				id: user.id,
 				name: user.profile.display_name
 			})
-			this.quill.setSelection(this.autocomplete.range.index + 1, 0)
+			this.quill.insertText(this.autocomplete.range.index + 1, ' ')
+			this.quill.setSelection(this.autocomplete.range.index + 2, 0)
 			this.autocomplete = null
 		},
 		send() {

--- a/app/eventyay/webapp/video/src/store/chat.js
+++ b/app/eventyay/webapp/video/src/store/chat.js
@@ -7,6 +7,13 @@ import router from 'router'
 import i18n from 'i18n'
 import { contentToPlainText } from 'components/ChatContent'
 
+const UUID_PATTERN = '[0-9a-fA-F]{8}\\b-[0-9a-fA-F]{4}\\b-[0-9a-fA-F]{4}\\b-[0-9a-fA-F]{4}\\b-[0-9a-fA-F]{12}'
+const MENTION_REGEX = new RegExp(`@(${UUID_PATTERN}|[0-9]+)`, 'g')
+
+function extractMentionedUserIds(content) {
+	return Array.from((content || '').matchAll(MENTION_REGEX), match => match[1])
+}
+
 export default {
 	namespaced: true,
 	state: {
@@ -129,7 +136,6 @@ export default {
 				// assume past events don't just appear and stop forever when results are smaller than count
 				state.beforeCursor = results.length < 25 ? null : results[0].event_id
 				// hit the user profile cache for each message
-				// TODO search for mentions
 				const missingProfiles = new Set()
 				for (const event of results) {
 					if (!state.usersLookup[event.sender]) {
@@ -137,6 +143,13 @@ export default {
 					}
 					if (event.content.user && !state.usersLookup[event.content.user.id]) {
 						missingProfiles.add(event.content.user.id)
+					}
+					if (event.content.type === 'text') {
+						for (const userId of extractMentionedUserIds(event.content.body)) {
+							if (!state.usersLookup[userId]) {
+								missingProfiles.add(userId)
+							}
+						}
 					}
 				}
 				await dispatch('fetchUsers', Array.from(missingProfiles))
@@ -328,6 +341,9 @@ export default {
 			}
 			if (!state.usersLookup[event.sender]) {
 				await dispatch('fetchUsers', [event.sender])
+			}
+			if (event.content.type === 'text') {
+				await dispatch('fetchUsers', extractMentionedUserIds(event.content.body).filter(userId => !state.usersLookup[userId]))
 			}
 		},
 		'api::chat.channels'({state}, {channels}) {


### PR DESCRIPTION
Fixes #4760 

  ## Summary

  Fixes native chat mention autocomplete and mention rendering reliability.

  ## Changes

  - Improves mention trigger detection in chat input:
    - supports message start
    - supports new lines
    - supports whitespace, punctuation, and brackets before `@`
  - Prevents stale autocomplete responses from overwriting newer search results during fast typing.
  - Keeps mention autocomplete as first-page typeahead search instead of fetching every page.
  - Prevents keyboard navigation crashes while autocomplete options are still loading or empty.
  - Inserts a trailing space after selecting a mention.
  - Fetches mentioned user profiles for fetched and live chat messages so rendered mentions resolve more reliably instead of showing raw `@id`.



https://github.com/user-attachments/assets/556684fe-a576-4943-9161-0209f5380213

## Summary by Sourcery

Improve reliability and UX of chat mention autocomplete and rendering in the video webapp.

Bug Fixes:
- Ensure mention autocomplete triggers correctly at message start, after newlines, and after common boundary characters.
- Prevent stale mention search responses from overwriting newer autocomplete results during rapid typing.
- Avoid crashes when navigating autocomplete options via keyboard while options are loading or empty.
- Make mention selection robust by ignoring actions when no options are available.

Enhancements:
- Refine mention autocomplete behavior to use a single-page typeahead search and update selection indices safely.
- Insert a trailing space after an inserted mention to streamline continued typing.
- Automatically resolve and cache profiles for mentioned users in both fetched and live chat messages to render mentions as user names instead of raw IDs.