### PR TITLE
Fix: Prevent duplicate teams from appearing on event dashboard

### DIFF
--- a/app/eventyay/base/models/event.py
+++ b/app/eventyay/base/models/event.py
@@ -2741,7 +2741,7 @@ class Event(
         that concern this event."""
 
         return self.organizer.teams.filter(
-            models.Q(all_events=True) | models.Q(models.Q(all_events=False) & models.Q(limit_events__in=[self]))
+            models.Q(all_events=True) | models.Q(models.Q(all_events=False) & models.Q(limit_events=self))
         ).distinct()
 
     @cached_property

--- a/app/eventyay/base/models/event.py
+++ b/app/eventyay/base/models/event.py
@@ -2740,9 +2740,9 @@ class Event(
         """Returns all :class:`~eventyay.base.models.organizer.Team` objects
         that concern this event."""
 
-        return self.organizer.teams.all().filter(
+        return self.organizer.teams.filter(
             models.Q(all_events=True) | models.Q(models.Q(all_events=False) & models.Q(limit_events__in=[self]))
-        )
+        ).distinct()
 
     @cached_property
     def reviewers(self):


### PR DESCRIPTION
Close : #4771

What happens behind the scenes: When you check the "All events" box, the system doesn't automatically delete the 5 specific events you previously selected from the database's hidden mapping table. It just leaves them there.

The Bug: When you now visit the Event Dashboard for one of those events, Django asks the database: "Give me all teams that either have 'All events' checked OR are specifically linked to this event."


https://github.com/user-attachments/assets/f813b956-3a3a-421b-9633-7159397bf3eb

## Summary by Sourcery

Bug Fixes:
- Prevent duplicate team entries on the event dashboard when teams are both global (all events) and explicitly linked to a specific event.