### PR TITLE
Move customer order field settings to a dedicated page

### DIFF
--- a/app/eventyay/control/forms/event.py
+++ b/app/eventyay/control/forms/event.py
@@ -807,8 +807,6 @@ class OrderFormSettingsForm(EventSettingsForm):
         'require_registered_account_for_tickets',
         'include_wikimedia_username',
         'checkout_show_copy_answers_button',
-        'checkout_email_helptext',
-        'checkout_phone_helptext',
     ]
 
     def __init__(self, *args, **kwargs):
@@ -829,6 +827,30 @@ class OrderFormSettingsForm(EventSettingsForm):
             set_system_question_field_overrides(self.obj, field_id, {})
 
         return result
+
+
+class OrderFormCustomerFieldSettingsForm(SettingsForm):
+    FIELD_LABELS = {
+        'order_email': _('E-mail'),
+        'order_phone': _('Phone number'),
+    }
+
+    def __init__(self, *args, **kwargs):
+        self.field_id = kwargs.pop('field_id', None)
+        
+        if self.field_id == 'order_email':
+            self.auto_fields = [
+                'order_email_asked_twice',
+                'checkout_email_helptext',
+            ]
+        elif self.field_id == 'order_phone':
+            self.auto_fields = [
+                'checkout_phone_helptext',
+            ]
+        else:
+            self.auto_fields = []
+            
+        super().__init__(*args, **kwargs)
 
 
 class OrderFormDefaultFieldSettingsForm(forms.Form):

--- a/app/eventyay/control/templates/pretixcontrol/items/orderform_customer_field_settings.html
+++ b/app/eventyay/control/templates/pretixcontrol/items/orderform_customer_field_settings.html
@@ -1,0 +1,42 @@
+{% extends 'pretixcontrol/items/base.html' %}
+{% load i18n %}
+{% load bootstrap3 %}
+
+{% block title %}{% blocktrans with field=field_label %}Field settings: {{ field }}{% endblocktrans %}{% endblock %}
+
+{% block inside %}
+  <nav id="event-nav" class="header-nav">
+    <div class="navigation">
+      <div class="navigation-title">
+        <h1>{% blocktrans with field=field_label %}Field settings: {{ field }}{% endblocktrans %}</h1>
+      </div>
+      {% include 'pretixcontrol/event/component_link.html' %}
+    </div>
+  </nav>
+
+  <form action="" method="post" class="form-horizontal">
+    {% csrf_token %}
+    {% bootstrap_form_errors form %}
+
+    <fieldset>
+      <legend>{% translate 'Settings' %}</legend>
+      {% if field_id == 'order_email' %}
+        {% bootstrap_field form.order_email_asked_twice layout='control' %}
+        {% bootstrap_field form.checkout_email_helptext layout='control' %}
+      {% elif field_id == 'order_phone' %}
+        {% bootstrap_field form.checkout_phone_helptext layout='control' %}
+      {% endif %}
+    </fieldset>
+
+    <div class="form-group submit-group">
+      <div class="col-md-offset-3 col-md-9">
+        <button type="submit" class="btn btn-primary btn-save">
+          {% translate 'Save' %}
+        </button>
+        <a href="{% url 'control:event.products.orderforms' organizer=request.event.organizer.slug event=request.event.slug %}" class="btn btn-default btn-cancel">
+          {% translate 'Back to order forms' %}
+        </a>
+      </div>
+    </div>
+  </form>
+{% endblock %}

--- a/app/eventyay/control/templates/pretixcontrol/items/orderforms.html
+++ b/app/eventyay/control/templates/pretixcontrol/items/orderforms.html
@@ -69,15 +69,8 @@
                                     </select>
                                 </div>
                             </td>
-                            <td class="text-center">
-                                {% with twice_field=sform.order_email_asked_twice %}
-                                {% if twice_field %}
-                                <label class="checkbox-inline" title="{% translate 'Ask for the order email address twice' %}">
-                                    <input type="checkbox" name="{{ twice_field.html_name }}" id="{{ twice_field.auto_id }}" {% if twice_field.value %}checked{% endif %} aria-label="{% translate 'Ask for the order email address twice' %}">
-                                    {% translate "Ask twice" %}
-                                </label>
-                                {% endif %}
-                                {% endwith %}
+                            <td class="dnd-container text-center text-nowrap">
+                                <a href="{% url 'control:event.products.orderforms.customerfield' organizer=request.event.organizer.slug event=request.event.slug field='order_email' %}" class="btn btn-default btn-sm" aria-label="{% translate 'Settings for E-mail' %}" title="{% translate 'Settings for E-mail' %}"><i class="fa fa-cog fa-fw"></i></a>
                             </td>
                         </tr>
                         {% endif %}
