### PR TITLE
feat(video): add voxbento caption box and whep playback support

### DIFF
--- a/app/eventyay/webapp/video/src/components/CaptionBox.vue
+++ b/app/eventyay/webapp/video/src/components/CaptionBox.vue
@@ -1,0 +1,169 @@
+<template lang="pug">
+.caption-box(v-if="isVisible")
+  .caption-header
+    span.status-dot(:class="{ active: isConnected && isBoothActive }")
+    span.status-text
+      template(v-if="!isConnected") {{ $t('Connecting to live subtitles...') }}
+      template(v-else-if="!isBoothActive") {{ $t('Interpreter is offline') }}
+      template(v-else) {{ $t('Live Subtitles') }}
+  .caption-content
+    .caption-line(v-for="caption in captions" :key="caption.id" :class="{ final: caption.is_final }")
+      | {{ caption.text }}
+</template>
+
+<script>
+export default {
+  name: 'CaptionBox',
+  props: {
+    captionUrl: {
+      type: String,
+      required: true
+    },
+    listenerToken: {
+      type: String,
+      required: true
+    }
+  },
+  data() {
+    return {
+      ws: null,
+      isConnected: false,
+      isBoothActive: false,
+      captions: [],
+      maxCaptions: 3,
+      isVisible: true
+    }
+  },
+  mounted() {
+    this.connect()
+  },
+  beforeUnmount() {
+    this.disconnect()
+  },
+  methods: {
+    connect() {
+      if (this.ws) {
+        this.ws.close()
+      }
+      
+      const url = new URL(this.captionUrl)
+      url.searchParams.set('token', this.listenerToken)
+      
+      this.ws = new WebSocket(url.toString())
+      
+      this.ws.onopen = () => {
+        this.isConnected = true
+      }
+      
+      this.ws.onclose = () => {
+        this.isConnected = false
+        this.isBoothActive = false
+        // Reconnect after 3 seconds
+        setTimeout(() => {
+          if (this.captionUrl && this.listenerToken && this._isMounted) {
+            this.connect()
+          }
+        }, 3000)
+      }
+      
+      this.ws.onerror = (error) => {
+        console.error('Caption WebSocket error:', error)
+      }
+      
+      this.ws.onmessage = (event) => {
+        try {
+          const message = JSON.parse(event.data)
+          if (message.type === 'booth:state') {
+            this.isBoothActive = message.payload.mic_active && message.payload.ingest_connected
+          } else if (message.type === 'caption') {
+            this.handleCaption(message.payload)
+          }
+        } catch (e) {
+          console.error('Failed to parse caption message:', e)
+        }
+      }
+    },
+    disconnect() {
+      if (this.ws) {
+        this.ws.close()
+        this.ws = null
+      }
+    },
+    handleCaption(payload) {
+      // Find existing caption by ID
+      const index = this.captions.findIndex(c => c.id === payload.id)
+      
+      if (index !== -1) {
+        // Update existing
+        this.captions[index] = payload
+      } else {
+        // Add new
+        this.captions.push(payload)
+      }
+      
+      // Remove old captions if exceeding max
+      if (this.captions.length > this.maxCaptions) {
+        this.captions = this.captions.slice(this.captions.length - this.maxCaptions)
+      }
+    }
+  },
+  watch: {
+    captionUrl() {
+      this.connect()
+    },
+    listenerToken() {
+      this.connect()
+    }
+  },
+  created() {
+    this._isMounted = true
+  },
+  unmounted() {
+    this._isMounted = false
+  }
+}
+</script>
+
+<style lang="stylus" scoped>
+.caption-box
+  background: var(--b-surface, #fff)
+  border: 1px solid var(--b-divider, #eee)
+  border-radius: 8px
+  padding: 12px
+  margin-top: 16px
+  box-shadow: 0 4px 6px rgba(0,0,0,0.05)
+
+.caption-header
+  display: flex
+  align-items: center
+  font-size: 12px
+  color: var(--b-text-subdued, #666)
+  margin-bottom: 8px
+  text-transform: uppercase
+  letter-spacing: 0.5px
+
+.status-dot
+  width: 8px
+  height: 8px
+  border-radius: 50%
+  background-color: var(--b-divider, #ccc)
+  margin-right: 8px
+  transition: background-color 0.3s ease
+
+  &.active
+    background-color: var(--b-success, #4CAF50)
+    box-shadow: 0 0 5px var(--b-success, #4CAF50)
+
+.caption-content
+  min-height: 24px
+  font-size: 16px
+  line-height: 1.5
+  color: var(--b-text, #333)
+
+.caption-line
+  opacity: 0.8
+  transition: opacity 0.2s ease
+  
+  &.final
+    opacity: 1.0
+</style>

--- a/app/eventyay/webapp/video/src/views/rooms/item.vue
+++ b/app/eventyay/webapp/video/src/views/rooms/item.vue
@@ -9,6 +9,7 @@
 			// Added dropdown menu for audio translations near the reactions bar
 			reactions-bar(:expanded="true", @expand="activeStageTool = 'reaction'")
 			AudioTranslationDropdown(v-if="languages.length > 1", :key="room.id", :languages="languages", :selected-language="selectedAudioTranslationLanguage", @languageChanged="handleLanguageChange")
+	CaptionBox(v-if="activeCaptionUrl && listenerToken", :captionUrl="activeCaptionUrl", :listenerToken="listenerToken")
 	media-source-placeholder(v-else-if="modules['call.bigbluebutton'] || modules['call.zoom']")
 	roulette(v-else-if="modules['networking.roulette'] && $features.enabled('roulette')", :module="modules['networking.roulette']", :room="room")
 	landing-page(v-else-if="modules['page.landing']", :module="modules['page.landing']")
@@ -48,8 +49,10 @@ import Questions from 'components/Questions'
 import MediaSourcePlaceholder from 'components/MediaSourcePlaceholder'
 import AudioTranslationDropdown from 'components/AudioTranslationDropdown'
 import UpcomingStreamCountdown from 'components/UpcomingStreamCountdown'
+import CaptionBox from 'components/CaptionBox'
 import { isUsableAudioTranslationEntry, normalizeAudioTranslationSource } from 'lib/validators'
 import { getStagePlaybackMode, PLAYBACK_MODE_SCHEDULE_DRIVEN } from 'lib/stage-streams'
+import config from 'config'
 
 export default {
 	name: 'Room',
@@ -70,6 +73,7 @@ export default {
 		MediaSourcePlaceholder,
 		AudioTranslationDropdown,
 		UpcomingStreamCountdown,
+		CaptionBox,
 	},
 	props: {
 		room: Object,
@@ -84,7 +88,9 @@ export default {
 				polls: false
 			},
 			activeStageTool: null, // reaction, qa
-			languages: [] // Languages for the dropdown menu
+			languages: [], // Languages for the dropdown menu
+			listenerToken: null,
+			voxbentoConfig: null,
 		}
 	},
 	computed: {
@@ -94,6 +100,12 @@ export default {
 		},
 		selectedAudioTranslationLanguage() {
 			return this.getLanguageForTranslation(this.currentYoutubeTranslation) || 'Original'
+		},
+		activeCaptionUrl() {
+			if (!this.voxbentoConfig?.booths) return null;
+			const booths = Object.values(this.voxbentoConfig.booths);
+			const matchingBooth = booths.find(b => b.language === this.selectedAudioTranslationLanguage);
+			return matchingBooth?.caption_url || null;
 		},
 		usesStreamPolling() {
 			return Boolean(
@@ -151,14 +163,47 @@ export default {
 				youtubeTranslation: translationConfig
 			})
 		},
-		initializeLanguages() {
+		async fetchVoxbentoConfig() {
+			if (!this.room?.id) return null;
+			try {
+				const res = await fetch(`${config.api.base}rooms/${this.room.id}/interpretation/config/`, {
+					headers: { 'Accept': 'application/json', 'Authorization': `Bearer ${this.$store.state.token}` }
+				});
+				if (!res.ok) return null;
+				const data = await res.json();
+				if (data.interpreter === 'voxbento' && data.room_enabled) {
+					// Also fetch listener token
+					const tokenRes = await fetch(`${config.api.base}rooms/${this.room.id}/interpretation/listener-token/`, {
+						method: 'GET',
+						headers: { 'Accept': 'application/json', 'Authorization': `Bearer ${this.$store.state.token}` }
+					});
+					if (tokenRes.ok) {
+						const tokenData = await tokenRes.json();
+						this.listenerToken = tokenData.token;
+					}
+					return data;
+				}
+			} catch (e) {
+				console.warn('Failed to fetch interpretation config', e);
+			}
+			return null;
+		},
+		async initializeLanguages() {
 			this.languages = []
+			this.voxbentoConfig = await this.fetchVoxbentoConfig();
 			let languageUrls = null
 
 			const stageModule = this.modules['livestream.native'] || this.modules['livestream.youtube'] || this.modules['livestream.iframe']
 			const isScheduleDriven = getStagePlaybackMode(stageModule) === PLAYBACK_MODE_SCHEDULE_DRIVEN
 
-			if (isScheduleDriven) {
+			if (this.voxbentoConfig?.booths) {
+				// Inject Voxbento booths as languages
+				languageUrls = Object.values(this.voxbentoConfig.booths).map(booth => ({
+					language: booth.language,
+					youtube_id: booth.whep_url,
+					use_video: false
+				}));
+			} else if (isScheduleDriven) {
 				if (this.room?.currentStream?.stream_type === 'youtube' && this.room.currentStream.config?.languageUrls) {
 					languageUrls = this.room.currentStream.config.languageUrls
 				}


### PR DESCRIPTION
## What does this PR do?
This PR integrates live subtitles and multi-language WHEP audio streams for interpreter support in the Video module.

### Changes
- Implements `CaptionBox.vue`, a WebSocket-powered live subtitle component.
- Modifies `item.vue` to fetch the Room's interpretation configuration (`/config`) directly from the Django backend.
- Conditionally renders `CaptionBox` directly below the video stage, strictly only when VoxBento interpretation is enabled.
- Passes the WHEP streaming URLs into Eventyay's existing `AudioTranslationDropdown` to reuse the existing multi-track interface.
- Fully compatible with Eventyay's existing WHEP/WebRTC translation clients.

## Summary by Sourcery

Integrate VoxBento-powered live subtitles and WHEP interpreter audio streams into the video room experience.

New Features:
- Add a CaptionBox component that displays live interpreter subtitles via WebSocket below the video stage when VoxBento interpretation is active.
- Support VoxBento interpretation booths as selectable audio translation languages using their WHEP URLs.

Enhancements:
- Fetch room interpretation configuration and listener token from the backend to drive caption and audio translation behavior in the video room view.