### PR TITLE
fix(control): resolve TemplateSyntaxError in checkin lists index

### DIFF
--- a/app/eventyay/control/templates/pretixcontrol/checkin/index.html
+++ b/app/eventyay/control/templates/pretixcontrol/checkin/index.html
@@ -8,7 +8,7 @@
     {% blocktrans with name=checkinlist.name %}Check-in list: {{ name }}{% endblocktrans %}
 {% endblock %}
 {% block content %}
-    {% blocktrans with name=checkinlist.name as header_title_var %}Check-in list: {{ name }}{% endblocktrans %}
+    {% blocktrans with name=checkinlist.name asvar header_title_var %}Check-in list: {{ name }}{% endblocktrans %}
     {% captureas header_extra_var %}
         {% if 'can_change_event_settings' in request.eventpermset %}
             <a href="{% url "control:event.orders.checkinlists.edit" event=request.event.slug organizer=request.event.organizer.slug list=checkinlist.pk %}"


### PR DESCRIPTION
Close : #4796

This PR fixes a `TemplateSyntaxError: Unknown argument for 'blocktrans' tag: 'as'` that was introduced in PR #4762.

In older Django template syntax (still heavily aliased in the codebase), when assigning a translated string to a variable inside `blocktrans`, the keyword is `asvar`, not `as`.

<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/f87d9cb8-0fa2-4e48-aee9-5f7e94d7634c" />

### Steps to Test
1. Go to Organizer Dashboard -> Select an event -> Click on Check-in lists.
2. The page should load successfully without throwing a 500 error.

## Summary by Sourcery

Bug Fixes:
- Resolve TemplateSyntaxError in the check-in lists index template caused by incorrect use of the blocktrans tag when assigning the header title variable.