@@ -106,7 +99,9 @@
                                     </select>
                                 </div>
                             </td>
-                            <td class="text-center"><span class="text-muted">—</span></td>
+                            <td class="dnd-container text-center text-nowrap">
+                                <a href="{% url 'control:event.products.orderforms.customerfield' organizer=request.event.organizer.slug event=request.event.slug field='order_phone' %}" class="btn btn-default btn-sm" aria-label="{% translate 'Settings for Phone number' %}" title="{% translate 'Settings for Phone number' %}"><i class="fa fa-cog fa-fw"></i></a>
+                            </td>
                         </tr>
                         {% endif %}
                         {% endwith %}
@@ -128,8 +123,6 @@
                     </tbody>
                 </table>
             </div>
-            {% bootstrap_field sform.checkout_email_helptext layout="control" %}
-            {% bootstrap_field sform.checkout_phone_helptext layout="control" %}
         </fieldset>
 
         <fieldset>

--- a/app/eventyay/control/urls.py
+++ b/app/eventyay/control/urls.py
@@ -302,6 +302,11 @@ urlpatterns = [
                     product.OrderFormDefaultFieldSettings.as_view(),
                     name='event.products.orderforms.defaultfield',
                 ),
+                url(
+                    r'^orderforms/customer-fields/(?P<field>[a-z_]+)/$',
+                    product.OrderFormCustomerFieldSettings.as_view(),
+                    name='event.products.orderforms.customerfield',
+                ),
                 url(r'^questions/$', product.QuestionList.as_view(), name='event.products.questions'),
                 url(r'^questions/reorder$', product.reorder_questions, name='event.products.questions.reorder'),
                 url(

--- a/app/eventyay/control/views/product.py
+++ b/app/eventyay/control/views/product.py
@@ -82,6 +82,7 @@ from eventyay.control.permissions import (
     EventPermissionRequiredMixin,
     event_permission_required,
 )
+from eventyay.control.views.event import EventSettingsFormView
 from eventyay.control.signals import product_forms, product_formsets
 from eventyay.helpers.models import modelcopy
 
@@ -1883,5 +1884,36 @@ class OrderFormDefaultFieldSettings(EventPermissionRequiredMixin, FormView):
                 'organizer': self.request.event.organizer.slug,
                 'event': self.request.event.slug,
                 'field': self.kwargs['field'],
+            },
+        )
+
+
+class OrderFormCustomerFieldSettings(EventSettingsFormView):
+    template_name = 'pretixcontrol/items/orderform_customer_field_settings.html'
+    permission = 'can_change_items'
+
+    def get_form_kwargs(self):
+        kwargs = super().get_form_kwargs()
+        kwargs['field_id'] = self.kwargs.get('field')
+        return kwargs
+
+    def get_form_class(self):
+        from eventyay.control.forms.event import OrderFormCustomerFieldSettingsForm
+        return OrderFormCustomerFieldSettingsForm
+
+    def get_context_data(self, **kwargs):
+        context = super().get_context_data(**kwargs)
+        field_id = self.kwargs.get('field')
+        from eventyay.control.forms.event import OrderFormCustomerFieldSettingsForm
+        context['field_id'] = field_id
+        context['field_label'] = OrderFormCustomerFieldSettingsForm.FIELD_LABELS.get(field_id, field_id)
+        return context
+
+    def get_success_url(self):
+        return reverse(
+            'control:event.products.orderforms',
+            kwargs={
+                'organizer': self.request.event.organizer.slug,
+                'event': self.request.event.slug,
             },
         )


### PR DESCRIPTION
https://github.com/user-attachments/assets/db19c6ca-c557-40a5-9368-a299ccc84433

closes #4688 

## Summary by Sourcery

Move email and phone customer order field settings to a dedicated settings page linked from the order forms overview.

New Features:
- Add a dedicated settings view and page for individual customer order fields such as email and phone.

Enhancements:
- Refactor order form settings so customer field-specific options are configured per field instead of inline on the main order forms page.